### PR TITLE
Remove stale types and imports

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -20,23 +20,6 @@ import {
 import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common'
 import { updateCreateInputWithConnectionField, updateUpdateInputWithConnectionField } from './definitions';
 
-interface QueryNameMap {
-    get?: string;
-    list?: string;
-    query?: string;
-}
-
-interface MutationNameMap {
-    create?: string;
-    update?: string;
-    delete?: string;
-}
-
-interface ModelDirectiveArgs {
-    queries?: QueryNameMap,
-    mutations?: MutationNameMap
-}
-
 function makeConnectionAttributeName(type: string, field?: string) {
     return field ? toCamelCase([type, field, 'id']) : toCamelCase([type, 'id'])
 }

--- a/packages/graphql-versioned-transformer/src/VersionedModelTransformer.ts
+++ b/packages/graphql-versioned-transformer/src/VersionedModelTransformer.ts
@@ -8,8 +8,7 @@ import {
 } from "graphql";
 import { printBlock, compoundExpression, set, ref, qref, obj, str, raw } from 'graphql-mapping-template'
 import {
-    ResourceConstants, blankObject, makeSchema,
-    makeOperationType,
+    ResourceConstants,
     ModelResourceIDs,
     ResolverResourceIDs,
     makeInputValueDefinition,


### PR DESCRIPTION
*Description of changes:*
While looking at how the `@connection` directive works, I noticed that there were a few types (namely: `QueryNameMap`, `MutationNameMap` and `ModelDirectiveArgs`) that were not used.

It looks as though these were possibly copied over from the `@model` directive when this was first created in commit https://github.com/aws-amplify/amplify-cli/commit/88e36f360258778b4684cd88a82fa1148cc8426b#diff-04ea72e1d9d6b9165d1777f19e9fed9aR22.

While removing those, I did a quick scan of the other `graphql-*` packages and found some imports in `VersionedModelTransformer` that also were not being used. I've removed those as well.

Thank you for the work you've done here!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.