### PR TITLE
Fix zip command not found on Windows

### DIFF
--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -15,7 +15,6 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
-    "bestzip": "^2.0.0",
     "cloudform": "^2.2.1",
     "graphql": "^0.13.2",
     "graphql-appsync-transformer": "^1.0.12",
@@ -26,6 +25,7 @@
   "devDependencies": {
     "@types/jest": "^23.1.1",
     "@types/node": "^10.3.4",
+    "bestzip": "^2.0.0",
     "graphql-dynamodb-transformer": "^1.0.12",
     "jest": "^23.1.0",
     "ts-jest": "^22.4.6",

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -4,7 +4,7 @@
   "description": "An AppSync model transform that takes a simple model and creates a DynamoDB table, DynamoDB stream, and ES index with the queries to match.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "tsc && zip -j lib/streaming-lambda.zip ./streaming-lambda/python_streaming_function.py",
+    "build": "tsc && cd streaming-lambda && bestzip ../lib/streaming-lambda.zip python_streaming_function.py",
     "clean": "rm -rf ./lib"
   },
   "keywords": [
@@ -15,6 +15,7 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
+    "bestzip": "^2.0.0",
     "cloudform": "^2.2.1",
     "graphql": "^0.13.2",
     "graphql-appsync-transformer": "^1.0.12",


### PR DESCRIPTION
*Issue #, if available:*
Issue #135 

*Description of changes:*
Changes are made to the graphql-elasticsearch-transformer package.
- Added npm package bestzip
- Using bestzip instead of zip in packages.json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.