### PR TITLE
[packages/amplify-graphql-docs-generator] Generate statements without…

### DIFF
--- a/packages/amplify-codegen/commands/codegen/codegen.js
+++ b/packages/amplify-codegen/commands/codegen/codegen.js
@@ -40,8 +40,7 @@ module.exports = {
       const forceDownloadSchema = !context.parameters.options.nodownload;
       await codeGen.generate(context, forceDownloadSchema);
     } catch (e) {
-      // context.print.info(e.message);
-      context.print.info(e);
+      context.print.info(e.message);
       process.exit(1);
     }
   },

--- a/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
+++ b/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
@@ -1,5 +1,5 @@
 const graphQLConfig = require('graphql-config');
-const { join } = require('path');
+const { join, isAbsolute, relative } = require('path');
 
 const { graphQlToAmplifyConfig } = require('./utils');
 
@@ -38,8 +38,11 @@ class AmplifyCodeGenConfig {
     if (!this.constructor.isValidAmplifyProject(project)) {
       return false;
     }
+    const schemaPath = isAbsolute(project.schema)
+      ? relative(this.gqlConfig.configDir, project.schema)
+      : project.schema;
     const newProject = {
-      schemaPath: project.schema,
+      schemaPath,
       includes: project.includes,
       excludes: project.excludes,
     };

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -28,7 +28,7 @@ async function generateStatements(context, forceDownloadSchema) {
       );
     }
     const frontend = getFrontEndHandler(context);
-    const language = frontend === 'javascript' ? 'javascript' : 'graphql';
+    const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
     opsGenSpinner.start();
     jetpack.dir(opsGenDirectory);

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -36,7 +36,7 @@ async function generateTypes(context, forceDownloadSchema) {
       }
       const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
       codeGenSpinner.start();
