### PR TITLE
Hosting update / fix typo

### DIFF
--- a/packages/amplify-category-analytics/package.json
+++ b/packages/amplify-category-analytics/package.json
@@ -7,7 +7,7 @@
     "amplify-category-auth": "^0.1.28",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "opn": "^5.3.0",
     "uuid": "^3.3.2"
   },

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -15,7 +15,7 @@
     "amplify-category-storage": "^0.1.28",
     "eslint": "^4.9.0",
     "fs-extra": "^6.0.1",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "moment": "^2.22.2",
     "uuid": "^2.0.3"
   },

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -8,7 +8,7 @@
     "fs-extra": "^7.0.0",
     "grunt": "^1.0.3",
     "grunt-aws-lambda": "^0.13.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -96,7 +96,7 @@ async function configure(context) {
       {
         name: 'ConfigCustomError',
         type: 'confirm',
-        message: 'Configure Custom Error Reponses',
+        message: 'Configure Custom Error Responses',
         default: true,
       },
     ];
@@ -162,7 +162,6 @@ async function configureCustomErrorResponse(DistributionConfig) {
 
 async function addCER(CustomErrorResponses) {
   const unConfiguredCodes = getUnConfiguredErrorCodes(CustomErrorResponses);
-  console.log(unConfiguredCodes);
   if (unConfiguredCodes.length > 0) {
     const selection = await inquirer.prompt({
       name: 'ErrorCode',

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
@@ -132,7 +132,7 @@
                         "ForwardedValues" : {
                             "QueryString" : "false"
                         },
-                        "ViewerProtocolPolicy" : "allow-all", 
+                        "ViewerProtocolPolicy" : "redirect-to-https", 
                         "DefaultTTL" : 86400,
                         "MaxTTL" : 31536000,
                         "MinTTL" : 60,

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -7,7 +7,7 @@
     "amplify-category-auth": "^0.1.28",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "opn": "^5.3.0",
     "ora": "^3.0.0",
     "uuid": "^3.3.2"

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -7,7 +7,7 @@
     "amplify-category-auth": "^0.1.28",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "uuid": "^2.0.3"
   },
   "scripts": {

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -39,7 +39,7 @@
     "fs-extra": "^6.0.1",
     "gluegun": "next",
     "ini": "^1.3.5",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "open-in-editor": "^2.2.0",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -20,7 +20,7 @@
     "fs-jetpack": "^2.1.0",
     "glob-all": "^3.1.0",
     "graphql-config": "^2.1.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "ora": "^3.0.0",
     "underscore": "^1.9.1"
   },


### PR DESCRIPTION
*Issue #, if available:*
- fixed a typo in the hosting category
- changed hosting category's cloudfront's default cache behavior, Viewer Protocol Policy:  'allow-all' -> 'redirect-to-https' 
- unified the requirer packages' versions to "^6.0.0"


*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.