### PR TITLE
CI: Use setup-dev script for build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: cd packages && rm -rf */package-lock.json && rm -rf */node_modules
       - run: npm install
       - run: npm config set workspaces-experimental true
-      - run: npm run setup-dev
+      - run: sudo npm run setup-dev
       - save_cache:
           key: amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
@@ -72,7 +72,7 @@ jobs:
         - run: pip install awscli
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
-        - run: npm run setup-dev
+        - run: sudo npm run setup-dev
         - run: amplify
         - run:
             name: "Clone auth test package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: cd packages && rm -rf */package-lock.json && rm -rf */node_modules
       - run: npm install
       - run: npm config set workspaces-experimental true
-      - run: npm run production-build
+      - run: npm run setup-dev
       - save_cache:
           key: amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
@@ -72,9 +72,6 @@ jobs:
         - run: pip install awscli
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
-        - run: npm install
-        - run: npm run clean
-        - run: sudo npm setup-dev
         - run: amplify
         - run:
             name: "Clone auth test package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
         - run: pip install awscli
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
-        - run: cd packages/amplify-cli
-        - run: sudo npm link
+        - run: sudo npm run clean
+        - run: sudo npm setup-dev
         - run: amplify
         - run:
             name: "Clone auth test package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
         - run: pip install awscli
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
+        - run: npm install
         - run: sudo npm run clean
         - run: sudo npm setup-dev
         - run: amplify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,7 @@ workflows:
                 - release
                 - master
                 - beta
+                - angular-codegen-test
           requires:
             - build
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: cd packages && rm -rf */package-lock.json && rm -rf */node_modules
       - run: npm install
       - run: npm config set workspaces-experimental true
-      - run: sudo npm run setup-dev
+      - run: npm run setup-dev
       - save_cache:
           key: amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
@@ -72,6 +72,7 @@ jobs:
         - run: pip install awscli
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
+        - run: npm run setup-dev
         - run: amplify
         - run:
             name: "Clone auth test package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ workflows:
                 - release
                 - master
                 - beta
-                - angular-codegen-test
           requires:
             - build
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ jobs:
         - run: pip install awscli
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
-        - run: sudo npm run setup-dev
+        - run: cd packages/amplify-cli
+        - run: sudo npm link
         - run: amplify
         - run:
             name: "Clone auth test package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
         - run: cd .circleci/ && chmod +x aws.sh
         - run: expect .circleci/aws_configure.exp 
         - run: npm install
-        - run: sudo npm run clean
+        - run: npm run clean
         - run: sudo npm setup-dev
         - run: amplify
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: cd packages && rm -rf */package-lock.json && rm -rf */node_modules
       - run: npm install
       - run: npm config set workspaces-experimental true
-      - run: npm run setup-dev
+      - run: sudo npm run setup-dev
       - save_cache:
           key: amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:


### PR DESCRIPTION
The CI script used to use `product-build` script to bootstrap the package. This script hoisted the dependencies to the monorepo root. In the integration tests, we run `setup-dev` script to make sure `amplify` command is available globally. But when the `setup-dev` script is run, it causes a conflict in what packages to use for building typescript packages.

Updating the `build` script to use `setup-dev` to prevent the conflict.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.