-      generate(queries, schema, output, '', target, 'gql', '', {
+      generate(queries, schema, output, '', target, '', '', {
         addTypename: true,
       });
       codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${output}`);

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -48,6 +48,7 @@ module.exports = {
   INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS: 'Code generated successfully and saved in file',
   INFO_MESSAGE_DOWNLOADING_SCHEMA: 'Downloading the introspection schema',
   INFO_MESSAGE_DOWNLOAD_SUCCESS: 'Downloaded the schema',
+  INFO_MESSAGE_DOWNLOAD_ERROR: 'Downloading schema failed',
   INFO_MESSAGE_OPS_GEN: 'Generating GraphQL operations',
   INFO_MESSAGE_OPS_GEN_SUCCESS: 'Generated GraphQL operations successfully and saved at ',
 };

--- a/packages/amplify-codegen/src/utils/generateIntrospectionSchemaWithProgress.js
+++ b/packages/amplify-codegen/src/utils/generateIntrospectionSchemaWithProgress.js
@@ -6,14 +6,19 @@ const constants = require('../constants');
 async function downloadSchemaWithProgressSpinner(context, apiId, downloadLocation, region) {
   const downloadSpinner = new Ora(constants.INFO_MESSAGE_DOWNLOADING_SCHEMA);
   downloadSpinner.start();
-  const schemaLocation = await downloadIntrospectionSchema(
-    context,
-    apiId,
-    downloadLocation,
-    region,
-  );
-  downloadSpinner.succeed(constants.INFO_MESSAGE_DOWNLOAD_SUCCESS);
-  return schemaLocation;
+  try {
+    const schemaLocation = await downloadIntrospectionSchema(
+      context,
+      apiId,
+      downloadLocation,
+      region,
+    );
+    downloadSpinner.succeed(constants.INFO_MESSAGE_DOWNLOAD_SUCCESS);
+    return schemaLocation;
+  } catch (e) {
+    downloadSpinner.fail(constants.INFO_MESSAGE_DOWNLOAD_ERROR);
+    throw e;
+  }
 }
 
 module.exports = downloadSchemaWithProgressSpinner;

--- a/packages/amplify-codegen/src/utils/getIncludePattern.js
+++ b/packages/amplify-codegen/src/utils/getIncludePattern.js
@@ -1,14 +1,19 @@
 const { join, dirname } = require('path');
 
-function getIncludePatterns(frontendHandler, schemaLocation) {
+function getIncludePatterns(language, schemaLocation) {
   let graphQLDirectory;
   let graphQLExtension;
-  switch (frontendHandler) {
+  switch (language) {
     case 'android':
       graphQLDirectory = dirname(schemaLocation);
       graphQLExtension = '*.graphql';
       break;
+    case 'typescript':
+      graphQLDirectory = join('src', 'graphql');
+      graphQLExtension = '*.ts';
+      break;
     case 'javascript':
+    case 'flow':
       graphQLDirectory = join('src', 'graphql');
       graphQLExtension = '*.js';
       break;

--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -17,12 +17,21 @@ const DEFAULT_EXCLUDE_PATTERNS = ['./amplify/**'];
 async function addWalkThrough(context, skip = []) {
   const frontendHandler = getFrontEndHandler(context);
   const schemaLocation = getSchemaDownloadLocation(context);
-  const includePatternDefault = getIncludePattern(frontendHandler, schemaLocation);
   const answers = {
     excludePattern: DEFAULT_EXCLUDE_PATTERNS,
     schemaLocation,
   };
 
+  let targetLanguage = 'android';
+
+  if (frontendHandler !== 'android') {
+    if (!skip.includes('targetLanguage')) {
+      answers.target = await askCodeGenTargetLanguage(context);
+      targetLanguage = answers.target;
+    }
+  }
+
+  const includePatternDefault = getIncludePattern(targetLanguage, schemaLocation);
   const includePathGlob = join(
     includePatternDefault.graphQLDirectory,
     '**',
@@ -32,20 +41,18 @@ async function addWalkThrough(context, skip = []) {
   if (!skip.includes('includePattern')) {
     answers.includePattern = await askCodeGenQueryFilePattern([includePathGlob]);
   }
-  if (frontendHandler !== 'android') {
-    if (!skip.includes('targetLanguage')) {
-      answers.target = await askCodeGenTargetLanguage(context);
-    }
+  if (!skip.includes('shouldGenerateDocs')) {
+    answers.shouldGenerateDocs = await askShouldGenerateDocs();
+    answers.docsFilePath = getGraphQLDocPath(frontendHandler, schemaLocation);
+  }
+
+  if (!(frontendHandler === 'android' || answers.target === 'javascript')) {
     if (!skip.includes('generatedFileName')) {
       answers.generatedFileName = await askTargetFileName('API', answers.target || '');
     }
     if (!skip.includes('shouldGenerateCode')) {
       answers.shouldGenerateCode = await askShouldGenerateCode();
     }
-  }
-  if (!skip.includes('shouldGenerateDocs')) {
-    answers.shouldGenerateDocs = await askShouldGenerateDocs();
-    answers.docsFilePath = getGraphQLDocPath(frontendHandler, schemaLocation);
   }
 
   return answers;

--- a/packages/amplify-codegen/src/walkthrough/configure.js
+++ b/packages/amplify-codegen/src/walkthrough/configure.js
@@ -1,8 +1,10 @@
+const { join } = require('path');
+
 const askForGraphQLAPIResource = require('./questions/selectProject');
 const askCodeGenTargetLanguage = require('./questions/languageTarget');
 const askCodeGeneQueryFilePattern = require('./questions/queryFilePattern');
 const askTargetFileName = require('./questions/generatedFileName');
-const { getFrontEndHandler } = require('../utils/');
+const { getFrontEndHandler, getIncludePattern } = require('../utils/');
 
 function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
@@ -20,20 +22,37 @@ async function configureProjectWalkThrough(context, amplifyConfig) {
   );
 
   const { amplifyExtension } = selectedProjectConfig;
-  selectedProjectConfig.includes = await askCodeGeneQueryFilePattern(
-    selectedProjectConfig.includes,
-  );
+  let targetLanguage = 'android';
+
   if (frontendHandler !== 'android') {
-    amplifyExtension.codeGenTarget = await askCodeGenTargetLanguage(
+    targetLanguage = await askCodeGenTargetLanguage(
       context,
       amplifyExtension.codeGenTarget,
     );
+  }
 
+  const includePatternDefault = getIncludePattern(targetLanguage, selectedProjectConfig.schema);
+  const includePathGlob = join(
+    includePatternDefault.graphQLDirectory,
+    '**',
+    includePatternDefault.graphQLExtension,
+  );
+  const includePattern =
+    targetLanguage === amplifyExtension.codeGenTarget
+      ? selectedProjectConfig.includes
+      : [includePathGlob];
+
+  selectedProjectConfig.includes = await askCodeGeneQueryFilePattern(includePattern);
+
+  if (!(frontendHandler === 'android' || targetLanguage === 'javascript')) {
     amplifyExtension.generatedFileName = await askTargetFileName(
       amplifyExtension.generatedFileName || 'API',
-      amplifyExtension.codeGenTarget,
+      targetLanguage,
     );
+  } else {
+    amplifyExtension.generatedFileName = '';
   }
+  amplifyExtension.codeGenTarget = targetLanguage;
 
   return selectedProjectConfig;
 }

--- a/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
@@ -6,8 +6,9 @@ const { getFrontEndHandler } = require('../../utils');
 
 const frontEndToTargetMappings = {
   ios: ['swift'],
-  javascript: ['typescript', 'flow'],
+  javascript: ['javascript', 'typescript', 'flow'],
 };
+
 async function askCodeGenTargetLanguage(context, target) {
   const frontend = getFrontEndHandler(context);
 

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -21,7 +21,7 @@ jest.mock('fs-jetpack');
 const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
 const MOCK_STATEMENTS_PATH = 'MOCK_STATEMENTS_PATH';
 const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
-const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_TARGET_LANGUAGE = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
 const MOCK_REGION = 'MOCK_AWS_REGION';
@@ -31,7 +31,7 @@ const MOCK_PROJECT = {
   schema: MOCK_SCHEMA,
   amplifyExtension: {
     generatedFileName: MOCK_GENERATED_FILE_NAME,
-    codeGenTarget: MOCK_TARGET,
+    codeGenTarget: MOCK_TARGET_LANGUAGE,
     graphQLApiId: MOCK_API_ID,
     docsFilePath: MOCK_STATEMENTS_PATH,
     region: MOCK_REGION,
@@ -60,7 +60,7 @@ describe('command - statements', () => {
     expect(generate).toHaveBeenCalledWith(
       path.resolve(MOCK_SCHEMA),
       MOCK_STATEMENTS_PATH,
-      { separateFiles: true, language: 'javascript' },
+      { separateFiles: true, language: MOCK_TARGET_LANGUAGE },
     );
   });
 

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -66,7 +66,7 @@ describe('command - types', () => {
       MOCK_GENERATED_FILE_NAME,
       '',
       MOCK_TARGET,
-      'gql',
+      '',
       '',
       { addTypename: true },
     );

--- a/packages/amplify-codegen/tests/walkthrough/configure.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/configure.test.js
@@ -1,8 +1,10 @@
+const { join } = require('path');
 const selectProject = require('../../src/walkthrough/questions/selectProject');
 const askCodegenTargetLanguage = require('../../src/walkthrough/questions/languageTarget');
 const askCodegneQueryFilePattern = require('../../src/walkthrough/questions/queryFilePattern');
 const askGeneratedFileName = require('../../src/walkthrough/questions/generatedFileName');
 const configure = require('../../src/walkthrough/configure');
+const { getIncludePattern } = require('../../src/utils');
 
 jest.mock('../../src/walkthrough/questions/selectProject');
 jest.mock('../../src/walkthrough/questions/languageTarget');
@@ -16,6 +18,9 @@ describe('configure walk-through', () => {
   const mockIncludes = 'MOCK_INCLUDE_PATTERN';
   const mockContext = 'MOCK_CONTEXT';
   const mockGeneratedFileName = 'MOCK_FILE_NAME.ts';
+  const mockGraphQLDirectory = 'MOCK_GQL_DIR';
+  const mockGraphQLExtension = 'MOCK_GQL_EXTENSION';
+
   const mockConfigs = [
     {
       projectName: 'One',
@@ -44,6 +49,10 @@ describe('configure walk-through', () => {
     askCodegenTargetLanguage.mockReturnValue(mockTargetLanguage);
     askCodegneQueryFilePattern.mockReturnValue(mockIncludes);
     askGeneratedFileName.mockReturnValue(mockGeneratedFileName);
+    getIncludePattern.mockReturnValue({
+      graphQLDirectory: mockGraphQLDirectory,
+      graphQLExtension: mockGraphQLExtension,
+    });
   });
 
   it('should pass the available list of AppSync APIs', async () => {
@@ -63,7 +72,7 @@ describe('configure walk-through', () => {
       mockContext,
       mockConfigs[1].amplifyExtension.codeGenTarget,
     );
-    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith(mockConfigs[1].includes);
+    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith([join(mockGraphQLDirectory, '**', mockGraphQLExtension)]);
     expect(askGeneratedFileName).toHaveBeenCalledWith(
       mockConfigs[1].amplifyExtension.generatedFileName,
       mockTargetLanguage,

--- a/packages/amplify-codegen/tests/walkthrough/questions/languageTarget.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/languageTarget.test.js
@@ -39,6 +39,6 @@ describe('askCodegenTargetLanguage', () => {
     const questions = inquirer.prompt.mock.calls[0][0];
     expect(questions[0].type).toEqual('list');
     expect(questions[0].name).toEqual('target');
-    expect(questions[0].choices).toEqual(['typescript', 'flow']);
+    expect(questions[0].choices).toEqual(['javascript', 'typescript', 'flow']);
   });
 });

--- a/packages/amplify-graphql-docs-generator/README.md
+++ b/packages/amplify-graphql-docs-generator/README.md
@@ -1,17 +1,16 @@
-# GraphQL Operation generator
-GraphQL operation generates takes a schema and generates all possible operations on that schema. This can act as a starting point for the users who are new to GraphQL
+# GraphQL Docs generator
+GraphQL document generator takes a schema and generates all possible statements(queries, mutations and subscription) on that schema. This can act as a starting point for the users who are new to GraphQL
 
 ## Installation and execution
 ```
-$ npm install
-$ npm run build
-$ ./bin/cli --schema test-data/schema.json --output all-operations.graphql
+$ npm install -g amplify-graphql-docs-generator
+$ amplify-graphql-docs-generator --schema test-data/schema.json --output all-operations.graphql --language graphql
 ``` 
 
 ## Todo:
 - [x] Add support for subscriptions
 - [x] Add type information
-- [ ] Add unit tests
+- [X] Add unit tests
 - [ ] Support generating operation by downloading schema from a GraphQL server
-- [ ] Support generation of separate files (queries.graphql, mutations.graphql and subscriptions.graphql)
+- [x] Support generation of separate files (queries.graphql, mutations.graphql and subscriptions.graphql)
 - [ ] Support de-duping of fragments (non inline fragments)

--- a/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -1,0 +1,914 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`end 2 end tests should generate statements 1`] = `
+"# this is an auto generated file. This will be overwritten
+query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+"
+`;
+
+exports[`end 2 end tests should generate statements in JS 1`] = `
+"// eslint-disable
+// this is an auto generated file. This will be overwritten
+
+export const hero = \`query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const reviews = \`query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const search = \`query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const character = \`query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const droid = \`query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+\`;
+export const human = \`query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const starship = \`query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+\`;
+export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+"
+`;
+
+exports[`end 2 end tests should generate statements in Typescript 1`] = `
+"// tslint:disable
+// this is an auto generated file. This will be overwritten
+
+export const hero = \`query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const reviews = \`query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const search = \`query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const character = \`query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const droid = \`query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+\`;
+export const human = \`query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const starship = \`query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+\`;
+export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+"
+`;
+
+exports[`end 2 end tests should generate statements in flow 1`] = `
+"// @flow
+// this is an auto generated file. This will be overwritten
+
+export const hero = \`query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const reviews = \`query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const search = \`query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const character = \`query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const droid = \`query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+\`;
+export const human = \`query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      ... on Human {
+        homePlanet
+        height
+        mass
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const starship = \`query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+\`;
+export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+"
+`;

--- a/packages/amplify-graphql-docs-generator/__integration__/e2e.test.ts
+++ b/packages/amplify-graphql-docs-generator/__integration__/e2e.test.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'path'
+import * as fs from 'fs';
+import generate from '../src'
+
+describe('end 2 end tests', () => {
+  const schemaPath = resolve(__dirname, '../fixtures/schema.json');
+  const outputpath = resolve(__dirname, './output.graphql')
+
+  afterEach(() => {
+    // delete the generated file
+    fs.unlinkSync(outputpath);
+  });
+
+  it('should generate statements', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'graphql' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  });
+
+  it('should generate statements in JS', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'javascript' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  })
+
+  it('should generate statements in Typescript', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'typescript' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  })
+
+  it('should generate statements in flow', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'flow' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  })
+})

