### PR TITLE
 Change aws-serverless-express package to latest used by lambda functions

### DIFF
--- a/packages/amplify-category-function/provider-utils/awscloudformation/function-template-dir/crud-package.json.ejs
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/function-template-dir/crud-package.json.ejs
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "aws-sdk": "^2.49.0",
-    "aws-serverless-express": "^2.2.0",
+    "aws-serverless-express": "^3.3.5",
     "body-parser": "^1.17.1",
     "express": "^4.15.2"
   },

--- a/packages/amplify-category-function/provider-utils/awscloudformation/function-template-dir/serverless-app.js.ejs
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/function-template-dir/serverless-app.js.ejs
@@ -29,8 +29,7 @@ app.use(function(req, res, next) {
 
 app.get('<%= props.path %>', function(req, res) {
   // Add your code here
-  // Return the API Gateway event and query string parameters for example
-  res.json(req.apiGateway.event);
+  res.json({success: 'get call succeed!', url: req.url});
 });
 
 app.get('<%= props.path %>/*', function(req, res) {

--- a/packages/amplify-category-function/provider-utils/awscloudformation/function-template-dir/serverless-package.json.ejs
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/function-template-dir/serverless-package.json.ejs
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "aws-serverless-express": "^2.2.0",
+    "aws-serverless-express": "^3.3.5",
     "body-parser": "^1.17.1",
     "express": "^4.15.2"
   },

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
@@ -23,7 +23,7 @@ async function init(context) {
 
   context.exeInfo.template.Resources.S3Bucket.Properties.BucketName = answers.HostingBucketName;
 
-  const configureModule = require(configurables['Website']);
+  const configureModule = require(configurables.Website);
   await configureModule.configure(context);
 }
 

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -158,7 +158,7 @@ async function getPinpointClient(context) {
   const { projectConfig } = context.exeInfo;
   const provider = require(projectConfig.providers[providerName]);
   const aws = await provider.getConfiguredAWSClient(context);
-  aws.config.update({region: 'us-east-1'});
+  aws.config.update({ region: 'us-east-1' });
   return new aws.Pinpoint();
 }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
@@ -2,7 +2,6 @@ const path = require('path');
 const fs = require('fs');
 const homedir = require('os').homedir();
 const amplifyCLIConstants = require('./constants.js');
-const { print } = require('gluegun/print');
 
 /* Helpers */
 
@@ -55,7 +54,7 @@ function getAmplifyDirPath(projectPath) {
       amplifyCLIConstants.AmplifyCLIDirName,
     ));
   }
-  throw new Error(`You are not working inside a valid amplify project.\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify`);
+  throw new Error('You are not working inside a valid amplify project.\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify');
 }
 
 // ///////////////////level 1
@@ -90,7 +89,7 @@ function getAmplifyRcFilePath(projectPath) {
       '.amplifyrc',
     ));
   }
-  throw new Error(`You are not working inside a valid amplify project.\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify`);
+  throw new Error('You are not working inside a valid amplify project.\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify');
 }
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/25

*Description of changes:*

Some basic logging and socket issues resolved in the new version of aws-serverless-express


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.