### PR TITLE
fix(amplify-codegen): update the params passed to types generator

### DIFF
--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -36,7 +36,7 @@ async function generateTypes(context, forceDownloadSchema) {
       }
       const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
       codeGenSpinner.start();
-      generate(queries, schema, output, '', target, '', '', {
+      generate(queries, schema, output, '', target, '', {
         addTypename: true,
       });
       codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${output}`);


### PR DESCRIPTION
codegen moved from using aws-appsync-codegen to amplify-graphql-types-generator and the argumentused by types generator changed its arity of the generate method. This caused errors reported in #434. Fixing the error by using the right params

#434

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.