### PR TITLE
Fix #355 - Consolidating inquirer package versions to ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf node_modules && lerna clean --yes",
     "production-build": "lerna exec -- rm -f package-lock.json && lerna bootstrap --hoist && lerna run build",
     "setup-dev": "lerna exec -- rm -f package-lock.json && lerna bootstrap && cd packages/amplify-cli && rm -f -- package-lock.json && npm link && cd ../.. && lerna run build",
-    "setup-dev-win": "lerna bootstrap && cd packages/amplify-cli && del /f package-lock.json && npm link",
+    "setup-dev-win": "lerna exec -- del /f package-lock.json && lerna bootstrap && cd packages/amplify-cli && del /f package-lock.json && npm link && cd ../.. && lerna run build",
     "publish:master": "lerna publish --canary --yes --independent  --preid=alpha --message 'chore(release): Publish [ci skip]' --no-git-tag-version --no-push",
     "publish:beta": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]'",
     "publish:release": "lerna publish --conventional-commits --cd-version=patch --yes --independent --message 'chore(release): Publish [ci skip]'",

--- a/packages/amplify-category-analytics/package.json
+++ b/packages/amplify-category-analytics/package.json
@@ -7,7 +7,7 @@
     "amplify-category-auth": "^0.1.30",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "opn": "^5.3.0",
     "uuid": "^3.3.2"
   },

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -15,7 +15,7 @@
     "amplify-category-storage": "^0.1.30",
     "eslint": "^4.9.0",
     "fs-extra": "^6.0.1",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "moment": "^2.22.2",
     "opn": "^5.3.0",
     "uuid": "^2.0.3"

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -8,7 +8,7 @@
     "fs-extra": "^7.0.0",
     "grunt": "^1.0.3",
     "grunt-aws-lambda": "^0.13.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -7,7 +7,7 @@
     "amplify-category-auth": "^0.1.30",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "opn": "^5.3.0",
     "ora": "^3.0.0",
     "uuid": "^3.3.2"

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -7,7 +7,7 @@
     "amplify-category-auth": "^0.1.30",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "uuid": "^2.0.3"
   },
   "scripts": {

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -39,7 +39,7 @@
     "fs-extra": "^6.0.1",
     "gluegun": "next",
     "ini": "^1.3.5",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "open-in-editor": "^2.2.0",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -21,7 +21,7 @@
     "glob-all": "^3.1.0",
     "graphql": "^14.0.2",
     "graphql-config": "^2.1.0",
-    "inquirer": "^3.2.1",
+    "inquirer": "^6.0.0",
     "ora": "^3.0.0",
     "underscore": "^1.9.1"
   },


### PR DESCRIPTION
inquirer <5.0.0 is not functioning properly under windows, after first prompt the console hangs and 3.2.1 was used by various modules and the main cli too.

*Issue #355 

*Description of changes:*

* Update package versions to 6.0.0 so it is the same now across the whole repo
* Update the setup-dev-win npm script to be in sync with the non-windows version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.