### PR TITLE
Fixing #55. @auth checks the resolver exists first.

### DIFF
--- a/packages/amplify-category-api/commands/api/gql-compile.js
+++ b/packages/amplify-category-api/commands/api/gql-compile.js
@@ -3,6 +3,11 @@ const subcommand = 'gql-compile';
 module.exports = {
   name: subcommand,
   run: async (context) => {
-    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', { noConfig: true });
+    try {
+      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', { noConfig: true });
+    } catch (err) {
+      context.print.info(err.stack);
+      context.print.error(err.message);
+    }
   },
 };

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -5,6 +5,15 @@ const pythonStreamingFunctionFileName = 'python_streaming_function.zip';
 const schemaFileName = 'schema.graphql';
 const S3 = require('../src/aws-utils/aws-s3');
 
+const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files'
+const providerName = require('./constants').ProviderName;
+
+function getProjectBucket(context) {
+  const projectDetails = context.amplify.getProjectDetails();
+  const projectBucket = projectDetails.amplifyMeta.providers ? projectDetails.amplifyMeta.providers[providerName].DeploymentBucketName : '';
+  return projectBucket
+}
+
 function uploadAppSyncFiles(context, resources) {
   resources = resources.filter(resource => resource.service === 'AppSync');
   const buildTimeStamp = new Date().getTime().toString();
@@ -41,13 +50,14 @@ function uploadAppSyncFiles(context, resources) {
     }
 
     const resolverFiles = fs.readdirSync(resolverDir);
+    const resolverBucket = getProjectBucket(context)
 
     resolverFiles.forEach((file) => {
       const resolverFilePath = path.join(resolverDir, file);
 
-      uploadFilePromises.push(uploadAppSyncFile(
+      uploadFilePromises.push(uploadAppSyncResolver(
         context, file,
-        resolverFilePath, s3LocationMap, buildTimeStamp,
+        resolverFilePath, buildTimeStamp,
       ));
     });
 
@@ -70,6 +80,11 @@ function uploadAppSyncFiles(context, resources) {
         }
 
         Object.assign(currentParameters, s3LocationMap);
+        Object.assign(currentParameters, {
+          ResolverBucket: resolverBucket,
+          ResolverRootKey: ROOT_APPSYNC_S3_KEY,
+          DeploymentTimestamp: buildTimeStamp
+        })
         const jsonString = JSON.stringify(currentParameters, null, 4);
         fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
       });
@@ -79,7 +94,7 @@ function uploadAppSyncFiles(context, resources) {
 function uploadAppSyncFile(context, fileName, filePath, s3LocationMap, buildTimeStamp) {
   const formattedName = fileName.split('.').map((s, i) => (i > 0 ? `${s[0].toUpperCase()}${s.slice(1, s.length)}` : s)).join('');
 
-  const s3Key = `amplify-appsync-files/${fileName}.${buildTimeStamp}`;
+  const s3Key = `${ROOT_APPSYNC_S3_KEY}/${fileName}.${buildTimeStamp}`;
 
   return new S3(context)
     .then((s3) => {
@@ -94,10 +109,25 @@ function uploadAppSyncFile(context, fileName, filePath, s3LocationMap, buildTime
     });
 }
 
+function uploadAppSyncResolver(context, fileName, filePath, buildTimeStamp) {
+  const formattedName = fileName.split('.').map((s, i) => (i > 0 ? `${s[0].toUpperCase()}${s.slice(1, s.length)}` : s)).join('');
+
+  const s3Key = `${ROOT_APPSYNC_S3_KEY}/${fileName}.${buildTimeStamp}`;
+
+  return new S3(context)
+    .then((s3) => {
+      const s3Params = {
+        Body: fs.createReadStream(filePath),
+        Key: s3Key,
+      };
+      return s3.uploadFile(s3Params);
+    })
+}
+
 function uploadLambdaStreamingFunction(context, fileName, filePath, s3LocationMap) {
   const bucketKeyParameterName = 'ElasticSearchStreamingLambdaCodeS3Bucket';
   const bucketKeyParameterKey = 'ElasticSearchStreamingLambdaCodeS3Key';
-  const s3Key = `amplify-appsync-files/${fileName}`;
+  const s3Key = `${ROOT_APPSYNC_S3_KEY}/${fileName}`;
 
   return new S3(context)
     .then((s3) => {

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -5,13 +5,13 @@ const pythonStreamingFunctionFileName = 'python_streaming_function.zip';
 const schemaFileName = 'schema.graphql';
 const S3 = require('../src/aws-utils/aws-s3');
 
-const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files'
+const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files';
 const providerName = require('./constants').ProviderName;
 
 function getProjectBucket(context) {
   const projectDetails = context.amplify.getProjectDetails();
   const projectBucket = projectDetails.amplifyMeta.providers ? projectDetails.amplifyMeta.providers[providerName].DeploymentBucketName : '';
-  return projectBucket
+  return projectBucket;
 }
 
 function uploadAppSyncFiles(context, resources) {
@@ -50,7 +50,7 @@ function uploadAppSyncFiles(context, resources) {
     }
 
     const resolverFiles = fs.readdirSync(resolverDir);
-    const resolverBucket = getProjectBucket(context)
+    const resolverBucket = getProjectBucket(context);
 
     resolverFiles.forEach((file) => {
       const resolverFilePath = path.join(resolverDir, file);
@@ -83,8 +83,8 @@ function uploadAppSyncFiles(context, resources) {
         Object.assign(currentParameters, {
           ResolverBucket: resolverBucket,
           ResolverRootKey: ROOT_APPSYNC_S3_KEY,
-          DeploymentTimestamp: buildTimeStamp
-        })
+          DeploymentTimestamp: buildTimeStamp,
+        });
         const jsonString = JSON.stringify(currentParameters, null, 4);
         fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
       });
@@ -110,8 +110,6 @@ function uploadAppSyncFile(context, fileName, filePath, s3LocationMap, buildTime
 }
 
 function uploadAppSyncResolver(context, fileName, filePath, buildTimeStamp) {
-  const formattedName = fileName.split('.').map((s, i) => (i > 0 ? `${s[0].toUpperCase()}${s.slice(1, s.length)}` : s)).join('');
-
   const s3Key = `${ROOT_APPSYNC_S3_KEY}/${fileName}.${buildTimeStamp}`;
 
   return new S3(context)
@@ -121,7 +119,7 @@ function uploadAppSyncResolver(context, fileName, filePath, buildTimeStamp) {
         Key: s3Key,
       };
       return s3.uploadFile(s3Params);
-    })
+    });
 }
 
 function uploadLambdaStreamingFunction(context, fileName, filePath, s3LocationMap) {

--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -141,6 +141,9 @@ export class AppSyncTransformer extends Transformer {
 
         const templateResources: { [key: string]: Resource } = ctx.template.Resources
 
+        const resolverParams = this.resources.makeResolverS3RootParams()
+        ctx.mergeParameters(resolverParams.Parameters);
+
         for (const resourceName of Object.keys(templateResources)) {
             const resource: Resource = templateResources[resourceName]
             if (resource.Type === 'AWS::AppSync::Resolver') {
@@ -172,17 +175,13 @@ export class AppSyncTransformer extends Transformer {
             const reqFieldName = resolverResource.Properties.FieldName
             const reqFileName = `${reqType}.${reqFieldName}.request`
             fs.writeFileSync(`${resolverFilePath}/${reqFileName}`, requestMappingTemplate)
-            const reqParam = this.resources.makeResolverParam(reqFileName);
-            ctx.mergeParameters(reqParam.Parameters);
 
             const respType = resolverResource.Properties.TypeName
             const respFieldName = resolverResource.Properties.FieldName
             const respFileName = `${respType}.${respFieldName}.response`
             fs.writeFileSync(`${resolverFilePath}/${respFileName}`, responseMappingTemplate)
-            const respParam = this.resources.makeResolverParam(respFileName);
-            ctx.mergeParameters(respParam.Parameters);
 
-            const updatedResolverResource = this.resources.updateResolverResource(resolverResource, reqFileName, respFileName)
+            const updatedResolverResource = this.resources.updateResolverResource(resolverResource)
             ctx.setResource(resourceName, updatedResolverResource)
         }
     }

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -135,8 +135,20 @@ export class ModelAuthTransformer extends Transformer {
             update: [],
             delete: []
         }
-        const matchQuery = (op: ModelQuery) => (rule: AuthRule) => rule && (!rule.queries || rule.queries.includes(op))
-        const matchMutation = (op: ModelMutation) => (rule: AuthRule) => rule && (!rule.mutations || rule.mutations.includes(op))
+        const matchQuery = (op: ModelQuery) => (rule: AuthRule) => {
+            if (rule.queries) {
+                const matchesOp = rule.queries.find(o => o === op)
+                return Boolean(matchesOp)
+            }
+            return false
+        }
+        const matchMutation = (op: ModelMutation) => (rule: AuthRule) => {
+            if (rule.mutations) {
+                const matchesOp = rule.mutations.find(o => o === op)
+                return Boolean(matchesOp)
+            }
+            return false
+        }
         for (const rule of rules) {
             if (matchQuery('get')(rule)) {
                 queryRules.get.push(rule)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-cli/issues/55

*Description of changes:*

@auth checks the resolver exists first before applying the auth rule correcting a bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.