### PR TITLE
Allow users to provide their own Query, Mutation, and Subscription root object types.

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/appsync-schemas/single-object-auth-schema.graphql
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/appsync-schemas/single-object-auth-schema.graphql
@@ -1,8 +1,8 @@
 type Task 
   @model 
   @auth(rules: [
-      {allow: groups, groups: ["Managers"], mutations: [create, update, delete]},
-      {allow: groups, groups: ["Employees"], queries: [get, list]}
+      {allow: groups, groups: ["Managers"], queries: null, mutations: [create, update, delete]},
+      {allow: groups, groups: ["Employees"], queries: [get, list], mutations: null}
     ])
 {
   id: ID!

--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -30,19 +30,6 @@ export class AppSyncTransformer extends Transformer {
     }
 
     public before = (ctx: TransformerContext): void => {
-        const queryType = blankObject('Query')
-        const mutationType = blankObject('Mutation')
-        const subscriptionType = blankObject('Subscription')
-        ctx.addObject(mutationType)
-        ctx.addObject(queryType)
-        ctx.addObject(subscriptionType)
-        const schema = makeSchema([
-            makeOperationType('query', 'Query'),
-            makeOperationType('mutation', 'Mutation'),
-            makeOperationType('subscription', 'Subscription')
-        ])
-        ctx.putSchema(schema)
-
         // Some downstream resources depend on this so put a placeholder in and
         // overwrite it in the after
         const schemaResource = this.resources.makeAppSyncSchema('placeholder')
@@ -55,26 +42,6 @@ export class AppSyncTransformer extends Transformer {
             this.printWithoutFilePath(ctx);
         } else {
             this.printWithFilePath(ctx);
-        }
-    }
-
-    private fillMissingNodes(ctx: TransformerContext): void {
-        for (const inputDef of ctx.inputDocument.definitions) {
-            switch (inputDef.kind) {
-                case Kind.OBJECT_TYPE_DEFINITION:
-                case Kind.SCALAR_TYPE_DEFINITION:
-                case Kind.INTERFACE_TYPE_DEFINITION:
-                case Kind.INPUT_OBJECT_TYPE_DEFINITION:
-                case Kind.ENUM_TYPE_DEFINITION:
-                case Kind.UNION_TYPE_DEFINITION:
-                    const typeDef = inputDef as TypeDefinitionNode
-                    if (!ctx.getType(typeDef.name.value)) {
-                        ctx.addType(typeDef)
-                    }
-                    break;
-                default:
-                /* pass any others */
-            }
         }
     }
 

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -97,10 +97,10 @@ export class DynamoDBModelTransformer extends Transformer {
         // ctx.addObject(def)
 
         let nonModelArray: ObjectTypeDefinitionNode[] = getNonModelObjectArray(
-                                                            def,
-                                                            ctx,
-                                                            new Map<string, ObjectTypeDefinitionNode>()
-                                                        )
+            def,
+            ctx,
+            new Map<string, ObjectTypeDefinitionNode>()
+        )
 
         nonModelArray.forEach(
             (value: ObjectTypeDefinitionNode) => {

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -147,7 +147,7 @@ export class DynamoDBModelTransformer extends Transformer {
         ctx.addInput(updateInput)
         ctx.addInput(deleteInput)
 
-        let mutationType = blankObjectExtension('Mutation')
+        const mutationFields = [];
         // Get any name overrides provided by the user. If an empty map it provided
         // then we do not generate those fields.
         const directiveArguments: ModelDirectiveArgs = super.getDirectiveArgumentMap(directive)
@@ -188,47 +188,38 @@ export class DynamoDBModelTransformer extends Transformer {
         if (shouldMakeCreate) {
             const createResolver = this.resources.makeCreateResolver(def.name.value, createFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName), createResolver)
-            mutationType = extensionWithFields(
-                mutationType,
-                [makeField(
-                    createResolver.Properties.FieldName,
-                    [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))],
-                    makeNamedType(def.name.value)
-                )]
-            )
+            mutationFields.push(makeField(
+                createResolver.Properties.FieldName,
+                [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))],
+                makeNamedType(def.name.value)
+            ));
         }
 
         if (shouldMakeUpdate) {
             const updateResolver = this.resources.makeUpdateResolver(def.name.value, updateFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName), updateResolver)
