### PR TITLE
Fixing #183

### DIFF
--- a/packages/graphql-auth-transformer/src/AuthRule.ts
+++ b/packages/graphql-auth-transformer/src/AuthRule.ts
@@ -1,0 +1,11 @@
+export type ModelQuery = 'get' | 'list'
+export type ModelMutation = 'create' | 'update' | 'delete'
+export interface AuthRule {
+    allow: 'owner' | 'groups';
+    ownerField: string;
+    identityField: string;
+    groupsField: string;
+    groups: string[];
+    queries: ModelQuery[]
+    mutations: ModelMutation[]
+}

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -332,7 +332,7 @@ export class ModelAuthTransformer extends Transformer {
                 if (rule.groups) {
                     const authSnippet = this.resources.staticGroupAuthorizationResponseMappingTemplate(rule.groups)
                     beforeRequest.push(authSnippet)
-                    beforeRequest.push(this.resources.disableAuthConditionWhenStaticGroupAuthorized())
+                    beforeRequest.push(this.resources.handleStaticGroupAuthorizationCheck())
                 } else if (rule.groupsField) {
                     const authSnippet = this.resources.dynamicGroupUpdateAndDeleteResolverRequestMappingTemplateSnippet(rule.groupsField)
                     beforeRequest.push(authSnippet)

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -3,6 +3,7 @@ import GraphQLAPI from 'cloudform/types/appSync/graphQlApi'
 import { ResourceFactory } from './resources'
 import { ObjectTypeDefinitionNode, DirectiveNode, ArgumentNode } from 'graphql'
 import { ResourceConstants, ResolverResourceIDs } from 'graphql-transformer-common'
+import { Expression } from 'graphql-mapping-template';
 import { valueFromASTUntyped } from 'graphql'
 
 const OWNER_AUTH_STRATEGY = "owner"
@@ -229,7 +230,7 @@ export class ModelAuthTransformer extends Transformer {
         if (!rules || rules.length === 0 || !resolver) {
             return
         }
-        const beforeExpressions = []
+        const beforeExpressions: Expression[] = [this.resources.setUserGroups()]
         const itemEquivalenceExpressions = []
         const beforeItemEquivalenceExpression = []
         for (const rule of rules) {
@@ -320,7 +321,7 @@ export class ModelAuthTransformer extends Transformer {
         if (!rules || rules.length === 0 || !resolver) {
             return
         }
-        const beforeRequest = []
+        const beforeRequest: string[] = [this.resources.setUserGroupsString()]
         for (const rule of rules) {
             if (rule.allow === OWNER_AUTH_STRATEGY) {
                 const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -332,7 +332,7 @@ export class ModelAuthTransformer extends Transformer {
                 if (rule.groups) {
                     const authSnippet = this.resources.staticGroupAuthorizationResponseMappingTemplate(rule.groups)
                     beforeRequest.push(authSnippet)
-                    beforeRequest.push(this.resources.throwWhenUnauthorized())
+                    beforeRequest.push(this.resources.disableAuthConditionWhenStaticGroupAuthorized())
                 } else if (rule.groupsField) {
                     const authSnippet = this.resources.dynamicGroupUpdateAndDeleteResolverRequestMappingTemplateSnippet(rule.groupsField)
                     beforeRequest.push(authSnippet)

--- a/packages/graphql-auth-transformer/src/constants.ts
+++ b/packages/graphql-auth-transformer/src/constants.ts
@@ -1,0 +1,5 @@
+export const OWNER_AUTH_STRATEGY = "owner"
+export const DEFAULT_OWNER_FIELD = "owner"
+export const DEFAULT_IDENTITY_FIELD = "username"
+export const GROUPS_AUTH_STRATEGY = "groups"
+export const DEFAULT_GROUPS_FIELD = "groups"

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -576,7 +576,7 @@ export class ResourceFactory {
             not(parens(
                 or([
                     equals(ref(ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable), raw('true')),
-                    raw('$authCondition && $authCondition.expression != ""')
+                    parens(raw('$authCondition && $authCondition.expression != ""'))
                 ])
             )), raw('$util.unauthorized()')
         )

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -270,8 +270,14 @@ export class ResourceFactory {
     public ownerCreateResolverRequestMappingTemplateSnippet = (
         ownerAttribute: string, identityField: string) => printBlock('Inject Ownership Information')(
             compoundExpression([
-                iff(raw(`$util.isNullOrBlank($ctx.identity.${identityField})`), raw('$util.unauthorized()')),
-                qref(`$ctx.args.input.put("${ownerAttribute}", $ctx.identity.${identityField})`)
+                iff(
+                    raw(`$util.isNullOrBlank($ctx.identity.${identityField})`),
+                    raw('$util.unauthorized()')
+                ),
+                compoundExpression([
+                    qref(`$ctx.args.input.put("${ownerAttribute}", $ctx.identity.${identityField})`),
+                    raw('#set($isAuthorized = true)')
+                ])
             ])
         )
 

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -413,7 +413,7 @@ export class ResourceFactory {
                     ref(ResourceConstants.SNIPPETS.AuthCondition),
                     obj({
                         expression: ref('groupAuthExpression'),
-                        expressionNames: obj({ groupsAttribute: str(groupsAttribute) }),
+                        expressionNames: obj({ '#groupsAttribute': str(groupsAttribute) }),
                         expressionValues: ref('groupAuthExpressionValues')
                     })
                 ),
@@ -422,7 +422,7 @@ export class ResourceFactory {
                         ref(`${ResourceConstants.SNIPPETS.AuthCondition}.expression`),
                         str(`$${ResourceConstants.SNIPPETS.AuthCondition}.expression AND ($groupAuthExpression)`)
                     ),
-                    raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionNames.put("groupsAttribute", "${groupsAttribute}"))`),
+                    raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionNames.put("#groupsAttribute", "${groupsAttribute}"))`),
                     raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionValues.putAll($groupAuthExpressionValues))`),
                 ])
             )

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -361,7 +361,6 @@ export class ResourceFactory {
             ruleNumber++
         }
         return block('Owner Authorization Checks', [
-            this.setUserGroups(),
             set(ref(variableToSet), raw(`false`)),
             ...groupAuthorizationExpressions,
         ])
@@ -453,7 +452,6 @@ export class ResourceFactory {
             ruleNumber++
         }
         return block('Owner Authorization Checks', [
-            this.setUserGroups(),
             set(ref('ownerAuthExpressions'), list([])),
             set(ref('ownerAuthExpressionValues'), obj({})),
             set(ref('ownerAuthExpressionNames'), obj({})),

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -446,7 +446,7 @@ export class ResourceFactory {
      * If the user is not authorized by the group and there is no auth condition
      * then fail.
      */
-    public disableAuthConditionWhenStaticGroupAuthorized(): string {
+    public handleStaticGroupAuthorizationCheck(): string {
         return printBlock("If authorized via a group then disable any authorization condition expressions.")(
             compoundExpression([
                 iff(

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -8,7 +8,7 @@ import {
     DynamoDBMappingTemplate, ElasticSearchMappingTemplate,
     print, str, ref, obj, set, iff, ifElse, list, raw, printBlock,
     forEach, compoundExpression, qref, toJson, equals, comment,
-    IfNode, or, Expression
+    IfNode, or, Expression, SetNode
 } from 'graphql-mapping-template'
 import { ResourceConstants } from 'graphql-transformer-common'
 
@@ -254,6 +254,14 @@ export class ResourceFactory {
         ])
     }
 
+    public setUserGroups(): SetNode {
+        return set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")'));
+    }
+
+    public setUserGroupsString(): string {
+        return print(set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")')));
+    }
+
 
     /**
      * Owner auth
@@ -412,7 +420,7 @@ export class ResourceFactory {
                 compoundExpression([
                     set(
                         ref(`${ResourceConstants.SNIPPETS.AuthCondition}.expression`),
-                        raw(`$${ResourceConstants.SNIPPETS.AuthCondition}.expression AND ($groupAuthExpression)`)
+                        str(`$${ResourceConstants.SNIPPETS.AuthCondition}.expression AND ($groupAuthExpression)`)
                     ),
                     raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionNames.put("groupsAttribute", "${groupsAttribute}"))`),
                     raw(`$util.qr($${ResourceConstants.SNIPPETS.AuthCondition}.expressionValues.putAll($groupAuthExpressionValues))`),

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -4,13 +4,24 @@ import Output from 'cloudform/types/output'
 import GraphQLAPI, { UserPoolConfig } from 'cloudform/types/appSync/graphQlApi'
 import Resolver from 'cloudform/types/appSync/resolver'
 import { Fn, StringParameter, Refs, NumberParameter, Condition } from 'cloudform'
+import { AuthRule } from './AuthRule'
 import {
     DynamoDBMappingTemplate, ElasticSearchMappingTemplate,
     print, str, ref, obj, set, iff, ifElse, list, raw, printBlock,
     forEach, compoundExpression, qref, toJson, equals, comment,
-    IfNode, or, Expression, SetNode
+    IfNode, or, Expression, SetNode, and, not, parens
 } from 'graphql-mapping-template'
 import { ResourceConstants } from 'graphql-transformer-common'
+
+import {
+    OWNER_AUTH_STRATEGY,
+    DEFAULT_OWNER_FIELD,
+    DEFAULT_IDENTITY_FIELD,
+    GROUPS_AUTH_STRATEGY,
+    DEFAULT_GROUPS_FIELD
+} from './constants'
+
+const NONE_VALUE = '___xamznone____'
 
 export class ResourceFactory {
 
@@ -192,18 +203,22 @@ export class ResourceFactory {
             compoundExpression([
                 set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")')),
                 set(ref('allowedGroups'), ref(`ctx.result.${groupsAttribute}`)),
-                raw('#set($isAuthorized = $util.defaultIfNull($isAuthorized, false))'),
+                set(ref(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('false')),
                 forEach(ref('userGroup'), ref('userGroups'), [
                     iff(
                         raw('$util.isList($allowedGroups)'),
-                        iff(raw(`$allowedGroups.contains($userGroup)`), set(ref('isAuthorized'), raw('true'))),
+                        iff(
+                            raw(`$allowedGroups.contains($userGroup)`),
+                            set(ref(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('true'))),
                     ),
                     iff(
                         raw(`$util.isString($allowedGroups)`),
-                        iff(raw(`$allowedGroups == $userGroup`), set(ref('isAuthorized'), raw('true'))),
+                        iff(
+                            raw(`$allowedGroups == $userGroup`),
+                            set(ref(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('true'))),
                     )
                 ]),
-                iff(raw('!$isAuthorized'), raw('$util.unauthorized()')),
+                iff(raw(`!$${ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable}`), raw('$util.unauthorized()')),
             ])
         )
     }
@@ -214,19 +229,21 @@ export class ResourceFactory {
                 set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")')),
                 set(ref('items'), list([])),
                 forEach(ref('item'), ref('ctx.result.items'), [
-                    raw('#set($isAuthorized = $util.defaultIfNull($isAuthorized, false))'),
+                    // tslint:disable
+                    set(ref(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('false')),
                     set(ref('allowedGroups'), ref(`item.${groupsAttribute}`)),
                     forEach(ref('userGroup'), ref('userGroups'), [
                         iff(
                             raw('$util.isList($allowedGroups)'),
-                            iff(raw(`$allowedGroups.contains($userGroup)`), set(ref('isAuthorized'), raw('true'))),
+                            iff(raw(`$allowedGroups.contains($userGroup)`), set(ref(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('true'))),
                         ),
                         iff(
                             raw(`$util.isString($allowedGroups)`),
-                            iff(raw(`$allowedGroups == $userGroup`), set(ref('isAuthorized'), raw('true'))),
+                            iff(raw(`$allowedGroups == $userGroup`), set(ref(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('true'))),
                         )
                     ]),
-                    iff(raw('$isAuthorized'), raw('$util.qr($items.add($item))')),
+                    iff(raw(ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable), raw('$util.qr($items.add($item))')),
+                    // tslint:enable
                 ])
             ])
         )
@@ -237,18 +254,32 @@ export class ResourceFactory {
             this.dynamicGroupListBeforeItemEquivalenceExpressionAST(groupsAttribute)
         )
     }
-    public dynamicGroupListBeforeItemEquivalenceExpressionAST(groupsAttribute: string) {
+
+    /**
+     * Returns an expression that looks as a single $item and determines if the
+     * logged in user is dynamic group authorized to access that item. If the
+     * user is authorized, set ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable
+     * to true.
+     * @param groupsAttribute The name of the groupsAttribute.
+     */
+    public dynamicGroupListBeforeItemEquivalenceExpressionAST(
+        groupsAttribute: string, itemName: string = 'item', variableName: string = ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable
+    ) {
         return compoundExpression([
-            set(ref('isAuthorizedLocal'), raw('false')),
-            set(ref('allowedGroups'), ref(`item.${groupsAttribute}`)),
+            set(ref(variableName), raw('false')),
+            set(ref('allowedGroups'), ref(`${itemName}.${groupsAttribute}`)),
             forEach(ref('userGroup'), ref('userGroups'), [
                 iff(
                     raw('$util.isList($allowedGroups)'),
-                    iff(raw(`$allowedGroups.contains($userGroup)`), set(ref('isAuthorizedLocal'), raw('true'))),
+                    iff(
+                        raw(`$allowedGroups.contains($userGroup)`),
+                        set(ref(variableName), raw('true'))),
                 ),
                 iff(
                     raw(`$util.isString($allowedGroups)`),
-                    iff(raw(`$allowedGroups == $userGroup`), set(ref('isAuthorizedLocal'), raw('true'))),
+                    iff(
+                        raw(`$allowedGroups == $userGroup`),
+                        set(ref(variableName), raw('true'))),
                 )
             ]),
         ])
@@ -276,7 +307,7 @@ export class ResourceFactory {
                 ),
                 compoundExpression([
                     qref(`$ctx.args.input.put("${ownerAttribute}", $ctx.identity.${identityField})`),
-                    raw('#set($isAuthorized = true)')
+                    set(ref(ResourceConstants.SNIPPETS.IsOwnerAuthorizedVariable), raw('true'))
                 ])
             ])
         )
@@ -316,7 +347,7 @@ export class ResourceFactory {
     public ownerGetResolverResponseMappingTemplateSnippet = (ownerAttribute: string, identityField: string) => printBlock('Validate Ownership')(
         iff(
             equals(ref(`ctx.result.${ownerAttribute}`), ref(`ctx.identity.${identityField}`)),
-            raw('#set($isAuthorized = true)'))
+            raw(`#set($${ResourceConstants.SNIPPETS.IsOwnerAuthorizedVariable} = true)`))
     )
 
     public ownerListResolverResponseMappingTemplateSnippet = (ownerAttribute: string, identityField: string) => printBlock("Filter Owned Items")(
@@ -370,12 +401,13 @@ export class ResourceFactory {
     public staticGroupAuthorizationResponseMappingTemplateAST = (groups: string[]) => compoundExpression([
         set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")')),
         set(ref('allowedGroups'), list(groups.map(s => str(s)))),
-        raw('#set($isAuthorized = $util.defaultIfNull($isAuthorized, false))'),
+        // tslint:disable-next-line
+        raw(`#set($${ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable} = $util.defaultIfNull($${ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable}, false))`),
         forEach(ref('userGroup'), ref('userGroups'), [
             forEach(ref('allowedGroup'), ref('allowedGroups'), [
                 iff(
                     raw('$allowedGroup == $userGroup'),
-                    set(ref('isAuthorized'), raw('true'))
+                    set(ref(ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable), raw('true'))
                 )
             ])
         ])
@@ -388,17 +420,25 @@ export class ResourceFactory {
         compoundExpression([
             set(ref("userGroups"), ref('ctx.identity.claims.get("cognito:groups")')),
             iff(raw('!$userGroups'), raw('$util.unauthorized()')),
-            raw('#set($isAuthorized = $util.defaultIfNull($isAuthorized, false))'),
+            // tslint:disable
+            raw(`#set($${ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable} = $util.defaultIfNull($${ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable}, false))`),
             forEach(ref('userGroup'), ref('userGroups'), [
                 iff(
                     raw(`$util.isList($ctx.args.input.${groupsAttribute})`),
-                    iff(raw(`$ctx.args.input.${groupsAttribute}.contains($userGroup)`), set(ref('isAuthorized'), raw('true'))),
+                    iff(
+                        raw(`$ctx.args.input.${groupsAttribute}.contains($userGroup)`),
+                        set(ref(ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable), raw('true'))
+                    ),
                 ),
                 iff(
                     raw(`$util.isString($ctx.args.input.${groupsAttribute})`),
-                    iff(raw(`$ctx.args.input.${groupsAttribute} == $userGroup`), set(ref('isAuthorized'), raw('true'))),
+                    iff(
+                        raw(`$ctx.args.input.${groupsAttribute} == $userGroup`),
+                        set(ref(ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable), raw('true'))
+                    ),
                 )
             ])
+            // tslint:enable
         ])
     )
 
@@ -470,5 +510,145 @@ export class ResourceFactory {
 
     public isAuthorizedLocallyOrGlobally(): Expression {
         return raw('$isAuthorized == true or $isAuthorizedLocal == true')
+    }
+
+    /**
+     * Builds a VTL expression that will set the
+     * ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable variable to
+     * true if the user is static group authorized.
+     * @param rules The list of static group authorization rules.
+     */
+    public staticGroupAuthorizationExpression(rules: AuthRule[]): Expression {
+        if (!rules || rules.length === 0) {
+            return comment(`No Static Group Authorization Rules`)
+        }
+        const allowedGroups: string[] = []
+        for (const rule of rules) {
+            const groups = rule.groups;
+            for (const group of groups) {
+                if (group) {
+                    allowedGroups.push(group);
+                }
+            }
+        }
+        // TODO: Enhance cognito:groups to work with non cognito based auth.
+        return compoundExpression([
+            comment(`[Start] Static Group Authorization Checks`),
+            set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")')),
+            set(ref('allowedGroups'), list(allowedGroups.map(s => str(s)))),
+            // tslint:disable-next-line
+            raw(`#set($${ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable} = $util.defaultIfNull($${ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable}, false))`),
+            forEach(ref('userGroup'), ref('userGroups'), [
+                forEach(ref('allowedGroup'), ref('allowedGroups'), [
+                    iff(
+                        raw('$allowedGroup == $userGroup'),
+                        set(ref(ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable), raw('true'))
+                    )
+                ])
+            ]),
+            comment(`[End] Static Group Authorization Checks`),
+        ])
+    }
+
+    /**
+     * Given a list of rules return a VTL expression that checks if the given variableToCheck
+     * statisies at least one of the auth rules.
+     * @param rules The list of dynamic group authorization rules.
+     */
+    public dynamicGroupAuthorizationExpressionForReadOperations(rules: AuthRule[], variableToCheck: string = 'ctx.result'): Expression {
+        if (!rules || rules.length === 0) {
+            return comment(`No Dynamic Group Authorization Rules`)
+        }
+        let groupAuthorizationExpressions = [];
+        const variableToSet: string = ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable
+        for (const rule of rules) {
+            const groupsAttribute = rule.groupsField || DEFAULT_GROUPS_FIELD
+            groupAuthorizationExpressions = groupAuthorizationExpressions.concat(
+                comment(`Authorization rule: { allow: "${rule.allow}", groupsField: "${groupsAttribute}" }`),
+                set(ref('allowedGroups'), ref(`${variableToCheck}.${groupsAttribute}`)),
+                forEach(ref('userGroup'), ref('userGroups'), [
+                    iff(
+                        raw('$util.isList($allowedGroups)'),
+                        iff(
+                            raw(`$allowedGroups.contains($userGroup)`),
+                            set(ref(variableToSet), raw('true'))),
+                    ),
+                    iff(
+                        raw(`$util.isString($allowedGroups)`),
+                        iff(
+                            raw(`$allowedGroups == $userGroup`),
+                            set(ref(variableToSet), raw('true'))),
+                    )
+                ])
+            )
+        }
+        return compoundExpression([
+            comment(`[Start] Dynamic Group Authorization Checks`),
+            set(ref(variableToSet), raw(`$util.defaultIfNull($${variableToSet}, false)`)),
+            ...groupAuthorizationExpressions,
+            comment(`[End] Dynamic Group Authorization Checks`),
+        ])
+    }
+
+    /**
+     * Given a list of rules return a VTL expression that checks if the given variableToCheck
+     * statisies at least one of the auth rules.
+     * @param rules The list of dynamic group authorization rules.
+     */
+    public ownerAuthorizationExpressionForReadOperations(rules: AuthRule[], variableToCheck: string = 'ctx.result'): Expression {
+        if (!rules || rules.length === 0) {
+            return comment(`No Owner Authorization Rules`)
+        }
+        let ownerAuthorizationExpressions = [];
+        const variableToSet: string = ResourceConstants.SNIPPETS.IsOwnerAuthorizedVariable
+        for (const rule of rules) {
+            const ownerAttribute = rule.ownerField || DEFAULT_OWNER_FIELD
+            const identityAttribute = rule.identityField || DEFAULT_IDENTITY_FIELD
+            ownerAuthorizationExpressions = ownerAuthorizationExpressions.concat(
+                comment(`Authorization rule: { allow: "${rule.allow}", ownerField: "${ownerAttribute}", identityField: "${identityAttribute}" }`),
+                set(ref('allowedOwners'), ref(`${variableToCheck}.${ownerAttribute}`)),
+                set(ref('identityValue'), raw(`$util.defaultIfNull($ctx.identity.${identityAttribute}, "${NONE_VALUE}")`)),
+                iff(
+                    raw('$util.isList($allowedOwners)'),
+                    forEach(ref('allowedOwner'), ref('allowedOwners'), [
+                        iff(
+                            raw(`$allowedOwner == $identityValue`),
+                            set(ref(variableToSet), raw('true'))),
+                    ])
+                ),
+                iff(
+                    raw(`$util.isString($allowedOwners)`),
+                    iff(
+                        raw(`$allowedOwners == $identityValue`),
+                        set(ref(variableToSet), raw('true'))),
+                )
+            )
+        }
+        return compoundExpression([
+            comment(`[Start] Owner Authorization Checks`),
+            set(ref(variableToSet), raw(`$util.defaultIfNull($${variableToSet}, false)`)),
+            ...ownerAuthorizationExpressions,
+            comment(`[End] Owner Authorization Checks`),
+        ])
+    }
+
+    /**
+     * Set the IsNotAuthProtectedVariable to true for the final auth check.
+     */
+    public isNotAuthProtectedSnippet(): Expression {
+        return set(ref(ResourceConstants.SNIPPETS.IsNotAuthProtectedVariable), raw('true'));
+    }
+
+    public throwIfUnauthorizedForReadOperations(): Expression {
+        return iff(
+            not(parens(
+                or([
+                    equals(ref(ResourceConstants.SNIPPETS.IsNotAuthProtectedVariable), raw('true')),
+                    equals(ref(ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable), raw('true')),
+                    equals(ref(ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable), raw('true')),
+                    equals(ref(ResourceConstants.SNIPPETS.IsOwnerAuthorizedVariable), raw('true'))
+                ])
+            )), raw('$util.unauthorized()')
+        )
     }
 }

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -251,7 +251,7 @@ export class ResourceFactory {
             RequestMappingTemplate: print(
                 compoundExpression([
                     ifElse(
-                        ref(ResourceConstants.SNIPPETS.AuthCondition),
+                        raw(`$${ResourceConstants.SNIPPETS.AuthCondition} && $${ResourceConstants.SNIPPETS.AuthCondition}.expression != ""`),
                         compoundExpression([
                             set(ref('condition'), ref(ResourceConstants.SNIPPETS.AuthCondition)),
                             qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),

--- a/packages/graphql-mapping-template/src/ast.ts
+++ b/packages/graphql-mapping-template/src/ast.ts
@@ -351,6 +351,23 @@ export function toJson(expr: Expression): ToJsonNode {
     }
 }
 
+export type NewLineNode = {
+    kind: 'NewLine'
+}
+export function newline(): NewLineNode {
+    return {
+        kind: 'NewLine',
+    }
+}
+
+export function block(name: string, exprs: Expression[]): CompoundExpressionNode {
+    return compoundExpression([
+        comment(`[Start] ${name}`),
+        ...exprs,
+        comment(`[End] ${name}`)
+    ])
+}
+
 /**
  * A flow expression is one that dictates program flow e.g. if, ifelse, for, while, etc.
  */
@@ -378,4 +395,5 @@ export type Expression =
     | CommentNode
     | CompoundExpressionNode
     | ToJsonNode
-    | NotNode;
+    | NotNode
+    | NewLineNode;

--- a/packages/graphql-mapping-template/src/ast.ts
+++ b/packages/graphql-mapping-template/src/ast.ts
@@ -111,6 +111,20 @@ export function notEquals(leftExpr: Expression, rightExpr: Expression): NotEqual
 }
 
 /**
+ * Compares two expressions for unequality.
+ */
+export interface NotNode {
+    kind: 'Not';
+    expr: Expression;
+}
+export function not(expr: Expression): NotNode {
+    return {
+        kind: 'Not',
+        expr,
+    }
+}
+
+/**
  * Iterates through a collection.
  */
 export interface ForEachNode {
@@ -363,4 +377,5 @@ export type Expression =
     | SetNode
     | CommentNode
     | CompoundExpressionNode
-    | ToJsonNode;
+    | ToJsonNode
+    | NotNode;

--- a/packages/graphql-mapping-template/src/print.ts
+++ b/packages/graphql-mapping-template/src/print.ts
@@ -3,7 +3,7 @@ import {
     ParensNode, EqualsNode, NotEqualsNode, ForEachNode,
     StringNode, IntNode, NullNode, ReferenceNode, QuietReferenceNode,
     ObjectNode, ListNode, FloatNode, QuotesNode, RawNode, SetNode, CompoundExpressionNode,
-    CommentNode, ToJsonNode, BooleanNode, compoundExpression, comment
+    CommentNode, ToJsonNode, BooleanNode, compoundExpression, comment, NotNode
 } from './ast';
 
 const TAB = '  ';
@@ -121,6 +121,10 @@ function printToJson(node: ToJsonNode, indent: string = ''): string {
     return `${indent}$util.toJson(${printExpr(node.expr, '')})`
 }
 
+function printNot(node: NotNode, indent: string = ''): string {
+    return `${indent}!${printExpr(node.expr)}`
+}
+
 function printExpr(expr: Expression, indent: string = ''): string {
     if (!expr) { return ''; }
     switch (expr.kind) {
@@ -170,6 +174,8 @@ function printExpr(expr: Expression, indent: string = ''): string {
             return printCompoundExpression(expr, indent)
         case 'Util.ToJson':
             return printToJson(expr, indent)
+        case 'Not':
+            return printNot(expr, indent)
         default:
             return '';
     }

--- a/packages/graphql-mapping-template/src/print.ts
+++ b/packages/graphql-mapping-template/src/print.ts
@@ -3,16 +3,16 @@ import {
     ParensNode, EqualsNode, NotEqualsNode, ForEachNode,
     StringNode, IntNode, NullNode, ReferenceNode, QuietReferenceNode,
     ObjectNode, ListNode, FloatNode, QuotesNode, RawNode, SetNode, CompoundExpressionNode,
-    CommentNode, ToJsonNode, BooleanNode, compoundExpression, comment, NotNode
+    CommentNode, ToJsonNode, BooleanNode, compoundExpression, comment, NotNode, NewLineNode
 } from './ast';
 
 const TAB = '  ';
 
 function printIf(node: IfNode, indent: string = '') {
     if (node.inline) {
-        return `#if( ${printExpr(node.predicate)} ) ${printExpr(node.expr)} #end`;
+        return `#if( ${printExpr(node.predicate, '')} ) ${printExpr(node.expr, '')} #end`;
     }
-    return `${indent}#if( ${printExpr(node.predicate)} )\n${printExpr(node.expr, indent + TAB)}\n${indent}#end`;
+    return `${indent}#if( ${printExpr(node.predicate, '')} )\n${printExpr(node.expr, indent + TAB)}\n${indent}#end`;
 }
 
 function printIfElse(node: IfElseNode, indent: string = '') {
@@ -24,9 +24,9 @@ function printIfElse(node: IfElseNode, indent: string = '') {
             `#end`;
     }
     return `${indent}#if( ${printExpr(node.predicate)} )\n` +
-        `${indent}${TAB}${printExpr(node.ifExpr)}\n` +
+        `${printExpr(node.ifExpr, indent + TAB)}\n` +
         `${indent}#else\n` +
-        `${indent}${TAB}${printExpr(node.elseExpr)}\n` +
+        `${printExpr(node.elseExpr, indent + TAB)}\n` +
         `${indent}#end`;
 }
 
@@ -64,8 +64,8 @@ function printBool(node: BooleanNode): string {
     return `${node.value}`;
 }
 
-function printRaw(node: RawNode): string {
-    return `${node.value}`;
+function printRaw(node: RawNode, indent: string = ''): string {
+    return `${indent}${node.value}`;
 }
 
 function printQuotes(node: QuotesNode): string {
@@ -88,8 +88,8 @@ function printReference(node: ReferenceNode): string {
     return `\$${node.value}`;
 }
 
-function printQuietReference(node: QuietReferenceNode): string {
-    return `$util.qr(${node.value})`;
+function printQuietReference(node: QuietReferenceNode, indent: string = ''): string {
+    return `${indent}$util.qr(${node.value})`;
 }
 
 export function printObject(node: ObjectNode, indent: string = ''): string {
@@ -101,12 +101,12 @@ export function printObject(node: ObjectNode, indent: string = ''): string {
 }
 
 function printList(node: ListNode, indent: string = ''): string {
-    const values = node.expressions.map((e: Expression) => printExpr(e, indent)).join(', ');
+    const values = node.expressions.map((e: Expression) => printExpr(e, '')).join(', ');
     return `${indent}[${values}]`;
 }
 
 function printSet(node: SetNode, indent: string = ''): string {
-    return `${indent}#set( ${printReference(node.key)} = ${printExpr(node.value)} )`
+    return `${indent}#set( ${printReference(node.key)} = ${printExpr(node.value, '')} )`
 }
 
 function printComment(node: CommentNode, indent: string = ''): string {
@@ -114,7 +114,7 @@ function printComment(node: CommentNode, indent: string = ''): string {
 }
 
 function printCompoundExpression(node: CompoundExpressionNode, indent: string = ''): string {
-    return node.expressions.map((node: Expression) => indent + printExpr(node, indent)).join(`\n${indent}`)
+    return node.expressions.map((node: Expression) => printExpr(node, indent)).join(`\n`)
 }
 
 function printToJson(node: ToJsonNode, indent: string = ''): string {
@@ -122,7 +122,11 @@ function printToJson(node: ToJsonNode, indent: string = ''): string {
 }
 
 function printNot(node: NotNode, indent: string = ''): string {
-    return `${indent}!${printExpr(node.expr)}`
+    return `${indent}!${printExpr(node.expr, '')}`
+}
+
+function printNewLine(node: NewLineNode): string {
+    return '\n'
 }
 
 function printExpr(expr: Expression, indent: string = ''): string {
@@ -147,7 +151,7 @@ function printExpr(expr: Expression, indent: string = ''): string {
         case 'String':
             return printString(expr);
         case 'Raw':
-            return printRaw(expr);
+            return printRaw(expr, indent);
         case 'Quotes':
             return printQuotes(expr);
         case 'Float':
@@ -161,7 +165,7 @@ function printExpr(expr: Expression, indent: string = ''): string {
         case 'Reference':
             return printReference(expr);
         case 'QuietReference':
-            return printQuietReference(expr);
+            return printQuietReference(expr, indent);
         case 'Object':
             return printObject(expr, indent);
         case 'List':
@@ -176,6 +180,8 @@ function printExpr(expr: Expression, indent: string = ''): string {
             return printToJson(expr, indent)
         case 'Not':
             return printNot(expr, indent)
+        case 'NewLine':
+            return printNewLine(expr)
         default:
             return '';
     }
@@ -188,9 +194,9 @@ export function print(expr: Expression): string {
 export function printBlock(name: string) {
     return (expr: Expression): string => {
         const wrappedExpr = compoundExpression([
-            comment(`START: ${name}.`),
+            comment(`[Start] ${name}.`),
             expr,
-            comment(`END: ${name}.`)
+            comment(`[End] ${name}.`)
         ])
         return printExpr(wrappedExpr);
     }

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -74,6 +74,11 @@ export class ResourceConstants {
 
     public static readonly SNIPPETS = {
         AuthCondition: "authCondition",
-        VersionedCondition: "versionedCondition"
+        VersionedCondition: "versionedCondition",
+        IsDynamicGroupAuthorizedVariable: "isDynamicGroupAuthorized",
+        IsLocalDynamicGroupAuthorizedVariable: "isLocalDynamicGroupAuthorized",
+        IsStaticGroupAuthorizedVariable: "isStaticGroupAuthorized",
+        IsOwnerAuthorizedVariable: "isOwnerAuthorized",
+        IsNotAuthProtectedVariable: "isNotAuthProtected",
     }
 }

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -79,6 +79,6 @@ export class ResourceConstants {
         IsLocalDynamicGroupAuthorizedVariable: "isLocalDynamicGroupAuthorized",
         IsStaticGroupAuthorizedVariable: "isStaticGroupAuthorized",
         IsOwnerAuthorizedVariable: "isOwnerAuthorized",
-        IsNotAuthProtectedVariable: "isNotAuthProtected",
+        IsLocalOwnerAuthorizedVariable: "isLocalOwnerAuthorized"
     }
 }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -1333,6 +1333,16 @@ test(`Test getAllThree as admin.`, async () => {
         `)
         console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4))
         expect(fetchOwnedBy2AsAdmin.data.getAllThree).toBeTruthy()
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id)
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();
@@ -1370,6 +1380,16 @@ test(`Test getAllThree as owner.`, async () => {
         `)
         console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4))
         expect(fetchOwnedBy2AsOwner.data.getAllThree).toBeTruthy()
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id)
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();
@@ -1407,6 +1427,16 @@ test(`Test getAllThree as one of a set of editors.`, async () => {
         `)
         console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4))
         expect(fetchOwnedBy2AsEditor.data.getAllThree).toBeTruthy()
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id)
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();
@@ -1459,6 +1489,16 @@ test(`Test getAllThree as a member of a dynamic group.`, async () => {
         console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4))
         expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1)
         expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized')
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id)
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();
@@ -1511,6 +1551,299 @@ test(`Test getAllThree as a member of the alternative group.`, async () => {
         console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4))
         expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1)
         expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized')
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id)
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+// here
+test(`Test listAllThrees as admin.`, async () => {
+    try {
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                owner: "user2@test.com"
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedBy2AsAdmin = await GRAPHQL_CLIENT_1.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4))
+        expect(fetchOwnedBy2AsAdmin.data.listAllThrees.items).toHaveLength(1)
+        expect(fetchOwnedBy2AsAdmin.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id)
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id)
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test listAllThrees as owner.`, async () => {
+    try {
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                owner: "user2@test.com"
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedBy2AsOwner = await GRAPHQL_CLIENT_2.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4))
+        expect(fetchOwnedBy2AsOwner.data.listAllThrees.items).toHaveLength(1)
+        expect(fetchOwnedBy2AsOwner.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id)
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id)
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test listAllThrees as one of a set of editors.`, async () => {
+    try {
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                editors: ["user2@test.com"]
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedBy2AsEditor = await GRAPHQL_CLIENT_2.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4))
+        expect(fetchOwnedBy2AsEditor.data.listAllThrees.items).toHaveLength(1)
+        expect(fetchOwnedBy2AsEditor.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id)
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id)
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test listAllThrees as a member of a dynamic group.`, async () => {
+    try {
+        const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                groups: ["Admin"]
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedByAdmins, null, 4))
+        expect(ownedByAdmins.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_1.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items).toHaveLength(1)
+        expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items[0].id).toEqual(ownedByAdmins.data.createAllThree.id)
+
+        const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_2.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsNonAdmin.data.listAllThrees.items).toHaveLength(0)
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id)
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test getAllThree as a member of the alternative group.`, async () => {
+    try {
+        const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                alternativeGroup: "Admin"
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedByAdmins, null, 4))
+        expect(ownedByAdmins.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_1.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items).toHaveLength(1)
+        expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items[0].id).toEqual(ownedByAdmins.data.createAllThree.id)
+
+        const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_2.query(`
+        query {
+            listAllThrees {
+                items {
+                    id
+                    owner
+                    editors
+                    groups
+                    alternativeGroup
+                }
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsNonAdmin.data.listAllThrees.items).toHaveLength(0)
+
+        const deleteReq = await GRAPHQL_CLIENT_1.query(`
+            mutation {
+                deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                    id
+                }
+            }
+        `)
+        console.log(JSON.stringify(deleteReq, null, 4))
+        expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id)
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -304,8 +304,8 @@ beforeAll(async () => {
 afterAll(async () => {
     try {
         console.log('Deleting stack ' + STACK_NAME)
-        await cf.deleteStack(STACK_NAME)
-        await cf.waitForStack(STACK_NAME)
+        // await cf.deleteStack(STACK_NAME)
+        // await cf.waitForStack(STACK_NAME)
         console.log('Successfully deleted stack ' + STACK_NAME)
     } catch (e) {
         if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
@@ -1048,7 +1048,7 @@ test(`Test listPWProtecteds when the user is authorized.`, async () => {
     }
 })
 
-test(`Test listPWProtecteds when the user is authorized.`, async () => {
+test(`Test Protecteds when the user is not authorized.`, async () => {
     const req = await GRAPHQL_CLIENT_1.query(`
     mutation {
         createPWProtected(input: { content: "Barbie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -319,8 +319,8 @@ beforeAll(async () => {
 afterAll(async () => {
     try {
         console.log('Deleting stack ' + STACK_NAME)
-        // await cf.deleteStack(STACK_NAME)
-        // await cf.waitForStack(STACK_NAME)
+        await cf.deleteStack(STACK_NAME)
+        await cf.waitForStack(STACK_NAME)
         console.log('Successfully deleted stack ' + STACK_NAME)
     } catch (e) {
         if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
@@ -1209,7 +1209,7 @@ test(`Test creating, updating, and deleting an admin note as an admin`, async ()
         }
         `)
         console.log(JSON.stringify(req2, null, 4))
-        expect(req2.data.updateAdminNote.id).toEqual(req.data.createSalary.id)
+        expect(req2.data.updateAdminNote.id).toEqual(req.data.createAdminNote.id)
         expect(req2.data.updateAdminNote.content).toEqual("Hello 2")
         const req3 = await GRAPHQL_CLIENT_1.query(`
         mutation {
@@ -1220,7 +1220,7 @@ test(`Test creating, updating, and deleting an admin note as an admin`, async ()
         }
         `)
         console.log(JSON.stringify(req3, null, 4))
-        expect(req3.data.deleteAdminNote.id).toEqual(req.data.createSalary.id)
+        expect(req3.data.deleteAdminNote.id).toEqual(req.data.createAdminNote.id)
         expect(req3.data.deleteAdminNote.content).toEqual("Hello 2")
     } catch (e) {
         console.error(e)
@@ -1243,7 +1243,7 @@ test(`Test creating, updating, and deleting an admin note as a non admin`, async
         expect(adminReq.data.createAdminNote.content).toEqual("Hello")
 
 
-        const req = await GRAPHQL_CLIENT_1.query(`
+        const req = await GRAPHQL_CLIENT_2.query(`
         mutation {
             createAdminNote(input: { content: "Hello" }) {
                 id
@@ -1255,9 +1255,9 @@ test(`Test creating, updating, and deleting an admin note as a non admin`, async
         expect(req.errors.length).toEqual(1)
         expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
 
-        const req2 = await GRAPHQL_CLIENT_1.query(`
+        const req2 = await GRAPHQL_CLIENT_2.query(`
         mutation {
-            updateAdminNote(input: { id: "${req.data.createAdminNote.id}", content: "Hello 2" }) {
+            updateAdminNote(input: { id: "${adminReq.data.createAdminNote.id}", content: "Hello 2" }) {
                 id
                 content
             }
@@ -1267,9 +1267,9 @@ test(`Test creating, updating, and deleting an admin note as a non admin`, async
         expect(req2.errors.length).toEqual(1)
         expect((req2.errors[0] as any).errorType).toEqual('Unauthorized')
 
-        const req3 = await GRAPHQL_CLIENT_1.query(`
+        const req3 = await GRAPHQL_CLIENT_2.query(`
         mutation {
-            deleteAdminNote(input: { id: "${req.data.createAdminNote.id}" }) {
+            deleteAdminNote(input: { id: "${adminReq.data.createAdminNote.id}" }) {
                 id
                 content
             }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -2478,7 +2478,7 @@ test(`Test updateAllThree and deleteAllThree as a member of a dynamic group.`, a
     }
 })
 
-test(`Test createAllThree as a member of the alternative group.`, async () => {
+test(`Test updateAllThree and deleteAllThree as a member of the alternative group.`, async () => {
     try {
         const ownedByDevs = await GRAPHQL_CLIENT_1.query(`
         mutation {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -245,6 +245,23 @@ beforeAll(async () => {
         participants: String
         watchers: String
     }
+    type AllThree
+        @auth(rules: [
+            {allow: owner},
+            {allow: owner, ownerField: "editors"},
+            {allow: groups, groups: ["Admin"]},
+            {allow: groups, groups: ["Execs"]},
+            {allow: groups, groupsField: "groups"},
+            {allow: groups, groupsField: "alternativeGroup"}
+        ])
+        @model
+    {
+        id: ID!
+        owner: String
+        editors: [String]
+        groups: [String]
+        alternativeGroup: String
+    }
     `
     const transformer = new GraphQLTransform({
         transformers: [
@@ -319,8 +336,8 @@ beforeAll(async () => {
 afterAll(async () => {
     try {
         console.log('Deleting stack ' + STACK_NAME)
-        await cf.deleteStack(STACK_NAME)
-        await cf.waitForStack(STACK_NAME)
+        // await cf.deleteStack(STACK_NAME)
+        // await cf.waitForStack(STACK_NAME)
         console.log('Successfully deleted stack ' + STACK_NAME)
     } catch (e) {
         if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
@@ -343,943 +360,1159 @@ afterAll(async () => {
     }
 })
 
-/**
- * Test queries below
- */
-test('Test createPost mutation', async () => {
+// /**
+//  * Test queries below
+//  */
+// test('Test createPost mutation', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         console.log(response);
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//     } catch (e) {
+//         console.error(e)
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test getPost query when authorized', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//         const getResponse = await GRAPHQL_CLIENT_1.query(`query {
+//             getPost(id: "${response.data.createPost.id}") {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(getResponse.data.getPost.id).toBeDefined()
+//         expect(getResponse.data.getPost.title).toEqual('Hello, World!')
+//         expect(getResponse.data.getPost.createdAt).toBeDefined()
+//         expect(getResponse.data.getPost.updatedAt).toBeDefined()
+//         expect(getResponse.data.getPost.owner).toBeDefined()
+//     } catch (e) {
+//         console.error(e)
+//         console.error(JSON.stringify(e.response.data))
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test getPost query when not authorized', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//         const getResponse = await GRAPHQL_CLIENT_2.query(`query {
+//             getPost(id: "${response.data.createPost.id}") {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(getResponse.data.getPost).toEqual(null)
+//         expect(getResponse.errors.length).toEqual(1)
+//         expect((getResponse.errors[0] as any).errorType).toEqual('Unauthorized')
+//     } catch (e) {
+//         console.error(e)
+//         console.error(JSON.stringify(e.response.data))
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test updatePost mutation when authorized', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//         const updateResponse = await GRAPHQL_CLIENT_1.query(`mutation {
+//             updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(updateResponse.data.updatePost.id).toEqual(response.data.createPost.id)
+//         expect(updateResponse.data.updatePost.title).toEqual('Bye, World!')
+//         expect(updateResponse.data.updatePost.updatedAt > response.data.createPost.updatedAt).toEqual(true)
+//     } catch (e) {
+//         console.error(e)
+//         console.error(JSON.stringify(e.response.data))
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test updatePost mutation when not authorized', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//         const updateResponse = await GRAPHQL_CLIENT_2.query(`mutation {
+//             updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(updateResponse.data.updatePost).toEqual(null)
+//         expect(updateResponse.errors.length).toEqual(1)
+//         expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
+//     } catch (e) {
+//         console.error(e)
+//         console.error(JSON.stringify(e.response.data))
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test deletePost mutation when authorized', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//         const deleteResponse = await GRAPHQL_CLIENT_1.query(`mutation {
+//             deletePost(input: { id: "${response.data.createPost.id}" }) {
+//                 id
+//             }
+//         }`, {})
+//         expect(deleteResponse.data.deletePost.id).toEqual(response.data.createPost.id)
+//     } catch (e) {
+//         console.error(e)
+//         console.error(JSON.stringify(e.response.data))
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test deletePost mutation when not authorized', async () => {
+//     try {
+//         const response = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "Hello, World!" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(response.data.createPost.id).toBeDefined()
+//         expect(response.data.createPost.title).toEqual('Hello, World!')
+//         expect(response.data.createPost.createdAt).toBeDefined()
+//         expect(response.data.createPost.updatedAt).toBeDefined()
+//         expect(response.data.createPost.owner).toBeDefined()
+//         const deleteResponse = await GRAPHQL_CLIENT_2.query(`mutation {
+//             deletePost(input: { id: "${response.data.createPost.id}" }) {
+//                 id
+//             }
+//         }`, {})
+//         expect(deleteResponse.data.deletePost).toEqual(null)
+//         expect(deleteResponse.errors.length).toEqual(1)
+//         expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
+//     } catch (e) {
+//         console.error(e)
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test('Test listPosts query when authorized', async () => {
+//     try {
+//         const firstPost = await GRAPHQL_CLIENT_1.query(`mutation {
+//             createPost(input: { title: "testing list" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         expect(firstPost.data.createPost.id).toBeDefined()
+//         expect(firstPost.data.createPost.title).toEqual('testing list')
+//         expect(firstPost.data.createPost.createdAt).toBeDefined()
+//         expect(firstPost.data.createPost.updatedAt).toBeDefined()
+//         expect(firstPost.data.createPost.owner).toBeDefined()
+//         const secondPost = await GRAPHQL_CLIENT_2.query(`mutation {
+//             createPost(input: { title: "testing list" }) {
+//                 id
+//                 title
+//                 createdAt
+//                 updatedAt
+//                 owner
+//             }
+//         }`, {})
+//         // There are two posts but only 1 created by me.
+//         const listResponse = await GRAPHQL_CLIENT_1.query(`query {
+//             listPosts(filter: { title: { eq: "testing list" } }, limit: 25) {
+//                 items {
+//                     id
+//                 }
+//             }
+//         }`, {})
+//         console.log(JSON.stringify(listResponse, null, 4))
+//         expect(listResponse.data.listPosts.items.length).toEqual(1)
+//     } catch (e) {
+//         console.error(e)
+//         console.error(JSON.stringify(e.response.data))
+//         // fail
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// /**
+//  * Static Group Auth
+//  */
+// test(`Test createSalary w/ Admin group protection authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 10 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(10)
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test update my own salary without admin permission`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createSalary(input: { wage: 10 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.wage).toEqual(10)
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req2, null, 4))
+//         expect(req2.data.updateSalary.wage).toEqual(14)
+//     } catch (e) {
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test updating someone else's salary as an admin`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createSalary(input: { wage: 11 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(11)
+//         const req2 = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             updateSalary(input: { id: "${req.data.createSalary.id}", wage: 12 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req2, null, 4))
+//         expect(req2.data.updateSalary.id).toEqual(req.data.createSalary.id)
+//         expect(req2.data.updateSalary.wage).toEqual(12)
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test updating someone else's salary when I am not admin.`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 13 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(13)
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         expect(req2.data.updateSalary).toEqual(null)
+//         expect(req2.errors.length).toEqual(1)
+//         expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test deleteSalary w/ Admin group protection authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 15 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(15)
+//         const req2 = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req2, null, 4))
+//         expect(req2.data.deleteSalary.id).toEqual(req.data.createSalary.id)
+//         expect(req2.data.deleteSalary.wage).toEqual(15)
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test deleteSalary w/ Admin group protection not authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 16 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(16)
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         expect(req2.data.deleteSalary).toEqual(null)
+//         expect(req2.errors.length).toEqual(1)
+//         expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test and Admin can get a salary created by any user`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createSalary(input: { wage: 15 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(15)
+//         const req2 = await GRAPHQL_CLIENT_1.query(`
+//         query {
+//             getSalary(id: "${req.data.createSalary.id}") {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id)
+//         expect(req2.data.getSalary.wage).toEqual(15)
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test owner can create and get a salary when not admin`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createSalary(input: { wage: 15 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(15)
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         query {
+//             getSalary(id: "${req.data.createSalary.id}") {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id)
+//         expect(req2.data.getSalary.wage).toEqual(15)
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test getSalary w/ Admin group protection not authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 16 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(16)
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         query {
+//             getSalary(id: "${req.data.createSalary.id}") {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         expect(req2.data.getSalary).toEqual(null)
+//         expect(req2.errors.length).toEqual(1)
+//         expect((req2.errors[0] as any).errorType).toEqual('Unauthorized')
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test listSalarys w/ Admin group protection authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 101 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(101)
+//         const req2 = await GRAPHQL_CLIENT_1.query(`
+//         query {
+//             listSalarys(filter: { wage: { eq: 101 }}) {
+//                 items {
+//                     id
+//                     wage
+//                 }
+//             }
+//         }
+//         `)
+//         expect(req2.data.listSalarys.items.length).toEqual(1)
+//         expect(req2.data.listSalarys.items[0].id).toEqual(req.data.createSalary.id)
+//         expect(req2.data.listSalarys.items[0].wage).toEqual(101)
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test listSalarys w/ Admin group protection not authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSalary(input: { wage: 102 }) {
+//                 id
+//                 wage
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSalary.id).toBeDefined()
+//         expect(req.data.createSalary.wage).toEqual(102)
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         query {
+//             listSalarys(filter: { wage: { eq: 102 }}) {
+//                 items {
+//                     id
+//                     wage
+//                 }
+//             }
+//         }
+//         `)
+//         expect(req2.data.listSalarys.items).toEqual([])
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// /**
+//  * Dynamic Group Auth
+//  */
+// test(`Test createManyGroupProtected w/ dynamic group protection authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
+//                 id
+//                 value
+//                 groups
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createManyGroupProtected.id).toBeDefined()
+//         expect(req.data.createManyGroupProtected.value).toEqual(10)
+//         expect(req.data.createManyGroupProtected.groups).toEqual(["Admin"])
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test createManyGroupProtected w/ dynamic group protection when not authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
+//                 id
+//                 value
+//                 groups
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createManyGroupProtected).toEqual(null)
+//         expect(req.errors.length).toEqual(1)
+//         expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test createSingleGroupProtected w/ dynamic group protection authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
+//                 id
+//                 value
+//                 group
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSingleGroupProtected.id).toBeDefined()
+//         expect(req.data.createSingleGroupProtected.value).toEqual(10)
+//         expect(req.data.createSingleGroupProtected.group).toEqual("Admin")
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test createSingleGroupProtected w/ dynamic group protection when not authorized`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
+//                 id
+//                 value
+//                 group
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createSingleGroupProtected).toEqual(null)
+//         expect(req.errors.length).toEqual(1)
+//         expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test listPWProtecteds when the user is authorized.`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createPWProtected(input: { content: "Foobie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
+//                 id
+//                 content
+//                 participants
+//                 watchers
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createPWProtected).toBeTruthy()
+
+//         const uReq = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
+//                 id
+//                 content
+//                 participants
+//                 watchers
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(uReq, null, 4))
+//         expect(uReq.data.updatePWProtected).toBeTruthy()
+
+//         const req2 = await GRAPHQL_CLIENT_1.query(`
+//         query {
+//             listPWProtecteds {
+//                 items {
+//                     id
+//                     content
+//                     participants
+//                     watchers
+//                 }
+//                 nextToken
+//             }
+//         }
+//         `)
+//         expect(req2.data.listPWProtecteds.items.length).toEqual(1)
+//         expect(req2.data.listPWProtecteds.items[0].id).toEqual(req.data.createPWProtected.id)
+//         expect(req2.data.listPWProtecteds.items[0].content).toEqual("Foobie2")
+
+
+//         const req3 = await GRAPHQL_CLIENT_1.query(`
+//         query {
+//             getPWProtected(id: "${req.data.createPWProtected.id}") {
+//                 id
+//                 content
+//                 participants
+//                 watchers
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req3, null, 4))
+//         expect(req3.data.getPWProtected).toBeTruthy()
+
+//         const dReq = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
+//                 id
+//                 content
+//                 participants
+//                 watchers
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(dReq, null, 4))
+//         expect(dReq.data.deletePWProtected).toBeTruthy()
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined();
+//     }
+// })
+
+// test(`Test Protecteds when the user is not authorized.`, async () => {
+//     const req = await GRAPHQL_CLIENT_1.query(`
+//     mutation {
+//         createPWProtected(input: { content: "Barbie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
+//             id
+//             content
+//             participants
+//             watchers
+//         }
+//     }
+//     `)
+//     console.log(JSON.stringify(req, null, 4))
+//     expect(req.data.createPWProtected).toBeTruthy()
+
+//     const req2 = await GRAPHQL_CLIENT_2.query(`
+//     query {
+//         listPWProtecteds {
+//             items {
+//                 id
+//                 content
+//                 participants
+//                 watchers
+//             }
+//             nextToken
+//         }
+//     }
+//     `)
+//     console.log(JSON.stringify(req2, null, 4))
+//     expect(req2.data.listPWProtecteds.items.length).toEqual(0)
+//     expect(req2.data.listPWProtecteds.nextToken).toBeNull()
+
+//     const uReq = await GRAPHQL_CLIENT_2.query(`
+//     mutation {
+//         updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
+//             id
+//             content
+//             participants
+//             watchers
+//         }
+//     }
+//     `)
+//     console.log(JSON.stringify(uReq, null, 4))
+//     expect(uReq.data.updatePWProtected).toBeNull()
+
+//     const req3 = await GRAPHQL_CLIENT_2.query(`
+//     query {
+//         getPWProtected(id: "${req.data.createPWProtected.id}") {
+//             id
+//             content
+//             participants
+//             watchers
+//         }
+//     }
+//     `)
+//     console.log(JSON.stringify(req3, null, 4))
+//     expect(req3.data.getPWProtected).toBeNull()
+
+//     const dReq = await GRAPHQL_CLIENT_2.query(`
+//     mutation {
+//         deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
+//             id
+//             content
+//             participants
+//             watchers
+//         }
+//     }
+//     `)
+//     console.log(JSON.stringify(dReq, null, 4))
+//     expect(dReq.data.deletePWProtected).toBeNull()
+
+//     // The record should still exist after delete.
+//     const getReq = await GRAPHQL_CLIENT_1.query(`
+//     query {
+//         getPWProtected(id: "${req.data.createPWProtected.id}") {
+//             id
+//             content
+//             participants
+//             watchers
+//         }
+//     }
+//     `)
+//     console.log(JSON.stringify(getReq, null, 4))
+//     expect(getReq.data.getPWProtected).toBeTruthy()
+// })
+
+// test(`Test creating, updating, and deleting an admin note as an admin`, async () => {
+//     try {
+//         const req = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createAdminNote(input: { content: "Hello" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.data.createAdminNote.id).toBeDefined()
+//         expect(req.data.createAdminNote.content).toEqual("Hello")
+//         const req2 = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             updateAdminNote(input: { id: "${req.data.createAdminNote.id}", content: "Hello 2" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req2, null, 4))
+//         expect(req2.data.updateAdminNote.id).toEqual(req.data.createAdminNote.id)
+//         expect(req2.data.updateAdminNote.content).toEqual("Hello 2")
+//         const req3 = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             deleteAdminNote(input: { id: "${req.data.createAdminNote.id}" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req3, null, 4))
+//         expect(req3.data.deleteAdminNote.id).toEqual(req.data.createAdminNote.id)
+//         expect(req3.data.deleteAdminNote.content).toEqual("Hello 2")
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+// test(`Test creating, updating, and deleting an admin note as a non admin`, async () => {
+//     try {
+//         const adminReq = await GRAPHQL_CLIENT_1.query(`
+//         mutation {
+//             createAdminNote(input: { content: "Hello" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(adminReq, null, 4))
+//         expect(adminReq.data.createAdminNote.id).toBeDefined()
+//         expect(adminReq.data.createAdminNote.content).toEqual("Hello")
+
+
+//         const req = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             createAdminNote(input: { content: "Hello" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req, null, 4))
+//         expect(req.errors.length).toEqual(1)
+//         expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
+
+//         const req2 = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             updateAdminNote(input: { id: "${adminReq.data.createAdminNote.id}", content: "Hello 2" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req2, null, 4))
+//         expect(req2.errors.length).toEqual(1)
+//         expect((req2.errors[0] as any).errorType).toEqual('Unauthorized')
+
+//         const req3 = await GRAPHQL_CLIENT_2.query(`
+//         mutation {
+//             deleteAdminNote(input: { id: "${adminReq.data.createAdminNote.id}" }) {
+//                 id
+//                 content
+//             }
+//         }
+//         `)
+//         console.log(JSON.stringify(req3, null, 4))
+//         expect(req3.errors.length).toEqual(1)
+//         expect((req3.errors[0] as any).errorType).toEqual('Unauthorized')
+//     } catch (e) {
+//         console.error(e)
+//         expect(e).toBeUndefined()
+//     }
+// })
+
+
+test(`Test getAllThree as admin.`, async () => {
     try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                owner: "user2@test.com"
+            }) {
                 id
-                title
-                createdAt
-                updatedAt
                 owner
-            }
-        }`, {})
-        console.log(response);
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-    } catch (e) {
-        console.error(e)
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test getPost query when authorized', async () => {
-    try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-        const getResponse = await GRAPHQL_CLIENT_1.query(`query {
-            getPost(id: "${response.data.createPost.id}") {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(getResponse.data.getPost.id).toBeDefined()
-        expect(getResponse.data.getPost.title).toEqual('Hello, World!')
-        expect(getResponse.data.getPost.createdAt).toBeDefined()
-        expect(getResponse.data.getPost.updatedAt).toBeDefined()
-        expect(getResponse.data.getPost.owner).toBeDefined()
-    } catch (e) {
-        console.error(e)
-        console.error(JSON.stringify(e.response.data))
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test getPost query when not authorized', async () => {
-    try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-        const getResponse = await GRAPHQL_CLIENT_2.query(`query {
-            getPost(id: "${response.data.createPost.id}") {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(getResponse.data.getPost).toEqual(null)
-        expect(getResponse.errors.length).toEqual(1)
-        expect((getResponse.errors[0] as any).errorType).toEqual('Unauthorized')
-    } catch (e) {
-        console.error(e)
-        console.error(JSON.stringify(e.response.data))
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test updatePost mutation when authorized', async () => {
-    try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-        const updateResponse = await GRAPHQL_CLIENT_1.query(`mutation {
-            updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(updateResponse.data.updatePost.id).toEqual(response.data.createPost.id)
-        expect(updateResponse.data.updatePost.title).toEqual('Bye, World!')
-        expect(updateResponse.data.updatePost.updatedAt > response.data.createPost.updatedAt).toEqual(true)
-    } catch (e) {
-        console.error(e)
-        console.error(JSON.stringify(e.response.data))
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test updatePost mutation when not authorized', async () => {
-    try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-        const updateResponse = await GRAPHQL_CLIENT_2.query(`mutation {
-            updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(updateResponse.data.updatePost).toEqual(null)
-        expect(updateResponse.errors.length).toEqual(1)
-        expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
-    } catch (e) {
-        console.error(e)
-        console.error(JSON.stringify(e.response.data))
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test deletePost mutation when authorized', async () => {
-    try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-        const deleteResponse = await GRAPHQL_CLIENT_1.query(`mutation {
-            deletePost(input: { id: "${response.data.createPost.id}" }) {
-                id
-            }
-        }`, {})
-        expect(deleteResponse.data.deletePost.id).toEqual(response.data.createPost.id)
-    } catch (e) {
-        console.error(e)
-        console.error(JSON.stringify(e.response.data))
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test deletePost mutation when not authorized', async () => {
-    try {
-        const response = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(response.data.createPost.id).toBeDefined()
-        expect(response.data.createPost.title).toEqual('Hello, World!')
-        expect(response.data.createPost.createdAt).toBeDefined()
-        expect(response.data.createPost.updatedAt).toBeDefined()
-        expect(response.data.createPost.owner).toBeDefined()
-        const deleteResponse = await GRAPHQL_CLIENT_2.query(`mutation {
-            deletePost(input: { id: "${response.data.createPost.id}" }) {
-                id
-            }
-        }`, {})
-        expect(deleteResponse.data.deletePost).toEqual(null)
-        expect(deleteResponse.errors.length).toEqual(1)
-        expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
-    } catch (e) {
-        console.error(e)
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-test('Test listPosts query when authorized', async () => {
-    try {
-        const firstPost = await GRAPHQL_CLIENT_1.query(`mutation {
-            createPost(input: { title: "testing list" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        expect(firstPost.data.createPost.id).toBeDefined()
-        expect(firstPost.data.createPost.title).toEqual('testing list')
-        expect(firstPost.data.createPost.createdAt).toBeDefined()
-        expect(firstPost.data.createPost.updatedAt).toBeDefined()
-        expect(firstPost.data.createPost.owner).toBeDefined()
-        const secondPost = await GRAPHQL_CLIENT_2.query(`mutation {
-            createPost(input: { title: "testing list" }) {
-                id
-                title
-                createdAt
-                updatedAt
-                owner
-            }
-        }`, {})
-        // There are two posts but only 1 created by me.
-        const listResponse = await GRAPHQL_CLIENT_1.query(`query {
-            listPosts(filter: { title: { eq: "testing list" } }, limit: 25) {
-                items {
-                    id
-                }
-            }
-        }`, {})
-        console.log(JSON.stringify(listResponse, null, 4))
-        expect(listResponse.data.listPosts.items.length).toEqual(1)
-    } catch (e) {
-        console.error(e)
-        console.error(JSON.stringify(e.response.data))
-        // fail
-        expect(e).toBeUndefined()
-    }
-})
-
-/**
- * Static Group Auth
- */
-test(`Test createSalary w/ Admin group protection authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 10 }) {
-                id
-                wage
-            }
-        }
-        `)
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(10)
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test update my own salary without admin permission`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createSalary(input: { wage: 10 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.wage).toEqual(10)
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req2, null, 4))
-        expect(req2.data.updateSalary.wage).toEqual(14)
-    } catch (e) {
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test updating someone else's salary as an admin`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createSalary(input: { wage: 11 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(11)
-        const req2 = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            updateSalary(input: { id: "${req.data.createSalary.id}", wage: 12 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req2, null, 4))
-        expect(req2.data.updateSalary.id).toEqual(req.data.createSalary.id)
-        expect(req2.data.updateSalary.wage).toEqual(12)
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test updating someone else's salary when I am not admin.`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 13 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(13)
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
-                id
-                wage
-            }
-        }
-        `)
-        expect(req2.data.updateSalary).toEqual(null)
-        expect(req2.errors.length).toEqual(1)
-        expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test deleteSalary w/ Admin group protection authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 15 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(15)
-        const req2 = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req2, null, 4))
-        expect(req2.data.deleteSalary.id).toEqual(req.data.createSalary.id)
-        expect(req2.data.deleteSalary.wage).toEqual(15)
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test deleteSalary w/ Admin group protection not authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 16 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(16)
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
-                id
-                wage
-            }
-        }
-        `)
-        expect(req2.data.deleteSalary).toEqual(null)
-        expect(req2.errors.length).toEqual(1)
-        expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException')
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test and Admin can get a salary created by any user`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createSalary(input: { wage: 15 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(15)
-        const req2 = await GRAPHQL_CLIENT_1.query(`
-        query {
-            getSalary(id: "${req.data.createSalary.id}") {
-                id
-                wage
-            }
-        }
-        `)
-        expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id)
-        expect(req2.data.getSalary.wage).toEqual(15)
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test owner can create and get a salary when not admin`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createSalary(input: { wage: 15 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(15)
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        query {
-            getSalary(id: "${req.data.createSalary.id}") {
-                id
-                wage
-            }
-        }
-        `)
-        expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id)
-        expect(req2.data.getSalary.wage).toEqual(15)
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test getSalary w/ Admin group protection not authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 16 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(16)
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        query {
-            getSalary(id: "${req.data.createSalary.id}") {
-                id
-                wage
-            }
-        }
-        `)
-        expect(req2.data.getSalary).toEqual(null)
-        expect(req2.errors.length).toEqual(1)
-        expect((req2.errors[0] as any).errorType).toEqual('Unauthorized')
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test listSalarys w/ Admin group protection authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 101 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(101)
-        const req2 = await GRAPHQL_CLIENT_1.query(`
-        query {
-            listSalarys(filter: { wage: { eq: 101 }}) {
-                items {
-                    id
-                    wage
-                }
-            }
-        }
-        `)
-        expect(req2.data.listSalarys.items.length).toEqual(1)
-        expect(req2.data.listSalarys.items[0].id).toEqual(req.data.createSalary.id)
-        expect(req2.data.listSalarys.items[0].wage).toEqual(101)
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test listSalarys w/ Admin group protection not authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSalary(input: { wage: 102 }) {
-                id
-                wage
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSalary.id).toBeDefined()
-        expect(req.data.createSalary.wage).toEqual(102)
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        query {
-            listSalarys(filter: { wage: { eq: 102 }}) {
-                items {
-                    id
-                    wage
-                }
-            }
-        }
-        `)
-        expect(req2.data.listSalarys.items).toEqual([])
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-/**
- * Dynamic Group Auth
- */
-test(`Test createManyGroupProtected w/ dynamic group protection authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
-                id
-                value
+                editors
                 groups
+                alternativeGroup
             }
         }
         `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createManyGroupProtected.id).toBeDefined()
-        expect(req.data.createManyGroupProtected.value).toEqual(10)
-        expect(req.data.createManyGroupProtected.groups).toEqual(["Admin"])
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createAllThree).toBeTruthy()
 
-test(`Test createManyGroupProtected w/ dynamic group protection when not authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
+        const fetchOwnedBy2AsAdmin = await GRAPHQL_CLIENT_1.query(`
+        query {
+            getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
                 id
-                value
+                owner
+                editors
                 groups
+                alternativeGroup
             }
         }
         `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createManyGroupProtected).toEqual(null)
-        expect(req.errors.length).toEqual(1)
-        expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test createSingleGroupProtected w/ dynamic group protection authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
-                id
-                value
-                group
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSingleGroupProtected.id).toBeDefined()
-        expect(req.data.createSingleGroupProtected.value).toEqual(10)
-        expect(req.data.createSingleGroupProtected.group).toEqual("Admin")
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test createSingleGroupProtected w/ dynamic group protection when not authorized`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
-                id
-                value
-                group
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createSingleGroupProtected).toEqual(null)
-        expect(req.errors.length).toEqual(1)
-        expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
-    } catch (e) {
-        console.error(e)
-        expect(e).toBeUndefined()
-    }
-})
-
-test(`Test listPWProtecteds when the user is authorized.`, async () => {
-    try {
-        const req = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            createPWProtected(input: { content: "Foobie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
-                id
-                content
-                participants
-                watchers
-            }
-        }
-        `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createPWProtected).toBeTruthy()
-
-        const uReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
-                id
-                content
-                participants
-                watchers
-            }
-        }
-        `)
-        console.log(JSON.stringify(uReq, null, 4))
-        expect(uReq.data.updatePWProtected).toBeTruthy()
-
-        const req2 = await GRAPHQL_CLIENT_1.query(`
-        query {
-            listPWProtecteds {
-                items {
-                    id
-                    content
-                    participants
-                    watchers
-                }
-                nextToken
-            }
-        }
-        `)
-        expect(req2.data.listPWProtecteds.items.length).toEqual(1)
-        expect(req2.data.listPWProtecteds.items[0].id).toEqual(req.data.createPWProtected.id)
-        expect(req2.data.listPWProtecteds.items[0].content).toEqual("Foobie2")
-
-
-        const req3 = await GRAPHQL_CLIENT_1.query(`
-        query {
-            getPWProtected(id: "${req.data.createPWProtected.id}") {
-                id
-                content
-                participants
-                watchers
-            }
-        }
-        `)
-        console.log(JSON.stringify(req3, null, 4))
-        expect(req3.data.getPWProtected).toBeTruthy()
-
-        const dReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
-                id
-                content
-                participants
-                watchers
-            }
-        }
-        `)
-        console.log(JSON.stringify(dReq, null, 4))
-        expect(dReq.data.deletePWProtected).toBeTruthy()
+        console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4))
+        expect(fetchOwnedBy2AsAdmin.data.getAllThree).toBeTruthy()
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();
     }
 })
 
-test(`Test Protecteds when the user is not authorized.`, async () => {
-    const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createPWProtected(input: { content: "Barbie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `)
-    console.log(JSON.stringify(req, null, 4))
-    expect(req.data.createPWProtected).toBeTruthy()
-
-    const req2 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listPWProtecteds {
-            items {
-                id
-                content
-                participants
-                watchers
-            }
-            nextToken
-        }
-    }
-    `)
-    console.log(JSON.stringify(req2, null, 4))
-    expect(req2.data.listPWProtecteds.items.length).toEqual(0)
-    expect(req2.data.listPWProtecteds.nextToken).toBeNull()
-
-    const uReq = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `)
-    console.log(JSON.stringify(uReq, null, 4))
-    expect(uReq.data.updatePWProtected).toBeNull()
-
-    const req3 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getPWProtected(id: "${req.data.createPWProtected.id}") {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `)
-    console.log(JSON.stringify(req3, null, 4))
-    expect(req3.data.getPWProtected).toBeNull()
-
-    const dReq = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `)
-    console.log(JSON.stringify(dReq, null, 4))
-    expect(dReq.data.deletePWProtected).toBeNull()
-
-    // The record should still exist after delete.
-    const getReq = await GRAPHQL_CLIENT_1.query(`
-    query {
-        getPWProtected(id: "${req.data.createPWProtected.id}") {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `)
-    console.log(JSON.stringify(getReq, null, 4))
-    expect(getReq.data.getPWProtected).toBeTruthy()
-})
-
-test(`Test creating, updating, and deleting an admin note as an admin`, async () => {
+test(`Test getAllThree as owner.`, async () => {
     try {
-        const req = await GRAPHQL_CLIENT_1.query(`
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
         mutation {
-            createAdminNote(input: { content: "Hello" }) {
+            createAllThree(input: {
+                owner: "user2@test.com"
+            }) {
                 id
-                content
+                owner
+                editors
+                groups
+                alternativeGroup
             }
         }
         `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.data.createAdminNote.id).toBeDefined()
-        expect(req.data.createAdminNote.content).toEqual("Hello")
-        const req2 = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            updateAdminNote(input: { id: "${req.data.createAdminNote.id}", content: "Hello 2" }) {
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedBy2AsOwner = await GRAPHQL_CLIENT_2.query(`
+        query {
+            getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
                 id
-                content
+                owner
+                editors
+                groups
+                alternativeGroup
             }
         }
         `)
-        console.log(JSON.stringify(req2, null, 4))
-        expect(req2.data.updateAdminNote.id).toEqual(req.data.createAdminNote.id)
-        expect(req2.data.updateAdminNote.content).toEqual("Hello 2")
-        const req3 = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAdminNote(input: { id: "${req.data.createAdminNote.id}" }) {
-                id
-                content
-            }
-        }
-        `)
-        console.log(JSON.stringify(req3, null, 4))
-        expect(req3.data.deleteAdminNote.id).toEqual(req.data.createAdminNote.id)
-        expect(req3.data.deleteAdminNote.content).toEqual("Hello 2")
+        console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4))
+        expect(fetchOwnedBy2AsOwner.data.getAllThree).toBeTruthy()
     } catch (e) {
         console.error(e)
-        expect(e).toBeUndefined()
+        expect(e).toBeUndefined();
     }
 })
 
-test(`Test creating, updating, and deleting an admin note as a non admin`, async () => {
+test(`Test getAllThree as one of a set of editors.`, async () => {
     try {
-        const adminReq = await GRAPHQL_CLIENT_1.query(`
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
         mutation {
-            createAdminNote(input: { content: "Hello" }) {
+            createAllThree(input: {
+                editors: ["user2@test.com"]
+            }) {
                 id
-                content
+                owner
+                editors
+                groups
+                alternativeGroup
             }
         }
         `)
-        console.log(JSON.stringify(adminReq, null, 4))
-        expect(adminReq.data.createAdminNote.id).toBeDefined()
-        expect(adminReq.data.createAdminNote.content).toEqual("Hello")
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createAllThree).toBeTruthy()
 
-
-        const req = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            createAdminNote(input: { content: "Hello" }) {
+        const fetchOwnedBy2AsEditor = await GRAPHQL_CLIENT_2.query(`
+        query {
+            getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
                 id
-                content
+                owner
+                editors
+                groups
+                alternativeGroup
             }
         }
         `)
-        console.log(JSON.stringify(req, null, 4))
-        expect(req.errors.length).toEqual(1)
-        expect((req.errors[0] as any).errorType).toEqual('Unauthorized')
-
-        const req2 = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            updateAdminNote(input: { id: "${adminReq.data.createAdminNote.id}", content: "Hello 2" }) {
-                id
-                content
-            }
-        }
-        `)
-        console.log(JSON.stringify(req2, null, 4))
-        expect(req2.errors.length).toEqual(1)
-        expect((req2.errors[0] as any).errorType).toEqual('Unauthorized')
-
-        const req3 = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            deleteAdminNote(input: { id: "${adminReq.data.createAdminNote.id}" }) {
-                id
-                content
-            }
-        }
-        `)
-        console.log(JSON.stringify(req3, null, 4))
-        expect(req3.errors.length).toEqual(1)
-        expect((req3.errors[0] as any).errorType).toEqual('Unauthorized')
+        console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4))
+        expect(fetchOwnedBy2AsEditor.data.getAllThree).toBeTruthy()
     } catch (e) {
         console.error(e)
-        expect(e).toBeUndefined()
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test getAllThree as a member of a dynamic group.`, async () => {
+    try {
+        const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                groups: ["Admin"]
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedByAdmins, null, 4))
+        expect(ownedByAdmins.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_1.query(`
+        query {
+            getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsAdmin.data.getAllThree).toBeTruthy()
+
+        const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_2.query(`
+        query {
+            getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1)
+        expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized')
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test getAllThree as a member of the alternative group.`, async () => {
+    try {
+        const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createAllThree(input: {
+                alternativeGroup: "Admin"
+            }) {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedByAdmins, null, 4))
+        expect(ownedByAdmins.data.createAllThree).toBeTruthy()
+
+        const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_1.query(`
+        query {
+            getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsAdmin.data.getAllThree).toBeTruthy()
+
+        const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_2.query(`
+        query {
+            getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+                id
+                owner
+                editors
+                groups
+                alternativeGroup
+            }
+        }
+        `)
+        console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4))
+        expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1)
+        expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized')
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
     }
 })


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-cli/issues/183

*Description of changes:*

This PR fixes #183 and totally revamps the logic for all @auth checks. This also adds extensive new e2e testing suites in addition to all the existing tests that were already in place. The resolver codegen is now much cleaner and more efficient + it works with much more complex rule combinations.

I have also added more docs to this PR https://github.com/aws-amplify/docs/pull/12 that explains the upgraded functionality.

For example, this is from the tests:

```graphql
type AllThree
        @auth(rules: [
            {allow: owner},
            {allow: owner, ownerField: "editors"},
            {allow: groups, groups: ["Admin"]},
            {allow: groups, groups: ["Execs"]},
            {allow: groups, groupsField: "groups"},
            {allow: groups, groupsField: "alternativeGroup"}
        ])
        @model
    {
        id: ID!
        owner: String
        editors: [String]
        groups: [String]
        alternativeGroup: String
    }
```

This enables the following stories:

* The logged in user can CRUD objects of the AllThree type they are the **owner** of the object.
* The logged in user can CRUD objects of the AllThree type if they are one of a set of **editors** on the object.
* The logged in user can CRUD objects of the AllThree type if they are a member of the "Admin" group
* The logged in user can CRUD objects of the AllThree type if they are a member of the "Exec" group
* The logged in user can CRUD objects of the AllThree type if they are a member of any of the groups in **groups**
* The logged in user can CRUD objects of the AllThree type if they are a member of the group specified by **alternativeGroup**

As mentioned above this also implement multi-owner auth that was previously on the back log. This also improves the readability of the generated velocity code which now has helpful comments and better indentation. Here are the generated mapping templates that implement the auth checks for the above type:

**Query.getAllThree.response**

```vtl
## [Start] Static Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $allowedGroups = ["Admin", "Execs"] )
#set($isStaticGroupAuthorized = $util.defaultIfNull($isStaticGroupAuthorized, false))
#foreach( $userGroup in $userGroups )
  #foreach( $allowedGroup in $allowedGroups )
    #if( $allowedGroup == $userGroup )
      #set( $isStaticGroupAuthorized = true )
    #end
  #end
#end
## [End] Static Group Authorization Checks **


## [Start] Dynamic Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $isDynamicGroupAuthorized = $util.defaultIfNull($isDynamicGroupAuthorized, false) )
## Authorization rule: { allow: "groups", groupsField: "groups" } **
#set( $allowedGroups = $ctx.result.groups )
#foreach( $userGroup in $userGroups )
  #if( $util.isList($allowedGroups) )
    #if( $allowedGroups.contains($userGroup) )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
  #if( $util.isString($allowedGroups) )
    #if( $allowedGroups == $userGroup )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
#end
## Authorization rule: { allow: "groups", groupsField: "alternativeGroup" } **
#set( $allowedGroups = $ctx.result.alternativeGroup )
#foreach( $userGroup in $userGroups )
  #if( $util.isList($allowedGroups) )
    #if( $allowedGroups.contains($userGroup) )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
  #if( $util.isString($allowedGroups) )
    #if( $allowedGroups == $userGroup )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
#end
## [End] Dynamic Group Authorization Checks **


## [Start] Owner Authorization Checks **
#set( $isOwnerAuthorized = $util.defaultIfNull($isOwnerAuthorized, false) )
## Authorization rule: { allow: "owner", ownerField: "owner", identityField: "username" } **
#set( $allowedOwners0 = $ctx.result.owner )
#set( $identityValue = $util.defaultIfNull($ctx.identity.username, "___xamznone____") )
#if( $util.isList($allowedOwners0) )
  #foreach( $allowedOwner in $allowedOwners0 )
    #if( $allowedOwner == $identityValue )
      #set( $isOwnerAuthorized = true )
    #end
  #end
#end
#if( $util.isString($allowedOwners0) )
  #if( $allowedOwners0 == $identityValue )
    #set( $isOwnerAuthorized = true )
  #end
#end
## Authorization rule: { allow: "owner", ownerField: "editors", identityField: "username" } **
#set( $allowedOwners1 = $ctx.result.editors )
#set( $identityValue = $util.defaultIfNull($ctx.identity.username, "___xamznone____") )
#if( $util.isList($allowedOwners1) )
  #foreach( $allowedOwner in $allowedOwners1 )
    #if( $allowedOwner == $identityValue )
      #set( $isOwnerAuthorized = true )
    #end
  #end
#end
#if( $util.isString($allowedOwners1) )
  #if( $allowedOwners1 == $identityValue )
    #set( $isOwnerAuthorized = true )
  #end
#end
## [End] Owner Authorization Checks **


## [Start] Throw if unauthorized **
#if( !($isStaticGroupAuthorized == true || $isDynamicGroupAuthorized == true || $isOwnerAuthorized == true) )
  $util.unauthorized()
#end
## [End] Throw if unauthorized **

$util.toJson($context.result)
```

**Query.listAllThrees.response**

```velocity
## [Start] Static Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $allowedGroups = ["Admin", "Execs"] )
#set($isStaticGroupAuthorized = $util.defaultIfNull($isStaticGroupAuthorized, false))
#foreach( $userGroup in $userGroups )
  #foreach( $allowedGroup in $allowedGroups )
    #if( $allowedGroup == $userGroup )
      #set( $isStaticGroupAuthorized = true )
    #end
  #end
#end
## [End] Static Group Authorization Checks **


## [Start] If not static group authorized, filter items **
#if( ! $isStaticGroupAuthorized )
  #set( $items = [] )
  #foreach( $item in $ctx.result.items )
    ## [Start] Dynamic Group Authorization Checks **
    #set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
    #set( $isLocalDynamicGroupAuthorized = false )
    ## Authorization rule: { allow: "groups", groupsField: "groups" } **
    #set( $allowedGroups = $item.groups )
    #foreach( $userGroup in $userGroups )
      #if( $util.isList($allowedGroups) )
        #if( $allowedGroups.contains($userGroup) )
          #set( $isLocalDynamicGroupAuthorized = true )
        #end
      #end
      #if( $util.isString($allowedGroups) )
        #if( $allowedGroups == $userGroup )
          #set( $isLocalDynamicGroupAuthorized = true )
        #end
      #end
    #end
    ## Authorization rule: { allow: "groups", groupsField: "alternativeGroup" } **
    #set( $allowedGroups = $item.alternativeGroup )
    #foreach( $userGroup in $userGroups )
      #if( $util.isList($allowedGroups) )
        #if( $allowedGroups.contains($userGroup) )
          #set( $isLocalDynamicGroupAuthorized = true )
        #end
      #end
      #if( $util.isString($allowedGroups) )
        #if( $allowedGroups == $userGroup )
          #set( $isLocalDynamicGroupAuthorized = true )
        #end
      #end
    #end
    ## [End] Dynamic Group Authorization Checks **


    ## [Start] Owner Authorization Checks **
    #set( $isLocalOwnerAuthorized = false )
    ## Authorization rule: { allow: "owner", ownerField: "owner", identityField: "username" } **
    #set( $allowedOwners0 = $item.owner )
    #set( $identityValue = $util.defaultIfNull($ctx.identity.username, "___xamznone____") )
    #if( $util.isList($allowedOwners0) )
      #foreach( $allowedOwner in $allowedOwners0 )
        #if( $allowedOwner == $identityValue )
          #set( $isLocalOwnerAuthorized = true )
        #end
      #end
    #end
    #if( $util.isString($allowedOwners0) )
      #if( $allowedOwners0 == $identityValue )
        #set( $isLocalOwnerAuthorized = true )
      #end
    #end
    ## Authorization rule: { allow: "owner", ownerField: "editors", identityField: "username" } **
    #set( $allowedOwners1 = $item.editors )
    #set( $identityValue = $util.defaultIfNull($ctx.identity.username, "___xamznone____") )
    #if( $util.isList($allowedOwners1) )
      #foreach( $allowedOwner in $allowedOwners1 )
        #if( $allowedOwner == $identityValue )
          #set( $isLocalOwnerAuthorized = true )
        #end
      #end
    #end
    #if( $util.isString($allowedOwners1) )
      #if( $allowedOwners1 == $identityValue )
        #set( $isLocalOwnerAuthorized = true )
      #end
    #end
    ## [End] Owner Authorization Checks **


    #if( ($isLocalDynamicGroupAuthorized == true || $isLocalOwnerAuthorized == true) )
      $util.qr($items.add($item))
    #end
  #end
  #set( $ctx.result.items = $items )
#end
## [End] If not static group authorized, filter items **

$util.toJson($ctx.result)
```

**Mutation.createAllThree.request**

```velocity
## [Start] Static Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $allowedGroups = ["Admin", "Execs"] )
#set($isStaticGroupAuthorized = $util.defaultIfNull($isStaticGroupAuthorized, false))
#foreach( $userGroup in $userGroups )
  #foreach( $allowedGroup in $allowedGroups )
    #if( $allowedGroup == $userGroup )
      #set( $isStaticGroupAuthorized = true )
    #end
  #end
#end
## [End] Static Group Authorization Checks **


## [Start] Dynamic Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
## Authorization rule: { allow: "groups", groupsField: "groups" } **
#set( $isDynamicGroupAuthorized = $util.defaultIfNull($isDynamicGroupAuthorized, false) )
#foreach( $userGroup in $userGroups )
  #if( $$util.isList($ctx.args.input.groups) )
    #if( $ctx.args.input.groups.contains($userGroup) )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
  #if( $util.isString($ctx.args.input.groups) )
    #if( $ctx.args.input.groups == $userGroup )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
#end
## Authorization rule: { allow: "groups", groupsField: "alternativeGroup" } **
#set( $isDynamicGroupAuthorized = $util.defaultIfNull($isDynamicGroupAuthorized, false) )
#foreach( $userGroup in $userGroups )
  #if( $$util.isList($ctx.args.input.alternativeGroup) )
    #if( $ctx.args.input.alternativeGroup.contains($userGroup) )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
  #if( $util.isString($ctx.args.input.alternativeGroup) )
    #if( $ctx.args.input.alternativeGroup == $userGroup )
      #set( $isDynamicGroupAuthorized = true )
    #end
  #end
#end
## [End] Dynamic Group Authorization Checks **


## [Start] Owner Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $isOwnerAuthorized = false )
## Authorization rule: { allow: "owner", ownerField: "owner", identityField: "username" } **
#set( $allowedOwners0 = $util.defaultIfNull($ctx.args.input.owner, null) )
#set( $identityValue = $util.defaultIfNull($ctx.identity.username, "___xamznone____") )
#if( $util.isList($allowedOwners0) )
  #foreach( $allowedOwner in $allowedOwners0 )
    #if( $allowedOwner == $identityValue )
      #set( $isOwnerAuthorized = true )
    #end
  #end
#end
#if( $util.isString($allowedOwners0) )
  #if( $allowedOwners0 == $identityValue )
    #set( $isOwnerAuthorized = true )
  #end
#end
#if( $util.isNull($allowedOwners0) && (! $ctx.args.input.containsKey("owner")) )
  $util.qr($ctx.args.input.put("owner", $identityValue))
  #set( $isOwnerAuthorized = true )
#end
## Authorization rule: { allow: "owner", ownerField: "editors", identityField: "username" } **
#set( $allowedOwners1 = $util.defaultIfNull($ctx.args.input.editors, null) )
#set( $identityValue = $util.defaultIfNull($ctx.identity.username, "___xamznone____") )
#if( $util.isList($allowedOwners1) )
  #foreach( $allowedOwner in $allowedOwners1 )
    #if( $allowedOwner == $identityValue )
      #set( $isOwnerAuthorized = true )
    #end
  #end
#end
#if( $util.isString($allowedOwners1) )
  #if( $allowedOwners1 == $identityValue )
    #set( $isOwnerAuthorized = true )
  #end
#end
#if( $util.isNull($allowedOwners1) && (! $ctx.args.input.containsKey("editors")) )
  $util.qr($ctx.args.input.put("editors", ["$identityValue"]))
  #set( $isOwnerAuthorized = true )
#end
## [End] Owner Authorization Checks **


## [Start] Throw if unauthorized **
#if( !($isStaticGroupAuthorized == true || $isDynamicGroupAuthorized == true || $isOwnerAuthorized == true) )
  $util.unauthorized()
#end
## [End] Throw if unauthorized **

## [Start] Prepare DynamoDB PutItem Request. **
$util.qr($context.args.input.put("createdAt", $util.time.nowISO8601()))
$util.qr($context.args.input.put("updatedAt", $util.time.nowISO8601()))
$util.qr($context.args.input.put("__typename", "AllThree"))
{
  "version": "2017-02-28",
  "operation": "PutItem",
  "key": {
      "id": {
          "S": "$util.autoId()"
    }
  },
  "attributeValues": $util.dynamodb.toMapValuesJson($context.args.input),
  "condition": {
      "expression": "attribute_not_exists(#id)",
      "expressionNames": {
          "#id": "id"
    }
  }
}
## [End] Prepare DynamoDB PutItem Request. **
```

**Mutation.updateAllThree.request**

```velocity
## [Start] Static Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $allowedGroups = ["Admin", "Execs"] )
#set($isStaticGroupAuthorized = $util.defaultIfNull($isStaticGroupAuthorized, false))
#foreach( $userGroup in $userGroups )
  #foreach( $allowedGroup in $allowedGroups )
    #if( $allowedGroup == $userGroup )
      #set( $isStaticGroupAuthorized = true )
    #end
  #end
#end
## [End] Static Group Authorization Checks **


#if( ! $isStaticGroupAuthorized )
  ## [Start] Dynamic Group Authorization Checks **
  #set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
  #set( $groupAuthExpressions = [] )
  #set( $groupAuthExpressionValues = {} )
  #set( $groupAuthExpressionNames = {} )
  ## Authorization rule: { allow: "groups", groupsField: "groups" } **
  #foreach( $userGroup in $userGroups )
    $util.qr($groupAuthExpressions.add("contains(#groupsAttribute0, :group0$foreach.count)"))
    $util.qr($groupAuthExpressionValues.put(":group0$foreach.count", { "S": $userGroup }))
  #end
  $util.qr($groupAuthExpressionNames.put("#groupsAttribute0", "groups"))
  ## Authorization rule: { allow: "groups", groupsField: "alternativeGroup" } **
  #foreach( $userGroup in $userGroups )
    $util.qr($groupAuthExpressions.add("contains(#groupsAttribute1, :group1$foreach.count)"))
    $util.qr($groupAuthExpressionValues.put(":group1$foreach.count", { "S": $userGroup }))
  #end
  $util.qr($groupAuthExpressionNames.put("#groupsAttribute1", "alternativeGroup"))
  ## [End] Dynamic Group Authorization Checks **


  ## [Start] Owner Authorization Checks **
  #set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
  #set( $ownerAuthExpressions = [] )
  #set( $ownerAuthExpressionValues = {} )
  #set( $ownerAuthExpressionNames = {} )
  ## Authorization rule: { allow: "owner", ownerField: "owner", identityField: "username" } **
  $util.qr($ownerAuthExpressions.add("#owner0 = :identity0"))
  $util.qr($ownerAuthExpressionNames.put("#owner0", "owner"))
  $util.qr($ownerAuthExpressionValues.put(":identity0", { "S": "$ctx.identity.username"}))
  ## Authorization rule: { allow: "owner", ownerField: "editors", identityField: "username" } **
  $util.qr($ownerAuthExpressions.add("contains(#owner1, :identity1)"))
  $util.qr($ownerAuthExpressionNames.put("#owner1", "editors"))
  $util.qr($ownerAuthExpressionValues.put(":identity1", { "S": "$ctx.identity.username"}))
  ## [End] Owner Authorization Checks **


  ## [Start] Collect Auth Condition **
  #set( $authCondition = {
  "expression": "",
  "expressionNames": {},
  "expressionValues": {}
} )
  #set( $totalAuthExpression = "" )
  ## Add dynamic group auth conditions if they exist **
  #if( $groupAuthExpressions )
    #foreach( $authExpr in $groupAuthExpressions )
      #set( $totalAuthExpression = "$totalAuthExpression $authExpr" )
      #if( $foreach.hasNext )
        #set( $totalAuthExpression = "$totalAuthExpression OR" )
      #end
    #end
  #end
  #if( $groupAuthExpressionNames )
    $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
  #end
  #if( $groupAuthExpressionValues )
    $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
  #end
  ## Add owner auth conditions if they exist **
  #if( $totalAuthExpression != "" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
    #set( $totalAuthExpression = "$totalAuthExpression OR" )
  #end
  #if( $ownerAuthExpressions )
    #foreach( $authExpr in $ownerAuthExpressions )
      #set( $totalAuthExpression = "$totalAuthExpression $authExpr" )
      #if( $foreach.hasNext )
        #set( $totalAuthExpression = "$totalAuthExpression OR" )
      #end
    #end
  #end
  #if( $ownerAuthExpressionNames )
    $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
  #end
  #if( $ownerAuthExpressionValues )
    $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
  #end
  ## Set final expression if it has changed. **
  #if( $totalAuthExpression != "" )
    #set( $authCondition.expression = "($totalAuthExpression)" )
  #end
  ## [End] Collect Auth Condition **
#end


## [Start] Throw if unauthorized **
#if( !($isStaticGroupAuthorized == true || $authCondition && $authCondition.expression != "") )
  $util.unauthorized()
#end
## [End] Throw if unauthorized **

#if( $authCondition && $authCondition.expression != "" )
  #set( $condition = $authCondition )
  $util.qr($condition.put("expression", "$condition.expression AND attribute_exists(#id)"))
  $util.qr($condition.expressionNames.put("#id", "id"))
#else
  #set( $condition = {
  "expression": "attribute_exists(#id)",
  "expressionNames": {
      "#id": "id"
  },
  "expressionValues": {}
} )
#end
## Automatically set the updatedAt timestamp. **
$util.qr($context.args.input.put("updatedAt", $util.time.nowISO8601()))
$util.qr($context.args.input.put("__typename", "AllThree"))
## Update condition if type is @versioned **
#if( $versionedCondition )
  $util.qr($condition.put("expression", "($condition.expression) AND $versionedCondition.expression"))
  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
#end
#set( $expNames = {} )
#set( $expValues = {} )
#set( $expSet = {} )
#set( $expAdd = {} )
#set( $expRemove = [] )
#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, ["id"]).entrySet() )
  #if( $util.isNull($entry.value) )
    #set( $discard = $expRemove.add("#$entry.key") )
    $util.qr($expNames.put("#$entry.key", "$entry.key"))
  #else
    $util.qr($expSet.put("#$entry.key", ":$entry.key"))
    $util.qr($expNames.put("#$entry.key", "$entry.key"))
    $util.qr($expValues.put(":$entry.key", $util.dynamodb.toDynamoDB($entry.value)))
  #end
#end
#set( $expression = "" )
#if( !$expSet.isEmpty() )
  #set( $expression = "SET" )
  #foreach( $entry in $expSet.entrySet() )
    #set( $expression = "$expression $entry.key = $entry.value" )
    #if( $foreach.hasNext() )
      #set( $expression = "$expression," )
    #end
  #end
#end
#if( !$expAdd.isEmpty() )
  #set( $expression = "$expression ADD" )
  #foreach( $entry in $expAdd.entrySet() )
    #set( $expression = "$expression $entry.key $entry.value" )
    #if( $foreach.hasNext() )
      #set( $expression = "$expression," )
    #end
  #end
#end
#if( !$expRemove.isEmpty() )
  #set( $expression = "$expression REMOVE" )
  #foreach( $entry in $expRemove )
    #set( $expression = "$expression $entry" )
    #if( $foreach.hasNext() )
      #set( $expression = "$expression," )
    #end
  #end
#end
#set( $update = {} )
$util.qr($update.put("expression", "$expression"))
#if( !$expNames.isEmpty() )
  $util.qr($update.put("expressionNames", $expNames))
#end
#if( !$expValues.isEmpty() )
  $util.qr($update.put("expressionValues", $expValues))
#end
{
  "version": "2017-02-28",
  "operation": "UpdateItem",
  "key": {
      "id": {
          "S": "$context.args.input.id"
    }
  },
  "update": $util.toJson($update),
  "condition": $util.toJson($condition)
}
```

**Mutation.deleteAllThree.request**

```velocity
## [Start] Static Group Authorization Checks **
#set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
#set( $allowedGroups = ["Admin", "Execs"] )
#set($isStaticGroupAuthorized = $util.defaultIfNull($isStaticGroupAuthorized, false))
#foreach( $userGroup in $userGroups )
  #foreach( $allowedGroup in $allowedGroups )
    #if( $allowedGroup == $userGroup )
      #set( $isStaticGroupAuthorized = true )
    #end
  #end
#end
## [End] Static Group Authorization Checks **


#if( ! $isStaticGroupAuthorized )
  ## [Start] Dynamic Group Authorization Checks **
  #set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
  #set( $groupAuthExpressions = [] )
  #set( $groupAuthExpressionValues = {} )
  #set( $groupAuthExpressionNames = {} )
  ## Authorization rule: { allow: "groups", groupsField: "groups" } **
  #foreach( $userGroup in $userGroups )
    $util.qr($groupAuthExpressions.add("contains(#groupsAttribute0, :group0$foreach.count)"))
    $util.qr($groupAuthExpressionValues.put(":group0$foreach.count", { "S": $userGroup }))
  #end
  $util.qr($groupAuthExpressionNames.put("#groupsAttribute0", "groups"))
  ## Authorization rule: { allow: "groups", groupsField: "alternativeGroup" } **
  #foreach( $userGroup in $userGroups )
    $util.qr($groupAuthExpressions.add("contains(#groupsAttribute1, :group1$foreach.count)"))
    $util.qr($groupAuthExpressionValues.put(":group1$foreach.count", { "S": $userGroup }))
  #end
  $util.qr($groupAuthExpressionNames.put("#groupsAttribute1", "alternativeGroup"))
  ## [End] Dynamic Group Authorization Checks **


  ## [Start] Owner Authorization Checks **
  #set( $userGroups = $ctx.identity.claims.get("cognito:groups") )
  #set( $ownerAuthExpressions = [] )
  #set( $ownerAuthExpressionValues = {} )
  #set( $ownerAuthExpressionNames = {} )
  ## Authorization rule: { allow: "owner", ownerField: "owner", identityField: "username" } **
  $util.qr($ownerAuthExpressions.add("#owner0 = :identity0"))
  $util.qr($ownerAuthExpressionNames.put("#owner0", "owner"))
  $util.qr($ownerAuthExpressionValues.put(":identity0", { "S": "$ctx.identity.username"}))
  ## Authorization rule: { allow: "owner", ownerField: "editors", identityField: "username" } **
  $util.qr($ownerAuthExpressions.add("contains(#owner1, :identity1)"))
  $util.qr($ownerAuthExpressionNames.put("#owner1", "editors"))
  $util.qr($ownerAuthExpressionValues.put(":identity1", { "S": "$ctx.identity.username"}))
  ## [End] Owner Authorization Checks **


  ## [Start] Collect Auth Condition **
  #set( $authCondition = {
  "expression": "",
  "expressionNames": {},
  "expressionValues": {}
} )
  #set( $totalAuthExpression = "" )
  ## Add dynamic group auth conditions if they exist **
  #if( $groupAuthExpressions )
    #foreach( $authExpr in $groupAuthExpressions )
      #set( $totalAuthExpression = "$totalAuthExpression $authExpr" )
      #if( $foreach.hasNext )
        #set( $totalAuthExpression = "$totalAuthExpression OR" )
      #end
    #end
  #end
  #if( $groupAuthExpressionNames )
    $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
  #end
  #if( $groupAuthExpressionValues )
    $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
  #end
  ## Add owner auth conditions if they exist **
  #if( $totalAuthExpression != "" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
    #set( $totalAuthExpression = "$totalAuthExpression OR" )
  #end
  #if( $ownerAuthExpressions )
    #foreach( $authExpr in $ownerAuthExpressions )
      #set( $totalAuthExpression = "$totalAuthExpression $authExpr" )
      #if( $foreach.hasNext )
        #set( $totalAuthExpression = "$totalAuthExpression OR" )
      #end
    #end
  #end
  #if( $ownerAuthExpressionNames )
    $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
  #end
  #if( $ownerAuthExpressionValues )
    $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
  #end
  ## Set final expression if it has changed. **
  #if( $totalAuthExpression != "" )
    #set( $authCondition.expression = "($totalAuthExpression)" )
  #end
  ## [End] Collect Auth Condition **
#end


## [Start] Throw if unauthorized **
#if( !($isStaticGroupAuthorized == true || $authCondition && $authCondition.expression != "") )
  $util.unauthorized()
#end
## [End] Throw if unauthorized **

#if( $authCondition )
  #set( $condition = $authCondition )
  $util.qr($condition.put("expression", "$condition.expression AND attribute_exists(#id)"))
  $util.qr($condition.expressionNames.put("#id", "id"))
#else
  #set( $condition = {
  "expression": "attribute_exists(#id)",
  "expressionNames": {
      "#id": "id"
  }
} )
#end
#if( $versionedCondition )
  $util.qr($condition.put("expression", "($condition.expression) AND $versionedCondition.expression"))
  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
  #set( $expressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
  $util.qr($expressionValues.putAll($versionedCondition.expressionValues))
  #set( $condition.expressionValues = $expressionValues )
#end
{
  "version": "2017-02-28",
  "operation": "DeleteItem",
  "key": {
      "id": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
  },
  "condition": $util.toJson($condition)
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.