### PR TITLE
Update exclude path to be more explicit

### DIFF
--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -11,7 +11,7 @@ const {
 } = require('../errors')
 const constants = require('../constants')
 
-const DEFAULT_EXCLUDE_PATTERNS = ['amplify/**']
+const DEFAULT_EXCLUDE_PATTERNS = ['./amplify/**']
 
 async function addWalkThrough(context, configs) {
   const availableAppSyncApis = getAppSyncAPIDetails(context) // published and up published


### PR DESCRIPTION
*Issue #, if available:*
Fixes  #103

*Description of changes:*
Amplify creates schema.graphql which has special directives that are meant
only for transformers and its stored in amplify directory. Code gen should ignore
this schema.graphql. Updated the codegen config to make amplify path explicit



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.