### PR TITLE
Add support to add cross region AppSync API to codegen

### DIFF
--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -6,15 +6,19 @@ const generateTypes = require('./types');
 const {
   AmplifyCodeGenNoAppSyncAPIAvailableError: NoAppSyncAPIAvailableError,
   AmplifyCodeGenAPIPendingPush,
+  AmplifyCodeGenAPINotFoundError,
 } = require('../errors');
 const {
   downloadIntrospectionSchemaWithProgress,
   getAppSyncAPIDetails,
   getAppSyncAPIInfo,
+  getProjectAwsRegion,
 } = require('../utils');
 const addWalkThrough = require('../walkthrough/add');
+const changeAppSyncRegion = require('../walkthrough/changeAppSyncRegions');
 
 async function add(context, apiId = null) {
+  let region = getProjectAwsRegion(context);
   const config = loadConfig(context);
   if (config.getProjects().length) {
     throw new Error(constants.ERROR_CODEGEN_SUPPORT_MAX_ONE_API);
@@ -31,10 +35,28 @@ async function add(context, apiId = null) {
     }
     [apiDetails] = availableAppSyncApis;
   } else {
-    const apiDetailSpinner = new Ora();
-    apiDetailSpinner.start('getting API details');
-    apiDetails = await getAppSyncAPIInfo(context, apiId);
-    apiDetailSpinner.stop();
+    let shouldRetry = true;
+    while (shouldRetry) {
+      const apiDetailSpinner = new Ora();
+      try {
+        apiDetailSpinner.start('Getting API details');
+        apiDetails = await getAppSyncAPIInfo(context, apiId, region);
+        apiDetailSpinner.succeed();
+        break;
+      } catch (e) {
+        apiDetailSpinner.fail();
+        if (e instanceof AmplifyCodeGenAPINotFoundError) {
+          context.print.info(`AppSync API was not found in region ${region}`);
+          ({ shouldRetry, region } = await changeAppSyncRegion(context, region));
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  if (!apiDetails) {
+    return;
   }
   const answer = await addWalkThrough(context);
 
@@ -42,6 +64,7 @@ async function add(context, apiId = null) {
     context,
     apiDetails.id,
     answer.schemaLocation,
+    region,
   );
 
   const newProject = {
@@ -54,6 +77,7 @@ async function add(context, apiId = null) {
       codeGenTarget: answer.target || '',
       generatedFileName: answer.generatedFileName || '',
       docsFilePath: answer.docsFilePath,
+      region,
     },
     endpoint: apiDetails.endpoint,
   };

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -19,6 +19,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema) {
         context,
         cfg.amplifyExtension.graphQLApiId,
         cfg.schema,
+        cfg.amplifyExtension.region,
       ),
     );
     await Promise.all(downloadPromises);

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -24,6 +24,7 @@ async function generateStatements(context, forceDownloadSchema) {
         context,
         cfg.amplifyExtension.graphQLApiId,
         cfg.schema,
+        cfg.amplifyExtension.region,
       );
     }
     const frontend = getFrontEndHandler(context);

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -31,6 +31,7 @@ async function generateTypes(context, forceDownloadSchema) {
           context,
           cfg.amplifyExtension.graphQLApiId,
           cfg.schema,
+          cfg.amplifyExtension.region,
         );
       }
       const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -7,10 +7,12 @@ module.exports = {
   PROMPT_MSG_GQL_FILE_PATTERN:
     'Enter the file name pattern of graphql queries, mutations and subscriptions',
   PROMPT_MSG_GENERATE_CODE: 'Do you want to generate code for your newly created GraphQL API',
+  PROMPT_MSG_CHANGE_REGION: 'Do you want to choose a different region',
   PROMPT_MSG_UPDATE_CODE: 'Do you want to update code for your updated GraphQL API',
   PROMPT_MSG_GENERATE_OPS:
     'Do you want to generate/update all possible GraphQL operations - queries, mutations and subscriptions',
   PROMPT_MSG_SELECT_PROJECT: 'Choose the AppSync API',
+  PROMPT_MSG_SELECT_REGION: 'Choose AWS Region',
   ERROR_CODEGEN_TARGET_NOT_SUPPORTED: 'is not supported by codegen plugin',
   ERROR_CODEGEN_FRONTEND_NOT_SUPPORTED: 'The project frontend is not supported by codegen',
   ERROR_CODEGEN_NO_API_AVAILABLE:

--- a/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
@@ -4,7 +4,7 @@ const { dirname, relative } = require('path');
 const { AmplifyCodeGenAPINotFoundError } = require('../errors');
 const constants = require('../constants');
 
-async function downloadIntrospectionSchema(context, apiId, downloadLocation) {
+async function downloadIntrospectionSchema(context, apiId, downloadLocation, region) {
   const { amplify } = context;
   try {
     const schema = await context.amplify.executeProviderUtils(
@@ -13,6 +13,7 @@ async function downloadIntrospectionSchema(context, apiId, downloadLocation) {
       'getIntrospectionSchema',
       {
         apiId,
+        region,
       },
     );
     const introspectionDir = dirname(downloadLocation);

--- a/packages/amplify-codegen/src/utils/generateIntrospectionSchemaWithProgress.js
+++ b/packages/amplify-codegen/src/utils/generateIntrospectionSchemaWithProgress.js
@@ -3,10 +3,15 @@ const Ora = require('ora');
 const downloadIntrospectionSchema = require('./downloadIntrospectionSchema');
 const constants = require('../constants');
 
-async function downloadSchemaWithProgressSpinner(context, apiId, downloadLocation) {
+async function downloadSchemaWithProgressSpinner(context, apiId, downloadLocation, region) {
   const downloadSpinner = new Ora(constants.INFO_MESSAGE_DOWNLOADING_SCHEMA);
   downloadSpinner.start();
-  const schemaLocation = await downloadIntrospectionSchema(context, apiId, downloadLocation);
+  const schemaLocation = await downloadIntrospectionSchema(
+    context,
+    apiId,
+    downloadLocation,
+    region,
+  );
   downloadSpinner.succeed(constants.INFO_MESSAGE_DOWNLOAD_SUCCESS);
   return schemaLocation;
 }

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfo.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfo.js
@@ -1,18 +1,29 @@
-async function getAppSyncAPIInfo(context, apiId) {
+const { AmplifyCodeGenAPINotFoundError } = require('../errors');
+const constants = require('../constants');
+
+async function getAppSyncAPIInfo(context, apiId, region) {
   const { amplify } = context;
-  const { graphqlApi } = await amplify.executeProviderUtils(
-    context,
-    'awscloudformation',
-    'getGraphQLApiDetails',
-    {
-      apiId,
-    },
-  );
-  return {
-    id: graphqlApi.apiId,
-    endpoint: graphqlApi.uris.GRAPHQL,
-    name: graphqlApi.name,
-  };
+  try {
+    const { graphqlApi } = await amplify.executeProviderUtils(
+      context,
+      'awscloudformation',
+      'getGraphQLApiDetails',
+      {
+        apiId,
+        region,
+      },
+    );
+    return {
+      id: graphqlApi.apiId,
+      endpoint: graphqlApi.uris.GRAPHQL,
+      name: graphqlApi.name,
+    };
+  } catch (e) {
+    if (e.code === 'NotFoundException') {
+      throw new AmplifyCodeGenAPINotFoundError(constants.ERROR_APPSYNC_API_NOT_FOUND);
+    }
+    throw e;
+  }
 }
 
 module.exports = getAppSyncAPIInfo;

--- a/packages/amplify-codegen/src/utils/getProjectAWSRegion.js
+++ b/packages/amplify-codegen/src/utils/getProjectAWSRegion.js
@@ -1,0 +1,7 @@
+function getProjectAWSRegion(context) {
+  const projectMeta = context.amplify.getProjectMeta();
+  const { awscloudformation } = projectMeta.providers;
+  return awscloudformation.Region;
+}
+
+module.exports = getProjectAWSRegion;

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -5,6 +5,7 @@ const downloadIntrospectionSchema = require('./downloadIntrospectionSchema');
 const getSchemaDownloadLocation = require('./getSchemaDownloadLocation');
 const getIncludePattern = require('./getIncludePattern');
 const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
+const getProjectAwsRegion = require('./getProjectAWSRegion');
 const getGraphQLDocPath = require('./getGraphQLDocPath');
 const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
 const isAppSyncApiPendingPush = require('./isAppSyncApiPendingPush');
@@ -18,6 +19,7 @@ module.exports = {
   downloadIntrospectionSchemaWithProgress,
   getIncludePattern,
   getAppSyncAPIInfo,
+  getProjectAwsRegion,
   getGraphQLDocPath,
   isAppSyncApiPendingPush,
 };

--- a/packages/amplify-codegen/src/walkthrough/changeAppSyncRegions.js
+++ b/packages/amplify-codegen/src/walkthrough/changeAppSyncRegions.js
@@ -1,0 +1,19 @@
+const askShouldTryWithDifferentRegion = require('./questions/changeRegion');
+const changeRegion = require('./questions/selectRegions');
+
+async function changeAppSyncRegion(context, currentRegion) {
+  const regions = await context.amplify.executeProviderUtils(
+    context,
+    'awscloudformation',
+    'getRegionMappings',
+  );
+
+  const shouldRetry = await askShouldTryWithDifferentRegion();
+  const region = shouldRetry && (await changeRegion(regions, currentRegion));
+  return {
+    shouldRetry,
+    region,
+  };
+}
+
+module.exports = changeAppSyncRegion;

--- a/packages/amplify-codegen/src/walkthrough/questions/changeRegion.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/changeRegion.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askShouldChangeRegion() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'changeRegion',
+      message: constants.PROMPT_MSG_CHANGE_REGION,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.changeRegion;
+}
+
+module.exports = askShouldChangeRegion;

--- a/packages/amplify-codegen/src/walkthrough/questions/selectRegions.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/selectRegions.js
@@ -1,0 +1,22 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function selectRegions(regions, currentRegion) {
+  const regionMap = Object.keys(regions).map(r => ({
+    value: r,
+    name: regions[r],
+  }));
+  const answer = await inquirer.prompt([
+    {
+      name: 'region',
+      type: 'list',
+      message: constants.PROMPT_MSG_SELECT_REGION,
+      choices: regionMap,
+      default: currentRegion || null,
+    },
+  ]);
+  return answer.region;
+}
+
+module.exports = selectRegions;

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -27,6 +27,7 @@ const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
 const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
 
 const MOCK_PROJECT = {
   includes: [MOCK_INCLUDE_PATH],
@@ -36,6 +37,7 @@ const MOCK_PROJECT = {
     codeGenTarget: MOCK_TARGET,
     graphQLApiId: MOCK_API_ID,
     docsFilePath: MOCK_STATEMENTS_PATH,
+    region: MOCK_REGION,
   },
 };
 
@@ -63,6 +65,7 @@ describe('command - generateStatementsAndTypes', () => {
       MOCK_CONTEXT,
       MOCK_API_ID,
       MOCK_SCHEMA,
+      MOCK_REGION,
     );
   });
 

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -24,6 +24,7 @@ const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
 const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
 
 const MOCK_PROJECT = {
   includes: [MOCK_INCLUDE_PATH],
@@ -33,6 +34,7 @@ const MOCK_PROJECT = {
     codeGenTarget: MOCK_TARGET,
     graphQLApiId: MOCK_API_ID,
     docsFilePath: MOCK_STATEMENTS_PATH,
+    region: MOCK_REGION,
   },
 };
 
@@ -80,6 +82,7 @@ describe('command - statements', () => {
       MOCK_CONTEXT,
       MOCK_API_ID,
       MOCK_SCHEMA,
+      MOCK_REGION,
     );
   });
 
@@ -91,6 +94,7 @@ describe('command - statements', () => {
       MOCK_CONTEXT,
       MOCK_API_ID,
       MOCK_SCHEMA,
+      MOCK_REGION,
     );
   });
 

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -27,6 +27,7 @@ const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
 const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
 
 const MOCK_PROJECT = {
   excludes: [MOCK_EXCLUDE_PATH],
@@ -36,6 +37,7 @@ const MOCK_PROJECT = {
     generatedFileName: MOCK_GENERATED_FILE_NAME,
     codeGenTarget: MOCK_TARGET,
     graphQLApiId: MOCK_API_ID,
+    region: MOCK_REGION,
   },
 };
 sync.mockReturnValue(MOCK_QUERIES);
@@ -84,6 +86,7 @@ describe('command - types', () => {
       MOCK_CONTEXT,
       MOCK_API_ID,
       MOCK_SCHEMA,
+      MOCK_REGION,
     );
   });
 
@@ -95,6 +98,7 @@ describe('command - types', () => {
       MOCK_CONTEXT,
       MOCK_API_ID,
       MOCK_SCHEMA,
+      MOCK_REGION,
     );
   });
 

--- a/packages/amplify-provider-awscloudformation/lib/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/lib/utility-functions.js
@@ -5,41 +5,51 @@ const DynamoDB = require('../src/aws-utils/aws-dynamodb');
 const AppSync = require('../src/aws-utils/aws-appsync');
 const { transformGraphQLSchema } = require('./transform-graphql-schema');
 
-
 module.exports = {
   compileSchema: (context, options) => transformGraphQLSchema(context, options),
   getRegions: () => awsRegions.regions,
+  getRegionMappings: () => awsRegions.regionMappings,
   /*eslint-disable*/
   staticRoles: context => ({
-    unAuthRoleName: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation.UnauthRoleName,
-    authRoleName: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation.AuthRoleName,
-    unAuthRoleArn: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation.UnauthRoleArn,
-    authRoleArn: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation.AuthRoleArn,
+    unAuthRoleName: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation
+      .UnauthRoleName,
+    authRoleName: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation
+      .AuthRoleName,
+    unAuthRoleArn: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation
+      .UnauthRoleArn,
+    authRoleArn: context.amplify.getProjectDetails().amplifyMeta.providers.awscloudformation
+      .AuthRoleArn,
   }),
   /* eslint-enable */
-  getUserPools: (context, options) => new Cognito(context)
-    .then(cognitoModel => cognitoModel.cognito.listUserPools({ MaxResults: 60 }).promise()
-      .then((result) => {
-        let userPools = result.UserPools;
-        if (options && options.region) {
-          userPools = userPools.filter(userPool => userPool.Id.startsWith(options.region));
-        }
-        return userPools;
-      }))
-    .catch((err) => {
-      context.print.error('Failed to fetch user pools');
-      throw err;
-    }),
+  getUserPools: (context, options) =>
+    new Cognito(context)
+      .then(cognitoModel =>
+        cognitoModel.cognito
+          .listUserPools({ MaxResults: 60 })
+          .promise()
+          .then((result) => {
+            let userPools = result.UserPools;
+            if (options && options.region) {
+              userPools = userPools.filter(userPool => userPool.Id.startsWith(options.region));
+            }
+            return userPools;
+          }))
+      .catch((err) => {
+        context.print.error('Failed to fetch user pools');
+        throw err;
+      }),
   getLambdaFunctions: async (context) => {
     const lambdaModel = await new Lambda(context);
     let nextMarker;
     const lambdafunctions = [];
     try {
       do {
-        const paginatedFunctions = await lambdaModel.lambda.listFunctions({
-          MaxItems: 10000,
-          Marker: nextMarker,
-        }).promise();
+        const paginatedFunctions = await lambdaModel.lambda
+          .listFunctions({
+            MaxItems: 10000,
+            Marker: nextMarker,
+          })
+          .promise();
         if (paginatedFunctions && paginatedFunctions.Functions) {
           lambdafunctions.push(...paginatedFunctions.Functions);
         }
@@ -60,7 +70,8 @@ module.exports = {
     try {
       do {
         const paginatedTables = await dynamodbModel.dynamodb
-          .listTables({ Limit: 100, ExclusiveStartTableName: nextToken }).promise();
+          .listTables({ Limit: 100, ExclusiveStartTableName: nextToken })
+          .promise();
         const dynamodbTables = paginatedTables.TableNames;
         nextToken = paginatedTables.LastEvaluatedTableName;
         for (let i = 0; i < dynamodbTables.length; i += 1) {
@@ -94,31 +105,36 @@ module.exports = {
       throw err;
     }
   },
-  getAppSyncAPIs: context => (
+  getAppSyncAPIs: context =>
     new AppSync(context)
       .then((result) => {
         const appSyncModel = result;
         context.print.debug(result);
         return appSyncModel.appSync.listGraphqlApis({ maxResults: 25 }).promise();
       })
-      .then(result => result.graphqlApis)
-  ),
-  getIntrospectionSchema: (context, options) => (
-    new AppSync(context)
+      .then(result => result.graphqlApis),
+  getIntrospectionSchema: (context, options) => {
+    const awsOptions = {};
+    if (options.region) {
+      awsOptions.region = options.region;
+    }
+    return new AppSync(context, { region: options.region })
       .then((result) => {
         const appSyncModel = result;
         return appSyncModel.appSync
           .getIntrospectionSchema({ apiId: options.apiId, format: 'JSON' })
           .promise();
       })
-      .then(result => result.schema.toString() || null)
-  ),
-  getGraphQLApiDetails: (context, options) => (
-    new AppSync(context)
-      .then((result) => {
-        const appSyncModel = result;
-        return appSyncModel.appSync.getGraphqlApi({ apiId: options.apiId })
-          .promise();
-      })
-  ),
+      .then(result => result.schema.toString() || null);
+  },
+  getGraphQLApiDetails: (context, options) => {
+    const awsOptions = {};
+    if (options.region) {
+      awsOptions.region = options.region;
+    }
+    return new AppSync(context, awsOptions).then((result) => {
+      const appSyncModel = result;
+      return appSyncModel.appSync.getGraphqlApi({ apiId: options.apiId }).promise();
+    });
+  },
 };

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-appsync.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-appsync.js
@@ -1,10 +1,10 @@
 const aws = require('./aws.js');
 
 class AppSync {
-  constructor(context) {
+  constructor(context, options = {}) {
     return aws.configureWithCreds(context).then((awsItem) => {
       this.context = context;
-      this.appSync = new awsItem.AppSync();
+      this.appSync = new awsItem.AppSync(options);
       return this;
     });
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
amplify codegen add --apiId <api-id>` fails if you run this command in a project which is set to use `<region1 >` and the AppSync API is in <region2>`. 

Updated add command to detect this and prompt user to choose different region.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.