### PR TITLE
CI: fix circle ci publish failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,12 +157,6 @@ jobs:
             - amplify-ssh-deps
             - amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:
-          name: "Update SSH configs"
-          command: |
-            mkdir ~/.ssh
-            echo $SSH_HOST_PUBLIC_KEY
-            echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts            
-      - run:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
       - restore_cache:
           keys: 
             - amplify-ssh-deps-{{ .Branch }}
-            - amplify-ssh-deps
+            - amplify-cli-ssh-deps-{{ .Branch }}
             - amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:
           name: Authenticate with npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,6 @@ jobs:
           at: ./
       - restore_cache:
           keys: 
-            - amplify-ssh-deps-{{ .Branch }}
             - amplify-cli-ssh-deps-{{ .Branch }}
             - amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,9 @@ workflows:
       - deploy:
           requires:
             - build
+            - test
+            - integration_test
+            - graphql_e2e_tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,12 +196,10 @@ workflows:
       - deploy:
           requires:
             - build
-            - test
-            - integration_test
-            - graphql_e2e_tests
           filters:
             branches:
               only:
                 - release
                 - master
                 - beta
+                - publish-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,4 +202,3 @@ workflows:
                 - release
                 - master
                 - beta
-                - publish-test

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "publish:master": "lerna publish --canary --yes --independent  --preid=alpha --message 'chore(release): Publish [ci skip]' --no-git-tag-version --no-push",
     "publish:beta": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]'",
     "publish:release": "lerna publish --conventional-commits --cd-version=patch --yes --independent --message 'chore(release): Publish [ci skip]'",
-    "postpublish:release": "git fetch . release:master && git push",
-    "publish:publish-test": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=publish-test --preid=publish-test --message 'chore(release): Publish [ci skip]'",
+    "postpublish:release": "git fetch . release:master && git push upstream master",
     "commit": "git-cz"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "publish:beta": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]'",
     "publish:release": "lerna publish --conventional-commits --cd-version=patch --yes --independent --message 'chore(release): Publish [ci skip]'",
     "postpublish:release": "git fetch . release:master && git push",
+    "publish:publish-test": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=publish-test --preid=publish-test --message 'chore(release): Publish [ci skip]'",
     "commit": "git-cz"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "publish:master": "lerna publish --canary --yes --independent  --preid=alpha --message 'chore(release): Publish [ci skip]' --no-git-tag-version --no-push",
     "publish:beta": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]'",
     "publish:release": "lerna publish --conventional-commits --cd-version=patch --yes --independent --message 'chore(release): Publish [ci skip]'",
-    "postpublish:release": "git fetch . release:master && git push upstream master",
+    "postpublish:release": "git fetch . release:master && git push origin master",
     "commit": "git-cz"
   },
   "bugs": {


### PR DESCRIPTION
CircleCI publish of the packages use to fail due to missing ssh keys. This was caused because ci script was using the wrong key to restore the ssh cache. 

Also updated the post publish release hook to explicitly push master branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.