### PR TITLE
Add option/flag in amplify push command to not automatically re-compile annotated GraphQL schema

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -27,6 +27,11 @@ Run \`amplify update api\` and choose "Amazon Cognito User Pool" as the authoriz
 }
 
 async function transformGraphQLSchema(context, options) {
+  const flags = context.parameters.options;
+  if ('gql-override' in flags && !flags['gql-override']) {
+    return;
+  }
+
   let { resourceDir, parameters } = options;
   // const { noConfig } = options;
 


### PR DESCRIPTION
By default, the GraphQL annotated schema gets compiled on each push and overrides any changes in the resolvers or cfn files. 
Added option/flag in amplify push command to not automatically re-compile annotated GraphQL schema and override the above-mentioned files.

Command -> `amplify push --no-gql-override`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.