### PR TITLE
Fix yarn global path

### DIFF
--- a/packages/amplify-cli/src/lib/get-global-prefix.js
+++ b/packages/amplify-cli/src/lib/get-global-prefix.js
@@ -15,9 +15,9 @@ function getPrefix() {
 function getYarnPrefix() {
   const home = os.homedir();
 
-  let yarnPrefix = path.join(home, '.config', 'yarn', 'global');
+  let yarnPrefix = path.join(home, '.config', 'yarn', 'global', 'node_modules');
   if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
-    yarnPrefix = path.join(process.env.LOCALAPPDATA, 'Yarn', 'config', 'global');
+    yarnPrefix = path.join(process.env.LOCALAPPDATA, 'Yarn', 'config', 'global', 'node_modules');
   }
 
   return yarnPrefix;


### PR DESCRIPTION
System Information:
Yarn:
```
yarn --version
1.9.4
```
OS:
```
LSB Version:	1.4
Distributor ID:	Arch
Description:	Arch Linux
Release:	rolling
Codename:	n/a
```


Installation:
yarn global - using `yarn global add @aws-amplify/cli`
Issue:
When i'm executing `amplify init` at step `s1-initFrontendHandler` i couln't find any fronted option

Output:
```
hostname :: _debug/react-native/vanillaapp % amplify init 
Note: It is recommended to run this command from the root of your app directory
? Choose your default editor: Visual Studio Code
? Choose the type of app that you're building (Use arrow keys)

```

*Description of changes:*

Solution:
Turns out it was looking at  `~/.config/yarn/global` instead of `~/.config/yarn/global/_node_modules` ( where the frontend package lived ),
```
hostname :: _debug/react-native/vanillaapp % ls ~/.config/yarn/global/node_modules | grep -i amplify-frontend
amplify-frontend-android
amplify-frontend-ios
amplify-frontend-javascript
```
Simply adding node_modules path at  solved the issue


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.