### PR TITLE
Enforce profile name: set AWS.config.credentials.

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -348,7 +348,9 @@ function logProjectSpecificConfg(context, awsClient) {
     const configInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'));
     if (configInfo.useProfile && configInfo.profileName) {
       process.env.AWS_PROFILE = configInfo.profileName;
-      const credentials = new awsClient.SharedIniFileCredentials({profile: configInfo.profileName});
+      const credentials = new awsClient.SharedIniFileCredentials({
+        profile: configInfo.profileName,
+      });
       awsClient.config.credentials = credentials;
     } else if (configInfo.awsConfigFilePath && fs.existsSync(configInfo.awsConfigFilePath)) {
       awsClient.config.loadFromPath(configInfo.awsConfigFilePath);

--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -348,6 +348,8 @@ function logProjectSpecificConfg(context, awsClient) {
     const configInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'));
     if (configInfo.useProfile && configInfo.profileName) {
       process.env.AWS_PROFILE = configInfo.profileName;
+      const credentials = new awsClient.SharedIniFileCredentials({profile: configInfo.profileName});
+      awsClient.config.credentials = credentials;
     } else if (configInfo.awsConfigFilePath && fs.existsSync(configInfo.awsConfigFilePath)) {
       awsClient.config.loadFromPath(configInfo.awsConfigFilePath);
     }

--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -59,7 +59,9 @@ function getConfiguredAwsCfnClient(context) {
   if (projectConfigInfo.action === 'init') {
     if (projectConfigInfo.useProfile && projectConfigInfo.profileName) {
       process.env.AWS_PROFILE = projectConfigInfo.profileName;
-      const credentials = new aws.SharedIniFileCredentials({profile: projectConfigInfo.profileName});
+      const credentials = new aws.SharedIniFileCredentials({
+        profile: projectConfigInfo.profileName,
+      });
       aws.config.credentials = credentials;
     } else {
       aws.config.update({

--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -59,6 +59,8 @@ function getConfiguredAwsCfnClient(context) {
   if (projectConfigInfo.action === 'init') {
     if (projectConfigInfo.useProfile && projectConfigInfo.profileName) {
       process.env.AWS_PROFILE = projectConfigInfo.profileName;
+      const credentials = new aws.SharedIniFileCredentials({profile: projectConfigInfo.profileName});
+      aws.config.credentials = credentials;
     } else {
       aws.config.update({
         accessKeyId: projectConfigInfo.accessKeyId,

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -7,6 +7,7 @@ const TransformPackage = require('graphql-transformer-core');
 const GraphQLTransform = TransformPackage.default;
 const { collectDirectiveNames } = TransformPackage;
 const DynamoDBModelTransformer = require('graphql-dynamodb-transformer').default;
+const CustomTransformer = require('graphql-custom-transformer').default;
 const ModelAuthTransformer = require('graphql-auth-transformer').default;
 const AppSyncTransformer = require('graphql-appsync-transformer').default;
 const ModelConnectionTransformer = require('graphql-connection-transformer').default;
@@ -76,6 +77,7 @@ async function transformGraphQLSchema(context, options) {
   const transformerList = [
     new AppSyncTransformer(buildDir),
     new DynamoDBModelTransformer(),
+    new CustomTransformer(),
     new ModelConnectionTransformer(),
     new VersionedModelTransformer(),
   ];

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -19,6 +19,7 @@
     "graphql-auth-transformer": "^1.0.12",
     "graphql-connection-transformer": "^1.0.12",
     "graphql-dynamodb-transformer": "^1.0.12",
+    "graphql-custom-transformer": "^1.0.12",
     "graphql-elasticsearch-transformer": "^1.0.12",
     "graphql-transformer-common": "^1.0.12",
     "graphql-transformer-core": "^1.0.12",

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -171,14 +171,16 @@ export class ModelAuthTransformer extends Transformer {
      * @param rules The auth rules to apply.
      */
     private protectGetQuery(ctx: TransformerContext, resolverResourceId: string, rules: AuthRule[]) {
-        if (!rules || rules.length === 0) {
+        const resolver = ctx.getResource(resolverResourceId)
+        if (!rules || rules.length === 0 || !resolver) {
             return
         }
         const beforeResponse = []
         for (const rule of rules) {
             if (rule.allow === OWNER_AUTH_STRATEGY) {
                 const ownerField = rule.ownerField || OWNER_AUTH_STRATEGY
-                const authSnippet = this.resources.ownerGetResolverResponseMappingTemplateSnippet(ownerField)
+                const identityField = rule.identityField || DEFAULT_IDENTITY_FIELD
+                const authSnippet = this.resources.ownerGetResolverResponseMappingTemplateSnippet(ownerField, identityField)
                 beforeResponse.push(authSnippet)
             } else if (rule.allow === GROUPS_AUTH_STRATEGY) {
                 if (rule.groups) {
@@ -193,7 +195,6 @@ export class ModelAuthTransformer extends Transformer {
             }
         }
         // Join together the authorization expressions and update the resolver.
-        const resolver = ctx.getResource(resolverResourceId)
         const templateParts = [...beforeResponse, this.resources.throwWhenUnauthorized(), resolver.Properties.ResponseMappingTemplate]
         resolver.Properties.ResponseMappingTemplate = templateParts.join('\n\n')
         ctx.setResource(resolverResourceId, resolver)
@@ -208,7 +209,8 @@ export class ModelAuthTransformer extends Transformer {
      * @param rules The set of rules that apply to the operation.
      */
     private protectListQuery(ctx: TransformerContext, resolverResourceId: string, rules: AuthRule[]) {
-        if (!rules || rules.length === 0) {
+        const resolver = ctx.getResource(resolverResourceId)
+        if (!rules || rules.length === 0 || !resolver) {
             return
         }
         const beforeExpressions = []
@@ -217,7 +219,8 @@ export class ModelAuthTransformer extends Transformer {
         for (const rule of rules) {
             if (rule.allow === OWNER_AUTH_STRATEGY) {
                 const ownerField = rule.ownerField || OWNER_AUTH_STRATEGY
-                const authSnippet = this.resources.ownerListResolverItemCheck(ownerField)
+                const identityField = rule.identityField || DEFAULT_IDENTITY_FIELD
+                const authSnippet = this.resources.ownerListResolverItemCheck(ownerField, identityField)
                 itemEquivalenceExpressions.push(authSnippet)
             } else if (rule.allow === GROUPS_AUTH_STRATEGY) {
                 if (rule.groups) {
@@ -240,7 +243,6 @@ export class ModelAuthTransformer extends Transformer {
             }
         }
         // Join together the authorization expressions and update the resolver.
-        const resolver = ctx.getResource(resolverResourceId)
         const templateParts = [
             this.resources.loopThroughResultItemsAppendingAuthorized(itemEquivalenceExpressions, beforeExpressions, beforeItemEquivalenceExpression),
             resolver.Properties.ResponseMappingTemplate
@@ -257,15 +259,16 @@ export class ModelAuthTransformer extends Transformer {
      * @param rules
      */
     private protectCreateMutation(ctx: TransformerContext, resolverResourceId: string, rules: AuthRule[]) {
-        if (!rules || rules.length === 0) {
+        const resolver = ctx.getResource(resolverResourceId)
+        if (!rules || rules.length === 0 || !resolver) {
             return
         }
         const beforeRequest = []
         for (const rule of rules) {
             if (rule.allow === OWNER_AUTH_STRATEGY) {
                 const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD
-                const idenityField = rule.ownerField || DEFAULT_IDENTITY_FIELD
-                const authSnippet = this.resources.ownerCreateResolverRequestMappingTemplateSnippet(ownerField, idenityField)
+                const identityField = rule.identityField || DEFAULT_IDENTITY_FIELD
+                const authSnippet = this.resources.ownerCreateResolverRequestMappingTemplateSnippet(ownerField, identityField)
                 beforeRequest.push(authSnippet)
             } else if (rule.allow === GROUPS_AUTH_STRATEGY) {
                 if (rule.groups) {
@@ -282,7 +285,6 @@ export class ModelAuthTransformer extends Transformer {
             }
         }
         // Join together the authorization expressions and update the resolver.
-        const resolver = ctx.getResource(resolverResourceId)
         const templateParts = [...beforeRequest, resolver.Properties.RequestMappingTemplate]
         resolver.Properties.RequestMappingTemplate = templateParts.join('\n\n')
         ctx.setResource(resolverResourceId, resolver)
@@ -298,15 +300,16 @@ export class ModelAuthTransformer extends Transformer {
      * @param rules The list of rules to apply.
      */
     private protectUpdateOrDeleteMutation(ctx: TransformerContext, resolverResourceId: string, rules: AuthRule[]) {
-        if (!rules || rules.length === 0) {
+        const resolver = ctx.getResource(resolverResourceId)
+        if (!rules || rules.length === 0 || !resolver) {
             return
         }
         const beforeRequest = []
         for (const rule of rules) {
             if (rule.allow === OWNER_AUTH_STRATEGY) {
                 const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD
-                const idenityField = rule.ownerField || DEFAULT_IDENTITY_FIELD
-                const authSnippet = this.resources.ownerUpdateAndDeleteResolverRequestMappingTemplateSnippet(ownerField, idenityField)
+                const identityField = rule.identityField || DEFAULT_IDENTITY_FIELD
+                const authSnippet = this.resources.ownerUpdateAndDeleteResolverRequestMappingTemplateSnippet(ownerField, identityField)
                 beforeRequest.push(authSnippet)
             } else if (rule.allow === GROUPS_AUTH_STRATEGY) {
                 if (rule.groups) {
@@ -322,7 +325,6 @@ export class ModelAuthTransformer extends Transformer {
             }
         }
         // Join together the authorization expressions and update the resolver.
-        const resolver = ctx.getResource(resolverResourceId)
         const templateParts = [...beforeRequest, resolver.Properties.RequestMappingTemplate]
         resolver.Properties.RequestMappingTemplate = templateParts.join('\n\n')
         ctx.setResource(resolverResourceId, resolver)

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -254,15 +254,15 @@ export class ResourceFactory {
      * @param ownerAttribute The name of the owner attribute.
      */
     public ownerCreateResolverRequestMappingTemplateSnippet = (
-        ownerAttribute: string, idenityField: string) => printBlock('Inject Ownership Information')(
+        ownerAttribute: string, identityField: string) => printBlock('Inject Ownership Information')(
             compoundExpression([
-                iff(raw(`$util.isNullOrBlank($ctx.identity.${idenityField})`), raw('$util.unauthorized()')),
-                qref(`$ctx.args.input.put("${ownerAttribute}", $ctx.identity.${idenityField})`)
+                iff(raw(`$util.isNullOrBlank($ctx.identity.${identityField})`), raw('$util.unauthorized()')),
+                qref(`$ctx.args.input.put("${ownerAttribute}", $ctx.identity.${identityField})`)
             ])
         )
 
     public ownerUpdateAndDeleteResolverRequestMappingTemplateSnippet =
-        (ownerAttribute: string, idenityField: string) => printBlock('Prepare Ownership Condition')(
+        (ownerAttribute: string, identityField: string) => printBlock('Prepare Ownership Condition')(
             compoundExpression([
                 ifElse(
                     raw(`!$${ResourceConstants.SNIPPETS.AuthCondition}`),
@@ -275,7 +275,7 @@ export class ResourceFactory {
                             }),
                             expressionValues: obj({
                                 ":username": obj({
-                                    "S": str(`$ctx.identity.${idenityField}`)
+                                    "S": str(`$ctx.identity.${identityField}`)
                                 })
                             })
                         })
@@ -287,29 +287,30 @@ export class ResourceFactory {
                         ),
                         raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionNames.put("#owner", "${ownerAttribute}"))`),
                         // tslint:disable-next-line
-                        raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionValues.put(":username", { "S": "$ctx.identity.${idenityField}"}))`),
+                        raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionValues.put(":username", { "S": "$ctx.identity.${identityField}"}))`),
                     ])
                 )
             ])
         )
 
-    public ownerGetResolverResponseMappingTemplateSnippet = (ownerAttribute: string) => printBlock('Validate Ownership')(
+    public ownerGetResolverResponseMappingTemplateSnippet = (ownerAttribute: string, identityField: string) => printBlock('Validate Ownership')(
         iff(
-            equals(ref(`ctx.result.${ownerAttribute}`), ref('ctx.identity.username')),
+            equals(ref(`ctx.result.${ownerAttribute}`), ref(`ctx.identity.${identityField}`)),
             raw('#set($isAuthorized = true)'))
     )
 
-    public ownerListResolverResponseMappingTemplateSnippet = (ownerAttribute: string) => printBlock("Filter Owned Items")(
+    public ownerListResolverResponseMappingTemplateSnippet = (ownerAttribute: string, identityField: string) => printBlock("Filter Owned Items")(
         compoundExpression([
             set(ref('items'), list([])),
             forEach(ref('item'), ref('ctx.result.items'), [
-                iff(raw(`$item.${ownerAttribute} == $ctx.identity.username`), qref('$items.add($item)'))
+                iff(raw(`$item.${ownerAttribute} == $ctx.identity.${identityField}`), qref('$items.add($item)'))
             ]),
             set(ref('ctx.result.items'), ref('items'))
         ])
     )
 
-    public ownerListResolverItemCheck = (ownerAttribute: string) => raw(`$item.${ownerAttribute} == $ctx.identity.username`)
+    public ownerListResolverItemCheck = (ownerAttribute: string, identityField: string) =>
+        raw(`$item.${ownerAttribute} == $ctx.identity.${identityField}`)
 
     public loopThroughResultItemsAppendingAuthorized(
         ifExprs: Expression[],
@@ -330,11 +331,11 @@ export class ResourceFactory {
     }
 
 
-    public ownerQueryResolverResponseMappingTemplateSnippet = (ownerAttribute: string) => printBlock('Filter Owned Items')(
+    public ownerQueryResolverResponseMappingTemplateSnippet = (ownerAttribute: string, identityField: string) => printBlock('Filter Owned Items')(
         compoundExpression([
             set(ref('items'), list([])),
             forEach(ref('item'), ref('ctx.result.items'), [
-                iff(raw(`$item.${ownerAttribute} == $ctx.identity.username`), qref('$items.add($item)'))
+                iff(raw(`$item.${ownerAttribute} == $ctx.identity.${identityField}`), qref('$items.add($item)'))
             ]),
             set(ref('ctx.result.items'), ref('items'))
         ])

--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -54,7 +54,7 @@ export class ModelConnectionTransformer extends Transformer {
     constructor() {
         super(
             'ModelConnectionTransformer',
-            `directive @connection(name: String, keyField: String) on FIELD_DEFINITION`
+            `directive @connection(name: String, keyField: String, sortField: String) on FIELD_DEFINITION`
         )
         this.resources = new ResourceFactory();
     }
@@ -119,6 +119,7 @@ export class ModelConnectionTransformer extends Transformer {
         const rightConnectionIsList = associatedConnectionField ? isListType(associatedConnectionField.type) : undefined
 
         let connectionAttributeName = getDirectiveArgument(directive)("keyField")
+        let sortAttributeName = getDirectiveArgument(directive)("sortField")
 
         // Relationship Cardinalities:
         // 1. [] to []
@@ -157,7 +158,7 @@ export class ModelConnectionTransformer extends Transformer {
             }
             const tableLogicalId = ModelResourceIDs.ModelTableResourceID(parentTypeName)
             const table = ctx.getResource(tableLogicalId) as Table
-            const updated = this.resources.updateTableForConnection(table, connectionName, connectionAttributeName)
+            const updated = this.resources.updateTableForConnection(table, connectionName, connectionAttributeName, sortAttributeName)
             ctx.setResource(tableLogicalId, updated)
 
             const getResolver = this.resources.makeGetItemConnectionResolver(
@@ -192,7 +193,7 @@ export class ModelConnectionTransformer extends Transformer {
 
             const tableLogicalId = ModelResourceIDs.ModelTableResourceID(relatedTypeName)
             const table = ctx.getResource(tableLogicalId) as Table
-            const updated = this.resources.updateTableForConnection(table, connectionName, connectionAttributeName)
+            const updated = this.resources.updateTableForConnection(table, connectionName, connectionAttributeName, sortAttributeName)
             ctx.setResource(tableLogicalId, updated)
 
             const queryResolver = this.resources.makeQueryConnectionResolver(

--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -35,6 +35,7 @@ export class ResourceFactory {
         table: Table,
         connectionName: string,
         connectionAttributeName: string,
+        sortAttributeName?: string
     ): Table {
         const gsis = table.Properties.GlobalSecondaryIndexes || [] as GlobalSecondaryIndex[]
         if (gsis.length >= 5) {
@@ -54,6 +55,7 @@ export class ResourceFactory {
                         AttributeName: connectionAttributeName,
                         KeyType: 'HASH'
                     })
+                    , ...(sortAttributeName ? [new KeySchema({ AttributeName: sortAttributeName, KeyType: 'RANGE' })] : [])
                 ],
                 Projection: new Projection({
                     ProjectionType: 'ALL'
@@ -73,6 +75,13 @@ export class ResourceFactory {
                 AttributeName: connectionAttributeName,
                 AttributeType: 'S'
             }))
+        }
+
+        if (sortAttributeName) {
+            const existingSortAttribute = attributeDefinitions.find(attr => attr.AttributeName === sortAttributeName)
+            if (!existingSortAttribute) {
+                attributeDefinitions.push(new AttributeDefinition({ AttributeName: sortAttributeName, AttributeType: 'S' }))
+            }
         }
         table.Properties.GlobalSecondaryIndexes = gsis
         table.Properties.AttributeDefinitions = attributeDefinitions

--- a/packages/graphql-custom-transformer/CHANGELOG.md
+++ b/packages/graphql-custom-transformer/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+<a name="1.0.12"></a>
+## [1.0.12](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.11...graphql-dynamodb-transformer@1.0.12) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.11"></a>
+## [1.0.11](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.10...graphql-dynamodb-transformer@1.0.11) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.10"></a>
+## [1.0.10](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.9...graphql-dynamodb-transformer@1.0.10) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.9"></a>
+## [1.0.9](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.8...graphql-dynamodb-transformer@1.0.9) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.8"></a>
+## [1.0.8](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.7...graphql-dynamodb-transformer@1.0.8) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.7"></a>
+## [1.0.7](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.6...graphql-dynamodb-transformer@1.0.7) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.6"></a>
+## [1.0.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.5...graphql-dynamodb-transformer@1.0.6) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.5"></a>
+## [1.0.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-dynamodb-transformer@1.0.4...graphql-dynamodb-transformer@1.0.5) (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.4"></a>
+## 1.0.4 (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.3"></a>
+## 1.0.3 (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.2"></a>
+## 1.0.2 (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer
+
+<a name="1.0.1"></a>
+## 1.0.1 (2018-08-23)
+
+
+
+
+**Note:** Version bump only for package graphql-dynamodb-transformer

--- a/packages/graphql-custom-transformer/package.json
+++ b/packages/graphql-custom-transformer/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "graphql-custom-transformer",
+  "version": "1.0.12",
+  "description": "An AppSync model transform that takes a simple model and creates a DynamoDB table, DynamoDB stream, and ES index with the queries to match.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "clean": "rm -rf ./lib"
+  },
+  "keywords": [
+    "graphql",
+    "appsync",
+    "aws"
+  ],
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "cloudform": "^2.2.1",
+    "graphql": "^0.13.2",
+    "graphql-mapping-template": "^1.0.12",
+    "graphql-transformer-common": "^1.0.12",
+    "graphql-transformer-core": "^1.0.12"
+  },
+  "devDependencies": {
+    "@types/graphql": "^0.13.1",
+    "@types/jest": "^23.1.1",
+    "@types/node": "^10.3.4",
+    "aws-sdk": "^2.259.1",
+    "graphql-appsync-transformer": "^1.0.12",
+    "jest": "^23.1.0",
+    "ts-jest": "^22.4.6",
+    "tslint": "^5.10.0",
+    "typescript": "^2.8.3"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testURL": "http://localhost",
+    "testRegex": "(src/__tests__/.*.test.*)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  }
+}

--- a/packages/graphql-custom-transformer/src/CustomTransformer.ts
+++ b/packages/graphql-custom-transformer/src/CustomTransformer.ts
@@ -1,0 +1,94 @@
+import { Transformer, TransformerContext } from 'graphql-transformer-core'
+import { DirectiveNode, ObjectTypeDefinitionNode, NamedTypeNode, InterfaceTypeDefinitionNode, FieldDefinitionNode } from 'graphql'
+import { ResourceFactory } from './resources'
+import { blankObjectExtension, extensionWithFields, ResolverResourceIDs, toUpper, getDirectiveArgument  } from 'graphql-transformer-common'
+import Resource from "cloudform/types/resource";
+
+/**
+ * custom transformer includes files from custom/resolvers folder
+ */
+export class CustomTransformer extends Transformer {
+
+    resources: ResourceFactory
+    blanks: {[key: string]: any} = {
+        Mutation: blankObjectExtension('Mutation'),
+        Query: blankObjectExtension('Query')
+    }
+
+    constructor() {
+        super(
+            'CustomTransformer',
+            `directive @custom(name: String) on OBJECT | FIELD_DEFINITION`
+        )
+        this.resources = new ResourceFactory();
+    }
+
+    public after = (ctx: TransformerContext): void => {
+        ctx.addObjectExtension(this.blanks.Mutation)
+        ctx.addObjectExtension(this.blanks.Query)
+        this.linkResolversToFilePath(ctx);
+    }
+
+    private linkResolversToFilePath(ctx: TransformerContext): void {
+
+        const templateResources: { [key: string]: Resource } = ctx.template.Resources
+
+        for (const resourceName of Object.keys(templateResources)) {
+            const resource: Resource = templateResources[resourceName]
+            if (resource.Type === 'AWS::AppSync::Resolver' && resource.Properties.RequestMappingTemplateS3Location) {
+                this.updateParameters(resourceName, ctx)
+            }
+        }
+    }
+
+    private updateParameters(resourceName: string, ctx: TransformerContext): void {
+        const resolverResource = ctx.template.Resources[resourceName]
+
+        const reqFileName = resolverResource.Properties.RequestMappingTemplateS3Location
+        const respFileName = resolverResource.Properties.ResponseMappingTemplateS3Location
+        if (reqFileName && respFileName) {
+            const reqTypeName = resolverResource.Properties.TypeName
+            const reqFieldName = resolverResource.Properties.FieldName
+            const reqFileName = `${reqTypeName}.${reqFieldName}.request`
+            const reqParam = this.resources.makeResolverParam(reqFileName);
+            ctx.mergeParameters(reqParam.Parameters);
+
+            const respTypeName = resolverResource.Properties.TypeName
+            const respFieldName = resolverResource.Properties.FieldName
+            const respFileName = `${respTypeName}.${respFieldName}.response`
+            const respParam = this.resources.makeResolverParam(respFileName);
+            ctx.mergeParameters(respParam.Parameters);
+        }
+    }
+
+    public field = (
+        parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+        field: FieldDefinitionNode,
+        directive: DirectiveNode,
+        ctx: TransformerContext
+    ): void => {
+        const defName = parent.name.value
+        const fieldName = field.name.value
+        let typeName = getDirectiveArgument(directive)('name');
+        let typeNode = field.type
+        while (!typeName) {
+            if (typeNode.kind === 'NamedType') {
+                typeName = (typeNode as NamedTypeNode).name.value
+            } else {
+                typeNode = typeNode.type
+            }
+        }
+        const resolver = this.resources.makeCustomResolverWithS3(defName, fieldName, typeName)
+        ctx.setResource(ResolverResourceIDs.ResolverResourceID(defName, toUpper(fieldName)), resolver)
+
+        if (defName === 'Mutation') {
+            this.blanks.Mutation = extensionWithFields(this.blanks.Mutation, [field])
+        } else if (defName === 'Query') {
+            this.blanks.Query = extensionWithFields(this.blanks.Query, [field])
+        }
+    }
+
+    public object = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
+        //no work
+    }
+}

--- a/packages/graphql-custom-transformer/src/CustomTransformer.ts
+++ b/packages/graphql-custom-transformer/src/CustomTransformer.ts
@@ -1,7 +1,7 @@
 import { Transformer, TransformerContext } from 'graphql-transformer-core'
 import { DirectiveNode, ObjectTypeDefinitionNode, NamedTypeNode, InterfaceTypeDefinitionNode, FieldDefinitionNode } from 'graphql'
 import { ResourceFactory } from './resources'
-import { blankObjectExtension, extensionWithFields, ResolverResourceIDs, toUpper, getDirectiveArgument  } from 'graphql-transformer-common'
+import { blankObjectExtension, extensionWithFields, ResolverResourceIDs, toUpper, getDirectiveArgument } from 'graphql-transformer-common'
 import Resource from "cloudform/types/resource";
 
 /**
@@ -10,9 +10,10 @@ import Resource from "cloudform/types/resource";
 export class CustomTransformer extends Transformer {
 
     resources: ResourceFactory
-    blanks: {[key: string]: any} = {
+    blanks: { [key: string]: any } = {
         Mutation: blankObjectExtension('Mutation'),
-        Query: blankObjectExtension('Query')
+        Query: blankObjectExtension('Query'),
+        Subscription: blankObjectExtension('Subscription')
     }
 
     constructor() {

--- a/packages/graphql-custom-transformer/src/index.ts
+++ b/packages/graphql-custom-transformer/src/index.ts
@@ -1,0 +1,3 @@
+import { CustomTransformer } from './CustomTransformer'
+export * from './CustomTransformer'
+export default CustomTransformer

--- a/packages/graphql-custom-transformer/src/resources.ts
+++ b/packages/graphql-custom-transformer/src/resources.ts
@@ -1,0 +1,45 @@
+import AppSync from 'cloudform/types/appSync'
+import Template from 'cloudform/types/template'
+import { Fn, StringParameter } from 'cloudform'
+import { ResourceConstants, toUpper, ModelResourceIDs } from 'graphql-transformer-common'
+
+export class ResourceFactory {
+
+    public makeResolverParam(name: string): Template {
+        return {
+            Parameters: {
+                [this.removeDotsAndCamelcase(name)]: new StringParameter({
+                    Description: `The S3 location for the Resolver: ${name}`,
+                })
+            }
+        }
+    }
+
+    /**
+     * Create a resolver that creates an item in DynamoDB.
+     * @param type
+     */
+    public makeCustomResolverWithS3(type: string, fieldName: string, fieldTypeName: string) {
+        const requestParamName = `${type}.${fieldName}.request`
+        const responseParamName = `${type}.${fieldName}.response`
+        return new AppSync.Resolver({
+            ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+            DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(fieldTypeName), 'Name'),
+            FieldName: fieldName,
+            TypeName: type,
+            RequestMappingTemplateS3Location: Fn.Ref(this.removeDotsAndCamelcase(requestParamName)),
+            ResponseMappingTemplateS3Location: Fn.Ref(this.removeDotsAndCamelcase(responseParamName))
+        }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID)
+    }
+
+    public removeDotsAndCamelcase(name: string) {
+        return name.split('.').reduce((acc, cur, i) => (acc + (i > 0 ? toUpper(cur) : cur )), "")
+        // var nameCopy = name
+        // for (var i = 0; i < name.length; i++) {
+        //     if (name[i] === '.') {
+        //         nameCopy = nameCopy.substr(0, i + 1) + nameCopy.charAt(i + 1).toUpperCase() + nameCopy.slice(i + 2)
+        //     }
+        // }
+        // return nameCopy.replace(/\./g, '')
+    }
+}

--- a/packages/graphql-custom-transformer/src/run.ts
+++ b/packages/graphql-custom-transformer/src/run.ts
@@ -1,0 +1,35 @@
+import GraphQLTransform from "graphql-transformer-core";
+import { CustomTransformer } from "./CustomTransformer";
+import AppSyncTransformer from 'graphql-appsync-transformer';
+
+import fs = require('fs');
+
+const validSchema = `type Post @model(queries: { get: "customGetPost", list: "customListPost", query: "customQueryPost" }) {
+    id: ID!
+    title: String!
+    upvotes: Int
+    downvotes: Int
+    percantageUp: Float
+    comments: [String]
+    isPublished: Boolean
+}
+
+type User @model {
+    id: ID!
+    name: String!
+}
+`;
+
+// const transformer = new GraphQLTransform({
+//     transformers: [
+//         new AppSyncTransformer(),
+//         new DynamoDBModelTransformer()
+//     ]
+// });
+// const out = transformer.transform(validSchema);
+// fs.writeFile('cf.out.json', JSON.stringify(out, null, 4), (err) => {
+//     if (err) {
+//         throw err;
+//     }
+//     console.log('SUCCESS!');
+// });

--- a/packages/graphql-custom-transformer/tsconfig.json
+++ b/packages/graphql-custom-transformer/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "sourceMap": true,
+        "outDir": "lib",
+        "lib": [
+            "es2015",
+            "es2016.array.include",
+            "esnext.asynciterable",
+            "dom"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
+}

--- a/packages/graphql-custom-transformer/tslint.json
+++ b/packages/graphql-custom-transformer/tslint.json
@@ -1,0 +1,64 @@
+{
+    "rules": {
+        "class-name": true,
+        "curly": true,
+        "eofline": false,
+        "forin": true,
+        "indent": false,
+        "label-position": true,
+        "max-line-length": [
+            true,
+            150
+        ],
+        "no-arg": true,
+        "no-bitwise": true,
+        "no-console": false,
+        "no-construct": true,
+        "no-constructor-vars": false,
+        "no-debugger": true,
+        "no-duplicate-variable": true,
+        "no-empty": true,
+        "no-eval": true,
+        "no-string-literal": true,
+        "no-switch-case-fall-through": true,
+        "no-trailing-whitespace": true,
+        "no-unused-expression": true,
+        "no-unused-variable": false,
+        "no-use-before-declare": true,
+        "no-var-requires": false,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-catch",
+            "check-else",
+            "check-whitespace"
+        ],
+        "semicolon": false,
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "typedef": [
+            true,
+            "callSignature",
+            "indexSignature",
+            "parameter",
+            "propertySignature",
+            "variableDeclarator",
+            "memberVariableDeclarator"
+        ],
+        "use-strict": false,
+        "variable-name": [
+            true,
+            "allow-leading-underscore"
+        ],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

amplify-cli does not seem to apply the profile name specified on init.
Looking at: packages/amplify-provider-awscloudformation/lib/{configuration-manager.js,initializer.js}

process.env.AWS_PROFILE is being set to the profile name.
However, the AWS library has already been loaded and AWS_PROFILE env variable will not be read again.

Need to explicitly reconfigure credentials.
see ref: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.