### PR TITLE
(packages/amplify-codegen) Update api push (update workflow) of codegen

### DIFF
--- a/packages/amplify-codegen/src/callbacks/prePushUpdateCallback.js
+++ b/packages/amplify-codegen/src/callbacks/prePushUpdateCallback.js
@@ -1,6 +1,6 @@
 const loadConfig = require('../codegen-config');
 const askShouldUpdateCode = require('../walkthrough/questions/updateCode');
-const askShouldGenerateDocs = require('../walkthrough/questions/generateCode');
+const askShouldUpdateStatements = require('../walkthrough/questions/updateDocs');
 
 async function prePushUpdateCallback(context, resourceName) {
   const config = loadConfig(context);
@@ -9,7 +9,7 @@ async function prePushUpdateCallback(context, resourceName) {
     .find(projectItem => projectItem.projectName === resourceName);
   if (project) {
     if (await askShouldUpdateCode()) {
-      const shouldGenerateDocs = await askShouldGenerateDocs();
+      const shouldGenerateDocs = await askShouldUpdateStatements();
       return {
         gqlConfig: project,
         shouldGenerateDocs,

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -7,6 +7,7 @@ module.exports = {
   PROMPT_MSG_GQL_FILE_PATTERN:
     'Enter the file name pattern of graphql queries, mutations and subscriptions',
   PROMPT_MSG_GENERATE_CODE: 'Do you want to generate code for your newly created GraphQL API',
+  PROMPT_MSG_UPDATE_STATEMENTS: 'Do you want to generate GraphQL statements (queries, mutations and subscription) based on your schema types? This will overwrite your current graphql queries, mutations and subscriptions',
   PROMPT_MSG_CHANGE_REGION: 'Do you want to choose a different region',
   PROMPT_MSG_UPDATE_CODE: 'Do you want to update code for your updated GraphQL API',
   PROMPT_MSG_GENERATE_OPS:

--- a/packages/amplify-codegen/src/walkthrough/questions/updateDocs.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/updateDocs.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askUpdateDocs() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'confirmUpdateDocs',
+      message: constants.PROMPT_MSG_UPDATE_STATEMENTS,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.confirmUpdateDocs;
+}
+
+module.exports = askUpdateDocs;

--- a/packages/amplify-codegen/tests/callbacks/prePushUpdateCallback.test.js
+++ b/packages/amplify-codegen/tests/callbacks/prePushUpdateCallback.test.js
@@ -1,6 +1,6 @@
 const loadConfig = require('../../src/codegen-config');
 const askShouldUpdateCode = require('../../src/walkthrough/questions/updateCode');
-const askShouldGenerateDocs = require('../../src/walkthrough/questions/generateCode');
+const askShouldUpdateStatements = require('../../src/walkthrough/questions/updateDocs');
 
 const prePushUpdateCallback = require('../../src/callbacks/prePushUpdateCallback');
 
@@ -12,7 +12,7 @@ const MOCK_CONTEXT = {
 
 jest.mock('../../src/codegen-config');
 jest.mock('../../src/walkthrough/questions/updateCode');
-jest.mock('../../src/walkthrough/questions/generateCode');
+jest.mock('../../src/walkthrough/questions/updateDocs');
 
 const MOCK_PROJECT_NAME = 'MOCK_PROJECT';
 const MOCK_SELECTED_PROJECT = { projectName: MOCK_PROJECT_NAME, foo: 'bar' };
@@ -30,7 +30,7 @@ describe('callback - prepushUpdate AppSync API', () => {
     loadConfig.mockReturnValue(LOAD_CONFIG_METHODS);
     LOAD_CONFIG_METHODS.getProjects.mockReturnValue(MOCK_PROJECTS);
     askShouldUpdateCode.mockReturnValue(true);
-    askShouldGenerateDocs.mockReturnValue(true);
+    askShouldUpdateStatements.mockReturnValue(true);
   });
 
   it('should ask prompt user to update statements and types', async () => {
@@ -46,7 +46,7 @@ describe('callback - prepushUpdate AppSync API', () => {
   });
 
   it('should set shouldGenerateDocs when user declines statement generation', async () => {
-    askShouldGenerateDocs.mockReturnValue(false);
+    askShouldUpdateStatements.mockReturnValue(false);
     const result = await prePushUpdateCallback(MOCK_CONTEXT, MOCK_PROJECT_NAME);
     expect(result.shouldGenerateDocs).toEqual(false);
   });

--- a/packages/amplify-codegen/tests/walkthrough/questions/updateDocs.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/updateDocs.test.js
@@ -1,0 +1,17 @@
+const inquirer = require('inquirer');
+
+const updateDocs = require('../../../src/walkthrough/questions/updateDocs');
+
+jest.mock('inquirer');
+
+describe('shouldUpdateDocs', () => {
+  inquirer.prompt.mockReturnValue({ confirmUpdateDocs: false });
+  it('should confirm users if they want to update the docs', async () => {
+    const answer = await updateDocs();
+    expect(answer).toBe(false);
+    const questions = inquirer.prompt.mock.calls[0][0];
+    expect(questions[0].name).toEqual('confirmUpdateDocs');
+    expect(questions[0].type).toEqual('confirm');
+    expect(questions[0].default).toEqual(true);
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When user did an amplify api push, code gen workflow gets triggered. The workflow
updates/overwrites both GraphQL types and Statements. The workflow did not ask the right
question about updating statements and did not inform user that the files will be over written

Updated the workflow to show the right question and inform user about file over write

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.