### PR TITLE
Retain cognito user pool id after graphql schema update

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -60,7 +60,10 @@ function uploadAppSyncFiles(context, resources) {
           try {
             currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
             // Clear the parameters cache
-            currentParameters = { AppSyncApiName: currentParameters.AppSyncApiName };
+            currentParameters = {
+              AppSyncApiName: currentParameters.AppSyncApiName,
+              AuthCognitoUserPoolId: currentParameters.AuthCognitoUserPoolId,
+            };
           } catch (e) {
             currentParameters = {};
           }


### PR DESCRIPTION
*Issue #, if available:*
Fixes -> https://github.com/aws-amplify/amplify-cli/issues/118
Fixes -> https://github.com/aws-amplify/amplify-cli/issues/113
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.