### PR TITLE
Fixing bug due to typo in appsync transformer

### DIFF
--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -134,11 +134,9 @@ export class AppSyncTransformer extends Transformer {
 
         const resolverFilePath = normalize(this.outputPath + '/resolvers')
         if (fs.existsSync(resolverFilePath)) {
-            try {
-                const files = fs.readdirSync(resolverFilePath)
-                files.forEach(file => fs.unlinkSync(resolverFilePath + '/' + files))
-                fs.rmdirSync(resolverFilePath)
-            } catch (e) { return }
+            const files = fs.readdirSync(resolverFilePath)
+            files.forEach(file => fs.unlinkSync(resolverFilePath + '/' + file))
+            fs.rmdirSync(resolverFilePath)
         }
 
         const templateResources: { [key: string]: Resource } = ctx.template.Resources
@@ -209,7 +207,6 @@ export class AppSyncTransformer extends Transformer {
             fs.mkdirSync(functionPath);
         }
         const sourcePath = normalize(ctx.metadata.get('ElasticSearchPathToStreamingLambda'))
-        // console.log('ElasticSearchPathToStreamingLambda Source Path: ' + sourcePath)
         const destPath = normalize(`${this.outputPath}/functions/python_streaming_function.zip`)
 
         const lambdaCode = fs.readFileSync(sourcePath)


### PR DESCRIPTION
*Description of changes:*

An error due to unlinking a non-existing file was getting swallowed and breaking amplify push. This fixes that bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.