### PR TITLE
Fix codegen to handle all permutations of LIST args

### DIFF
--- a/packages/amplify-graphql-docs-generator/src/generator/types.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/types.ts
@@ -37,6 +37,8 @@ export type GQLTemplateArgDeclaration = {
   name: string
   type: string
   isRequired: boolean
+  isList: boolean
+  isListRequired: boolean
   defaultValue: string | null
 }
 

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
@@ -3,8 +3,7 @@ export default function isRequired(typeObj: GraphQLType): boolean {
   if (isNonNullType(typeObj) && isListType(typeObj.ofType)) {
     // See if it's a Non-null List of Non-null Types  
     return isRequired(typeObj.ofType.ofType)
-  }
-  else if (isListType(typeObj)) {
+  } else if (isListType(typeObj)) {
     // See if it's a Nullable List of Non-null Types
     return isNonNullType(typeObj.ofType);
   }

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
@@ -1,7 +1,7 @@
 import { GraphQLType, isNonNullType, isListType } from "graphql";
 export default function isRequired(typeObj: GraphQLType): boolean {
   if (isNonNullType(typeObj) && isListType(typeObj.ofType)) {
-    // See if it's a Non-null List of Non-null Types  
+    // See if it's a Non-null List of Non-null Types
     return isRequired(typeObj.ofType.ofType)
   } else if (isListType(typeObj)) {
     // See if it's a Nullable List of Non-null Types

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
@@ -1,11 +1,11 @@
 import { GraphQLType, isNonNullType, isListType } from "graphql";
 export default function isRequired(typeObj: GraphQLType): boolean {
-  // See if it's a Non-null List of Non-null Types
   if (isNonNullType(typeObj) && isListType(typeObj.ofType)) {
+    // See if it's a Non-null List of Non-null Types  
     return isRequired(typeObj.ofType.ofType)
   }
-  // See if it's a Nullable List of Non-null Types
   else if (isListType(typeObj)) {
+    // See if it's a Nullable List of Non-null Types
     return isNonNullType(typeObj.ofType);
   }
   return isNonNullType(typeObj);

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isRequired.ts
@@ -1,7 +1,12 @@
 import { GraphQLType, isNonNullType, isListType } from "graphql";
 export default function isRequired(typeObj: GraphQLType): boolean {
+  // See if it's a Non-null List of Non-null Types
   if (isNonNullType(typeObj) && isListType(typeObj.ofType)) {
     return isRequired(typeObj.ofType.ofType)
+  }
+  // See if it's a Nullable List of Non-null Types
+  else if (isListType(typeObj)) {
+    return isNonNullType(typeObj.ofType);
   }
   return isNonNullType(typeObj);
 }

--- a/packages/amplify-graphql-docs-generator/templates/_renderArgDeclaration.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderArgDeclaration.hbs
@@ -1,7 +1,7 @@
 {{#if args.length}}
   (
     {{#each args as |arg index|}}
-      ${{ arg.name }}:{{#if isList}}[{{/if}}{{arg.type}}{{#if arg.isRequired}}!{{/if}}{{#if isList}}]{{#if isRequiredList}}!{{/if}}{{/if}}{{#if arg.defaultValue}}={{arg.defaultValue}}{{/if}}{{#unless @last}},{{/unless}}
+      ${{ arg.name }}:{{#if isList}}[{{/if}}{{arg.type}}{{#if arg.isRequired}}!{{/if}}{{#if isList}}]{{#if isListRequired}}!{{/if}}{{/if}}{{#if arg.defaultValue}}={{arg.defaultValue}}{{/if}}{{#unless @last}},{{/unless}}
     {{/each}}
   )
 {{/if}}


### PR DESCRIPTION
This is a tested fix for issues with the code-gen module so that it properly handles all four permutations of GraphQL LIST arguments, which are:

Nullable List Type: [] e.g. [String]
Nullable List of Non-null Types: [!] e.g . [String!]
Non-null List Type: []! e.g. [String]!
Non-null List of Non-null Types: [!]! e.g [String!]!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.