### PR TITLE
Fix(aws-amplify/amplify-cli) #50 Check if the API exists during codegen

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/lib/utility-functions.js
@@ -111,7 +111,7 @@ module.exports = {
           .promise();
       })
       .then(result => result.schema.toString() || null)
-      .catch((e) => {
-        context.print.debug(e);
+      .catch(() => {
+        throw new Error('Failed to download introspection schema');
       }),
 };


### PR DESCRIPTION
*Issue #, if available:*
Fixes #50 
*Description of changes:*
Updated codegen generate code to make sure that the configured API in .graphqlconfig.yml file indeed exist in the current amplify project


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.