### PR TITLE
feat: detect if Pinpoint project exists before prompt for remove command

### DIFF
--- a/packages/amplify-category-notifications/commands/notifications/remove.js
+++ b/packages/amplify-category-notifications/commands/notifications/remove.js
@@ -11,51 +11,56 @@ module.exports = {
   alias: ['disable', 'delete'],
   run: async (context) => {
     context.exeInfo = context.amplify.getProjectDetails();
-    const availableChannels = notificationManager.getAvailableChannels(context);
-    const enabledChannels = notificationManager.getEnabledChannels(context);
+    const pinpointApp = pinpointHelper.getPinpointApp(context);
+    if (pinpointApp) {
+      const availableChannels = notificationManager.getAvailableChannels(context);
+      const enabledChannels = notificationManager.getEnabledChannels(context);
 
-    enabledChannels.push(PinpointApp);
-    enabledChannels.push(Cancel);
+      enabledChannels.push(PinpointApp);
+      enabledChannels.push(Cancel);
 
-    let channelName = context.parameters.first;
+      let channelName = context.parameters.first;
 
-    if (!channelName || !availableChannels.includes(channelName)) {
-      const answer = await inquirer.prompt({
-        name: 'selection',
-        type: 'list',
-        message: 'Choose what to remove.',
-        choices: enabledChannels,
-        default: enabledChannels[0],
-      });
-      channelName = answer.selection;
-    } else if (!enabledChannels.includes(channelName)) {
-      context.print.info(`The ${channelName} channel has NOT been enabled.`);
-      channelName = undefined;
-    }
-
-    if (channelName && channelName !== Cancel) {
-      if (channelName !== PinpointApp) {
-        await pinpointHelper.ensurePinpointApp(context);
-        await notificationManager.disableChannel(context, channelName);
-        writeAmplifyMeta(context);
-      } else if (pinpointHelper.isAnalyticsAdded(context)) {
-        context.print.error('Execution aborted.');
-        context.print.info('You have an analytics resource in your backend tied to the Amazon Pinpoint resource');
-        context.print.info('The Analytics resource must be removed before Amazon Pinpoint can be deleted from the cloud');
-      } else {
+      if (!channelName || !availableChannels.includes(channelName)) {
         const answer = await inquirer.prompt({
-          name: 'deletePinpointApp',
-          type: 'confirm',
-          message: 'Confirm that you want to delete the associated Amazon Pinpoint application',
-          default: false,
+          name: 'selection',
+          type: 'list',
+          message: 'Choose what to remove.',
+          choices: enabledChannels,
+          default: enabledChannels[0],
         });
-        if (answer.deletePinpointApp) {
-          await pinpointHelper.deletePinpointApp(context);
-          context.print.info('The Pinpoint application has been successfully deleted.');
+        channelName = answer.selection;
+      } else if (!enabledChannels.includes(channelName)) {
+        context.print.info(`The ${channelName} channel has NOT been enabled.`);
+        channelName = undefined;
+      }
+      if (channelName && channelName !== Cancel) {
+        if (channelName !== PinpointApp) {
+          await pinpointHelper.ensurePinpointApp(context);
+          await notificationManager.disableChannel(context, channelName);
           writeAmplifyMeta(context);
+        } else if (pinpointHelper.isAnalyticsAdded(context)) {
+          context.print.error('Execution aborted.');
+          context.print.info('You have an analytics resource in your backend tied to the Amazon Pinpoint resource');
+          context.print.info('The Analytics resource must be removed before Amazon Pinpoint can be deleted from the cloud');
+        } else {
+          const answer = await inquirer.prompt({
+            name: 'deletePinpointApp',
+            type: 'confirm',
+            message: 'Confirm that you want to delete the associated Amazon Pinpoint application',
+            default: false,
+          });
+          if (answer.deletePinpointApp) {
+            await pinpointHelper.deletePinpointApp(context);
+            context.print.info('The Pinpoint application has been successfully deleted.');
+            writeAmplifyMeta(context);
+          }
         }
       }
+    } else {
+      context.print.error('Notifications have not been added to your project.');
     }
     return context;
   },
 };
+

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -9,6 +9,15 @@ const writeAmplifyMeta = require('./writeAmplifyMeta');
 const providerName = 'awscloudformation';
 const spinner = ora('');
 
+function getPinpointApp(context) {
+  const { amplifyMeta } = context.exeInfo;
+  let pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.CategoryName]);
+  if (!pinpointApp) {
+    pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.AnalyticsCategoryName]);
+  }
+  return pinpointApp;
+}
+
 async function ensurePinpointApp(context) {
   const { amplifyMeta } = context.exeInfo;
   let pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.CategoryName]);
@@ -33,7 +42,8 @@ async function ensurePinpointApp(context) {
     }
   }
   context.exeInfo.pinpointApp = pinpointApp;
-  context.exeInfo.serviceMeta = amplifyMeta[constants.CategoryName][pinpointApp.Name];
+  context.exeInfo.serviceMeta =
+    context.exeInfo.amplifyMeta[constants.CategoryName][pinpointApp.Name];
 }
 
 async function createPinpointApp(context) {
@@ -74,8 +84,6 @@ async function createPinpointApp(context) {
   context.print.info('');
   await authHelper.ensureAuth(context);
   context.print.info('');
-  // refresh the metadata becuse the auth might have changed it
-  context.exeInfo.amplifyMeta = context.amplify.getProjectMeta();
 
   return pinpointApp;
 }
@@ -232,6 +240,7 @@ function isAnalyticsAdded(context) {
 }
 
 module.exports = {
+  getPinpointApp,
   ensurePinpointApp,
   deletePinpointApp,
   getPinpointClient,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the `amplify notificaitons remove` command prompts for what to remove, previously pinpoint project is always an option, this PR checks to see if a Pinpoint project exists, if not, it will just print out error message without prompt, because there's nothing to remove. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.