--- a/packages/amplify-graphql-docs-generator/src/index.ts
+++ b/packages/amplify-graphql-docs-generator/src/index.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as handlebars from 'handlebars'
 import * as prettier from 'prettier'
+const camelCase = require('camel-case');
+
 import {
   buildClientSchema,
   DocumentNode,
@@ -40,6 +42,8 @@ function generate(
   const maxDepth = options.maxDepth || 3
   const gqlOperations: GQLAllOperations = generateAllOps(schema, maxDepth)
   registerPartials()
+  registerHelpers()
+
   const fileExtension = FILE_EXTENSION_MAP[language]
   if (options.separateFiles) {
     ['queries', 'mutations', 'subscriptions'].forEach((op) => {
@@ -66,8 +70,8 @@ function renderOps(operations: Array<GQLTemplateOp>, language: string = 'graphql
   const templateFiles = {
     javascript: 'javascript.hbs',
     graphql: 'graphql.hbs',
-    typescript: 'javascript.hbs',
-    flow: 'javascript.hbs',
+    typescript: 'typescript.hbs',
+    flow: 'flow.hbs',
   }
 
   const templatePath = path.join(TEMPLATE_DIR, templateFiles[language])
@@ -92,6 +96,15 @@ function registerPartials() {
     const partialContent = fs.readFileSync(partialPath, 'utf8')
     handlebars.registerPartial(partialName.substring(1), partialContent)
   })
+}
+
+function registerHelpers() {
+  handlebars.registerHelper('format', function(options: any) {
+    const result = options.fn(this);
+    return format(result);
+  });
+
+  handlebars.registerHelper('camelCase', camelCase);
 }
 
 function format(str: string, language: string = 'graphql'): string {

--- a/packages/amplify-graphql-docs-generator/src/index.ts
+++ b/packages/amplify-graphql-docs-generator/src/index.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as handlebars from 'handlebars'
 import * as prettier from 'prettier'
-const camelCase = require('camel-case');
+const camelCase = require('camel-case')
 
 import {
   buildClientSchema,
@@ -46,7 +46,7 @@ function generate(
 
   const fileExtension = FILE_EXTENSION_MAP[language]
   if (options.separateFiles) {
-    ['queries', 'mutations', 'subscriptions'].forEach((op) => {
+    ;['queries', 'mutations', 'subscriptions'].forEach((op) => {
       const ops = gqlOperations[op]
       if (ops.length) {
         const gql = renderOps(gqlOperations[op], language)
@@ -100,11 +100,11 @@ function registerPartials() {
 
 function registerHelpers() {
   handlebars.registerHelper('format', function(options: any) {
-    const result = options.fn(this);
-    return format(result);
-  });
+    const result = options.fn(this)
+    return format(result)
+  })
 
-  handlebars.registerHelper('camelCase', camelCase);
+  handlebars.registerHelper('camelCase', camelCase)
 }
 
 function format(str: string, language: string = 'graphql'): string {

--- a/packages/amplify-graphql-docs-generator/src/index.ts
+++ b/packages/amplify-graphql-docs-generator/src/index.ts
@@ -46,7 +46,7 @@ function generate(
 
   const fileExtension = FILE_EXTENSION_MAP[language]
   if (options.separateFiles) {
-    ;['queries', 'mutations', 'subscriptions'].forEach((op) => {
+    ['queries', 'mutations', 'subscriptions'].forEach((op) => {
       const ops = gqlOperations[op]
       if (ops.length) {
         const gql = renderOps(gqlOperations[op], language)

--- a/packages/amplify-graphql-docs-generator/templates/_renderToVariable.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderToVariable.hbs
@@ -1,0 +1,5 @@
+{{#each operations }}
+  export const {{camelCase name}} =  `{{#format }}
+      {{> renderOp }}
+    {{/format}}`;
+{{/each}}

--- a/packages/amplify-graphql-docs-generator/templates/flow.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/flow.hbs
@@ -1,4 +1,4 @@
-// eslint-disable
+// @flow
 // this is an auto generated file. This will be overwritten
 
 {{> renderToVariable }}

--- a/packages/amplify-graphql-docs-generator/templates/typescript.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/typescript.hbs
@@ -1,4 +1,4 @@
-// eslint-disable
+// tslint:disable
 // this is an auto generated file. This will be overwritten
 
 {{> renderToVariable }}

--- a/packages/amplify-graphql-docs-generator/tsconfig.json
+++ b/packages/amplify-graphql-docs-generator/tsconfig.json
@@ -19,5 +19,8 @@
         "node_modules",
         "lib",
         "__tests__"
+    ],
+    "include": [
+        "src/"
     ]
 }


### PR DESCRIPTION
… gql tag

Update amplify-graphql-docs-generator to export statements without the gql tag
Disable linter on generated statements. 
Updated the codegen walk through to support Javascript along with Typescript and flow. If users choose Javascript, generate only statements with `.js` extension.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.