### PR TITLE
Add support for subscriptions in the @model transformer.

### DIFF
--- a/how-to-write-a-transformer.md
+++ b/how-to-write-a-transformer.md
@@ -122,7 +122,7 @@ const VERSIONED_DIRECTIVE = `
 Our `@versioned` directive can be applied to `OBJECT` type definitions and automatically adds object versioning and conflict detection to an APIs mutations. For example, we might write
 
 ```graphql
-# Any mutations that deal with the Post type will ask for an `expectedVersion` 
+# Any mutations that deal with the Post type will ask for an `expectedVersion`
 # input that will be checked using DynamoDB condition expressions.
 type Post @model @versioned {
     id: ID!
@@ -175,18 +175,18 @@ export class VersionedModelTransformer extends Transformer {
 
     /**
      * When a type is annotated with @versioned enable conflict resolution for the type.
-     * 
+     *
      * Usage:
-     * 
+     *
      * type Post @model @versioned(versionField: "version", versionInput: "expectedVersion") {
      *   id: ID!
      *   title: String
      *   version: Int!
      * }
-     * 
-     * Enabling conflict resolution automatically manages a "version" attribute in 
+     *
+     * Enabling conflict resolution automatically manages a "version" attribute in
      * the @model type's DynamoDB table and injects a conditional expression into
-     * the types mutations that actually perform the conflict resolutions by 
+     * the types mutations that actually perform the conflict resolutions by
      * checking the "version" attribute in the table with the "expectedVersion" passed
      * by the user.
      */
@@ -272,12 +272,12 @@ import {
     Kind
 } from "graphql";
 import { printBlock, compoundExpression, set, ref, qref, obj, str, raw } from 'graphql-mapping-template'
-import { 
-    ResourceConstants, blankObject, makeSchema, 
+import {
+    ResourceConstants, blankObject, makeSchema,
     makeOperationType,
     ModelResourceIDs,
     ResolverResourceIDs,
-    makeArg,
+    makeInputValueDefinition,
     makeNonNullType,
     makeNamedType,
     getBaseType,
@@ -296,18 +296,18 @@ export class VersionedModelTransformer extends Transformer {
 
     /**
      * When a type is annotated with @versioned enable conflict resolution for the type.
-     * 
+     *
      * Usage:
-     * 
+     *
      * type Post @model @versioned(versionField: "version", versionInput: "expectedVersion") {
      *   id: ID!
      *   title: String
      *   version: Int!
      * }
-     * 
-     * Enabling conflict resolution automatically manages a "version" attribute in 
+     *
+     * Enabling conflict resolution automatically manages a "version" attribute in
      * the @model type's DynamoDB table and injects a conditional expression into
-     * the types mutations that actually perform the conflict resolutions by 
+     * the types mutations that actually perform the conflict resolutions by
      * checking the "version" attribute in the table with the "expectedVersion" passed
      * by the user.
      */
@@ -340,9 +340,9 @@ export class VersionedModelTransformer extends Transformer {
 
     /**
      * Set the "version"  to 1.
-     * @param ctx 
-     * @param versionField 
-     * @param versionInput 
+     * @param ctx
+     * @param versionField
+     * @param versionInput
      */
     private augmentCreateMutation(ctx: TransformerContext, typeName: string, versionField: string, versionInput: string) {
         const snippet = printBlock(`Setting "${versionField}" to 1`)(
@@ -359,9 +359,9 @@ export class VersionedModelTransformer extends Transformer {
     /**
      * Prefix the update operation with a conditional expression that checks
      * the object versions.
-     * @param ctx 
-     * @param versionField 
-     * @param versionInput 
+     * @param ctx
+     * @param versionField
+     * @param versionInput
      */
     private augmentDeleteMutation(ctx: TransformerContext, typeName: string, versionField: string, versionInput: string) {
         const mutationResolverLogicalId = ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName)
@@ -466,7 +466,7 @@ export class VersionedModelTransformer extends Transformer {
         if (input && input.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
             const updatedFields = [
                 ...input.fields,
-                makeArg(versionInput, makeNonNullType(makeNamedType("Int")))
+                makeInputValueDefinition(versionInput, makeNonNullType(makeNamedType("Int")))
             ]
             const updatedInput = {
                 ...input,
@@ -475,7 +475,7 @@ export class VersionedModelTransformer extends Transformer {
             ctx.putType(updatedInput)
         }
     }
-    
+
     private enforceVersionedFieldOnType(
         ctx: TransformerContext,
         typeName: string,

--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -32,11 +32,14 @@ export class AppSyncTransformer extends Transformer {
     public before = (ctx: TransformerContext): void => {
         const queryType = blankObject('Query')
         const mutationType = blankObject('Mutation')
+        const subscriptionType = blankObject('Subscription')
         ctx.addObject(mutationType)
         ctx.addObject(queryType)
+        ctx.addObject(subscriptionType)
         const schema = makeSchema([
             makeOperationType('query', 'Query'),
-            makeOperationType('mutation', 'Mutation')
+            makeOperationType('mutation', 'Mutation'),
+            makeOperationType('subscription', 'Subscription')
         ])
         ctx.putSchema(schema)
 
@@ -81,8 +84,10 @@ export class AppSyncTransformer extends Transformer {
     private buildSchema(ctx: TransformerContext): string {
         const mutationNode: any = ctx.nodeMap.Mutation
         const queryNode: any = ctx.nodeMap.Query
+        const subscriptionNode: any = ctx.nodeMap.Subscription
         let includeMutation = true
         let includeQuery = true
+        let includeSubscription = true
         if (!mutationNode || mutationNode.fields.length === 0) {
             delete ctx.nodeMap.Mutation
             includeMutation = false
@@ -91,12 +96,19 @@ export class AppSyncTransformer extends Transformer {
             delete ctx.nodeMap.Query
             includeQuery = false
         }
+        if (!subscriptionNode || subscriptionNode.fields.length === 0) {
+            delete ctx.nodeMap.Subscription
+            includeSubscription = false
+        }
         const ops = []
         if (includeQuery) {
             ops.push(makeOperationType('query', 'Query'))
         }
         if (includeMutation) {
             ops.push(makeOperationType('mutation', 'Mutation'))
+        }
+        if (includeSubscription) {
+            ops.push(makeOperationType('subscription', 'Subscription'))
         }
         const schema = makeSchema(ops)
         ctx.putSchema(schema)
@@ -105,7 +117,7 @@ export class AppSyncTransformer extends Transformer {
         const astSansDirectives = stripDirectives({
             kind: 'Document',
             definitions: Object.keys(ctx.nodeMap).map((k: string) => ctx.getType(k))
-        })
+        }, ['aws_subscribe'])
         const SDL = print(astSansDirectives)
         return SDL;
     }

--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -112,8 +112,6 @@ export class AppSyncTransformer extends Transformer {
         }
         const schema = makeSchema(ops)
         ctx.putSchema(schema)
-
-
         const astSansDirectives = stripDirectives({
             kind: 'Document',
             definitions: Object.keys(ctx.nodeMap).map((k: string) => ctx.getType(k))

--- a/packages/graphql-appsync-transformer/src/__tests__/AppSyncTransformer.test.ts
+++ b/packages/graphql-appsync-transformer/src/__tests__/AppSyncTransformer.test.ts
@@ -11,7 +11,7 @@ import path = require('path');
 
 test('Test AppSyncTransformer validation happy case', () => {
     const validSchema = `
-    type Post @model @searchable {
+    type Post {
         id: ID!
         title: String!
         createdAt: String

--- a/packages/graphql-connection-transformer/src/definitions.ts
+++ b/packages/graphql-connection-transformer/src/definitions.ts
@@ -1,5 +1,5 @@
 import { InputObjectTypeDefinitionNode } from 'graphql'
-import { makeArg, makeNonNullType, makeNamedType } from 'graphql-transformer-common';
+import { makeInputValueDefinition, makeNonNullType, makeNamedType } from 'graphql-transformer-common';
 
 export function updateCreateInputWithConnectionField(
     input: InputObjectTypeDefinitionNode,
@@ -8,7 +8,7 @@ export function updateCreateInputWithConnectionField(
 ): InputObjectTypeDefinitionNode {
     const updatedFields = [
         ...input.fields,
-        makeArg(connectionFieldName, nonNull ? makeNonNullType(makeNamedType('ID')) : makeNamedType('ID'))
+        makeInputValueDefinition(connectionFieldName, nonNull ? makeNonNullType(makeNamedType('ID')) : makeNamedType('ID'))
     ]
     return {
         ...input,
@@ -22,7 +22,7 @@ export function updateUpdateInputWithConnectionField(
 ): InputObjectTypeDefinitionNode {
     const updatedFields = [
         ...input.fields,
-        makeArg(connectionFieldName, makeNamedType('ID'))
+        makeInputValueDefinition(connectionFieldName, makeNamedType('ID'))
     ]
     return {
         ...input,

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -1,6 +1,6 @@
 import {
     ObjectTypeDefinitionNode, parse, FieldDefinitionNode, DocumentNode,
-    DefinitionNode, Kind, InputObjectTypeDefinitionNode
+    DefinitionNode, Kind, InputObjectTypeDefinitionNode, ListValueNode
 } from 'graphql'
 import GraphQLTransform from 'graphql-transformer-core'
 import { ResourceConstants } from 'graphql-transformer-common'
@@ -51,10 +51,16 @@ test('Test DynamoDBModelTransformer with query overrides', () => {
     expect(queryType).toBeDefined()
     expectFields(queryType, ['customGetPost'])
     expectFields(queryType, ['customListPost'])
+    const subscriptionType = getObjectType(parsed, 'Subscription')
+    expect(subscriptionType).toBeDefined()
+    expectFields(subscriptionType, ['onPostCreated', 'onPostUpdated', 'onPostDeleted'])
+    const subField = subscriptionType.fields.find(f => f.name.value === 'onPostCreated')
+    expect(subField.directives.length).toEqual(1)
+    expect(subField.directives[0].name.value).toEqual('aws_subscribe')
 });
 
 test('Test DynamoDBModelTransformer with mutation overrides', () => {
-    const validSchema = `type Post @model(mutations: { create: "customCreatePost", update: "customUpdatePost", delete: "customDeletePost" }) { 
+    const validSchema = `type Post @model(mutations: { create: "customCreatePost", update: "customUpdatePost", delete: "customDeletePost" }) {
         id: ID!
         title: String!
         createdAt: String
@@ -80,7 +86,7 @@ test('Test DynamoDBModelTransformer with mutation overrides', () => {
 });
 
 test('Test DynamoDBModelTransformer with only create mutations', () => {
-    const validSchema = `type Post @model(mutations: { create: "customCreatePost" }) { 
+    const validSchema = `type Post @model(mutations: { create: "customCreatePost" }) {
         id: ID!
         title: String!
         createdAt: String
@@ -244,8 +250,33 @@ test('Test DynamoDBModelTransformer with queries set to null', () => {
     const queryType = getObjectType(parsed, 'Query')
     expect(queryType).not.toBeDefined()
 })
+test('Test DynamoDBModelTransformer with subscriptions set to null', () => {
+    const validSchema = `type Post @model(subscriptions: null) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `
+    const transformer = new GraphQLTransform({
+        transformers: [new AppSyncTransformer(), new DynamoDBModelTransformer()]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
+    expect(schema).toBeDefined()
+    const definition = schema.Properties.Definition
+    expect(definition).toBeDefined()
+    const parsed = parse(definition);
+    const mutationType = getObjectType(parsed, 'Mutation')
+    expect(mutationType).toBeDefined()
+    const queryType = getObjectType(parsed, 'Query')
+    expect(queryType).toBeDefined()
+    const subscriptionType = getObjectType(parsed, 'Subscription')
+    expect(subscriptionType).not.toBeDefined()
+})
 test('Test DynamoDBModelTransformer with queries and mutations set to null', () => {
-    const validSchema = `type Post @model(queries: null, mutations: null) {
+    const validSchema = `type Post @model(queries: null, mutations: null, subscriptions: null) {
           id: ID!
           title: String!
           createdAt: String
@@ -266,6 +297,44 @@ test('Test DynamoDBModelTransformer with queries and mutations set to null', () 
     expect(mutationType).not.toBeDefined()
     const queryType = getObjectType(parsed, 'Query')
     expect(queryType).not.toBeDefined()
+    const subscriptionType = getObjectType(parsed, 'Subscription')
+    expect(subscriptionType).not.toBeDefined()
+})
+test('Test DynamoDBModelTransformer with advanced subscriptions', () => {
+    const validSchema = `type Post @model(subscriptions: {
+            onCreate: ["onFeedUpdated", "onCreatePost"],
+            onUpdate: ["onFeedUpdated"],
+            onDelete: ["onFeedUpdated"]
+        }) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `
+    const transformer = new GraphQLTransform({
+        transformers: [new AppSyncTransformer(), new DynamoDBModelTransformer()]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
+    expect(schema).toBeDefined()
+    const definition = schema.Properties.Definition
+    expect(definition).toBeDefined()
+    const parsed = parse(definition);
+    const subscriptionType = getObjectType(parsed, 'Subscription')
+    expect(subscriptionType).toBeDefined()
+    expectFields(subscriptionType, ['onFeedUpdated', 'onCreatePost'])
+    const subField = subscriptionType.fields.find(f => f.name.value === 'onFeedUpdated')
+    expect(subField.directives.length).toEqual(1)
+    expect(subField.directives[0].name.value).toEqual('aws_subscribe')
+    const mutationsList = subField.directives[0].arguments.find(a => a.name.value === 'mutations').value as ListValueNode
+    console.log(mutationsList.values)
+    const mutList = mutationsList.values.map((v: any) => v.value)
+    expect(mutList.length).toEqual(3)
+    expect(mutList).toContain('createPost')
+    expect(mutList).toContain('updatePost')
+    expect(mutList).toContain('deletePost')
 })
 
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -6,8 +6,11 @@ import {
 import {
     wrapNonNull, unwrapNonNull, makeNamedType, toUpper, graphqlName, makeListType,
     isScalar, getBaseType, blankObjectExtension, extensionWithFields, makeField,
-    makeArg,
-    ModelResourceIDs
+    makeInputValueDefinition,
+    ModelResourceIDs,
+    makeDirective,
+    makeArgument,
+    makeValueNode
 } from 'graphql-transformer-common'
 
 const STRING_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith']
@@ -276,13 +279,27 @@ export function makeModelConnectionType(typeName: string): ObjectTypeExtensionNo
     return connectionTypeExtension
 }
 
+export function makeSubscriptionField(fieldName: string, returnTypeName: string, mutations: string[]): FieldDefinitionNode {
+    return makeField(
+        fieldName,
+        [],
+        makeNamedType(returnTypeName),
+        [
+            makeDirective(
+                'aws_subscribe',
+                [makeArgument('mutations', makeValueNode(mutations))]
+            )
+        ]
+    )
+}
+
 export function makeModelScanField(fieldName: string, returnTypeName: string): FieldDefinitionNode {
     return makeField(
         fieldName,
         [
-            makeArg('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
-            makeArg('limit', makeNamedType('Int')),
-            makeArg('nextToken', makeNamedType('String'))
+            makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
+            makeInputValueDefinition('limit', makeNamedType('Int')),
+            makeInputValueDefinition('nextToken', makeNamedType('String'))
         ],
         makeNamedType(ModelResourceIDs.ModelConnectionTypeName(returnTypeName))
     )
@@ -292,10 +309,10 @@ export function makeModelConnectionField(fieldName: string, returnTypeName: stri
     return makeField(
         fieldName,
         [
-            makeArg('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
-            makeArg('sortDirection', makeNamedType('ModelSortDirection')),
-            makeArg('limit', makeNamedType('Int')),
-            makeArg('nextToken', makeNamedType('String'))
+            makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
+            makeInputValueDefinition('sortDirection', makeNamedType('ModelSortDirection')),
+            makeInputValueDefinition('limit', makeNamedType('Int')),
+            makeInputValueDefinition('nextToken', makeNamedType('String'))
         ],
         makeNamedType(ModelResourceIDs.ModelConnectionTypeName(returnTypeName))
     )

--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -16,7 +16,7 @@ import {
     extensionWithFields,
     blankObject,
     makeListType,
-    makeArg,
+    makeInputValueDefinition,
     makeNonNullType
 } from "graphql-transformer-common";
 import { ResolverResourceIDs, SearchableResourceIDs } from 'graphql-transformer-common'
@@ -100,10 +100,10 @@ export class SearchableModelTransformer extends Transformer {
                     makeField(
                         searchResolver.Properties.FieldName,
                         [
-                            makeArg('filter', makeNamedType(`Searchable${def.name.value}FilterInput`)),
-                            makeArg('sort', makeNamedType(`Searchable${def.name.value}SortInput`)),
-                            makeArg('limit', makeNamedType('Int')),
-                            makeArg('nextToken', makeNamedType('Int'))
+                            makeInputValueDefinition('filter', makeNamedType(`Searchable${def.name.value}FilterInput`)),
+                            makeInputValueDefinition('sort', makeNamedType(`Searchable${def.name.value}SortInput`)),
+                            makeInputValueDefinition('limit', makeNamedType('Int')),
+                            makeInputValueDefinition('nextToken', makeNamedType('Int'))
                         ],
                         makeNamedType(`Searchable${def.name.value}Connection`)
                     )

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -33,4 +33,13 @@ export class ModelResourceIDs {
     static ModelCreateInputObjectName(typeName: string): string {
         return graphqlName(`Create` + toUpper(typeName) + 'Input')
     }
+    static ModelOnCreateSubscriptionName(typeName: string): string {
+        return graphqlName(`on` + toUpper(typeName) + 'Created')
+    }
+    static ModelOnUpdateSubscriptionName(typeName: string): string {
+        return graphqlName(`on` + toUpper(typeName) + 'Updated')
+    }
+    static ModelOnDeleteSubscriptionName(typeName: string): string {
+        return graphqlName(`on` + toUpper(typeName) + 'Deleted')
+    }
 }

--- a/packages/graphql-transformer-core/src/stripDirectives.ts
+++ b/packages/graphql-transformer-core/src/stripDirectives.ts
@@ -7,7 +7,7 @@ import {
     DocumentNode
 } from "graphql";
 
-export function stripDirectives(doc: DocumentNode): DocumentNode {
+export function stripDirectives(doc: DocumentNode, except: string[] = []): DocumentNode {
     const definitions = []
     for (const def of doc.definitions) {
         switch (def.kind) {
@@ -31,81 +31,84 @@ export function stripDirectives(doc: DocumentNode): DocumentNode {
                 break;
         }
     }
+
+    function excepted(dir: DirectiveNode) { return Boolean(except.find(f => dir.name.value === f))}
+
+    function stripObjectDirectives(node: ObjectTypeDefinitionNode): ObjectTypeDefinitionNode {
+        const fields = node.fields ? node.fields.map(stripFieldDirectives) : node.fields
+        return {
+            ...node,
+            fields,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripInterfaceDirectives(node: InterfaceTypeDefinitionNode): InterfaceTypeDefinitionNode {
+        const fields = node.fields ? node.fields.map(stripFieldDirectives) : node.fields
+        return {
+            ...node,
+            fields,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripFieldDirectives(node: FieldDefinitionNode): FieldDefinitionNode {
+        const args = node.arguments ? node.arguments.map(stripArgumentDirectives) : node.arguments
+        return {
+            ...node,
+            arguments: args,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripArgumentDirectives(node: InputValueDefinitionNode): InputValueDefinitionNode {
+        return {
+            ...node,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripUnionDirectives(node: UnionTypeDefinitionNode): UnionTypeDefinitionNode {
+        return {
+            ...node,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripScalarDirectives(node: ScalarTypeDefinitionNode): ScalarTypeDefinitionNode {
+        return {
+            ...node,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripInputObjectDirectives(node: InputObjectTypeDefinitionNode): InputObjectTypeDefinitionNode {
+        const fields = node.fields ? node.fields.map(stripArgumentDirectives) : node.fields
+        return {
+            ...node,
+            fields,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripEnumDirectives(node: EnumTypeDefinitionNode): EnumTypeDefinitionNode {
+        const values = node.values ? node.values.map(stripEnumValueDirectives) : node.values
+        return {
+            ...node,
+            values,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
+    function stripEnumValueDirectives(node: EnumValueDefinitionNode): EnumValueDefinitionNode {
+        return {
+            ...node,
+            directives: node.directives.filter(excepted)
+        }
+    }
+
     return {
         kind: Kind.DOCUMENT,
         definitions
-    }
-}
-
-export function stripObjectDirectives(node: ObjectTypeDefinitionNode): ObjectTypeDefinitionNode {
-    const fields = node.fields ? node.fields.map(stripFieldDirectives) : node.fields
-    return {
-        ...node,
-        fields,
-        directives: []
-    }
-}
-
-export function stripInterfaceDirectives(node: InterfaceTypeDefinitionNode): InterfaceTypeDefinitionNode {
-    const fields = node.fields ? node.fields.map(stripFieldDirectives) : node.fields
-    return {
-        ...node,
-        fields,
-        directives: []
-    }
-}
-
-export function stripFieldDirectives(node: FieldDefinitionNode): FieldDefinitionNode {
-    const args = node.arguments ? node.arguments.map(stripArgumentDirectives) : node.arguments
-    return {
-        ...node,
-        arguments: args,
-        directives: []
-    }
-}
-
-export function stripArgumentDirectives(node: InputValueDefinitionNode): InputValueDefinitionNode {
-    return {
-        ...node,
-        directives: []
-    }
-}
-
-export function stripUnionDirectives(node: UnionTypeDefinitionNode): UnionTypeDefinitionNode {
-    return {
-        ...node,
-        directives: []
-    }
-}
-
-export function stripScalarDirectives(node: ScalarTypeDefinitionNode): ScalarTypeDefinitionNode {
-    return {
-        ...node,
-        directives: []
-    }
-}
-
-export function stripInputObjectDirectives(node: InputObjectTypeDefinitionNode): InputObjectTypeDefinitionNode {
-    const fields = node.fields ? node.fields.map(stripArgumentDirectives) : node.fields
-    return {
-        ...node,
-        fields,
-        directives: []
-    }
-}
-
-export function stripEnumDirectives(node: EnumTypeDefinitionNode): EnumTypeDefinitionNode {
-    const values = node.values ? node.values.map(stripEnumValueDirectives) : node.values
-    return {
-        ...node,
-        values,
-        directives: []
-    }
-}
-
-export function stripEnumValueDirectives(node: EnumValueDefinitionNode): EnumValueDefinitionNode {
-    return {
-        ...node,
-        directives: []
     }
 }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AppSyncTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AppSyncTransformer.e2e.test.ts
@@ -1,0 +1,84 @@
+import {
+    ObjectTypeDefinitionNode, parse, FieldDefinitionNode, DocumentNode,
+    DefinitionNode, Kind, InputObjectTypeDefinitionNode
+} from 'graphql'
+import GraphQLTransform from 'graphql-transformer-core'
+import DynamoDBModelTransformer from 'graphql-dynamodb-transformer'
+import { AppSyncTransformer } from 'graphql-appsync-transformer'
+
+import fs = require('fs');
+import path = require('path');
+
+test('Test AppSyncTransformer validation happy case', () => {
+    const validSchema = `
+    type Post @model {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `
+    const directory = './fileTest';
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new AppSyncTransformer(directory + '//'),
+            new DynamoDBModelTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+
+    expect(fs.existsSync('./fileTest/schema.graphql')).toBeTruthy()
+    expect(out.Parameters.QueryGetPostRequest).toBeTruthy()
+    expect(out.Parameters.MutationCreatePostRequest).toBeTruthy()
+
+    cleanUpFiles(directory)
+});
+
+function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        expect(foundField).toBeDefined()
+    }
+}
+
+function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        expect(
+            type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        ).toBeUndefined()
+    }
+}
+
+function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+    return doc.definitions.find(
+        (def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type
+    ) as ObjectTypeDefinitionNode | undefined
+}
+
+function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+    return doc.definitions.find(
+        (def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type
+    ) as InputObjectTypeDefinitionNode | undefined
+}
+
+function verifyInputCount(doc: DocumentNode, type: string, count: number): boolean {
+    return doc.definitions.filter(def => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type).length == count;
+}
+
+function cleanUpFiles(directory: string) {
+    var files = fs.readdirSync(directory)
+    for (const file of files) {
+        const dir = path.join(directory, file)
+        if (!fs.lstatSync(dir).isDirectory()) {
+            fs.unlinkSync(dir)
+        } else {
+            cleanUpFiles(dir)
+        }
+    }
+    fs.rmdirSync(directory)
+}
+
+function readFile(filePath: string) {
+    return fs.readFileSync(filePath, "utf8")
+}

--- a/packages/graphql-versioned-transformer/src/VersionedModelTransformer.ts
+++ b/packages/graphql-versioned-transformer/src/VersionedModelTransformer.ts
@@ -12,7 +12,7 @@ import {
     makeOperationType,
     ModelResourceIDs,
     ResolverResourceIDs,
-    makeArg,
+    makeInputValueDefinition,
     makeNonNullType,
     makeNamedType,
     getBaseType,
@@ -31,7 +31,7 @@ export class VersionedModelTransformer extends Transformer {
 
     /**
      * When a type is annotated with @versioned enable conflict resolution for the type.
-     * 
+     *
      * Usage:
      *
      * type Post @model @versioned(versionField: "version", versionInput: "expectedVersion") {
@@ -40,9 +40,9 @@ export class VersionedModelTransformer extends Transformer {
      *   version: Int!
      * }
      *
-     * Enabling conflict resolution automatically manages a "version" attribute in 
+     * Enabling conflict resolution automatically manages a "version" attribute in
      * the @model type's DynamoDB table and injects a conditional expression into
-     * the types mutations that actually perform the conflict resolutions by 
+     * the types mutations that actually perform the conflict resolutions by
      * checking the "version" attribute in the table with the "expectedVersion" passed
      * by the user.
      */
@@ -75,9 +75,9 @@ export class VersionedModelTransformer extends Transformer {
 
     /**
      * Set the "version"  to 1.
-     * @param ctx 
-     * @param versionField 
-     * @param versionInput 
+     * @param ctx
+     * @param versionField
+     * @param versionInput
      */
     private augmentCreateMutation(ctx: TransformerContext, typeName: string, versionField: string, versionInput: string) {
         const snippet = printBlock(`Setting "${versionField}" to 1`)(
@@ -94,9 +94,9 @@ export class VersionedModelTransformer extends Transformer {
     /**
      * Prefix the update operation with a conditional expression that checks
      * the object versions.
-     * @param ctx 
-     * @param versionField 
-     * @param versionInput 
+     * @param ctx
+     * @param versionField
+     * @param versionInput
      */
     private augmentDeleteMutation(ctx: TransformerContext, typeName: string, versionField: string, versionInput: string) {
         const mutationResolverLogicalId = ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName)
@@ -201,7 +201,7 @@ export class VersionedModelTransformer extends Transformer {
         if (input && input.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
             const updatedFields = [
                 ...input.fields,
-                makeArg(versionInput, makeNonNullType(makeNamedType("Int")))
+                makeInputValueDefinition(versionInput, makeNonNullType(makeNamedType("Int")))
             ]
             const updatedInput = {
                 ...input,


### PR DESCRIPTION
*Description of changes:*

Adds subscription support to @model. The @model transformer directive definition has been expanded to:

```graphql
directive @model(
                queries: ModelQueryMap,
                mutations: ModelMutationMap,
                subscriptions: ModelSubscriptionMap
            ) on OBJECT
            input ModelMutationMap { create: String, update: String, delete: String }
            input ModelQueryMap { get: String, list: String }
            input ModelSubscriptionMap {
                onCreate: [String]
                onUpdate: [String]
                onDelete: [String]
            }
```

*Subscription Details*

- By default you get `onXCreated`, `onXUpdated`, and `onXDeleted` for each @model type "X".
- Since a single subscription field can subscribe to multiple mutations, this should be allowed. For example:

```graphql
type Post @model(
     subscriptions: {
        onCreate: ["onFeedUpdated", "onCreatePost"],
        onUpdate: ["onFeedUpdated"],
        onDelete: ["onFeedUpdated"]
    }) {
        id: ID!
        title: String!
        createdAt: String
        updatedAt: String
    }
```

Will generate two subscriptions fields "onFeedUpdated" and "onCreatePost". i.e.

```graphql
type Subscription {
  onFeedUpdated: Post
    @aws_subscribe(mutations: ["createPost", "updatePost","deletePost"])
  onCreatePost: Post
    @aws_subscribe(mutations: ["createPost"])
}
```

You may also turn off subscriptions by passing null

```graphql
type Post @model(subscriptions: null) { ... }
```

*Unfinished Tasks*

- Expose arguments in subscriptions. There are multiple ways to do this so we need to pick one.
- Auth? We can add auth to these subscriptions using the @auth directive and wire up per user/group level auth just like we do with queries/mutations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.