### PR TITLE
fix: codegen headless fix & ask AWS profile info when info not present when checking out a new env

### DIFF
--- a/packages/amplify-cli/sample-headless-scripts/headless_init_env.sh
+++ b/packages/amplify-cli/sample-headless-scripts/headless_init_env.sh
@@ -8,7 +8,7 @@ AWSCLOUDFORMATIONCONFIG="{\
 \"profileName\":\"default\"\
 }"
 AMPLIFY="{\
-\"envName\":\"dev2\"\
+\"envName\":\"mydevabc\"\
 }"
 PROVIDERS="{\
 \"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\

--- a/packages/amplify-codegen/src/codegen-config/utils/graphQlToAmplifyConfig.js
+++ b/packages/amplify-codegen/src/codegen-config/utils/graphQlToAmplifyConfig.js
@@ -5,16 +5,22 @@ function graphQlToAmplifyConfig(gqlConfig) {
     amplifyConfig.push({ ...cfg, __root__: true });
   }
   const projects = gqlConfig.getProjects() || {};
+
   Object.keys(projects).forEach((projectName) => {
     const project = projects[projectName];
-    cfg = getAmplifyConfig(project);
+    cfg = getAmplifyConfig(project.config);
+
     if (cfg) amplifyConfig.push({ ...cfg, __root__: false, projectName });
   });
+
   return amplifyConfig;
 }
 
 function getAmplifyConfig(config = {}) {
   if (config && config.extensions && config.extensions.amplify && config.includes) {
+    if (typeof config.includes === 'string') {
+      config.includes = [config.includes];
+    }
     return {
       schema: config.schemaPath,
       includes: config.includes,


### PR DESCRIPTION

Codegen headless fix & ask AWS profile info when info is not present when checking out a new env



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.