### PR TITLE
elasticsearch nextToken resolver 

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -468,7 +468,7 @@ export class ResourceFactory {
                         [
                             iff(
                                 raw('!$foreach.hasNext'),
-                                set(ref('nextToken'), '$forEach.count')
+                                set(ref('nextToken'), ref('$forEach.count'))
                             ),
                             qref('$items.add($entry.get("_source"))')
                         ]

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -468,7 +468,7 @@ export class ResourceFactory {
                         [
                             iff(
                                 raw('!$foreach.hasNext'),
-                                set(ref('nextToken'), str('$entry.sort.get(0)'))
+                                set(ref('nextToken'), '$forEach.count')
                             ),
                             qref('$items.add($entry.get("_source"))')
                         ]


### PR DESCRIPTION
Issue: elasticsearch nextToken returned "$entry.sort.get(0)" instead of an int which the request mapping expects.  

*Description of changes:*

Accessing the $forEach.count returns the correct value. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.