### PR TITLE
fix(amplify-provider-awscloudformation): no region

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
@@ -42,7 +42,7 @@ function run(context) {
           default: `amplify-${context.amplify.makeId()}`,
         }]);
     }).then((answers) => {
-      const deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', answers.userName).replace('{region}', answers.region);
+      const deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', answers.userName).replace('{region}', awsConfig.region);
       context.print.info('Complete the user creation using the AWS console');
       context.print.info(chalk.green(deepLinkURL));
       opn(deepLinkURL, { wait: false });


### PR DESCRIPTION
*Issue #, if available:*
`amplify configure` would during the creation of an IAM role not get the right region. It would try to fetch it from `answers` which only contains the username at that point.

*Description of changes:*
Instead of fetching from `answers` it now fetches from the global `awsConfig`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.