### PR TITLE
Add validation/regex check for project name entered to be alphanumeric during init

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
@@ -55,9 +55,7 @@ function getAmplifyDirPath(projectPath) {
       amplifyCLIConstants.AmplifyCLIDirName,
     ));
   }
-  print.error('You are not working inside a valid amplify project.');
-  print.info('Use \'amplify init\' in the root of your app directory to initialize your project with Amplify');
-  process.exit(0);
+  throw new Error(`You are not working inside a valid amplify project.\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify`);
 }
 
 // ///////////////////level 1
@@ -92,9 +90,7 @@ function getAmplifyRcFilePath(projectPath) {
       '.amplifyrc',
     ));
   }
-  print.error('You are not working inside a valid Amplify project.');
-  print.info('Run \'amplify init\' in the root of your app directory to initialize your project with Amplify');
-  process.exit(0);
+  throw new Error(`You are not working inside a valid amplify project.\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify`);
 }
 
 

--- a/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
@@ -14,7 +14,7 @@ async function run(context) {
         type: 'input',
         name: 'projectName',
         message: 'Enter a name for the project',
-        validate: input => new Promise((resolvePromise, reject) => ((input.length > 20 || input.length < 3) ? reject(new Error('Project name should be between 3 and 20 characters')) : resolvePromise(true))),
+        validate: input => new Promise((resolvePromise, reject) => ((input.length > 20 || input.length < 3 || /[^a-zA-Z0-9]/g.test(input)) ? reject(new Error('Project name should be between 3 and 20 characters and alphanumeric')) : resolvePromise(true))),
       };
 
       ({ projectName } = await inquirer.prompt(projectNameQuestion));


### PR DESCRIPTION
*Issue #, if available:*
The issue was raised by @rohandubal. If the project name is not alphanumeric it later creates issues when generating ID Pools etc


*Description of changes:*
Add a validation -regex check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.