### PR TITLE
feat(amplify-category-hosting):Change prod hosting to use private S3 bucket

### DIFF
--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -17,6 +17,8 @@ const originErrorCodes = {
 };
 
 async function configure(context) {
+  const templateFilePath = path.join(__dirname, '../template.json');
+  const originalTemplate = JSON.parse(fs.readFileSync(templateFilePath));
   if (!context.exeInfo.template.Resources.CloudFrontDistribution) {
     context.print.info('CloudFront is NOT in the current hosting');
     const answer = await inquirer.prompt({
@@ -26,14 +28,16 @@ async function configure(context) {
       default: false,
     });
     if (answer.AddCloudFront) {
-      const templateFilePath = path.join(__dirname, '../template.json');
-      const originalTemplate = JSON.parse(fs.readFileSync(templateFilePath));
-      const { CloudFrontDistribution } = originalTemplate.Resources;
+      const { CloudFrontDistribution, OriginAccessIdentity, PrivateBucketPolicy } = originalTemplate.Resources;
       const { Outputs } = originalTemplate;
+      context.exeInfo.template.Resources.OriginAccessIdentity = OriginAccessIdentity;
       context.exeInfo.template.Resources.CloudFrontDistribution = CloudFrontDistribution;
+      context.exeInfo.template.Resources.PrivateBucketPolicy = PrivateBucketPolicy;
       context.exeInfo.template.Outputs.CloudFrontDistributionID = Outputs.CloudFrontDistributionID;
       context.exeInfo.template.Outputs.CloudFrontDomainName = Outputs.CloudFrontDomainName;
       context.exeInfo.template.Outputs.CloudFrontSecureURL = Outputs.CloudFrontSecureURL;
+      delete context.exeInfo.template.Resources.BucketPolicy;
+      delete context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl;
     }
   } else {
     const answer = await inquirer.prompt({
@@ -43,10 +47,15 @@ async function configure(context) {
       default: false,
     });
     if (answer.RemoveCloudFront) {
+      const { BucketPolicy, S3Bucket } = originalTemplate.Resources;
+      delete context.exeInfo.template.Resources.OriginAccessIdentity;
       delete context.exeInfo.template.Resources.CloudFrontDistribution;
+      delete context.exeInfo.template.Resources.PrivateBucketPolicy;
       delete context.exeInfo.template.Outputs.CloudFrontDistributionID;
       delete context.exeInfo.template.Outputs.CloudFrontDomainName;
       delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
+      context.exeInfo.template.Resources.BucketPolicy = BucketPolicy;
+      context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl = S3Bucket.Properties.AccessControl;
     }
   }
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -28,9 +28,11 @@ async function configure(context) {
       default: false,
     });
     if (answer.AddCloudFront) {
-      const { CloudFrontDistribution, 
-              OriginAccessIdentity, 
-              PrivateBucketPolicy } = originalTemplate.Resources;
+      const {
+        CloudFrontDistribution,
+        OriginAccessIdentity,
+        PrivateBucketPolicy,
+      } = originalTemplate.Resources;
       const { Outputs } = originalTemplate;
       context.exeInfo.template.Resources.OriginAccessIdentity = OriginAccessIdentity;
       context.exeInfo.template.Resources.CloudFrontDistribution = CloudFrontDistribution;

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -28,7 +28,9 @@ async function configure(context) {
       default: false,
     });
     if (answer.AddCloudFront) {
-      const { CloudFrontDistribution, OriginAccessIdentity, PrivateBucketPolicy } = originalTemplate.Resources;
+      const { CloudFrontDistribution, 
+              OriginAccessIdentity, 
+              PrivateBucketPolicy } = originalTemplate.Resources;
       const { Outputs } = originalTemplate;
       context.exeInfo.template.Resources.OriginAccessIdentity = OriginAccessIdentity;
       context.exeInfo.template.Resources.CloudFrontDistribution = CloudFrontDistribution;
@@ -55,7 +57,8 @@ async function configure(context) {
       delete context.exeInfo.template.Outputs.CloudFrontDomainName;
       delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
       context.exeInfo.template.Resources.BucketPolicy = BucketPolicy;
-      context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl = S3Bucket.Properties.AccessControl;
+      const { AccessControl } = S3Bucket.Properties;
+      context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl = AccessControl;
     }
   }
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -64,14 +64,23 @@ async function checkCDN(context) {
   const answer = await inquirer.prompt(selectEnvironment);
   if (answer.environment === DEV) {
     removeCDN(context);
+  } else {
+    makeBucketPrivate(context);
   }
 }
 
 function removeCDN(context) {
+  delete context.exeInfo.template.Resources.OriginAccessIdentity;
   delete context.exeInfo.template.Resources.CloudFrontDistribution;
+  delete context.exeInfo.template.Resources.PrivateBucketPolicy;
   delete context.exeInfo.template.Outputs.CloudFrontDistributionID;
   delete context.exeInfo.template.Outputs.CloudFrontDomainName;
   delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
+}
+
+function makeBucketPrivate(context) {
+  delete context.exeInfo.template.Resources.BucketPolicy;
+  delete context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl;
 }
 
 async function configure(context) {
@@ -98,10 +107,16 @@ function publish(context, args) {
       return cloudFrontManager.invalidateCloudFront(context);
     })
     .then(() => {
-      const { WebsiteURL } = context.exeInfo.serviceMeta.output;
-      context.print.info('Your app is published successfully.');
-      context.print.info(chalk.green(WebsiteURL));
-      opn(WebsiteURL, { wait: false });
+      const { CloudFrontSecureURL } = context.exeInfo.serviceMeta.output;
+      if ( CloudFrontSecureURL != undefined ) {
+        context.print.info('Your app is published successfully.');
+        context.print.info(chalk.green(CloudFrontSecureURL));        
+      } else {
+        const { WebsiteURL } = context.exeInfo.serviceMeta.output;
+        context.print.info('Your app is published successfully.');
+        context.print.info(chalk.green(WebsiteURL));
+        opn(WebsiteURL, { wait: false });
+      }
     })
     .catch((e) => {
       spinner.fail('Error has occured during publish.');

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -108,9 +108,9 @@ function publish(context, args) {
     })
     .then(() => {
       const { CloudFrontSecureURL } = context.exeInfo.serviceMeta.output;
-      if ( CloudFrontSecureURL != undefined ) {
+      if (CloudFrontSecureURL !== undefined) {
         context.print.info('Your app is published successfully.');
-        context.print.info(chalk.green(CloudFrontSecureURL));        
+        context.print.info(chalk.green(CloudFrontSecureURL));
       } else {
         const { WebsiteURL } = context.exeInfo.serviceMeta.output;
         context.print.info('Your app is published successfully.');

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
@@ -52,9 +52,58 @@
                 }
             }
         },
+        "PrivateBucketPolicy": {
+            "Type": "AWS::S3::BucketPolicy",
+            "DependsOn": "OriginAccessIdentity",
+            "Properties": {
+                "PolicyDocument": {
+                    "Id": "MyPolicy",
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "APIReadForGetBucketObjects",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "CanonicalUser": {
+                                    "Fn::GetAtt": [
+                                        "OriginAccessIdentity",
+                                        "S3CanonicalUserId"
+                                    ]
+                                }
+                            },
+                            "Action": "s3:GetObject",
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:aws:s3:::",
+                                        {"Ref": "S3Bucket"},
+                                        "/*"
+                                    ]
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "Bucket": {
+                    "Ref": "S3Bucket"
+                }
+            }
+        },
+        "OriginAccessIdentity": {
+            "Type" : "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+            "Properties" : {
+                "CloudFrontOriginAccessIdentityConfig" : {
+                    "Comment": "CloudFrontOriginAccessIdentityConfig"
+                }
+            }
+        },
         "CloudFrontDistribution" : {
             "Type" : "AWS::CloudFront::Distribution",
-            "DependsOn" : "S3Bucket",
+            "DependsOn" : [
+                "S3Bucket",
+                "OriginAccessIdentity"
+            ],
             "Properties" : {
                 "DistributionConfig" : {
                     "Origins" : [ 
@@ -62,7 +111,18 @@
                             "DomainName" :  {"Fn::GetAtt": ["S3Bucket", "DomainName"]},
                             "Id" : "hostingS3Bucket",
                             "S3OriginConfig" : {
-                            }
+                                "OriginAccessIdentity": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "origin-access-identity/cloudfront/",
+                                            {
+                                                "Ref": "OriginAccessIdentity"
+                                            }
+                                        ]
+                                    ]
+                                }
+                           }
                         }
                     ],
                     "Enabled" : "true",


### PR DESCRIPTION
*Description of changes:*
This change makes the S3 bucket private when CloudFront is enabled for hosting. This allows Amplify to be used in environments where security policies do not allow public buckets to be created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.