### PR TITLE
fix: Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
             command: |
               git clone $API_CLONE_URL
               cd aws-amplify-cypress-api
-              npm
+              npm install
         - run: cd .circleci/ && chmod +x api.sh
         - run: expect .circleci/enable_api.exp
         - run: cd aws-amplify-cypress-api


### PR DESCRIPTION
Circle CI configuration was changed to use npm instead of yarn to package publishing. While changing one of the npm command was not converted to use `install` and this is failing integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.