### PR TITLE
ci: run jest in ci mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           key: amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:
           name: Run tests
-          command: npm run test
+          command: npm run test-ci
   graphql_e2e_tests:
     <<: *defaults
     steps:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test-changed": "lerna run test --since master",
     "test": "lerna run test",
+    "test-ci": "lerna run lint && lerna run test-ci",
     "pretest": "lerna run lint ",
     "e2e": "lerna run e2e",
     "lint": "lerna run lint",

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
-    "test": "jest"
+    "test": "jest",
+    "test-ci": "jest --ci -i"
   },
   "dependencies": {
     "chalk": "^2.4.1",

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test-ci": "jest --ci -i"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "lint": "eslint src",
     "lint-fix": "eslint . --fix"
   },

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint src/** tests/**",
     "lint-fix": "eslint src/** tests/** --fix",
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "test-watch": "jest --watch",
     "format": "prettier --write ./src/**/*.js ./__tests__/**/*.js"
   },

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "test-watch": "jest --watch",
     "build": "tsc",
     "watch": "tsc -w",

--- a/packages/graphql-appsync-transformer/package.json
+++ b/packages/graphql-appsync-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-mapping-template/package.json
+++ b/packages/graphql-mapping-template/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
+    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rm -rf ./lib"
   },


### PR DESCRIPTION
added a new script to run tests in CI, which will run tests
- inBand, to prevent overuse of memory in circle ci
- in ci mode, to fail when a snapshot is missing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.