### PR TITLE
fix(amplify-provider-awscloudformation): support nested resource dir

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -1,13 +1,10 @@
-const fs = require("fs");
-const path = require("path");
-const moment = require("moment");
-const archiver = require("archiver");
+const fs = require('fs');
+const path = require('path');
+const moment = require('moment');
+const archiver = require('archiver');
 
 async function run(context, category, resourceName) {
-  const { allResources } = await context.amplify.getResourceStatus(
-    category,
-    resourceName
-  );
+  const { allResources } = await context.amplify.getResourceStatus(category, resourceName);
 
   const resources = allResources.filter(resource => resource.build);
   const buildPromises = [];
@@ -19,36 +16,24 @@ async function run(context, category, resourceName) {
 function buildResource(context, resource) {
   const { category, resourceName } = resource;
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
-  const resourceDir = path.normalize(
-    path.join(backEndDir, category, resourceName, "src")
-  );
-  const packageJsonPath = path.normalize(
-    path.join(backEndDir, category, resourceName, "src", "package.json")
-  );
+  const resourceDir = path.normalize(path.join(backEndDir, category, resourceName, 'src'));
+  const packageJsonPath = path.normalize(path.join(backEndDir, category, resourceName, 'src', 'package.json'));
   const packageJsonMeta = fs.statSync(packageJsonPath);
-  const distDir = path.normalize(
-    path.join(backEndDir, category, resourceName, "dist")
-  );
+  const distDir = path.normalize(path.join(backEndDir, category, resourceName, 'dist'));
 
   let zipFilename = resource.distZipFilename;
-  let zipFilePath = zipFilename
-    ? path.normalize(path.join(distDir, zipFilename))
-    : "";
+  let zipFilePath = zipFilename ? path.normalize(path.join(distDir, zipFilename)) : '';
 
-  if (
-    !resource.lastBuildTimeStamp ||
-    new Date(packageJsonMeta.mtime) > new Date(resource.lastBuildTimeStamp)
-  ) {
-    const npm = /^win/.test(process.platform) ? "npm.cmd" : "npm";
-    require("child_process").spawnSync(npm, ["install"], { cwd: resourceDir });
+
+  if (!resource.lastBuildTimeStamp ||
+    new Date(packageJsonMeta.mtime) > new Date(resource.lastBuildTimeStamp)) {
+    const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    require('child_process').spawnSync(npm, ['install'], { cwd: resourceDir });
     context.amplify.updateamplifyMetaAfterBuild(resource);
   }
 
-  if (
-    !resource.lastPackageTimeStamp ||
-    !resource.distZipFilename ||
-    isPackageOutdated(resourceDir, resource.lastPackageTimeStamp)
-  ) {
+  if (!resource.lastPackageTimeStamp || !resource.distZipFilename ||
+    isPackageOutdated(resourceDir, resource.lastPackageTimeStamp)) {
     zipFilename = `${resourceName}-${moment().unix()}-latest-build.zip`;
 
     if (!fs.existsSync(distDir)) {
@@ -59,14 +44,14 @@ function buildResource(context, resource) {
     const output = fs.createWriteStream(zipFilePath);
 
     return new Promise((resolve, reject) => {
-      output.on("close", () => {
+      output.on('close', () => {
         context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename);
         resolve({ zipFilePath, zipFilename });
       });
-      output.on("error", () => {
-        reject(new Error("Failed to zip code."));
+      output.on('error', () => {
+        reject(new Error('Failed to zip code.'));
       });
-      const zip = archiver.create("zip", {});
+      const zip = archiver.create('zip', {});
       zip.pipe(output);
       zip.directory(resourceDir, false);
       zip.finalize();
@@ -77,7 +62,7 @@ function buildResource(context, resource) {
 }
 function isPackageOutdated(resourceDir, lastPackageTimeStamp) {
   const lastPackageDate = new Date(lastPackageTimeStamp);
-  const sourceFiles = getSourceFiles(resourceDir, "node_modules");
+  const sourceFiles = getSourceFiles(resourceDir, 'node_modules');
 
   for (let i = 0; i < sourceFiles.length; i += 1) {
     const file = sourceFiles[i];
@@ -88,6 +73,7 @@ function isPackageOutdated(resourceDir, lastPackageTimeStamp) {
   }
   return false;
 }
+
 function getSourceFiles(dir, ignoredDir) {
   if (!fs.statSync(dir).isDirectory()) return [dir];
   return fs.readdirSync(dir).reduce((acc, f) => {


### PR DESCRIPTION
AWS Cloudformation did not handle nested directories inside resource directory. The method that
generated a list of source file did not flatten the array of files inside nested directory. Updated
the code to flatten the files array

#404