### PR TITLE
 Enforce profile name: set AWS.config.credentials - copy

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -348,7 +348,9 @@ function logProjectSpecificConfg(context, awsClient) {
     const configInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'));
     if (configInfo.useProfile && configInfo.profileName) {
       process.env.AWS_PROFILE = configInfo.profileName;
-      const credentials = new awsClient.SharedIniFileCredentials({profile: configInfo.profileName});
+      const credentials = new awsClient.SharedIniFileCredentials({
+        profile: configInfo.profileName,
+      });
       awsClient.config.credentials = credentials;
     } else if (configInfo.awsConfigFilePath && fs.existsSync(configInfo.awsConfigFilePath)) {
       awsClient.config.loadFromPath(configInfo.awsConfigFilePath);

--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -348,6 +348,8 @@ function logProjectSpecificConfg(context, awsClient) {
     const configInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'));
     if (configInfo.useProfile && configInfo.profileName) {
       process.env.AWS_PROFILE = configInfo.profileName;
+      const credentials = new awsClient.SharedIniFileCredentials({profile: configInfo.profileName});
+      awsClient.config.credentials = credentials;
     } else if (configInfo.awsConfigFilePath && fs.existsSync(configInfo.awsConfigFilePath)) {
       awsClient.config.loadFromPath(configInfo.awsConfigFilePath);
     }

--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -59,7 +59,9 @@ function getConfiguredAwsCfnClient(context) {
   if (projectConfigInfo.action === 'init') {
     if (projectConfigInfo.useProfile && projectConfigInfo.profileName) {
       process.env.AWS_PROFILE = projectConfigInfo.profileName;
-      const credentials = new aws.SharedIniFileCredentials({profile: projectConfigInfo.profileName});
+      const credentials = new aws.SharedIniFileCredentials({
+        profile: projectConfigInfo.profileName,
+      });
       aws.config.credentials = credentials;
     } else {
       aws.config.update({

--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -59,6 +59,8 @@ function getConfiguredAwsCfnClient(context) {
   if (projectConfigInfo.action === 'init') {
     if (projectConfigInfo.useProfile && projectConfigInfo.profileName) {
       process.env.AWS_PROFILE = projectConfigInfo.profileName;
+      const credentials = new aws.SharedIniFileCredentials({profile: projectConfigInfo.profileName});
+      aws.config.credentials = credentials;
     } else {
       aws.config.update({
         accessKeyId: projectConfigInfo.accessKeyId,


### PR DESCRIPTION
Issue #, if available:

Description of changes:

copy of #96 

amplify-cli does not seem to apply the profile name specified on init.
Looking at: packages/amplify-provider-awscloudformation/lib/{configuration-manager.js,initializer.js}

process.env.AWS_PROFILE is being set to the profile name.
However, the AWS library has already been loaded and AWS_PROFILE env variable will not be read again.

Need to explicitly reconfigure credentials.
see ref: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.