### PR TITLE
feat(amplify-category-auth) add support for multi env 

### DIFF
--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "test": "jest",
+    "test-watch": "jest --watch",
     "test-ci": "jest --ci -i"
   },
   "dependencies": {

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -11,6 +11,7 @@ Parameters:
     Type: String
   unauthRoleArn:
     Type: String
+
   <% for(var i=0; i < Object.keys(props).length; i++) { -%>
   <% if (typeof Object.values(props)[i] === 'string' || Object.values(props)[i].value) { %>
   <%=Object.keys(props)[i]%>:
@@ -30,6 +31,9 @@ Parameters:
   <% } -%>
   <% } -%>
 
+Conditions:
+  ShouldNotCreateEnvResources: !Equals [ !Ref env, NONE ]
+
 Resources:
   <%if (props.authSelections !== 'identityPoolOnly') { %>
   # BEGIN SNS ROLE RESOURCE
@@ -37,7 +41,7 @@ Resources:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Ref roleName
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref roleName, !Join ['',[!Ref roleName, '-', !Ref env]]]
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"
         Statement: 
@@ -67,7 +71,7 @@ Resources:
   # Depends on SNS Role for Arn if MFA is enabled
     Type: AWS::Cognito::UserPool
     Properties:
-      UserPoolName: !Ref userPoolName
+      UserPoolName: !If [ShouldNotCreateEnvResources, !Ref userPoolName, !Join ['',[!Ref userPoolName, '-', !Ref env]]]
       Schema: 
         <% for(var i=0; i < props.requiredAttributes.length; i++) { %>
         -
@@ -129,7 +133,7 @@ Resources:
   # Created to execute Lambda which gets userpool app client config values
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Ref userpoolClientLambdaRole     
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -183,9 +187,9 @@ Resources:
   # Marked as depending on UserPoolClientRole for easier to understand CFN sequencing
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: !Ref userpoolClientLambdaPolicy
+      PolicyName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaPolicy, !Join ['',[!Ref userpoolClientLambdaPolicy, '-', !Ref env]]]
       Roles: 
-        - !Ref userpoolClientLambdaRole
+        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -200,9 +204,9 @@ Resources:
   # Marked as depending on UserPoolClientLambdaPolicy for easier to understand CFN sequencing
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: !Ref userpoolClientLogPolicy
+      PolicyName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLogPolicy, !Join ['',[!Ref userpoolClientLogPolicy, '-', !Ref env]]]
       Roles: 
