### PR TITLE
 feat: core metadata migration of projects using the old version of the CLI

### DIFF
--- a/packages/amplify-category-storage/index.js
+++ b/packages/amplify-category-storage/index.js
@@ -17,7 +17,17 @@ async function console(context) {
   context.print.info(`to be implemented: ${category} console`);
 }
 
+/* TODO: Migration logic for storage out here.
+
+async function migrateResourceFiles(providerName, service, resourceName) {
+
+}
+
+*/
+
+
 module.exports = {
   add,
   console,
+  // migrateResourceFiles,
 };

--- a/packages/amplify-cli/src/cli.js
+++ b/packages/amplify-cli/src/cli.js
@@ -2,11 +2,12 @@ const fs = require('fs-extra');
 const { build } = require('gluegun');
 const path = require('path');
 const globalPrefix = require('./lib/global-prefix');
+const { migrateProject } = require('./lib/migrate-project');
 
 async function run(argv) {
   const localNodeModulesDirPath = getLocalNodeModulesDirPath();
   const globalNodeModulesDirPath = globalPrefix.getGlobalNodeModuleDirPath();
-
+  // Check for old version of projects and ask for migration steps
   const cli = build()
     .brand('amplify')
     .src(__dirname)
@@ -16,6 +17,7 @@ async function run(argv) {
     .create();
 
   normalizeArgv(cli, argv);
+  await migrateProject(cli.plugins);
 
   // and run it
   const context = await cli.run(argv);
@@ -52,7 +54,6 @@ function normalizeArgv(cli, argv) {
     const strs = plugin.name.split('-');
     return strs[strs.length - 1];
   });
-
   if (argv.length > 3) {
     if ((!pluginNames.includes(argv[2])) && pluginNames.includes(argv[3])) {
       /*eslint-disable */

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-git-ignore-blob.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-git-ignore-blob.js
@@ -1,12 +1,14 @@
 const os = require('os');
 
 function getGitIgnoreBlob() {
+  const ignoreList = ['amplify/\\#current-cloud-backend',
+    'amplify/.config/local-*',
+    'amplify/backend/amplify-meta.json',
+    'aws-exports.js',
+    'awsconfiguration.json'];
+
   const toAppend = `${os.EOL + os.EOL
-  }amplify/\\#current-cloud-backend${os.EOL
-  }amplify/.config/local-*${os.EOL
-  }amplify/backend/amplify-meta.json${os.EOL
-  }aws-exports.js${os.EOL
-  }awsconfiguration.json`;
+  }${ignoreList.join(os.EOL)}`;
 
   return toAppend;
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-git-ignore-blob.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-git-ignore-blob.js
@@ -1,0 +1,16 @@
+const os = require('os');
+
+function getGitIgnoreBlob() {
+  const toAppend = `${os.EOL + os.EOL
+  }amplify/\\#current-cloud-backend${os.EOL
+  }amplify/.config/local-*${os.EOL
+  }amplify/backend/amplify-meta.json${os.EOL
+  }aws-exports.js${os.EOL
+  }awsconfiguration.json`;
+
+  return toAppend;
+}
+
+module.exports = {
+  getGitIgnoreBlob,
+};

--- a/packages/amplify-cli/src/lib/constants.js
+++ b/packages/amplify-cli/src/lib/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  PROJECT_CONFIG_VERSION: '1.0',
+};

--- a/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
@@ -4,6 +4,7 @@ const inquirer = require('inquirer');
 const { normalizeEditorCode, editorSelection } =
   require('../../extensions/amplify-helpers/editor-selection');
 const { makeId } = require('../../extensions/amplify-helpers/make-id');
+const { PROJECT_CONFIG_VERSION } = require('../constants');
 
 async function run(context) {
   context.print.warning('Note: It is recommended to run this command from the root of your app directory');
@@ -30,6 +31,7 @@ async function run(context) {
 
   context.exeInfo.projectConfig = {
     projectName,
+    version: PROJECT_CONFIG_VERSION,
   };
 
   context.exeInfo.localEnvInfo = {

--- a/packages/amplify-cli/src/lib/init-steps/s9-onSuccess.js
+++ b/packages/amplify-cli/src/lib/init-steps/s9-onSuccess.js
@@ -1,8 +1,8 @@
 const fs = require('fs-extra');
 const sequential = require('promise-sequential');
-const os = require('os');
 const { getFrontendPlugins } = require('../../extensions/amplify-helpers/get-frontend-plugins');
 const { getProviderPlugins } = require('../../extensions/amplify-helpers/get-provider-plugins');
+const { getGitIgnoreBlob } = require('../../extensions/amplify-helpers/get-git-ignore-blob');
 const { print } = require('gluegun/print');
 const { initializeEnv } = require('../initialize-env');
 
@@ -115,22 +115,11 @@ function generateGitIgnoreFile(context) {
   if (context.exeInfo.isNewProject) {
     const { projectPath } = context.exeInfo.localEnvInfo;
 
-    const getGitIgnoreAppendString = () => {
-      const toAppend = `${os.EOL + os.EOL
-      }amplify/\\#current-cloud-backend${os.EOL
-      }amplify/.config/local-*${os.EOL
-      }amplify/backend/amplify-meta.json${os.EOL
-      }aws-exports.js${os.EOL
-      }awsconfiguration.json`;
-
-      return toAppend;
-    };
-
     const gitIgnoreFilePath = context.amplify.pathManager.getGitIgnoreFilePath(projectPath);
     if (fs.existsSync(gitIgnoreFilePath)) {
-      fs.appendFileSync(gitIgnoreFilePath, getGitIgnoreAppendString());
+      fs.appendFileSync(gitIgnoreFilePath, getGitIgnoreBlob());
     } else {
-      fs.writeFileSync(gitIgnoreFilePath, getGitIgnoreAppendString().trim());
+      fs.writeFileSync(gitIgnoreFilePath, getGitIgnoreBlob().trim());
     }
   }
 }

--- a/packages/amplify-cli/src/lib/migrate-project.js
+++ b/packages/amplify-cli/src/lib/migrate-project.js
@@ -16,6 +16,7 @@ const {
 } = require('../extensions/amplify-helpers/path-manager');
 
 const { getGitIgnoreBlob } = require('../extensions/amplify-helpers/get-git-ignore-blob');
+const { PROJECT_CONFIG_VERSION } = require('./constants');
 
 async function migrateProject(plugins) {
   try {
@@ -28,7 +29,7 @@ async function migrateProject(plugins) {
     }
 
     const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
-    if (projectConfig.projectPath && await prompt.confirm('We detected the project was initialized using an older version of the CLI. Do you want to migrate the project, so that it is compatible with the latest version of the CLI?')) {
+    if (!projectConfig.version && await prompt.confirm('We detected the project was initialized using an older version of the CLI. Do you want to migrate the project, so that it is compatible with the latest version of the CLI?')) {
       // This is an older project & migration is needed
       generateNewProjectConfig(projectConfig, projectConfigFilePath);
       generateLocalEnvInfo(projectConfig);
@@ -96,10 +97,11 @@ function generateNewProjectConfig(projectConfig, projectConfigFilePath) {
 
   newProjectConfig.frontend = frontend;
   delete newProjectConfig.frontendHandler;
+  newProjectConfig.version = PROJECT_CONFIG_VERSION;
 
   // Modify provider handler
-  const provider = Object.keys(projectConfig.providers)[0];
-  newProjectConfig.providers = [provider];
+  const providers = Object.keys(projectConfig.providers);
+  newProjectConfig.providers = providers;
 
   const jsonString = JSON.stringify(newProjectConfig, null, 4);
   fs.writeFileSync(projectConfigFilePath, jsonString, 'utf8');

--- a/packages/amplify-cli/src/lib/migrate-project.js
+++ b/packages/amplify-cli/src/lib/migrate-project.js
@@ -1,0 +1,164 @@
+const fs = require('fs-extra');
+const path = require('path');
+const ora = require('ora');
+
+const spinner = ora('');
+const { prompt } = require('gluegun/prompt');
+const { print } = require('gluegun/print');
+const {
+  getDotConfigDirPath,
+  getProjectConfigFilePath,
+  getAmplifyMetaFilePath,
+  getLocalEnvFilePath,
+  getProviderInfoFilePath,
+  getBackendConfigFilePath,
+} = require('../extensions/amplify-helpers/path-manager');
+
+async function migrateProject(plugins) {
+  try {
+    let projectConfigFilePath;
+    try {
+      projectConfigFilePath = getProjectConfigFilePath();
+    } catch (e) {
+      // New project, hence not able to find the amplify dir
+      return;
+    }
+
+    const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+    if (projectConfig.projectPath && await prompt.confirm('We detected the project was initialized using an older version of the CLI. Do you want to migrate the project, so that it is compatible with the latest version of the CLI?')) {
+      // This is an older project & migration is needed
+      generateNewProjectConfig(projectConfig, projectConfigFilePath);
+      generateLocalEnvInfo(projectConfig);
+      generateAwsLocalInfo();
+      generateTeamProviderInfo();
+      generateBackendConfig();
+    }
+
+    // Give each category a chance to migrate their respective files
+
+    const categoryMigrationTasks = [];
+    const amplifyMetafilePath = getAmplifyMetaFilePath();
+    const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetafilePath));
+    const initializedCategories = Object.keys(amplifyMeta);
+
+    const categoryPlugins = {};
+    plugins.forEach((plugin) => {
+      if (plugin.name.includes('category')) {
+        const strs = plugin.name.split('-');
+        const categoryName = strs[strs.length - 1];
+        categoryPlugins[categoryName] = plugin.directory;
+      }
+    });
+
+    const availableCategory = Object.keys(plugins).filter(key =>
+      initializedCategories.includes(key));
+
+    availableCategory.forEach((category) => {
+      try {
+        const { migrateCategoryFiles } = require(categoryPlugins[category]);
+        if (migrateCategoryFiles) {
+          categoryMigrationTasks.push(() => migrateCategoryFiles());
+        }
+      } catch (e) {
+        print.warning(`Could not run migrateProject function for ${category} category`);
+      }
+    });
+
+    spinner.start('Migrating your project');
+    await Promise.all(categoryMigrationTasks);
+    spinner.succeed('Migrated your project successfully.');
+  } catch (e) {
+    spinner.fail('There was an error migrating your environment.');
+    throw e;
+  }
+}
+
+function generateNewProjectConfig(projectConfig, projectConfigFilePath) {
+  const newProjectConfig = {};
+
+  Object.assign(newProjectConfig, projectConfig);
+  // These attributes are now stores in amplify/.config/local-env-info.json
+  delete newProjectConfig.projectPath;
+  delete newProjectConfig.defaultEditor;
+
+  // Modify frontend handler
+  const frontendPluginPath = Object.keys(projectConfig.frontendHandler)[0];
+  const frontendPlugin = frontendPluginPath.split('/')[frontendPluginPath.split('/').length - 1];
+  const frontend = frontendPlugin.split('-')[frontendPlugin.split('-').length - 1];
+
+  newProjectConfig.frontend = frontend;
+  delete newProjectConfig.frontendHandler;
+
+  // Modify provider handler
+  const provider = Object.keys(projectConfig.providers)[0];
+  newProjectConfig.providers = [provider];
+
+  const jsonString = JSON.stringify(newProjectConfig, null, 4);
+  fs.writeFileSync(projectConfigFilePath, jsonString, 'utf8');
+}
+
+function generateLocalEnvInfo(projectConfig) {
+  const envInfo = {
+    projectPath: projectConfig.projectPath,
+    defaultEditor: projectConfig.defaultEditor,
+    envName: 'NONE',
+  };
+
+  const jsonString = JSON.stringify(envInfo, null, 4);
+  const localEnvFilePath = getLocalEnvFilePath();
+  fs.writeFileSync(localEnvFilePath, jsonString, 'utf8');
+}
+
+function generateAwsLocalInfo() {
+  const dotConfigDirPath = getDotConfigDirPath();
+  const awsInfoFilePath = path.join(dotConfigDirPath, 'aws-info.json');
+  if (fs.existsSync(awsInfoFilePath)) {
+    const awsInfo = JSON.parse(fs.readFileSync(awsInfoFilePath));
+    awsInfo.configLevel = 'project'; // Old version didn't support "General" configuation
+    const newAwsInfo = { NONE: awsInfo };
+
+    const jsonString = JSON.stringify(newAwsInfo, null, 4);
+    const localAwsInfoFilePath = path.join(dotConfigDirPath, 'local-aws-info.json');
+    fs.writeFileSync(localAwsInfoFilePath, jsonString, 'utf8');
+    fs.removeSync(awsInfoFilePath);
+  }
+}
+
+function generateTeamProviderInfo() {
+  const amplifyMetafilePath = getAmplifyMetaFilePath();
+  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetafilePath));
+
+  const teamProviderInfo = { NONE: amplifyMeta.providers };
+
+  const jsonString = JSON.stringify(teamProviderInfo, null, 4);
+  const teamProviderFilePath = getProviderInfoFilePath();
+  fs.writeFileSync(teamProviderFilePath, jsonString, 'utf8');
+}
+
+function generateBackendConfig() {
+  const amplifyMetafilePath = getAmplifyMetaFilePath();
+  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetafilePath));
+
+  const backendConfig = {};
+  Object.keys(amplifyMeta).forEach((category) => {
+    if (category !== 'providers') {
+      backendConfig[category] = {};
+      Object.keys(amplifyMeta[category]).forEach((resourceName) => {
+        backendConfig[category][resourceName] = {};
+        backendConfig[category][resourceName].service = amplifyMeta[category][resourceName].service;
+        backendConfig[category][resourceName].providerPlugin =
+        amplifyMeta[category][resourceName].providerPlugin;
+      });
+    }
+  });
+
+
+  const jsonString = JSON.stringify(backendConfig, null, 4);
+  const backendConfigFilePath = getBackendConfigFilePath();
+  fs.writeFileSync(backendConfigFilePath, jsonString, 'utf8');
+}
+
+
+module.exports = {
+  migrateProject,
+};

--- a/packages/amplify-codegen/tests/codegen-config/utils/graphQlToAmplifyConfig.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/utils/graphQlToAmplifyConfig.test.js
@@ -14,7 +14,7 @@ describe('graphQlToAmplifyConfig', () => {
   const graphQLApiId1 = 'proj1';
   const codeGenTarget1 = 'flow';
 
-  fit('should return items with amplify extensions', () => {
+  it('should return items with amplify extensions', () => {
     const projects = {
       [projectName]: {
         config: {

--- a/packages/amplify-codegen/tests/codegen-config/utils/graphQlToAmplifyConfig.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/utils/graphQlToAmplifyConfig.test.js
@@ -14,7 +14,7 @@ describe('graphQlToAmplifyConfig', () => {
   const graphQLApiId1 = 'proj1';
   const codeGenTarget1 = 'flow';
 
-  it('should return items with amplify extensions', () => {
+  fit('should return items with amplify extensions', () => {
     const projects = {
       [projectName]: {
         config: {


### PR DESCRIPTION
* Files generated as a part of the migration process:
amplify/backend/backend-config.jsin
amplify/.config/local-aws-info.json
amplify/.config/local-env-info.json
amplify/team-provider-info.json

* Files deleted as a part of the migration process:
amplify/aws-info.json (which is replaced by amplify/.config/local-aws-info.json)

* Files modified as a part of the migration process:
amplify/.config/project-config.json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.