### PR TITLE
Indicate the minimum node version

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -13,6 +13,9 @@
     "lint": "eslint src",
     "lint-fix": "eslint . --fix"
   },
+  "engines": {
+    "node": ">=8.11.0"
+  },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Issue #218 

*Description of changes:*

As there are core functions used that depend on a minimum node version, we can indicate this in package.json so users who need to upgrade get a warning on install.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.