-            mutationType = extensionWithFields(
-                mutationType,
-                [makeField(
-                    updateResolver.Properties.FieldName,
-                    [makeInputValueDefinition('input', makeNonNullType(makeNamedType(updateInput.name.value)))],
-                    makeNamedType(def.name.value)
-                )]
-            )
+            mutationFields.push(makeField(
+                updateResolver.Properties.FieldName,
+                [makeInputValueDefinition('input', makeNonNullType(makeNamedType(updateInput.name.value)))],
+                makeNamedType(def.name.value)
+            ));
         }
 
         if (shouldMakeDelete) {
             const deleteResolver = this.resources.makeDeleteResolver(def.name.value, deleteFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName), deleteResolver)
-            mutationType = extensionWithFields(
-                mutationType,
-                [makeField(
-                    deleteResolver.Properties.FieldName,
-                    [makeInputValueDefinition('input', makeNonNullType(makeNamedType(deleteInput.name.value)))],
-                    makeNamedType(def.name.value)
-                )]
-            )
+            mutationFields.push(makeField(
+                deleteResolver.Properties.FieldName,
+                [makeInputValueDefinition('input', makeNonNullType(makeNamedType(deleteInput.name.value)))],
+                makeNamedType(def.name.value)
+            ));
         }
-        ctx.addObjectExtension(mutationType)
+        ctx.addMutationFields(mutationFields)
     }
 
     private createQueries = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         const typeName = def.name.value
-        let queryType = blankObjectExtension('Query')
+        const queryFields = []
         const directiveArguments: ModelDirectiveArgs = this.getDirectiveArgumentMap(directive)
 
         // Configure queries based on *queries* argument
