### PR TITLE
Bug/340

### DIFF
--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -79,7 +79,7 @@ export class AppSyncTransformer extends Transformer {
         const astSansDirectives = stripDirectives({
             kind: 'Document',
             definitions: Object.keys(ctx.nodeMap).map((k: string) => ctx.getType(k))
-        }, ['aws_subscribe'])
+        }, ['aws_subscribe', 'aws_auth'])
         const SDL = print(astSansDirectives)
         return SDL;
     }

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -71,7 +71,7 @@ export class ModelAuthTransformer extends Transformer {
             input AuthRule {
                 allow: AuthStrategy!
                 ownerField: String # defaults to "owner"
-                identityField: String # defaults to "username"
+                identityField: String # defaults to "cognito:username"
                 groupsField: String
                 groups: [String]
                 queries: [ModelQuery]

--- a/packages/graphql-auth-transformer/src/constants.ts
+++ b/packages/graphql-auth-transformer/src/constants.ts
@@ -1,5 +1,5 @@
 export const OWNER_AUTH_STRATEGY = "owner"
 export const DEFAULT_OWNER_FIELD = "owner"
-export const DEFAULT_IDENTITY_FIELD = "username"
+export const DEFAULT_IDENTITY_FIELD = "cognito:username"
 export const GROUPS_AUTH_STRATEGY = "groups"
 export const DEFAULT_GROUPS_FIELD = "groups"

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -202,7 +202,7 @@ export class ResourceFactory {
                 AwsRegion: Fn.Select(3, Fn.Split(':', Fn.GetAtt(tableId, 'Arn'))),
                 TableName: Fn.Ref(tableId)
             }
-        })
+        }).dependsOn(tableId).dependsOn(iamRoleLogicalID)
     }
 
     /**

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -188,7 +188,7 @@ export default class GraphQLTransform {
         const context = new TransformerContext(schema)
         const validDirectiveNameMap = this.transformers.reduce(
             (acc: any, t: Transformer) => ({ ...acc, [t.directive.name.value]: true }),
-            { aws_subscribe: true }
+            { aws_subscribe: true, aws_auth: true }
         )
         let allModelDefinitions = [...context.inputDocument.definitions]
         for (const transformer of this.transformers) {
@@ -259,7 +259,7 @@ export default class GraphQLTransform {
     private transformObject(
         transformer: Transformer,
         def: ObjectTypeDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -289,7 +289,7 @@ export default class GraphQLTransform {
         transformer: Transformer,
         parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
         def: FieldDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -320,7 +320,7 @@ export default class GraphQLTransform {
         parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
         field: FieldDefinitionNode,
         arg: InputValueDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of arg.directives) {
@@ -346,7 +346,7 @@ export default class GraphQLTransform {
     private transformInterface(
         transformer: Transformer,
         def: InterfaceTypeDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext) {
         for (const dir of def.directives) {
             if (!validDirectiveNameMap[dir.name.value]) {
@@ -374,7 +374,7 @@ export default class GraphQLTransform {
     private transformScalar(
         transformer: Transformer,
         def: ScalarTypeDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -400,7 +400,7 @@ export default class GraphQLTransform {
     private transformUnion(
         transformer: Transformer,
         def: UnionTypeDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -426,7 +426,7 @@ export default class GraphQLTransform {
     private transformEnum(
         transformer: Transformer,
         def: EnumTypeDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -456,7 +456,7 @@ export default class GraphQLTransform {
         transformer: Transformer,
         enm: EnumTypeDefinitionNode,
         def: EnumValueDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -482,7 +482,7 @@ export default class GraphQLTransform {
     private transformInputObject(
         transformer: Transformer,
         def: InputObjectTypeDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {
@@ -512,7 +512,7 @@ export default class GraphQLTransform {
         transformer: Transformer,
         input: InputObjectTypeDefinitionNode,
         def: InputValueDefinitionNode,
-        validDirectiveNameMap: { [k: string]: boolean},
+        validDirectiveNameMap: { [k: string]: boolean },
         context: TransformerContext
     ) {
         for (const dir of def.directives) {

--- a/packages/graphql-transformer-core/src/validation.ts
+++ b/packages/graphql-transformer-core/src/validation.ts
@@ -89,6 +89,7 @@ scalar Double
 
 const EXTRA_DIRECTIVES_DOCUMENT = parse(`
 directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
+directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
 `)
 
 export function astBuilder(doc: DocumentNode): ASTDefinitionBuilder {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.e2e.test.ts
@@ -136,6 +136,9 @@ test('Test custom root query, mutation, and subscriptions.', () => {
     }
     type Query2 {
         additionalQueryField: String
+
+        authedField: String
+            @aws_auth(cognito_groups: ["Bloggers", "Readers"])
     }
     type Mutation2 {
         additionalMutationField: String
@@ -163,7 +166,10 @@ test('Test custom root query, mutation, and subscriptions.', () => {
     expect(definition).toBeDefined()
     const parsed = parse(definition);
     const queryType = getObjectType(parsed, 'Query2');
-    expectFields(queryType, ['getPost', 'listPosts', 'additionalQueryField'])
+    expectFields(queryType, ['getPost', 'listPosts', 'additionalQueryField', 'authedField'])
+    const authedField = queryType.fields.find(f => f.name.value === 'authedField')
+    expect(authedField.directives.length).toEqual(1)
+    expect(authedField.directives[0].name.value).toEqual('aws_auth')
     const mutationType = getObjectType(parsed, 'Mutation2');
     expectFields(mutationType, ['createPost', 'updatePost', 'deletePost', 'additionalMutationField'])
     const subscriptionType = getObjectType(parsed, 'Subscription2');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -254,8 +254,8 @@ beforeAll(async () => {
     }
     type AllThree
         @auth(rules: [
-            {allow: owner},
-            {allow: owner, ownerField: "editors"},
+            {allow: owner, identityField: "username" },
+            {allow: owner, ownerField: "editors", identityField: "cognito:username" },
             {allow: groups, groups: ["Admin"]},
             {allow: groups, groups: ["Execs"]},
             {allow: groups, groupsField: "groups"},
@@ -268,6 +268,12 @@ beforeAll(async () => {
         editors: [String]
         groups: [String]
         alternativeGroup: String
+    }
+    # The owner should always start with https://cognito-idp
+    type TestIdentity @model @auth(rules: [{ allow: owner, identityField: "iss" }]) {
+        id: ID!
+        title: String!
+        owner: String
     }
     `
     const transformer = new GraphQLTransform({
@@ -2582,6 +2588,94 @@ test(`Test updateAllThree and deleteAllThree as a member of the alternative grou
         `)
         console.log(JSON.stringify(deleteReq, null, 4))
         expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id)
+    } catch (e) {
+        console.error(e)
+        expect(e).toBeUndefined();
+    }
+})
+
+test(`Test createTestIdentity as admin.`, async () => {
+    try {
+        const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+        mutation {
+            createTestIdentity(input: {
+                title: "Test title"
+            }) {
+                id
+                title
+                owner
+            }
+        }
+        `)
+        console.log(JSON.stringify(ownedBy2, null, 4))
+        expect(ownedBy2.data.createTestIdentity).toBeTruthy()
+        expect(ownedBy2.data.createTestIdentity.title).toEqual("Test title")
+        expect(ownedBy2.data.createTestIdentity.owner.slice(0, 19)).toEqual("https://cognito-idp")
+
+        // user 2 should be able to update because they share the same issuer.
+        const update = await GRAPHQL_CLIENT_3.query(`
+        mutation {
+            updateTestIdentity(input: {
+                id: "${ownedBy2.data.createTestIdentity.id}",
+                title: "Test title update"
+            }) {
+                id
+                title
+                owner
+            }
+        }
+        `)
+        console.log(JSON.stringify(update, null, 4))
+        expect(update.data.updateTestIdentity).toBeTruthy()
+        expect(update.data.updateTestIdentity.title).toEqual("Test title update")
+        expect(update.data.updateTestIdentity.owner.slice(0, 19)).toEqual("https://cognito-idp")
+
+        // user 2 should be able to get because they share the same issuer.
+        const getReq = await GRAPHQL_CLIENT_3.query(`
+        query {
+            getTestIdentity(id: "${ownedBy2.data.createTestIdentity.id}") {
+                id
+                title
+                owner
+            }
+        }
+        `)
+        console.log(JSON.stringify(getReq, null, 4))
+        expect(getReq.data.getTestIdentity).toBeTruthy()
+        expect(getReq.data.getTestIdentity.title).toEqual("Test title update")
+        expect(getReq.data.getTestIdentity.owner.slice(0, 19)).toEqual("https://cognito-idp")
+
+        const listResponse = await GRAPHQL_CLIENT_3.query(`query {
+            listTestIdentitys(filter: { title: { eq: "Test title update" } }, limit: 100) {
+                items {
+                    id
+                    title
+                    owner
+                }
+            }
+        }`, {})
+        const relevantPost = listResponse.data.listTestIdentitys.items.find(p => p.id === getReq.data.getTestIdentity.id)
+        console.log(JSON.stringify(listResponse, null, 4))
+        expect(relevantPost).toBeTruthy()
+        expect(relevantPost.title).toEqual("Test title update")
+        expect(relevantPost.owner.slice(0, 19)).toEqual("https://cognito-idp")
+
+        // user 2 should be able to delete because they share the same issuer.
+        const delReq = await GRAPHQL_CLIENT_3.query(`
+        mutation {
+            deleteTestIdentity(input: {
+                id: "${ownedBy2.data.createTestIdentity.id}"
+            }) {
+                id
+                title
+                owner
+            }
+        }
+        `)
+        console.log(JSON.stringify(delReq, null, 4))
+        expect(delReq.data.deleteTestIdentity).toBeTruthy()
+        expect(delReq.data.deleteTestIdentity.title).toEqual("Test title update")
+        expect(delReq.data.deleteTestIdentity.owner.slice(0, 19)).toEqual("https://cognito-idp")
     } catch (e) {
         console.error(e)
         expect(e).toBeUndefined();


### PR DESCRIPTION
*Issue #, if available:*

#340 

*Description of changes:*

This tweaks the behaviour of the "identityField" to allow users to use any attributes of the `$ctx.identity.claims` map. Before if I set the "identityField" to be "customField" it would work out to be `$ctx.identity.customField` and now it will be `$ctx.identity.claims.get("customField")`.

One side note. Before this change, the default value for identityField was **"username"** and is now **"cognito:username"** as that is how it appears in the claims object. I have inserted a check that if you provide the value **"username"**, it will be automatically aliased to **cognito:username** to prevent breaking existing projects. This is open for discussion.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.