### PR TITLE
fix: handle dirty JSON for dynamo CFN during migration

### DIFF
--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -398,7 +398,20 @@ function copyCfnTemplate(context, categoryName, resourceName, options) {
 function migrate(projectPath, resourceName) {
   const resourceDirPath = path.join(projectPath, 'amplify', 'backend', category, resourceName);
   const cfnFilePath = path.join(resourceDirPath, `${resourceName}-cloudformation-template.json`);
-  const oldCfn = JSON.parse(fs.readFileSync(cfnFilePath, 'utf8'));
+
+  // Removes dangling commas from a JSON
+  const removeDanglingCommas = (value) => {
+    const regex = /,(?!\s*?[{["'\w])/g;
+    return value.replace(regex, '');
+  };
+
+  /* Current Dynamo CFN's have a trailing comma (accepted by CFN),
+  but fails on JSON.parse(), hence removing it */
+
+  let oldcfnString = fs.readFileSync(cfnFilePath, 'utf8');
+  oldcfnString = removeDanglingCommas(oldcfnString);
+  const oldCfn = JSON.parse(oldcfnString);
+
   const newCfn = {};
   Object.assign(newCfn, oldCfn);
 


### PR DESCRIPTION
Current Dynamo CFN's have a trailing comma (accepted by CFN),
  but fails on JSON.parse(), hence removing it before a JSON.parse() call

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.