### PR TITLE
Update docs with note for @searchable and existing data

### DIFF
--- a/graphql-transform-tutorial.md
+++ b/graphql-transform-tutorial.md
@@ -676,6 +676,8 @@ of the input field via the **versionField** and **versionInput** arguments on th
 The `@searchable` directive handles streaming the data of an `@model` object type to
 Amazon Elasticsearch Service and configures search resolvers that search that information.
 
+> Note: Support for adding the `@searchable` directive does not yet provide automatic indexing for any existing data to Elasticsearch. View the feature request [here](https://github.com/aws-amplify/amplify-cli/issues/98).
+
 #### Definition
 
 ```graphql


### PR DESCRIPTION
*Description of changes:*
In response to feature request #98 update the graphql-transform-tutorial.md docs to include note about adding `@searchable` to `@model` types that have existing data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.