### PR TITLE
fix(amplify-graphql-docs-generator): support list types in input

### DIFF
--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getArgs.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getArgs.test.ts
@@ -10,9 +10,13 @@ import isRequired from '../../src/generator/utils/isRequired'
 import getType from '../../src/generator/utils/getType'
 
 import getArgs from '../../src/generator/getArgs'
+import isList from '../../src/generator/utils/isList';
+import isRequiredList from '../../src/generator/utils/isRequiredList';
 
 jest.mock('../../src/generator/utils/isRequired')
 jest.mock('../../src/generator/utils/getType')
+jest.mock('../../src/generator/utils/isList')
+jest.mock('../../src/generator/utils/isRequiredList');
 
 describe('getArgs', () => {
   const id: GraphQLArgument = {
@@ -50,9 +54,12 @@ describe('getArgs', () => {
     jest.resetAllMocks()
     isRequired.mockReturnValue(false)
     getType.mockReturnValue({ name: 'mockType' })
+    isRequiredList.mockReturnValue(false);
+    isList.mockReturnValue(false);
   })
 
   it('should return arguments', () => {
+    isList.mockReturnValueOnce(true);
     const query = schema.getQueryType().getFields().searchArticle
     expect(getArgs(query.args)).toEqual([
       {
@@ -60,12 +67,16 @@ describe('getArgs', () => {
         type: 'mockType',
         defaultValue: '1',
         isRequired: false,
+        isList: true,
+        isListRequired: false,
       },
       {
         name: 'query',
         type: 'mockType',
         defaultValue: undefined,
         isRequired: false,
+        isList: false,
+        isListRequired: false,
       },
     ])
     expect(getType).toHaveBeenCalledTimes(2)
@@ -73,7 +84,10 @@ describe('getArgs', () => {
     expect(getType.mock.calls[1][0]).toEqual(GraphQLString)
 
     expect(isRequired).toHaveBeenCalledTimes(2)
-    expect(isRequired.mock.calls[0][0]).toEqual(query.args[0])
-    expect(isRequired.mock.calls[1][0]).toEqual(query.args[1])
+    expect(isRequired.mock.calls[0][0]).toEqual(query.args[0].type)
+    expect(isRequired.mock.calls[1][0]).toEqual(query.args[1].type)
+
+    expect(isList).toHaveBeenCalledTimes(2);
+    expect(isRequiredList).toHaveBeenCalledTimes(2);
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/utils/isRequired.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/utils/isRequired.test.ts
@@ -19,10 +19,10 @@ describe("isRequired", () => {
   });
 
   it("should return false for null types", () => {
-    expect(isRequired(testObj.getFields().street)).toEqual(false);
+    expect(isRequired(testObj.getFields().street.type)).toEqual(false);
   });
 
   it("should return true for non null types", () => {
-    expect(isRequired(testObj.getFields().requiredInt)).toEqual(true);
+    expect(isRequired(testObj.getFields().requiredInt.type)).toEqual(true);
   });
 });

--- a/packages/amplify-graphql-docs-generator/src/generator/getArgs.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getArgs.ts
@@ -1,16 +1,22 @@
 import { GraphQLArgument } from 'graphql'
 
 import getType from './utils/getType'
+import isList from './utils/isList';
 import isRequired from './utils/isRequired'
+import isRequiredList from './utils/isRequiredList';
 
 import { GQLTemplateArgDeclaration } from './types'
 
 export default function getArgs(args: GraphQLArgument[]): Array<GQLTemplateArgDeclaration> {
-  const argMaps = args.map((arg: GraphQLArgument) => ({
-    name: arg.name,
-    type: getType(arg.type).name,
-    isRequired: isRequired(arg),
-    defaultValue: arg.defaultValue,
-  }))
+  const argMaps = args.map((arg: GraphQLArgument) => {
+    return {
+      name: arg.name,
+      type: getType(arg.type).name,
+      isRequired: isRequired(arg.type),
+      isList: isList(arg.type),
+      isListRequired: isRequiredList(arg.type),
+      defaultValue: arg.defaultValue,
+    }
+  })
   return argMaps
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isList.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isList.ts
@@ -1,0 +1,8 @@
+import { GraphQLType, isNonNullType, isListType } from "graphql";
+
+export default function isList(typeObj: GraphQLType): boolean {
+  if (isNonNullType(typeObj)) {
+    return isList(typeObj.ofType);
+  }
+  return isListType(typeObj);
+}

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
@@ -1,4 +1,8 @@
-import { GraphQLArgument, GraphQLNonNull } from "graphql";
-export default function isRequired(arg: GraphQLArgument): boolean {
-  return arg.type instanceof GraphQLNonNull ? true : false;
+import { GraphQLType, isNonNullType, isListType } from "graphql";
+export default function isRequired(typeObj: GraphQLType): boolean {
+  if (isNonNullType(typeObj) && isListType(typeObj.ofType)) {
+    console.log('inside condition');
+    return isRequired(typeObj.ofType.ofType)
+  }
+  return isNonNullType(typeObj);
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
@@ -1,7 +1,6 @@
 import { GraphQLType, isNonNullType, isListType } from "graphql";
 export default function isRequired(typeObj: GraphQLType): boolean {
   if (isNonNullType(typeObj) && isListType(typeObj.ofType)) {
-    console.log('inside condition');
     return isRequired(typeObj.ofType.ofType)
   }
   return isNonNullType(typeObj);

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequiredList.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequiredList.ts
@@ -1,0 +1,4 @@
+import { GraphQLType, isNonNullType, isListType } from 'graphql'
+export default function isRequired(typeObj: GraphQLType): boolean {
+  return isNonNullType(typeObj) && isListType(typeObj.ofType)
+}

--- a/packages/amplify-graphql-docs-generator/templates/_renderArgDeclaration.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderArgDeclaration.hbs
@@ -1,7 +1,7 @@
 {{#if args.length}}
   (
     {{#each args as |arg index|}}
-      ${{ arg.name }}:{{arg.type}}{{#if arg.isRequired}}!{{/if}}{{#if arg.defaultValue}}={{arg.defaultValue}}{{/if}}{{#unless @last}},{{/unless}}
+      ${{ arg.name }}:{{#if isList}}[{{/if}}{{arg.type}}{{#if arg.isRequired}}!{{/if}}{{#if isList}}]{{#if isRequiredList}}!{{/if}}{{/if}}{{#if arg.defaultValue}}={{arg.defaultValue}}{{/if}}{{#unless @last}},{{/unless}}
     {{/each}}
   )
 {{/if}}


### PR DESCRIPTION
statement generator did not honor the list types in input. It used to coerce a list into a non list
type and the check for non null type was a shallow check. Updated code to support list in input
types

fix #295


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.