### PR TITLE
Fix auth add not found on Windows.

### DIFF
--- a/packages/amplify-category-auth/commands/auth/add.js
+++ b/packages/amplify-category-auth/commands/auth/add.js
@@ -1,0 +1,6 @@
+const enable = require('./enable');
+
+module.exports = {
+  name: 'add',
+  run: enable.run
+};


### PR DESCRIPTION
*Issue #, if available:*
Issue #138 

*Description of changes:*
- Added add.js under amplify-category-auth/commands/auth
- The *add* subcommand works as an alias for the *enable* subcommand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.