### PR TITLE
fix(amplify-category-auth):remove unsupported chars from auth defaults

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -99,7 +99,9 @@ const entityKeys = {
 };
 
 const getAllDefaults = (name) => {
-  const projectName = name.projectConfig ? `${name.projectConfig.projectName.toLowerCase()}${sharedId}` : name;
+  const disallowedChars = /[^A-Za-z0-9_]+/g;
+  let projectName = name.projectConfig ? `${name.projectConfig.projectName.toLowerCase().substring(0, 100)}${sharedId}` : name.substring(0, 100);
+  projectName = projectName.replace(disallowedChars, '_');
   const target = generalDefaults(projectName);
   const sources = [
     userPoolDefaults(projectName),


### PR DESCRIPTION
amplify lets users use the default settings while adding auth. These defaults make use of project
names. Auth uses cognito user pools which accepts have rules not to accept certain chars in the
name. Updating the code to replace unacceptable chars with underscore

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.