### PR TITLE
Update statement generator to skip level for Lists

### DIFF
--- a/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
@@ -5,6 +5,7 @@ import {
   GraphQLScalarType,
   GraphQLSchema,
   GraphQLUnionType,
+  GraphQLList,
 } from 'graphql'
 import getFragment from './getFragment'
 import { GQLConcreteType, GQLTemplateField, GQLTemplateFragment } from './types'
@@ -30,7 +31,12 @@ export default function getFields(
   }
 
   const fields: Array<GQLTemplateField> = Object.keys(subFields)
-    .map((fieldName) => getFields(subFields[fieldName], schema, depth - 1))
+    .map((fieldName) => {
+      // Don't decrease the depth if its a list of items
+      const subField = subFields[fieldName];
+      const newDepth = subField.type instanceof GraphQLList ? depth : depth - 1;
+      return getFields(subField, schema, newDepth)
+    })
     .filter((field) => field)
   const fragments: Array<GQLTemplateFragment> = Object.keys(subFragments)
     .map((fragment) => getFragment(subFragments[fragment], schema, depth, fields))


### PR DESCRIPTION
Fixes #222

GraphQL statements generator by default resolves fields 3 level deep, it
counted a list as a level but we should diregard list as a level. Updated
code to disregard list as a level

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.