### PR TITLE
Change file location of API models created to <root-app>/app/src/main…

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/download-api-models.js
+++ b/packages/amplify-provider-awscloudformation/lib/download-api-models.js
@@ -73,7 +73,7 @@ function copyFilesToSrc(context, apiName, framework) {
     case 'android': {
       const generatedSrc = `${tempDir}/${apiName}-Artifact-1.0/src/main/java`;
 
-      const target = `${context.amplify.getProjectConfig().projectPath}/src/main/java`;
+      const target = `${context.amplify.getProjectConfig().projectPath}/app/src/main/java`;
 
       fs.ensureDirSync(target);
 


### PR DESCRIPTION
…/java from <root-app>/src/main/java

*Issue #, if available:*

https://github.com/aws-amplify/amplify-cli/issues/51

*Description of changes:*

Change the location of generating API models for android

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.