### PR TITLE
Feature/441

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -69,11 +69,6 @@ function uploadAppSyncFiles(context, resources) {
         if (fs.existsSync(parametersFilePath)) {
           try {
             currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
-            // Clear the parameters cache
-            currentParameters = {
-              AppSyncApiName: currentParameters.AppSyncApiName,
-              AuthCognitoUserPoolId: currentParameters.AuthCognitoUserPoolId,
-            };
           } catch (e) {
             currentParameters = {};
           }

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -85,6 +85,7 @@ export class DynamoDBModelTransformer extends Transformer {
         ctx.mergeResources(template.Resources)
         ctx.mergeParameters(template.Parameters)
         ctx.mergeOutputs(template.Outputs)
+        ctx.mergeConditions(template.Conditions)
     }
 
     /**

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -26,6 +26,12 @@ export class ResourceFactory {
             [ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS]: new NumberParameter({
                 Description: 'The number of write IOPS the table should support.',
                 Default: 5
+            }),
+            [ResourceConstants.PARAMETERS.APIKeyExpirationEpoch]: new NumberParameter({
+                Description: 'The epoch time in seconds when the API Key should expire.' +
+                    ' Setting this to 0 will default to 1 week from the deployment date.' +
+                    ' Setting this to -1 will not create an API Key.',
+                Default: 0
             })
         }
     }
@@ -44,6 +50,17 @@ export class ResourceFactory {
                 [ResourceConstants.OUTPUTS.GraphQLAPIIdOutput]: this.makeAPIIDOutput(),
                 [ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput]: this.makeAPIEndpointOutput(),
                 [ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput]: this.makeApiKeyOutput()
+            },
+            Conditions: {
+                [ResourceConstants.CONDITIONS.APIKeyExpirationEpochIsNotNegOne]:
+                    Fn.Not(Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.APIKeyExpirationEpoch), -1)),
+                [ResourceConstants.CONDITIONS.APIKeyExpirationEpochIsZero]:
+                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.APIKeyExpirationEpoch), 0),
+                [ResourceConstants.CONDITIONS.APIKeyExpirationEpochIsPositive]:
+                    Fn.And([
+                        Fn.Not(Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.APIKeyExpirationEpoch), -1)),
+                        Fn.Not(Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.APIKeyExpirationEpoch), 0))
+                    ])
             }
         }
     }
@@ -65,10 +82,20 @@ export class ResourceFactory {
         })
     }
 
+    /**
+     * Creates an API key
+     */
     public makeAppSyncApiKey() {
+        const oneWeekFromNowInSeconds = 60 /* s */ * 60 /* m */ * 24 /* h */ * 7 /* d */
+        const nowEpochTime = Math.floor(Date.now() / 1000)
         return new AppSync.ApiKey({
-            ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId')
-        })
+            ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+            Expires: Fn.If(
+                ResourceConstants.CONDITIONS.APIKeyExpirationEpochIsPositive,
+                Fn.Ref(ResourceConstants.PARAMETERS.APIKeyExpirationEpoch),
+                nowEpochTime + oneWeekFromNowInSeconds
+            ),
+        }).condition(ResourceConstants.CONDITIONS.APIKeyExpirationEpochIsNotNegOne)
     }
 
     /**
@@ -94,13 +121,14 @@ export class ResourceFactory {
         }
     }
 
-    public makeApiKeyOutput(): Output {
+    public makeApiKeyOutput(): any {
         return {
             Description: "Your GraphQL API key. Provide via 'x-api-key' header.",
             Value: Fn.GetAtt(ResourceConstants.RESOURCES.APIKeyLogicalID, 'ApiKey'),
             Export: {
                 Name: Fn.Join(':', [Refs.StackName, "GraphQLApiKey"])
-            }
+            },
+            Condition: ResourceConstants.CONDITIONS.APIKeyExpirationEpochIsNotNegOne
         }
     }
 

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -23,6 +23,7 @@ export class ResourceConstants {
     public static PARAMETERS = {
         // AppSync
         AppSyncApiName: 'AppSyncApiName',
+        APIKeyExpirationEpoch: 'APIKeyExpirationEpoch',
 
         // DynamoDB
         DynamoDBModelTableReadIOPS: 'DynamoDBModelTableReadIOPS',
@@ -51,6 +52,11 @@ export class ResourceConstants {
     }
     public static MAPPINGS = {}
     public static CONDITIONS = {
+        // General
+        APIKeyExpirationEpochIsZero: 'APIKeyExpirationEpochIsZero',
+        APIKeyExpirationEpochIsNotNegOne: 'APIKeyExpirationEpochIsNotNegOne',
+        APIKeyExpirationEpochIsPositive: 'APIKeyExpirationEpochIsPositive',
+
         // Auth
         AuthShouldCreateUserPool: 'AuthShouldCreateUserPool'
     }


### PR DESCRIPTION
*Issue #, if available:*

#441

*Description of changes:*

This adds support for custom API key expiration dates as well as supports auto-refreshing API keys on push. This also changes CLI behaviour in that now it now merges instead of overwriting the parameters.json file. This also adds a new parameter named **APIKeyExpirationEpoch** that can be used to tweak API keys as follows:

**Resets the API Key to expire 1 week after the next `amplify push`**

```
{
  "APIKeyExpirationEpoch": "0"
}
```

**Do not create an API key**

```
{
  "APIKeyExpirationEpoch": "-1"
}
```

**Set a custom API key**

```
{
  "APIKeyExpirationEpoch": "1544745428"
}
```

would make the key expire Thursday, December 13, 2018 11:57:08 PM GMT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.