### PR TITLE
Fixing GraphQL e2e tests

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -19,7 +19,7 @@ import {
     toCamelCase, isNonNullType
 } from 'graphql-transformer-common'
 import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common'
-import { updateCreateInputWithConnectionField, updateUpdateInputWithConnectionField } from './definitions';
+import { updateCreateInputWithConnectionField, updateUpdateInputWithConnectionField, updateFilterInputWithConnectionField } from './definitions';
 
 function makeConnectionAttributeName(type: string, field?: string) {
     return field ? toCamelCase([type, field, 'id']) : toCamelCase([type, 'id'])
@@ -224,6 +224,13 @@ export class ModelConnectionTransformer extends Transformer {
                 ctx.putType(updated)
             }
 
+            const filterInputName = ModelResourceIDs.ModelFilterInputTypeName(parentTypeName)
+            const filterInput = ctx.getType(filterInputName) as InputObjectTypeDefinitionNode
+            if (filterInput) {
+                const updated = updateFilterInputWithConnectionField(filterInput, connectionAttributeName)
+                ctx.putType(updated)
+            }
+
         } else if (leftConnectionIsList) {
             // 4. [] to ?
             // Store foreign key on the related table and wire up a Query resolver.
@@ -265,6 +272,13 @@ export class ModelConnectionTransformer extends Transformer {
                 const updated = updateUpdateInputWithConnectionField(updateInput, connectionAttributeName)
                 ctx.putType(updated)
             }
+
+            const filterInputName = ModelResourceIDs.ModelFilterInputTypeName(relatedTypeName)
+            const filterInput = ctx.getType(filterInputName) as InputObjectTypeDefinitionNode
+            if (filterInput) {
+                const updated = updateFilterInputWithConnectionField(filterInput, connectionAttributeName)
+                ctx.putType(updated)
+            }
         } else {
             // 5. {} to ?
             // Store foreign key on this table and wire up a GetItem resolver.
@@ -296,6 +310,13 @@ export class ModelConnectionTransformer extends Transformer {
             const updateInput = ctx.getType(updateInputName) as InputObjectTypeDefinitionNode
             if (updateInput) {
                 const updated = updateUpdateInputWithConnectionField(updateInput, connectionAttributeName)
+                ctx.putType(updated)
+            }
+
+            const filterInputName = ModelResourceIDs.ModelFilterInputTypeName(parentTypeName)
+            const filterInput = ctx.getType(filterInputName) as InputObjectTypeDefinitionNode
+            if (filterInput) {
+                const updated = updateFilterInputWithConnectionField(filterInput, connectionAttributeName)
                 ctx.putType(updated)
             }
         }

--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -1,7 +1,7 @@
 import {
     ObjectTypeDefinitionNode, parse, FieldDefinitionNode, DocumentNode,
     DefinitionNode, Kind, InputObjectTypeDefinitionNode,
-    InputValueDefinitionNode
+    InputValueDefinitionNode, NamedTypeNode
 } from 'graphql'
 import GraphQLTransform, { InvalidDirectiveError } from 'graphql-transformer-core'
 import { ResourceConstants, ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common'
@@ -328,6 +328,7 @@ test('Test ModelConnectionTransformer with non null @connections', () => {
     expect(out).toBeDefined()
     expect(out.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy()
     const schemaDoc = parse(out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID].Properties.Definition)
+    console.log(out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID].Properties.Definition)
 
     // Post.comments field
     const postType = getObjectType(schemaDoc, 'Post')
@@ -360,6 +361,19 @@ test('Test ModelConnectionTransformer with non null @connections', () => {
     const postConnectionId = postCreateInput.fields.find(f => f.name.value === 'postSingleCommentId')
     expect(postConnectionId).toBeTruthy()
     expect(postConnectionId.type.kind).toEqual(Kind.NON_NULL_TYPE)
+
+    // Check the filter input types
+    const commentFilterInput = getInputType(schemaDoc, ModelResourceIDs.ModelFilterInputTypeName('Comment'))
+    const postFilterInput = getInputType(schemaDoc, ModelResourceIDs.ModelFilterInputTypeName('Post'))
+    const postIdInputField = commentFilterInput.fields.find(f => f.name.value === 'postId')
+    expect(postIdInputField).toBeTruthy()
+    expect((postIdInputField.type as NamedTypeNode).name.value).toEqual('ModelIDFilterInput')
+    const postManyCommentsIdInputField = commentFilterInput.fields.find(f => f.name.value === 'postManyCommentsId')
+    expect(postManyCommentsIdInputField).toBeTruthy()
+    expect((postManyCommentsIdInputField.type as NamedTypeNode).name.value).toEqual('ModelIDFilterInput')
+    const postSingleCommentIdInputField = postFilterInput.fields.find(f => f.name.value === 'postSingleCommentId')
+    expect(postSingleCommentIdInputField).toBeTruthy()
+    expect((postSingleCommentIdInputField.type as NamedTypeNode).name.value).toEqual('ModelIDFilterInput')
 });
 
 test('Test ModelConnectionTransformer with sortField fails if not specified in associated type', () => {

--- a/packages/graphql-connection-transformer/src/definitions.ts
+++ b/packages/graphql-connection-transformer/src/definitions.ts
@@ -1,5 +1,5 @@
 import { InputObjectTypeDefinitionNode } from 'graphql'
-import { makeInputValueDefinition, makeNonNullType, makeNamedType } from 'graphql-transformer-common';
+import { makeInputValueDefinition, makeNonNullType, makeNamedType, ModelResourceIDs } from 'graphql-transformer-common';
 
 export function updateCreateInputWithConnectionField(
     input: InputObjectTypeDefinitionNode,
@@ -35,6 +35,26 @@ export function updateUpdateInputWithConnectionField(
     const updatedFields = [
         ...input.fields,
         makeInputValueDefinition(connectionFieldName, makeNamedType('ID'))
+    ]
+    return {
+        ...input,
+        fields: updatedFields
+    }
+}
+
+export function updateFilterInputWithConnectionField(
+    input: InputObjectTypeDefinitionNode,
+    connectionFieldName: string
+): InputObjectTypeDefinitionNode {
+    const keyFieldExists = Boolean(input.fields.find(f => f.name.value === connectionFieldName))
+    // If the key field already exists then do not change the input.
+    // The @connection field will validate that the key field is valid.
+    if (keyFieldExists) {
+        return input;
+    }
+    const updatedFields = [
+        ...input.fields,
+        makeInputValueDefinition(connectionFieldName, makeNamedType(ModelResourceIDs.ModelFilterInputTypeName('ID')))
     ]
     return {
         ...input,

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
@@ -195,7 +195,7 @@ async function deleteBucket(name: string) {
     })
 }
 
-const TMP_ROOT = '/tmp/graphql_transform_tests/'
+const TMP_ROOT = '/tmp/connections_with_auth_test/'
 
 const ROOT_KEY = ''
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -194,7 +194,7 @@ async function deleteBucket(name: string) {
     })
 }
 
-const TMP_ROOT = '/tmp/graphql_transform_tests/'
+const TMP_ROOT = '/tmp/model_auth_transform_tests/'
 
 const ROOT_KEY = ''
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -102,7 +102,7 @@ afterAll(async () => {
  * Test queries below
  */
 
-test('Test queryPost query', async () => {
+test('Test connection queries', async () => {
     try {
         const createResponse = await GRAPHQL_CLIENT.query(`mutation {
             createPost(input: { title: "Test Query" }) {
@@ -138,10 +138,32 @@ test('Test queryPost query', async () => {
                 }
             }
         }`, {})
+        console.log(JSON.stringify(queryResponse, null, 4))
         expect(queryResponse.data.getPost).toBeDefined()
         const items = queryResponse.data.getPost.comments.items
         expect(items.length).toEqual(1)
         expect(items[0].id).toEqual(createCommentResponse.data.createComment.id)
+
+        const queryWithConnectionFilterResponse = await GRAPHQL_CLIENT.query(`query {
+            getPost(id: "${createResponse.data.createPost.id}") {
+                id
+                title
+                comments(
+                    filter: { postId: { eq: "${createResponse.data.createPost.id}" }},
+                    limit: 100
+                ) {
+                    items {
+                        id
+                        content
+                    }
+                }
+            }
+        }`, {})
+        console.log(JSON.stringify(queryWithConnectionFilterResponse, null, 4))
+        expect(queryWithConnectionFilterResponse.data.getPost).toBeDefined()
+        const resItems = queryWithConnectionFilterResponse.data.getPost.comments.items
+        expect(resItems.length).toEqual(1)
+        expect(resItems[0].id).toEqual(createCommentResponse.data.createComment.id)
     } catch (e) {
         console.error(e)
         // fail

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -143,27 +143,6 @@ test('Test connection queries', async () => {
         const items = queryResponse.data.getPost.comments.items
         expect(items.length).toEqual(1)
         expect(items[0].id).toEqual(createCommentResponse.data.createComment.id)
-
-        const queryWithConnectionFilterResponse = await GRAPHQL_CLIENT.query(`query {
-            getPost(id: "${createResponse.data.createPost.id}") {
-                id
-                title
-                comments(
-                    filter: { postId: { eq: "${createResponse.data.createPost.id}" }},
-                    limit: 100
-                ) {
-                    items {
-                        id
-                        content
-                    }
-                }
-            }
-        }`, {})
-        console.log(JSON.stringify(queryWithConnectionFilterResponse, null, 4))
-        expect(queryWithConnectionFilterResponse.data.getPost).toBeDefined()
-        const resItems = queryWithConnectionFilterResponse.data.getPost.comments.items
-        expect(resItems.length).toEqual(1)
-        expect(resItems[0].id).toEqual(createCommentResponse.data.createComment.id)
     } catch (e) {
         console.error(e)
         // fail


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This fixes the graphql-e2e-tests. The tests failed when run in parallel because of a race condition on the local file system when writing resolvers to disk. Each test now has its own local directory to save resolvers in. This also removed a defective test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.