### PR TITLE
fix: integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@ jobs:
             command: |
               git clone $AUTH_CLONE_URL
               cd aws-amplify-cypress-auth
-              npm
+              npm install
         - run: cd .circleci/ && chmod +x auth.sh
         - run: expect .circleci/enable_auth.exp
         - run: cd aws-amplify-cypress-auth
-        - run: npm
+        - run: npm install
         - run: cd aws-amplify-cypress-auth/src && cat $(find . -type f -name 'aws-exports*')
         - run:
             name: "Start Auth test server in background"
@@ -96,7 +96,7 @@ jobs:
         - run: cd .circleci/ && chmod +x api.sh
         - run: expect .circleci/enable_api.exp
         - run: cd aws-amplify-cypress-api
-        - run: npm
+        - run: npm install
         - run: cd aws-amplify-cypress-api/src && cat $(find . -type f -name 'aws-exports*')
         - run:
             name: "Start API test server in background"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
             command: |
               git clone $API_CLONE_URL
               cd aws-amplify-cypress-api
-              npm
+              npm install
         - run: cd .circleci/ && chmod +x api.sh
         - run: expect .circleci/enable_api.exp
         - run: cd aws-amplify-cypress-api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ workflows:
           requires:
             - build
             - test
+            - integration_test
           filters:
             branches:
               only:


### PR DESCRIPTION
After moving to npm missed to add `install` in some integration test commands

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.