### PR TITLE
Fixing #24 where connection transformer doesn't make filters

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -304,7 +304,7 @@ export class ModelConnectionTransformer extends Transformer {
                 ctx.addEnum(modelSortDirection)
             }
 
-            this.generateFilterInputs(ctx, parent)
+            this.generateFilterInputs(ctx, returnType)
         } else {
             throw new InvalidDirectiveError(`Could not find a object or interface type named ${parent.name.value}.`)
         }


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-cli/issues/24

*Description of changes:*

Fixing #24 and creating the correct filter objects.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.