@@ -266,17 +257,14 @@ export class DynamoDBModelTransformer extends Transformer {
 
         // Create get queries
         if (shouldMakeGet) {
-            const getResolver = this.resources.makeGetResolver(def.name.value, getFieldNameOverride)
+            const getResolver = this.resources.makeGetResolver(def.name.value, getFieldNameOverride, ctx.getQueryTypeName())
             ctx.setResource(ResolverResourceIDs.DynamoDBGetResolverResourceID(typeName), getResolver)
 
-            queryType = extensionWithFields(
-                queryType,
-                [makeField(
-                    getResolver.Properties.FieldName,
-                    [makeInputValueDefinition('id', makeNonNullType(makeNamedType('ID')))],
-                    makeNamedType(def.name.value)
-                )]
-            )
+            queryFields.push(makeField(
+                getResolver.Properties.FieldName,
+                [makeInputValueDefinition('id', makeNonNullType(makeNamedType('ID')))],
+                makeNamedType(def.name.value)
+            ))
         }
 
         if (shouldMakeList) {
@@ -284,19 +272,15 @@ export class DynamoDBModelTransformer extends Transformer {
             this.generateModelXConnectionType(ctx, def)
 
             // Create the list resolver
-            const listResolver = this.resources.makeListResolver(def.name.value, listFieldNameOverride)
+            const listResolver = this.resources.makeListResolver(def.name.value, listFieldNameOverride, ctx.getQueryTypeName())
             ctx.setResource(ResolverResourceIDs.DynamoDBListResolverResourceID(typeName), listResolver)
 
             this.generateFilterInputs(ctx, def)
 
-            // Extend the query type to include listX
-            queryType = extensionWithFields(
-                queryType,
-                [makeModelScanField(listResolver.Properties.FieldName, def.name.value)]
-            )
+            queryFields.push(makeModelScanField(listResolver.Properties.FieldName, def.name.value))
         }
 
-        ctx.addObjectExtension(queryType)
+        ctx.addQueryFields(queryFields)
     }
 
     /**
@@ -321,7 +305,7 @@ export class DynamoDBModelTransformer extends Transformer {
      */
     private createSubscriptions = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         const typeName = def.name.value
-        let subscriptionType = blankObjectExtension('Subscription')
+        const subscriptionFields = []
 
         const directiveArguments: ModelDirectiveArgs = this.getDirectiveArgumentMap(directive)
 
@@ -360,10 +344,7 @@ export class DynamoDBModelTransformer extends Transformer {
                     typeName,
                     subscriptionToMutationsMap[subFieldName]
                 )
-                subscriptionType = extensionWithFields(
-                    subscriptionType,
-                    [subField]
-                )
+                subscriptionFields.push(subField)
             }
         } else {
             // Add the default subscriptions
@@ -373,10 +354,7 @@ export class DynamoDBModelTransformer extends Transformer {
                     typeName,
                     [createResolver.Properties.FieldName]
                 )
-                subscriptionType = extensionWithFields(
-                    subscriptionType,
-                    [onCreateField]
-                )
+                subscriptionFields.push(onCreateField)
             }
             if (updateResolver) {
                 const onUpdateField = makeSubscriptionField(
@@ -384,10 +362,7 @@ export class DynamoDBModelTransformer extends Transformer {
                     typeName,
                     [updateResolver.Properties.FieldName]
                 )
-                subscriptionType = extensionWithFields(
-                    subscriptionType,
-                    [onUpdateField]
-                )
+                subscriptionFields.push(onUpdateField)
             }
             if (deleteResolver) {
                 const onDeleteField = makeSubscriptionField(
@@ -395,14 +370,11 @@ export class DynamoDBModelTransformer extends Transformer {
                     typeName,
                     [deleteResolver.Properties.FieldName]
                 )
-                subscriptionType = extensionWithFields(
-                    subscriptionType,
-                    [onDeleteField]
-                )
+                subscriptionFields.push(onDeleteField)
             }
         }
 
-        ctx.addObjectExtension(subscriptionType)
+        ctx.addSubscriptionFields(subscriptionFields)
     }
 
     private typeExist(type: string, ctx: TransformerContext): boolean {

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -209,13 +209,13 @@ export class ResourceFactory {
      * Create a resolver that creates an item in DynamoDB.
      * @param type
      */
-    public makeCreateResolver(type: string, nameOverride?: string) {
+    public makeCreateResolver(type: string, nameOverride?: string, mutationTypeName: string = 'Mutation') {
         const fieldName = nameOverride ? nameOverride : graphqlName('create' + toUpper(type))
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
             FieldName: fieldName,
-            TypeName: 'Mutation',
+            TypeName: mutationTypeName,
             RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
                 compoundExpression([
                     qref('$context.args.input.put("createdAt", $util.time.nowISO8601())'),
@@ -241,13 +241,13 @@ export class ResourceFactory {
         }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID)
     }
 
-    public makeUpdateResolver(type: string, nameOverride?: string) {
+    public makeUpdateResolver(type: string, nameOverride?: string, mutationTypeName: string = 'Mutation') {
         const fieldName = nameOverride ? nameOverride : graphqlName(`update` + toUpper(type))
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
             FieldName: fieldName,
-            TypeName: 'Mutation',
+            TypeName: mutationTypeName,
             RequestMappingTemplate: print(
                 compoundExpression([
                     ifElse(
@@ -296,13 +296,13 @@ export class ResourceFactory {
      * Create a resolver that creates an item in DynamoDB.
      * @param type
      */
-    public makeGetResolver(type: string, nameOverride?: string) {
+    public makeGetResolver(type: string, nameOverride?: string, queryTypeName: string = 'Query') {
         const fieldName = nameOverride ? nameOverride : graphqlName('get' + toUpper(type))
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
             FieldName: fieldName,
-            TypeName: 'Query',
+            TypeName: queryTypeName,
             RequestMappingTemplate: print(
                 DynamoDBMappingTemplate.getItem({
                     key: obj({
@@ -320,14 +320,14 @@ export class ResourceFactory {
      * Create a resolver that queries an item in DynamoDB.
      * @param type
      */
-    public makeQueryResolver(type: string, nameOverride?: string) {
+    public makeQueryResolver(type: string, nameOverride?: string, queryTypeName: string = 'Query') {
         const fieldName = nameOverride ? nameOverride : graphqlName(`query${toUpper(type)}`)
         const defaultPageLimit = 10
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
             FieldName: fieldName,
-            TypeName: 'Query',
+            TypeName: queryTypeName,
             RequestMappingTemplate: print(
                 compoundExpression([
                     set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
@@ -381,7 +381,7 @@ export class ResourceFactory {
      * TODO: actually fill out the right filter expression. This is a placeholder only.
      * @param type
      */
-    public makeListResolver(type: string, nameOverride?: string) {
+    public makeListResolver(type: string, nameOverride?: string, queryTypeName: string = 'Query') {
         const fieldName = nameOverride ? nameOverride : graphqlName('list' + plurality(toUpper(type)))
         const defaultPageLimit = 10
 
@@ -389,7 +389,7 @@ export class ResourceFactory {
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
             FieldName: fieldName,
-            TypeName: 'Query',
+            TypeName: queryTypeName,
             RequestMappingTemplate: print(
                 compoundExpression([
                     set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
@@ -419,13 +419,13 @@ export class ResourceFactory {
      * @param type The name of the type to delete an item of.
      * @param nameOverride A user provided override for the field name.
      */
-    public makeDeleteResolver(type: string, nameOverride?: string) {
+    public makeDeleteResolver(type: string, nameOverride?: string, mutationTypeName: string = 'Mutation') {
         const fieldName = nameOverride ? nameOverride : graphqlName('delete' + toUpper(type))
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
             FieldName: fieldName,
-            TypeName: 'Mutation',
+            TypeName: mutationTypeName,
             RequestMappingTemplate: print(
                 compoundExpression([
                     ifElse(

--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -85,7 +85,7 @@ export class SearchableModelTransformer extends Transformer {
         )
 
         //SearchablePostSortableFields
-        let queryType = blankObjectExtension('Query')
+        const queryFields = [];
 
         // Create listX
         if (shouldMakeSearch) {
@@ -94,24 +94,19 @@ export class SearchableModelTransformer extends Transformer {
 
             const searchResolver = this.resources.makeSearchResolver(def.name.value, searchFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.ElasticsearchSearchResolverResourceID(def.name.value), searchResolver)
-            queryType = extensionWithFields(
-                queryType,
+            queryFields.push(makeField(
+                searchResolver.Properties.FieldName,
                 [
-                    makeField(
-                        searchResolver.Properties.FieldName,
-                        [
-                            makeInputValueDefinition('filter', makeNamedType(`Searchable${def.name.value}FilterInput`)),
-                            makeInputValueDefinition('sort', makeNamedType(`Searchable${def.name.value}SortInput`)),
-                            makeInputValueDefinition('limit', makeNamedType('Int')),
-                            makeInputValueDefinition('nextToken', makeNamedType('Int'))
-                        ],
-                        makeNamedType(`Searchable${def.name.value}Connection`)
-                    )
-                ]
-            )
+                    makeInputValueDefinition('filter', makeNamedType(`Searchable${def.name.value}FilterInput`)),
+                    makeInputValueDefinition('sort', makeNamedType(`Searchable${def.name.value}SortInput`)),
+                    makeInputValueDefinition('limit', makeNamedType('Int')),
+                    makeInputValueDefinition('nextToken', makeNamedType('Int'))
+                ],
+                makeNamedType(`Searchable${def.name.value}Connection`)
+            ))
         }
 
-        ctx.addObjectExtension(queryType)
+        ctx.addQueryFields(queryFields)
     };
 
     private generateSearchableXConnectionType(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -413,13 +413,13 @@ export class ResourceFactory {
     /**
      * Create the ElasticSearch search resolver.
      */
-    public makeSearchResolver(type: string, nameOverride?: string) {
+    public makeSearchResolver(type: string, nameOverride?: string, queryTypeName: string = 'Query') {
         const fieldName = nameOverride ? nameOverride : graphqlName('search' + plurality(toUpper(type)))
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ResourceConstants.RESOURCES.ElasticSearchDataSourceLogicalID, 'Name'),
             FieldName: fieldName,
-            TypeName: 'Query',
+            TypeName: queryTypeName,
             RequestMappingTemplate: Fn.Sub(
                 print(
                     compoundExpression([

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -185,7 +185,7 @@ export default class GraphQLTransform {
         const context = new TransformerContext(schema)
         const validDirectiveNameMap = this.transformers.reduce(
             (acc: any, t: Transformer) => ({ ...acc, [t.directive.name.value]: true }),
-            {}
+            { aws_subscribe: true }
         )
         let allModelDefinitions = [...context.inputDocument.definitions]
         for (const transformer of this.transformers) {

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -296,10 +296,7 @@ export default class TransformerContext {
      * @param fields The fields to add the query type.
      */
     public addQueryFields(fields: FieldDefinitionNode[]) {
-        const schemaNode = this.getSchema();
-        const queryTypeOperation = schemaNode.operationTypes.find((op: OperationTypeDefinitionNode) => op.operation === 'query');
-        const queryTypeName = queryTypeOperation && queryTypeOperation.type && queryTypeOperation.type.name && queryTypeOperation.type.name.value ?
-            queryTypeOperation.type.name.value : undefined;
+        const queryTypeName = this.getQueryTypeName();
         if (queryTypeName) {
             if (!this.getType(queryTypeName)) {
                 this.addType(blankObject(queryTypeName))
@@ -316,12 +313,7 @@ export default class TransformerContext {
      * @param fields The fields to add the mutation type.
      */
     public addMutationFields(fields: FieldDefinitionNode[]) {
-        const schemaNode = this.getSchema();
-        const mutationTypeOperation = schemaNode.operationTypes.find((op: OperationTypeDefinitionNode) => op.operation === 'mutation');
-        const mutationTypeName = (
-            mutationTypeOperation && mutationTypeOperation.type &&
-            mutationTypeOperation.type.name && mutationTypeOperation.type.name.value
-        ) ? mutationTypeOperation.type.name.value : undefined;
+        const mutationTypeName = this.getMutationTypeName();
         if (mutationTypeName) {
             if (!this.getType(mutationTypeName)) {
                 this.addType(blankObject(mutationTypeName))
@@ -338,12 +330,7 @@ export default class TransformerContext {
      * @param fields The fields to add the subscription type.
      */
     public addSubscriptionFields(fields: FieldDefinitionNode[]) {
-        const schemaNode = this.getSchema();
-        const subscriptionTypeOperation = schemaNode.operationTypes.find((op: OperationTypeDefinitionNode) => op.operation === 'subscription');
-        const subscriptionTypeName = (
-            subscriptionTypeOperation && subscriptionTypeOperation.type &&
-            subscriptionTypeOperation.type.name && subscriptionTypeOperation.type.name.value
-        ) ? subscriptionTypeOperation.type.name.value : undefined;
+        const subscriptionTypeName = this.getSubscriptionTypeName();
         if (subscriptionTypeName) {
             if (!this.getType(subscriptionTypeName)) {
                 this.addType(blankObject(subscriptionTypeName))

--- a/packages/graphql-transformer-core/src/defaultSchema.ts
+++ b/packages/graphql-transformer-core/src/defaultSchema.ts
@@ -1,0 +1,41 @@
+import { SchemaDefinitionNode, Kind } from 'graphql';
+const DEFAULT_SCHEMA_DEFINITION: SchemaDefinitionNode = {
+    kind: Kind.SCHEMA_DEFINITION,
+    directives: [],
+    operationTypes: [
+        {
+            kind: Kind.OPERATION_TYPE_DEFINITION,
+            operation: 'query',
+            type: {
+                kind: Kind.NAMED_TYPE,
+                name: {
+                    kind: Kind.NAME,
+                    value: 'Query'
+                }
+            }
+        },
+        {
+            kind: Kind.OPERATION_TYPE_DEFINITION,
+            operation: 'mutation',
+            type: {
+                kind: Kind.NAMED_TYPE,
+                name: {
+                    kind: Kind.NAME,
+                    value: 'Mutation'
+                }
+            }
+        },
+        {
+            kind: Kind.OPERATION_TYPE_DEFINITION,
+            operation: 'subscription',
+            type: {
+                kind: Kind.NAMED_TYPE,
+                name: {
+                    kind: Kind.NAME,
+                    value: 'Subscription'
+                }
+            }
+        }
+    ]
+}
+export default DEFAULT_SCHEMA_DEFINITION;

--- a/packages/graphql-transformer-core/src/validation.ts
+++ b/packages/graphql-transformer-core/src/validation.ts
@@ -1,6 +1,8 @@
 import { GraphQLScalarType } from 'graphql'
 import {
-    Kind, DocumentNode, TypeDefinitionNode, DirectiveDefinitionNode, ScalarTypeDefinitionNode, parse, SchemaDefinitionNode
+    Kind, DocumentNode, TypeSystemDefinitionNode,
+    DirectiveDefinitionNode, ScalarTypeDefinitionNode, parse,
+    SchemaDefinitionNode, TypeDefinitionNode
 } from 'graphql/language'
 import { GraphQLSchema, GraphQLObjectType, isOutputType } from 'graphql/type'
 import { validate } from 'graphql/validation'
@@ -85,12 +87,18 @@ scalar BigInt
 scalar Double
 `)
 
+const EXTRA_DIRECTIVES_DOCUMENT = parse(`
+directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
+`)
+
 export function astBuilder(doc: DocumentNode): ASTDefinitionBuilder {
-    const nodeMap = doc.definitions.reduce(
-        (a: { [k: string]: TypeDefinitionNode }, def: TypeDefinitionNode) => ({
-            ...a,
-            [def.name.value]: def
-        }), {})
+    const nodeMap = doc.definitions
+        .filter((def: TypeSystemDefinitionNode) => def.kind !== Kind.SCHEMA_DEFINITION && Boolean(def.name))
+        .reduce(
+            (a: { [k: string]: TypeDefinitionNode }, def: TypeDefinitionNode) => ({
+                ...a,
+                [def.name.value]: def
+            }), {})
     return new ASTDefinitionBuilder(
         nodeMap,
         {},
@@ -105,7 +113,8 @@ export function validateModelSchema(doc: DocumentNode) {
         kind: Kind.DOCUMENT,
         definitions: [
             ...doc.definitions,
-            ...EXTRA_SCALARS_DOCUMENT.definitions
+            ...EXTRA_SCALARS_DOCUMENT.definitions,
+            ...EXTRA_DIRECTIVES_DOCUMENT.definitions
         ]
     }
     const builder = astBuilder(fullDocument)
@@ -113,7 +122,7 @@ export function validateModelSchema(doc: DocumentNode) {
         .filter(d => d.kind === Kind.DIRECTIVE_DEFINITION)
         .map((d: DirectiveDefinitionNode) => builder.buildDirective(d))
     const types = fullDocument.definitions
-        .filter(d => d.kind !== Kind.DIRECTIVE_DEFINITION)
+        .filter(d => d.kind !== Kind.DIRECTIVE_DEFINITION && d.kind !== Kind.SCHEMA_DEFINITION)
         .map((d: TypeDefinitionNode) => builder.buildType(d))
     const outputTypes = types.filter(
         t => isOutputType(t)

--- a/packages/graphql-transformer-core/src/validation.ts
+++ b/packages/graphql-transformer-core/src/validation.ts
@@ -122,10 +122,14 @@ export function validateModelSchema(doc: DocumentNode) {
         (acc, t) => ({ ...acc, [t.name]: { type: t } }),
         {}
     )
-    const queryType = new GraphQLObjectType({
-        name: 'Query',
-        fields
-    })
+    // TODO: Lookup the root schema query type name.
+    const existingQueryType = types.find(t => t.name === 'Query') as GraphQLObjectType;
+    const queryType = existingQueryType ?
+        existingQueryType :
+        new GraphQLObjectType({
+            name: 'Query',
+            fields
+        })
     const schema = new GraphQLSchema({ query: queryType, types, directives });
     return validate(schema, fullDocument, specifiedRules)
 }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.test.ts
@@ -1,0 +1,96 @@
+import {
+    ObjectTypeDefinitionNode, parse, FieldDefinitionNode, DocumentNode,
+    DefinitionNode, Kind, InputObjectTypeDefinitionNode
+} from 'graphql'
+import GraphQLTransform from 'graphql-transformer-core'
+import DynamoDBModelTransformer from 'graphql-dynamodb-transformer'
+import { AppSyncTransformer } from 'graphql-appsync-transformer'
+import { ResourceConstants } from 'graphql-transformer-common';
+
+import fs = require('fs');
+import path = require('path');
+
+test('Test custom root types with additional fields.', () => {
+    const validSchema = `
+    type Query {
+        additionalQueryField: String
+    }
+    type Mutation {
+        additionalMutationField: String
+    }
+    type Subscription {
+        additionalSubscriptionField: String
+    }
+    type Post @model {
+        id: ID!
+        title: String
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new AppSyncTransformer(),
+            new DynamoDBModelTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
+    expect(schema).toBeDefined()
+    const definition = schema.Properties.Definition
+    expect(definition).toBeDefined()
+    const parsed = parse(definition);
+    const queryType = getObjectType(parsed, 'Query');
+    expectFields(queryType, ['getPost', 'listPosts', 'additionalQueryField'])
+    const mutationType = getObjectType(parsed, 'Mutation');
+    expectFields(mutationType, ['createPost', 'updatePost', 'deletePost', 'additionalMutationField'])
+    const subscriptionType = getObjectType(parsed, 'Subscription');
+    expectFields(subscriptionType, ['onCreatePost', 'onUpdatePost', 'onDeletePost', 'additionalSubscriptionField'])
+});
+
+function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        expect(foundField).toBeDefined()
+    }
+}
+
+function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        expect(
+            type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        ).toBeUndefined()
+    }
+}
+
+function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+    return doc.definitions.find(
+        (def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type
+    ) as ObjectTypeDefinitionNode | undefined
+}
+
+function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+    return doc.definitions.find(
+        (def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type
+    ) as InputObjectTypeDefinitionNode | undefined
+}
+
+function verifyInputCount(doc: DocumentNode, type: string, count: number): boolean {
+    return doc.definitions.filter(def => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type).length == count;
+}
+
+function cleanUpFiles(directory: string) {
+    var files = fs.readdirSync(directory)
+    for (const file of files) {
+        const dir = path.join(directory, file)
+        if (!fs.lstatSync(dir).isDirectory()) {
+            fs.unlinkSync(dir)
+        } else {
+            cleanUpFiles(dir)
+        }
+    }
+    fs.rmdirSync(directory)
+}
+
+function readFile(filePath: string) {
+    return fs.readFileSync(filePath, "utf8")
+}


### PR DESCRIPTION
*Description of changes:*

These changes allow users to provide their own Query, Mutation and Subscription root object types.

For example,

```graphql
type Post @model {
  id: ID!
  title: String
}
type Query {
  customQuery: String
}
```

With this input, after compilation the root query type will be:

```graphql
type Query {
  customQuery: String
  getPost(id: ID!): Post
  listPosts(...): PostConnection
}
```

You can also now turn off mutations/subscriptions entirely simply by leaving them out in your schema definition without having to update every @model or @searchable:

```graphql
schema {
  query: Query
  # explicitly leaving out mutation so no mutations will be created
}
type Query {
  customQuery: String
}
type Post @model { # NOTE: I do not have to set mutations: null to turn off mutations.
  id: ID!
  title: String!
}
```

You can also change the name of the root object types.

```graphql
schema {
  query: MyQueryType
}
type MyQueryType {
  customQuery: String
}
type Post @model {
  id: ID!
  title: String!
}
```

and the generated query fields will be placed on the `MyQueryType` type instead of the default `Query`.
