### PR TITLE
fix(amplify-graphql-docs-generator): Support scalar returns in statements

### DIFF
--- a/packages/amplify-graphql-docs-generator/templates/_renderOp.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderOp.hbs
@@ -1,6 +1,8 @@
 {{type}} {{name}} {{>renderArgDeclaration args=args}}{
-    {{body.name}}{{> renderCallArgs args=body.args}} {
+    {{body.name}}{{> renderCallArgs args=body.args}} 
+    {{#if body.hasBody}} {
       {{> renderFields fields=body.fields}}
       {{> renderFragment fragments=body.fragments}}
-    }      
+    }
+    {{/if}}
 }


### PR DESCRIPTION
Fixes #264

Statement generator generated invalid graphql statements when an operation had scalar type as return by adding an empty body around the statement. Updated code to conditionally add body.

If the graphql schema had an mutation
```graphql 
deletePodcast(input: DeletePodcastInput!): String
```
the statement generator used to generate
```graphql
mutation DeletePodcast($input: DeletePodcastInput!) {
  deletePodcast(input: $input) {
  }
}
``` 
which is not valid graphql. With this update the generated statement looks like
```graphql
mutation DeletePodcast($input: DeletePodcastInput!) {
  deletePodcast(input: $input)
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.