### PR TITLE
fix(graphql-dynamodb-transformer): refactoring for future transforms

### DIFF
--- a/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
+++ b/packages/graphql-appsync-transformer/src/AppSyncTransformer.ts
@@ -35,6 +35,10 @@ export class AppSyncTransformer extends Transformer {
         // overwrite it in the after
         const schemaResource = this.resources.makeAppSyncSchema('placeholder')
         ctx.setResource(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID, schemaResource)
+        const template = this.resources.initTemplate();
+        ctx.mergeResources(template.Resources)
+        ctx.mergeParameters(template.Parameters)
+        ctx.mergeOutputs(template.Outputs)
     }
 
     public after = (ctx: TransformerContext): void => {

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -82,9 +82,7 @@ export class DynamoDBModelTransformer extends Transformer {
 
     public before = (ctx: TransformerContext): void => {
         const template = this.resources.initTemplate();
-        ctx.mergeResources(template.Resources)
         ctx.mergeParameters(template.Parameters)
-        ctx.mergeOutputs(template.Outputs)
     }
 
     /**


### PR DESCRIPTION
Refactoring DynamoDB transformer to move boilerplate into AppSync transformer for future non-model transforms. This is in aid of a FunctionTransformer I'm currently working on (#83 `@function directive`)

`DynamoDBModelTransformer` has some boilerplate that all transforms would need. I'm writing a new transform and realized I'm going to need all of this so I figured a better place would be to hoist it up to `AppSyncTransformer`. Now any non-model templates will start with (in addition to the schema):

Resources:
* AppSync API
* API Key

Outputs:
* API Id
* API Endpoint
* API Key

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.