-        - !Ref userpoolClientLambdaRole
+        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -232,7 +236,7 @@ Resources:
   # Created to execute Lambda which sets MFA config values
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Ref mfaLambdaRole     
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref mfaLambdaRole, !Join ['',[!Ref mfaLambdaRole     , '-', !Ref env]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -250,7 +254,7 @@ Resources:
             - Effect: Allow
               Action:
                 - 'iam:PassRole'
-              Resource: <%= `arn:aws:iam:::role/${props.mfaLambdaRole}` %>
+              Resource: !If [ShouldNotCreateEnvResources, '<%= `arn:aws:iam:::role/${props.mfaLambdaRole}` %>', !Join ['',['<%= `arn:aws:iam:::role/${props.mfaLambdaRole}` %>', '-', !Ref env]]]
   MFALambda:
   # Lambda which sets MFA config values
   # Depends on MFALambdaRole for role ARN
@@ -306,9 +310,9 @@ Resources:
   # Marked as depending on MFALambda for easier to understand CFN sequencing
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: !Ref mfaLambdaIAMPolicy
+      PolicyName: !If [ShouldNotCreateEnvResources, !Ref mfaLambdaIAMPolicy, !Join ['',[!Ref mfaLambdaIAMPolicy, '-', !Ref env]]]
       Roles: 
-        - !Ref mfaLambdaRole
+        - !If [ShouldNotCreateEnvResources, !Ref mfaLambdaRole, !Join ['',[!Ref mfaLambdaRole, '-', !Ref env]]]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -324,7 +328,7 @@ Resources:
     Properties:
       PolicyName: !Ref mfaLambdaLogPolicy
       Roles: 
-        - !Ref mfaLambdaRole
+        - !If [ShouldNotCreateEnvResources, !Ref mfaLambdaRole, !Join ['',[!Ref mfaLambdaRole, '-', !Ref env]]]
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -362,7 +366,7 @@ Resources:
   # Depends on UserPoolClientInputs to prevent further identity pool resources from being created before userpool is ready
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Ref openIdLambdaRoleName     
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref openIdLambdaRoleName, !Join ['',[!Ref openIdLambdaRoleName, '-', !Ref env]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -380,7 +384,7 @@ Resources:
             - Effect: Allow
               Action:
                 - 'iam:PassRole'
-              Resource: <%= `arn:aws:iam:::role/${props.openIdLambdaRoleName}` %>
+              Resource: !If [ShouldNotCreateEnvResources, <%= `arn:aws:iam:::role/${props.openIdLambdaRoleName}` %>, !Join ['',[<%= `arn:aws:iam:::role/${props.openIdLambdaRoleName}` %>, '-', !Ref env]]]
     DependsOn: UserPoolClientInputs
   OpenIdLambda:
   # Lambda which sets OpenId Values
@@ -468,7 +472,7 @@ Resources:
     Properties:
       PolicyName: !Ref openIdLambdaIAMPolicy
       Roles: 
-        - !Ref openIdLambdaRoleName
+        - !If [ShouldNotCreateEnvResources, !Ref openIdLambdaRoleName, !Join ['',[!Ref openIdLambdaRoleName, '-', !Ref env]]]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -495,7 +499,7 @@ Resources:
     Properties:
       PolicyName: !Ref openIdLogPolicy
       Roles: 
-        - !Ref openIdLambdaRoleName
+        - !If [ShouldNotCreateEnvResources, !Ref openIdLambdaRoleName, !Join ['',[!Ref openIdLambdaRoleName, '-', !Ref env]]]
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -524,7 +528,7 @@ Resources:
   # Always created
     Type: AWS::Cognito::IdentityPool
     Properties: 
-      IdentityPoolName: <%= props.identityPoolName %>
+      IdentityPoolName: !If [ShouldNotCreateEnvResources, '<%= props.identityPoolName %>', !Join ['',['<%= props.identityPoolName %>', '__', !Ref env]]]
       <%if (props.authSelections !== 'identityPoolOnly') { %>
       CognitoIdentityProviders:
         - ClientId:  !Ref UserPoolClient

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -187,7 +187,7 @@ Resources:
   # Marked as depending on UserPoolClientRole for easier to understand CFN sequencing
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaPolicy, !Join ['',[!Ref userpoolClientLambdaPolicy, '-', !Ref env]]]
+      PolicyName: !Ref userpoolClientLambdaPolicy
       Roles: 
         - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
       PolicyDocument:
@@ -204,7 +204,7 @@ Resources:
   # Marked as depending on UserPoolClientLambdaPolicy for easier to understand CFN sequencing
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLogPolicy, !Join ['',[!Ref userpoolClientLogPolicy, '-', !Ref env]]]
+      PolicyName: !Ref userpoolClientLogPolicy
       Roles: 
         - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
       PolicyDocument:
@@ -310,7 +310,7 @@ Resources:
   # Marked as depending on MFALambda for easier to understand CFN sequencing
     Type: 'AWS::IAM::Policy'
     Properties:
-      PolicyName: !If [ShouldNotCreateEnvResources, !Ref mfaLambdaIAMPolicy, !Join ['',[!Ref mfaLambdaIAMPolicy, '-', !Ref env]]]
+      PolicyName: !Ref mfaLambdaIAMPolicy
       Roles: 
         - !If [ShouldNotCreateEnvResources, !Ref mfaLambdaRole, !Join ['',[!Ref mfaLambdaRole, '-', !Ref env]]]
       PolicyDocument:

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const { serviceWalkthrough } = require('./service-walkthroughs/auth-questions');
 
 let serviceMetadata;
 
@@ -197,7 +196,7 @@ function updateResource(context, category, serviceResult) {
 async function updateConfigOnEnvInit(context, category, service) {
   const srvcMetaData = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))
     .Cognito;
-  const { defaultValuesFilename, stringMapFilename } = srvcMetaData;
+  const { defaultValuesFilename, stringMapFilename, serviceWalkthroughFilename } = srvcMetaData;
 
   const providerPlugin = context.amplify.getPluginInstance(context, srvcMetaData.provider);
   // previously selected answers
@@ -207,6 +206,9 @@ async function updateConfigOnEnvInit(context, category, service) {
   srvcMetaData.inputs = srvcMetaData.inputs.filter(input =>
     ENV_SPECIFIC_PARAMS.includes(input.key) &&
       !Object.keys(currentEnvSpecificValues).includes(input.key));
+
+  const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
+  const { serviceWalkthrough } = require(serviceWalkthroughSrc);
 
   const result = await serviceWalkthrough(
     context,

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -8,15 +8,13 @@ async function serviceWalkthrough(
   defaultValuesFilename,
   stringMapsFilename,
   serviceMetadata,
+  coreAnswers = {},
 ) {
   const { inputs } = serviceMetadata;
   const { amplify } = context;
   const { parseInputs } = require(`${__dirname}/../question-factories/core-questions.js`);
   const projectType = amplify.getProjectConfig().frontend;
 
-
-  let coreAnswers = {};
-  /* eslint-disable */
 
   // QUESTION LOOP
   for (let i = 0; i < inputs.length; i = i + 1) {

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -29,7 +29,7 @@ async function serviceWalkthrough(
       context,
     );
     const answer = await inquirer.prompt(q);
-    // user has selected leran more. Don't advance the question
+    // user has selected learn more. Don't advance the question
     if (new RegExp(/learn/i).test(answer[questionObj.key]) && questionObj.learnMore) {
       const helpText = `\n${questionObj.learnMore.replace(new RegExp('[\\n]', 'g'), '\n\n')}\n\n`;
       questionObj.prefix = chalkpipe(null, chalk.green)(helpText);
@@ -47,7 +47,7 @@ async function serviceWalkthrough(
   /*
     create key/value pairs of third party auth providers,
     where key = name accepted by updateIdentityPool API call and value = id entered by user
-    TODO: evalutate need for abstracted version of this operation
+    TODO: evaluate need for abstracted version of this operation
   */
   if (coreAnswers.thirdPartyAuth) {
     coreAnswers.selectedParties = {};

--- a/packages/amplify-category-auth/tests/commands/enable.test.js
+++ b/packages/amplify-category-auth/tests/commands/enable.test.js
@@ -15,6 +15,8 @@ describe('auth enable: ', () => {
     },
     print: {
       warning: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
     },
   };
 
@@ -35,8 +37,8 @@ describe('auth enable: ', () => {
         },
       });
     });
-    it('enable method should detect existing auth metadata and return after printing warning text', () => {
-      add.run(mockContext);
+    it('enable method should detect existing auth metadata and return after printing warning text', async () => {
+      await add.run(mockContext);
       expect(mockContext.print.warning).toBeCalledWith(messages.authExists);
       expect(mockContext.amplify.serviceSelectionPrompt).not.toBeCalled();
     });
@@ -51,8 +53,8 @@ describe('auth enable: ', () => {
         amplifyMeta: {},
       });
     });
-    it('service selection prompt should be called', () => {
-      add.run(mockContext);
+    it('service selection prompt should be called', async () => {
+      await add.run(mockContext);
       expect(mockContext.amplify.serviceSelectionPrompt).toBeCalled();
     });
   });

--- a/packages/amplify-category-auth/tests/commands/remove.test.js
+++ b/packages/amplify-category-auth/tests/commands/remove.test.js
@@ -5,7 +5,7 @@ describe('auth remove: ', () => {
   const mockExecuteProviderUtils = jest.fn();
   const mockGetProjectDetails = jest.fn();
   const warningString = messages.dependenciesExists;
-  const mockRemoveResource = jest.fn(() => Promise.resolve({}));
+  const mockRemoveResource = jest.fn().mockReturnValue(Promise.resolve({}));
   const mockProjectPath = '/User/someone/Documents/Project/amplify-test';
   const mockContext = {
     amplify: {
@@ -39,12 +39,12 @@ describe('auth remove: ', () => {
           amplifyMeta,
         });
       });
-      it(`remove method should detect existing ${d} metadata and display warning`, () => {
-        remove.run(mockContext);
+      it(`remove method should detect existing ${d} metadata and display warning`, async () => {
+        await remove.run(mockContext);
         expect(mockContext.print.info).toBeCalledWith(warningString);
       });
-      it(`remove method should still be called even when warning displayed for existing ${d} resource`, () => {
-        remove.run(mockContext);
+      it(`remove method should still be called even when warning displayed for existing ${d} resource`, async () => {
+        await remove.run(mockContext);
         expect(mockContext.amplify.removeResource).toBeCalled();
       });
     });
@@ -52,7 +52,7 @@ describe('auth remove: ', () => {
 
   describe('case: auth and other resources not yet enabled', () => {
     beforeEach(() => {
-      jest.resetAllMocks();
+      jest.clearAllMocks();
       mockGetProjectDetails.mockReturnValue({
         projectConfig: {
           projectPath: mockProjectPath,
@@ -60,12 +60,12 @@ describe('auth remove: ', () => {
         amplifyMeta: {},
       });
     });
-    it('service selection prompt should be called', () => {
-      remove.run(mockContext);
+    it('service selection prompt should be called', async () => {
+      await remove.run(mockContext);
       expect(mockContext.amplify.removeResource).toBeCalled();
     });
-    it('should not display a warning for existing resources', () => {
-      remove.run(mockContext);
+    it('should not display a warning for existing resources', async () => {
+      await remove.run(mockContext);
       expect(mockContext.print.info).not.toBeCalledWith(warningString);
     });
   });

--- a/packages/amplify-cli/src/cli.js
+++ b/packages/amplify-cli/src/cli.js
@@ -41,7 +41,7 @@ function getLocalNodeModulesDirPath() {
         baseDirPath = parentDirPath;
       }
     }
-  } while (true);
+  } while (true); // eslint-disable-line
 
   return result;
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-plugin-instance.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-plugin-instance.js
@@ -1,0 +1,15 @@
+function getPluginInstance(context, pluginName) {
+  const { plugins } = context.runtime;
+  const pluginObj = plugins.find((plugin) => {
+    // TODO: Change the way plugins are detected 
+    const nameSplit = plugin.name.split('-');
+    return (nameSplit[nameSplit.length - 1] === pluginName)
+  });
+  if (pluginObj) {
+    return require(pluginObj.directory);
+  }
+}
+
+module.exports = {
+  getPluginInstance,
+};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-plugin-instance.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-plugin-instance.js
@@ -1,9 +1,9 @@
 function getPluginInstance(context, pluginName) {
   const { plugins } = context.runtime;
   const pluginObj = plugins.find((plugin) => {
-    // TODO: Change the way plugins are detected 
+    // TODO: Change the way plugins are detected
     const nameSplit = plugin.name.split('-');
-    return (nameSplit[nameSplit.length - 1] === pluginName)
+    return (nameSplit[nameSplit.length - 1] === pluginName);
   });
   if (pluginObj) {
     return require(pluginObj.directory);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
@@ -5,6 +5,7 @@ const pathManager = require('./path-manager');
 const {
   updateBackendConfigAfterResourceRemove,
 } = require('./update-backend-config');
+const { removeResourceParameters } = require('./stageResourceParams');
 
 function removeResource(context, category) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
@@ -62,7 +63,7 @@ function removeResource(context, category) {
 
             // Remove resource directory from backend/
             context.filesystem.remove(resourceDir);
-
+            removeResourceParameters(category, resourceName);
             updateBackendConfigAfterResourceRemove(category, resourceName);
 
             context.print.success('Successfully removed resource');

--- a/packages/amplify-cli/src/extensions/amplify-helpers/stageResourceParams.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/stageResourceParams.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const fs = require('fs');
+const pathManager = require('./path-manager');
+const { getEnvInfo } = require('./get-env-info');
+
+function loadAllResourceParameters() {
+  const teamProviderInfoFilePath = pathManager.getProviderInfoFilePath();
+  try {
+    if (fs.existsSync(teamProviderInfoFilePath)) {
+      return JSON.parse(fs.readFileSync(teamProviderInfoFilePath));
+    }
+  } catch (e) {
+    return {};
+  }
+}
+
+function getOrCreateSubObject(data, keys) {
+  let currentObj = data;
+  keys.forEach((key) => {
+    if (!(key in currentObj)) {
+      currentObj[key] = {};
+    }
+    currentObj = currentObj[key];
+  });
+  return currentObj;
+}
+
+function saveAllResourceParams(data) {
+  const teamProviderInfoFilePath = pathManager.getProviderInfoFilePath();
+  fs.writeFileSync(teamProviderInfoFilePath, JSON.stringify(data, null, 4));
+}
+
+function saveEnvResourceParameters(category, resource, parameters) {
+  const allParams = loadAllResourceParameters();
+  const currentEnv = getEnvInfo().envName;
+  const resources = getOrCreateSubObject(allParams, [currentEnv, category]);
+  resources[resource] = parameters;
+
+  saveAllResourceParams(allParams);
+}
+
+function loadEnvResourceParameters(category, resource) {
+  const allParams = loadAllResourceParameters();
+  try {
+    const currentEnv = getEnvInfo().envName;
+    return getOrCreateSubObject(allParams, [currentEnv, category, resource]);
+  } catch (e) {
+    return {};
+  }
+}
+
+function removeResourceParameters(category, resource) {
+  const allParams = loadAllResourceParameters();
+  const envs = Object.keys(allParams);
+  envs.forEach((env) => {
+    const envObj = allParams[env];
+    if (category in envObj) {
+      if (resource in envObj[category]) {
+        delete envObj[category][resource];
+        if (!Object.keys(envObj[category]).length) delete envObj[category];
+      }
+    }
+  });
+  saveAllResourceParams(allParams);
+}
+
+module.exports = {
+  loadEnvResourceParameters,
+  saveEnvResourceParameters,
+  removeResourceParameters,
+};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/stageResourceParams.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/stageResourceParams.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const fs = require('fs');
 const pathManager = require('./path-manager');
 const { getEnvInfo } = require('./get-env-info');

--- a/packages/amplify-cli/src/extensions/amplify.js
+++ b/packages/amplify-cli/src/extensions/amplify.js
@@ -35,6 +35,7 @@ const { serviceSelectionPrompt } = require('./amplify-helpers/service-select-pro
 const { updateProjectConfig } = require('./amplify-helpers/update-project-config');
 const { isRunningOnEC2 } = require('./amplify-helpers/is-running-on-EC2');
 const { onCategoryOutputsChange } = require('./amplify-helpers/on-category-outputs-change');
+const { getPluginInstance } = require('./amplify-helpers/get-plugin-instance');
 const {
   updateProvideramplifyMeta,
   updateamplifyMetaAfterPush,
@@ -52,6 +53,11 @@ const { showHelp } = require('./amplify-helpers/show-help');
 const { executeProviderUtils } = require('./amplify-helpers/execute-provider-utils');
 const { showHelpfulProviderLinks } = require('./amplify-helpers/show-helpful-provider-links');
 
+const {
+  loadEnvResourceParameters,
+  saveEnvResourceParameters,
+} = require('./amplify-helpers/stageResourceParams');
+
 module.exports = (context) => {
   const amplify = {
     buildResources,
@@ -67,6 +73,7 @@ module.exports = (context) => {
     getEnvDetails,
     getEnvInfo,
     getProviderPlugins,
+    getPluginInstance,
     getProjectConfig,
     getProjectDetails,
     getProjectMeta,
@@ -98,6 +105,8 @@ module.exports = (context) => {
     updateAmplifyMetaAfterPackage,
     updateBackendConfigAfterResourceAdd,
     updateBackendConfigAfterResourceRemove,
+    loadEnvResourceParameters,
+    saveEnvResourceParameters,
   };
 
   context.amplify = amplify;

--- a/packages/amplify-cli/src/lib/initialize-env.js
+++ b/packages/amplify-cli/src/lib/initialize-env.js
@@ -49,7 +49,7 @@ async function initializeEnv(context) {
       ));
     });
 
-    
+
     spinner.start(`Initializing your environment: ${currentEnv}`);
     await sequential(initializationTasks);
 
@@ -80,7 +80,7 @@ function populateAmplifyMeta(context, amplifyMeta) {
   const backendConfigFilePath = context.amplify.pathManager.getBackendConfigFilePath(projectPath);
 
   const backendResourceInfo = JSON.parse(fs.readFileSync(backendConfigFilePath));
-  
+
   Object.assign(amplifyMeta, backendResourceInfo);
 
   const backendMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath(projectPath);

--- a/packages/amplify-provider-awscloudformation/index.js
+++ b/packages/amplify-provider-awscloudformation/index.js
@@ -10,6 +10,7 @@ const setupNewUser = require('./lib/setup-new-user');
 const { displayHelpfulURLs } = require('./lib/display-helpful-urls');
 const aws = require('./src/aws-utils/aws');
 const consoleCommand = require('./lib/console');
+const { loadResourceParameters, saveResourceParameters } = require('./src/resourceParams');
 
 function init(context) {
   return initializer.run(context);
@@ -70,4 +71,6 @@ module.exports = {
   getConfiguredAWSClient,
   showHelpfulLinks,
   deleteProject,
+  loadResourceParameters,
+  saveResourceParameters,
 };

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -12,6 +12,7 @@ const { prePushGraphQLCodegen, postPushGraphQLCodegen } = require('./graphql-cod
 const { transformGraphQLSchema } = require('./transform-graphql-schema');
 const { displayHelpfulURLs } = require('./display-helpful-urls');
 const { downloadAPIModels } = require('./download-api-models');
+const { loadResourceParameters } = require('../src/resourceParams');
 
 const spinner = ora('Updating resources in the cloud. This may take a few minutes...');
 const nestedStackFileName = 'nested-cloudformation-stack.yml';
@@ -322,10 +323,9 @@ function formNestedStack(context, projectDetails) {
     resources.forEach((resource) => {
       const resourceDetails = amplifyMeta[category][resource];
       const resourceKey = category + resource;
-      const { projectPath } = context.amplify.getEnvInfo();
       let templateURL;
       if (resourceDetails.providerPlugin) {
-        const parameters = getResourceParameters(context, projectPath, category, resource);
+        const parameters = loadResourceParameters(context, category, resource);
         const { dependsOn } = resourceDetails;
 
         if (dependsOn) {
@@ -365,17 +365,6 @@ function formNestedStack(context, projectDetails) {
     });
   });
   return nestedStack;
-}
-
-function getResourceParameters(context, projectPath, category, resource) {
-  let parameters = {};
-  const backendDirPath = context.amplify.pathManager.getBackendDirPath(projectPath);
-  const resourceDirPath = path.join(backendDirPath, category, resource);
-  const parametersFilePath = path.join(resourceDirPath, 'parameters.json');
-  if (fs.existsSync(parametersFilePath)) {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
-  }
-  return parameters;
 }
 
 module.exports = {

--- a/packages/amplify-provider-awscloudformation/src/resourceParams.js
+++ b/packages/amplify-provider-awscloudformation/src/resourceParams.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const fs = require('fs');
+
+function getResourceDirPath(context, category, resource) {
+  const { projectPath } = context.amplify.getEnvInfo();
+  const backendDirPath = context.amplify.pathManager.getBackendDirPath(projectPath);
+  return path.join(backendDirPath, category, resource);
+}
+
+function saveResourceParameters(context, category, resource, parameters, envSpecificParamsName = []) {
+  const resourceDirPath = getResourceDirPath(context, category, resource);
+  const parametersFilePath = path.join(resourceDirPath, 'parameters.json');
+  const envSpecificParams = {};
+  const sharedParams = { ...parameters };
+  envSpecificParamsName.forEach((paramName) => {
+    if ( paramName in parameters) {
+      envSpecificParams[paramName] = parameters[paramName];
+      delete sharedParams[paramName];
+    }
+  });
+
+  const jsonString = JSON.stringify(sharedParams, null, 4);
+  fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
+  context.amplify.saveEnvResourceParameters(category, resource, envSpecificParams);
+  return parameters;
+}
+
+function loadResourceParameters(context, category, resource) {
+  let parameters = {};
+  const resourceDirPath = getResourceDirPath(context, category, resource);
+
+  const parametersFilePath = path.join(resourceDirPath, 'parameters.json');
+  if (fs.existsSync(parametersFilePath)) {
+    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+  }
+  const envSpecificParams = context.amplify.loadEnvResourceParameters(category, resource);
+  return {...parameters, ...envSpecificParams };
+}
+
+module.exports = {
+  loadResourceParameters,
+  saveResourceParameters,
+};

--- a/packages/amplify-provider-awscloudformation/src/resourceParams.js
+++ b/packages/amplify-provider-awscloudformation/src/resourceParams.js
@@ -7,13 +7,19 @@ function getResourceDirPath(context, category, resource) {
   return path.join(backendDirPath, category, resource);
 }
 
-function saveResourceParameters(context, category, resource, parameters, envSpecificParamsName = []) {
+function saveResourceParameters(
+  context,
+  category,
+  resource,
+  parameters,
+  envSpecificParamsName = [],
+) {
   const resourceDirPath = getResourceDirPath(context, category, resource);
   const parametersFilePath = path.join(resourceDirPath, 'parameters.json');
   const envSpecificParams = {};
   const sharedParams = { ...parameters };
   envSpecificParamsName.forEach((paramName) => {
-    if ( paramName in parameters) {
+    if (paramName in parameters) {
       envSpecificParams[paramName] = parameters[paramName];
       delete sharedParams[paramName];
     }
@@ -34,7 +40,7 @@ function loadResourceParameters(context, category, resource) {
     parameters = JSON.parse(fs.readFileSync(parametersFilePath));
   }
   const envSpecificParams = context.amplify.loadEnvResourceParameters(category, resource);
-  return {...parameters, ...envSpecificParams };
+  return { ...parameters, ...envSpecificParams };
 }
 
 module.exports = {


### PR DESCRIPTION
Add auth support for multi env. Updated the cloud formation templates to create new instances of resources based on env name.

Another PR to follow adding support for env specific third party auth providers


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.