### PR TITLE
Fixing 262

### DIFF
--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -7,7 +7,7 @@ import {
     ref, obj, set, nul,
     ifElse, compoundExpression, bool, equals, iff, raw
 } from 'graphql-mapping-template'
-import { ResourceConstants, ModelResourceIDs, DEFAULT_SCALARS } from 'graphql-transformer-common'
+import { ResourceConstants, ModelResourceIDs, DEFAULT_SCALARS, NONE_VALUE } from 'graphql-transformer-common'
 import { InvalidDirectiveError } from 'graphql-transformer-core';
 
 export class ResourceFactory {
@@ -106,7 +106,7 @@ export class ResourceFactory {
             RequestMappingTemplate: print(
                 DynamoDBMappingTemplate.getItem({
                     key: obj({
-                        id: ref(`util.dynamodb.toDynamoDBJson($ctx.source.${connectionAttribute})`)
+                        id: ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${connectionAttribute}, "${NONE_VALUE}"))`)
                     })
                 })
             ),

--- a/packages/graphql-transformer-common/src/util.ts
+++ b/packages/graphql-transformer-common/src/util.ts
@@ -17,3 +17,5 @@ export function toCamelCase(words: string[]): string {
     const formatted = words.map((w, i) => i === 0 ? w.charAt(0).toLowerCase() + w.slice(1) : w.charAt(0).toUpperCase() + w.slice(1))
     return formatted.join('')
 }
+
+export const NONE_VALUE = '___xamznone____'

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -247,3 +247,38 @@ test('Test queryPost query with sortField', async () => {
         expect(e).toBeUndefined()
     }
 })
+
+test('Test create comment without a post and then querying the comment.', async () => {
+    try {
+        const createCommentResponse1 = await GRAPHQL_CLIENT.query(`mutation {
+            createComment(input:
+                { content: "${comment1}" }) {
+                id
+                content
+                post {
+                    id
+                    title
+                }
+            }
+        }`, {})
+        expect(createCommentResponse1.data.createComment.id).toBeDefined()
+        expect(createCommentResponse1.data.createComment.content).toEqual(comment1)
+        expect(createCommentResponse1.data.createComment.post).toBeNull()
+
+        const queryResponseDesc = await GRAPHQL_CLIENT.query(`query {
+            getComment(id: "${createCommentResponse1.data.createComment.id}") {
+                id
+                content
+                post {
+                    id
+                }
+            }
+        }`, {})
+        expect(queryResponseDesc.data.getComment).toBeDefined()
+        expect(queryResponseDesc.data.getComment.post).toBeNull()
+    } catch (e) {
+        console.error(e)
+        // fail
+        expect(e).toBeUndefined()
+    }
+})


### PR DESCRIPTION
*Issue #, if available:*

#262 

*Description of changes:*

This fixes an issue where if you create an object that has a connection without associating the object to another and then query it, an error is thrown from DynamoDB.

This puts a missing `$util.defaultIfNullOrBlank` check in the connection GetItem call as well as adds e2e tests to verify the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.