### PR TITLE
Remove ava from test in core amplify cli package

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -10,10 +10,7 @@
   },
   "scripts": {
     "lint": "eslint src",
-    "lint-fix": "eslint . --fix",
-    "test": "ava",
-    "watch": "ava --watch",
-    "coverage": "nyc ava"
+    "lint-fix": "eslint . --fix"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",


### PR DESCRIPTION
*Description of changes:*
Remove not functional test command from amplify core package

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.