### PR TITLE
feat(amplify-graphql-types-generator): detect complex types

### DIFF
--- a/packages/amplify-graphql-types-generator/src/cli.js
+++ b/packages/amplify-graphql-types-generator/src/cli.js
@@ -89,10 +89,11 @@ yargs
         default: true,
         type: 'boolean'
       },
-      "add-s3-wrapper": {
+      "complex-object-support": {
         demand: false,
-        describe: "Adds S3 wrapper code to the output",
-        default: false
+        describe: "Adds S3 wrapper code to the output. [Swift only]",
+        default: 'auto',
+        choices: ['yes', 'no', 'auto'],
       }
     },
     argv => {
@@ -118,7 +119,7 @@ yargs
         addS3Wrapper: argv["add-s3-wrapper"]
       };
 
-      generate(inputPaths, argv.schema, argv.output, argv.only, argv.target, argv.tagName, argv.projectName, options);
+      generate(inputPaths, argv.schema, argv.output, argv.only, argv.target, argv.tagName, options);
     },
   )
   .fail(function(message, error) {

--- a/packages/amplify-graphql-types-generator/src/cli.js
+++ b/packages/amplify-graphql-types-generator/src/cli.js
@@ -116,7 +116,7 @@ yargs
         namespace: argv.namespace,
         mergeInFieldsFromFragmentSpreads: argv["merge-in-fields-from-fragment-spreads"],
         useFlowExactObjects: argv['use-flow-exact-objects'],
-        addS3Wrapper: argv["add-s3-wrapper"]
+        complexObjectSupport: argv["complex-object-support"],
       };
 
       generate(inputPaths, argv.schema, argv.output, argv.only, argv.target, argv.tagName, options);

--- a/packages/amplify-graphql-types-generator/src/generate.ts
+++ b/packages/amplify-graphql-types-generator/src/generate.ts
@@ -14,6 +14,7 @@ import { generateSource as generateFlowSource } from './flow';
 import { generateSource as generateFlowModernSource } from './flow-modern';
 import { generateSource as generateScalaSource } from './scala';
 import { generateSource as generateAngularSource } from './angular';
+import { hasS3Fields } from './utilities/complextypes';
 
 type TargetType = 'json' | 'swift' | 'ts' | 'typescript' | 'flow' | 'scala' | 'flow-modern' | 'angular';
 
@@ -35,7 +36,14 @@ export default function generate(
   if (target === 'swift') {
     options.addTypename = true;
     const context = compileToIR(schema, document, options);
-
+    // Complex object suppport
+    if (options.complexObjectSupport === 'auto') {
+      options.addS3Wrapper = context.typesUsed.some(typesUsed => hasS3Fields(typesUsed));
+    } else if (options.complexObjectSupport === 'yes') {
+      options.addS3Wrapper = true;
+    } else {
+      options.addS3Wrapper = false;
+    }
     const outputIndividualFiles = fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
     const generator = generateSwiftSource(context, outputIndividualFiles, only);

--- a/packages/amplify-graphql-types-generator/src/utilities/complextypes.ts
+++ b/packages/amplify-graphql-types-generator/src/utilities/complextypes.ts
@@ -1,0 +1,21 @@
+import { GraphQLType, isInputObjectType, getNamedType, isObjectType } from 'graphql';
+
+const S3_FIELD_NAMES = ['bucket', 'key', 'region', 'localUri', 'mimeType'];
+
+export function hasS3Fields(input: GraphQLType): boolean {
+  if (isObjectType(input) || isInputObjectType(input)) {
+    const fields = input.getFields();
+    const stringFields = Object.keys(fields).filter(f => {
+      const typeName = getNamedType(fields[f].type);
+      return typeName.name === 'String';
+    });
+    const isS3FileField = S3_FIELD_NAMES.every(fieldName => stringFields.includes(fieldName));
+    if (isS3FileField) {
+      return true;
+    }
+    return Object.keys(fields)
+      .filter(f => !stringFields.includes(f))
+      .some(f => hasS3Fields((<any>fields[f]) as GraphQLType));
+  }
+  return false;
+}


### PR DESCRIPTION
Types generator expected users to pass add-s3-wrapper param to CLI if they wanted to include the S3
Wrapper code when generating swift code. Changed the param to complex-object-support and accept
either yes, no or detect. When user passes detect, the types generator loops through the types used
and adds the S3 wrapper code if the types use S3 Object

#375

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.