### PR TITLE
Change user agent action string to include cfn update calls

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-frontend-plugins.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-frontend-plugins.js
@@ -3,7 +3,6 @@ function getFrontendPlugins(context) {
   context.runtime.plugins.forEach((plugin) => {
     if (plugin.name.includes('frontend')) {
       const strs = plugin.name.split('-');
-      console.log(strs);
       const frontendName = strs[strs.length - 1];
       frontendPlugins[frontendName] = plugin.directory;
     }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-frontend-plugins.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-frontend-plugins.js
@@ -3,6 +3,7 @@ function getFrontendPlugins(context) {
   context.runtime.plugins.forEach((plugin) => {
     if (plugin.name.includes('frontend')) {
       const strs = plugin.name.split('-');
+      console.log(strs);
       const frontendName = strs[strs.length - 1];
       frontendPlugins[frontendName] = plugin.directory;
     }

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -38,7 +38,7 @@ async function run(context, category, resourceName) {
       if (resources.length > 0 || resourcesToBeDeleted.length > 0) {
         return updateCloudFormationNestedStack(
           context,
-          formNestedStack(context, projectDetails), resourcesToBeCreated,
+          formNestedStack(context, projectDetails), resourcesToBeCreated, resourcesToBeUpdated,
         );
       }
     })
@@ -162,7 +162,11 @@ function packageResources(context, resources) {
 }
 
 
-function updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated) {
+function updateCloudFormationNestedStack(
+  context, nestedStack,
+  resourcesToBeCreated,
+  resourcesToBeUpdated,
+) {
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
   const nestedStackFilepath = path.normalize(path.join(
     backEndDir,
@@ -171,16 +175,33 @@ function updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCrea
   ));
 
   const uniqueCategoriesAdded = getAllUniqueCategories(resourcesToBeCreated);
+  const uniqueCategoriesUpdated = getAllUniqueCategories(resourcesToBeUpdated);
 
   let userAgentAction = '';
 
-  if (uniqueCategoriesAdded.size > 0) {
-    userAgentAction = `create ${Array.from(uniqueCategoriesAdded).join(' ')}`;
+  if (uniqueCategoriesAdded.length > 0) {
+    uniqueCategoriesAdded.forEach((category) => {
+      if (category.length >= 2) {
+        category = category.substring(0, 2);
+      }
+
+      userAgentAction += `${category}:c `;
+    });
+    // userAgentAction = `create ${Array.from(uniqueCategoriesAdded).join(' ')}`;
+  }
+
+  if (uniqueCategoriesUpdated.length > 0) {
+    uniqueCategoriesUpdated.forEach((category) => {
+      if (category.length >= 2) {
+        category = category.substring(0, 2);
+      }
+      userAgentAction += `${category}:u `;
+    });
+    // userAgentAction = `create ${Array.from(uniqueCategoriesAdded).join(' ')}`;
   }
 
   const jsonString = JSON.stringify(nestedStack, null, '\t');
   context.filesystem.write(nestedStackFilepath, jsonString);
-
 
   return new Cloudformation(context, undefined, userAgentAction)
     .then(cfnItem => cfnItem.updateResourceStack(
@@ -194,7 +215,7 @@ function getAllUniqueCategories(resources) {
 
   resources.forEach(resource => categories.add(resource.category));
 
-  return categories;
+  return [...categories];
 }
 
 function updateS3Templates(context, resourcesToBeUpdated, amplifyMeta) {

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -187,7 +187,6 @@ function updateCloudFormationNestedStack(
 
       userAgentAction += `${category}:c `;
     });
-    // userAgentAction = `create ${Array.from(uniqueCategoriesAdded).join(' ')}`;
   }
 
   if (uniqueCategoriesUpdated.length > 0) {
@@ -197,7 +196,6 @@ function updateCloudFormationNestedStack(
       }
       userAgentAction += `${category}:u `;
     });
-    // userAgentAction = `create ${Array.from(uniqueCategoriesAdded).join(' ')}`;
   }
 
   const jsonString = JSON.stringify(nestedStack, null, '\t');


### PR DESCRIPTION
Include update calls in the user agent metrics"
New format example:

'fu:c au:u ap:c '

In the above string, a new function is created,  an auth resource is updated and an API category is created as well/ Using the first two chars of the category as the category identifier.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.