### PR TITLE
Fixing unit tests in graphql packages

### DIFF
--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -4,7 +4,6 @@
   "description": "An AppSync model transform that takes a simple model and creates a DynamoDB table, DynamoDB stream, and ES index with the queries to match.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "jest",
     "build": "tsc && zip -j lib/streaming-lambda.zip ./streaming-lambda/python_streaming_function.py",
     "clean": "rm -rf ./lib",
     "lint": "tslint -p ./tslint.json"

--- a/packages/graphql-transformer-core/src/__tests__/GraphQLTransform.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/GraphQLTransform.test.ts
@@ -57,7 +57,7 @@ test('Test graphql transformer validation. Unknown directive.', () => {
     try {
         transformer.transform(invalidSchema);
     } catch (e) {
-        expect(e.name).toEqual('TransformSchemaError')
+        expect(e.name).toEqual('SchemaValidationError')
     }
 });
 
@@ -91,7 +91,7 @@ test('Test graphql transformer validation on bad shapes. @ping directive.', () =
         expect(true).toEqual(false)
     } catch (e) {
         console.log(e.message)
-        expect(e.name).toEqual('TransformSchemaError')
+        expect(e.name).toEqual('SchemaValidationError')
     }
 });
 

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -4,7 +4,7 @@
   "description": "End to end functional tests for appsync supported transformers.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "jest",
+    "e2e": "jest",
     "build": "tsc",
     "clean": "rm -rf ./lib",
     "lint": "tslint -p ./tslint.json"


### PR DESCRIPTION
*Description of changes:*

Fixes unit tests. e2e package test command changed to e2e.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.