### PR TITLE
fix(graphql-auth-transformer): re-names user pool resource in description

### DIFF
--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -21,7 +21,7 @@ export class ResourceFactory {
                 Default: ResourceConstants.NONE
             }),
             [ResourceConstants.PARAMETERS.AuthCognitoUserPoolName]: new StringParameter({
-                Description: 'The name of the AppSync API',
+                Description: 'The name of the user pool.',
                 Default: 'AppSyncUserPool'
             }),
             [ResourceConstants.PARAMETERS.AuthCognitoUserPoolMobileClientName]: new StringParameter({


### PR DESCRIPTION
*Description of changes:*
Saw in the CloudFormation template that the resource is a Cognito UserPool. The change is a small re-name of the resource's description.

I'm really liking this project 👍 Keep up the great work!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.