### PR TITLE
fix nullable parameter order and command in gqlAPIServiceArguments

### DIFF
--- a/packages/amplify-graphql-types-generator/src/angular/index.ts
+++ b/packages/amplify-graphql-types-generator/src/angular/index.ts
@@ -164,8 +164,11 @@ export function propertyFromVar(
 function variableDeclaration(generator: CodeGenerator, properties: Property[]) {
   properties
     .sort((a, b) => {
-      if (b.isNullable && !a.isNullable) {
+      if (!a.isNullable && b.isNullable) {
         return -1;
+      }
+      if (!b.isNullable && a.isNullable) {
+        return 1;
       }
       return 0;
     })
@@ -194,7 +197,7 @@ function variableAssignmentToInput(generator: CodeGenerator, vars: Property[]) {
       () => {
         // non nullable arguments
         vars.filter(v => !v.isNullable).forEach(v => {
-          generator.printOnNewline(`${v.fieldName}`);
+          generator.printOnNewline(`${v.fieldName},`);
         });
       },
       '{',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- fix sort function to push nullable vars to end of array
- add comma in input generator (dangling comma removed by prettier)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.