### PR TITLE
fix: update pinpoint IAM policy to use mobiletargeting instead of mobileanalytics

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
@@ -208,7 +208,7 @@
                   {
                     "Effect": "Allow",
                     "Action": [
-                        "mobileanalytics:PutEvents"
+                        "mobiletargeting:PutEvents"
                     ],
                     "Resource": [
                         "*"
@@ -284,7 +284,7 @@
                   {
                     "Effect": "Allow",
                     "Action": [
-                        "mobileanalytics:PutEvents"
+                        "mobiletargeting:PutEvents"
                     ],
                     "Resource": [
                         "*"

--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
@@ -208,15 +208,7 @@
                   {
                     "Effect": "Allow",
                     "Action": [
-                        "mobiletargeting:PutEvents"
-                    ],
-                    "Resource": [
-                        "*"
-                    ]
-                  },
-                  {
-                    "Effect": "Allow",
-                    "Action": [
+                        "mobiletargeting:PutEvents",
                         "mobiletargeting:UpdateEndpoint"
                     ],
                     "Resource": [
@@ -284,15 +276,7 @@
                   {
                     "Effect": "Allow",
                     "Action": [
-                        "mobiletargeting:PutEvents"
-                    ],
-                    "Resource": [
-                        "*"
-                    ]
-                  },
-                  {
-                    "Effect": "Allow",
-                    "Action": [
+                        "mobiletargeting:PutEvents",
                         "mobiletargeting:UpdateEndpoint"
                     ],
                     "Resource": [

--- a/packages/amplify-category-notifications/lib/auth-helper.js
+++ b/packages/amplify-category-notifications/lib/auth-helper.js
@@ -96,7 +96,7 @@ function getPolicyDoc(context) {
       {
         Effect: 'Allow',
         Action: [
-          'mobileanalytics:PutEvents',
+          'mobiletargeting:PutEvents',
         ],
         Resource: [
           '*',

--- a/packages/amplify-category-notifications/lib/auth-helper.js
+++ b/packages/amplify-category-notifications/lib/auth-helper.js
@@ -97,14 +97,6 @@ function getPolicyDoc(context) {
         Effect: 'Allow',
         Action: [
           'mobiletargeting:PutEvents',
-        ],
-        Resource: [
-          '*',
-        ],
-      },
-      {
-        Effect: 'Allow',
-        Action: [
           'mobiletargeting:UpdateEndpoint',
         ],
         Resource: [


### PR DESCRIPTION

*Description of changes:*
Due to a recent change with Pinpoint API's, IAM policies need to be changed for the newly created Pinpoint API's. This PR modifies the IAM policies generated for a pinpoint endpoint using the CLI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.