### PR TITLE
Ensures we don't add multiple non-model input types

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -105,10 +105,9 @@ export class DynamoDBModelTransformer extends Transformer {
         nonModelArray.forEach(
             (value: ObjectTypeDefinitionNode) => {
                 let nonModelObject = makeNonModelInputObject(value, nonModelArray, ctx)
-                if (this.typeExist(nonModelObject.name.value, ctx)) {
-                    return
+                if (!this.typeExist(nonModelObject.name.value, ctx)) {
+                    ctx.addInput(nonModelObject)
                 }
-                ctx.addInput(nonModelObject)
             }
         )
 

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -105,6 +105,9 @@ export class DynamoDBModelTransformer extends Transformer {
         nonModelArray.forEach(
             (value: ObjectTypeDefinitionNode) => {
                 let nonModelObject = makeNonModelInputObject(value, nonModelArray, ctx)
+                if (this.typeExist(nonModelObject.name.value, ctx)) {
+                    return
+                }
                 ctx.addInput(nonModelObject)
             }
         )

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -35,7 +35,17 @@ beforeAll(async () => {
         createdAt: AWSDateTime
         updatedAt: AWSDateTime
         metadata: PostMetadata
+        entityMetadata: EntityMetadata
         appearsIn: [Episode!]
+    }
+    type Author @model {
+        id: ID!
+        name: String!
+        postMetadata: PostMetadata
+        entityMetadata: EntityMetadata
+    }
+    type EntityMetadata {
+        isActive: Boolean
     }
     type PostMetadata {
         tags: Tag
@@ -100,6 +110,35 @@ afterAll(async () => {
 /**
  * Test queries below
  */
+test('Test createAuthor mutation', async () => {
+    try {
+        const response = await GRAPHQL_CLIENT.query(`mutation($input: CreateAuthorInput!) {
+            createAuthor(input: $input) {
+                id
+                name
+                entityMetadata {
+                    isActive
+                }
+            }
+        }`, {
+            input: {
+                name: 'Jeff B',
+                entityMetadata: {
+                    isActive: true
+                }
+            }
+        })
+        expect(response.data.createAuthor.id).toBeDefined()
+        expect(response.data.createAuthor.name).toEqual('Jeff B')
+        expect(response.data.createAuthor.entityMetadata).toBeDefined()
+        expect(response.data.createAuthor.entityMetadata.isActive).toEqual(true)
+    } catch (e) {
+        console.error(e)
+        // fail
+        expect(e).toBeUndefined()
+    }
+})
+
 test('Test createPost mutation', async () => {
     try {
         const response = await GRAPHQL_CLIENT.query(`mutation {


### PR DESCRIPTION
*Issue #, if available:*
This is related to [Issue #214](https://github.com/aws-amplify/amplify-cli/pull/214)

*Description of changes:*
When a non-model type is referenced within multiple @model types, the transformer ran into issues.

For example, this test used to fail before:

```graphql
    type Post @model {
        id: ID!
        title: String!
        createdAt: AWSDateTime
        updatedAt: AWSDateTime
        metadata: PostMetadata
        entityMetadata: EntityMetadata
        appearsIn: [Episode!]
    }
    type Author @model {
        id: ID!
        name: String!
        postMetadata: PostMetadata
        entityMetadata: EntityMetadata
    }
    type EntityMetadata {
        isActive: Boolean
    }
    type PostMetadata {
        tags: Tag
    }
    type Tag {
        published: Boolean
        metadata: PostMetadata
    }
    enum Episode {
        NEWHOPE
        EMPIRE
        JEDI
    }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.