### PR TITLE
Ci publish fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: cd packages && rm -rf */package-lock.json && rm -rf */node_modules
       - run: npm install
       - run: npm config set workspaces-experimental true
-      - run: sudo npm run setup-dev
+      - run: npm run production-build
       - save_cache:
           key: amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.31",
   "description": "End to end functional tests for appsync supported transformers.",
   "main": "lib/index.js",
+  "private": true,
   "scripts": {
     "e2e": "jest",
     "build": "tsc",

--- a/packages/graphql-transformers-e2e-tests/tsconfig.json
+++ b/packages/graphql-transformers-e2e-tests/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "skipLibCheck": true,
         "target": "es5",
         "module": "commonjs",
         "sourceMap": true,


### PR DESCRIPTION
- Reverting ci to use production build
- Adding skipLibCheck to ensure e2e test package builds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.