### PR TITLE
Add cloudwatch policies to lambda functions

### DIFF
--- a/packages/amplify-category-function/provider-utils/awscloudformation/cloudformation-templates/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/cloudformation-templates/lambda-cloudformation-template.json.ejs
@@ -47,7 +47,6 @@
                 }
             }
         }
-        <% if (props.database && props.database.resourceName) { %>
         ,"lambdaexecutionpolicy": {
             "DependsOn": ["LambdaExecutionRole"],
             "Type": "AWS::IAM::Policy",
@@ -58,10 +57,15 @@
                     "Version": "2012-10-17",
                     "Statement": [
                         {
-                            "Effect": "Allow","Action":["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"],"Resource": "arn:aws:logs:*:*:*"
-                        },
+                            "Effect": "Allow",
+                            "Action":["logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents"],
+                            "Resource": { "Fn::Sub" : [ "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*", { "region": {"Ref": "AWS::Region"},  "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
+                        }<% if (props.database && props.database.resourceName) { %>,
                         {
-                            "Effect": "Allow", "Action": ["dynamodb:GetItem","dynamodb:Query","dynamodb:Scan","dynamodb:PutItem","dynamodb:UpdateItem","dynamodb:DeleteItem"],
+                            "Effect": "Allow", 
+                            "Action": ["dynamodb:GetItem","dynamodb:Query","dynamodb:Scan","dynamodb:PutItem","dynamodb:UpdateItem","dynamodb:DeleteItem"],
                             "Resource": [
                             <% if (props.database && props.database.Arn) { %>
                                 "<%= props.database.Arn %>"
@@ -70,11 +74,11 @@
                             <% } %>
                             ]
                         }
+                        <% } %>
                     ]
                 }
             }
         }
-        <% } %>
     },
     "Outputs": {
         "Name": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/110
*Description of changes:*
Adding cloudwatch logs to standalone lambda functions - Right now it is adding only when the lambda function is backed up by a DDB table
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.