### PR TITLE
fix(cli): remove calls to gluegun's prompt.confirm

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
@@ -108,7 +108,7 @@ function configure(context, defaultValuesFilename, serviceMetadata, resourceName
     if (foundUnmetRequirements) {
       context.print.warning('Adding analytics would add the Auth category to the project if not already added.');
       if (
-        await context.prompt.confirm('Apps need authorization to send analytics events. Do you want to allow guests and unauthenticated users to send analytics events? (we recommend you allow this when getting started)')
+        await amplify.confirmPrompt('Apps need authorization to send analytics events. Do you want to allow guests and unauthenticated users to send analytics events? (we recommend you allow this when getting started)')
       ) {
         try {
           await externalAuthEnable(context, 'api', answers.resourceName, apiRequirements);

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -116,7 +116,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
 
   // The user doesn't have an annotated schema file
 
-  if (!await context.prompt.confirm('Do you want a guided schema creation?')) {
+  if (!await amplify.confirmPrompt('Do you want a guided schema creation?')) {
     // Copy the most basic schema onto the users resource dir and transform that
 
     const targetSchemaFilePath = `${resourceDir}/${schemaFileName}`;

--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -125,7 +125,7 @@ async function addResource(context, category, service, options) {
 
 async function openEditor(context, category, options) {
   const targetDir = context.amplify.pathManager.getBackendDirPath();
-  if (await context.prompt.confirm('Do you want to edit the local lambda function now?')) {
+  if (await context.amplify.confirmPrompt('Do you want to edit the local lambda function now?')) {
     switch (options.functionTemplate) {
       case 'helloWorld':
         await context.amplify.openEditor(context, `${targetDir}/${category}/${options.resourceName}/src/index.js`);

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -149,7 +149,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
         AttributeType: defaultValues.sortKeyType,
       },
     );
-    continueAttributeQuestion = await confirm('Would you like to add another column?');
+    continueAttributeQuestion = await amplify.confirmPrompt('Would you like to add another column?');
   }
   const indexableAttributeList = [];
 
@@ -158,7 +158,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
 
     if (attributeAnswers.findIndex(attribute => attribute.AttributeName
       === attributeAnswer[inputs[2].key]) !== -1) {
-      continueAttributeQuestion = await confirm('This attribute was already added. Do you want to add another attribute?');
+      continueAttributeQuestion = await amplify.confirmPrompt('This attribute was already added. Do you want to add another attribute?');
       continue;
     }
 
@@ -170,7 +170,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
     if (attributeTypes[attributeAnswer[inputs[3].key]].indexable) {
       indexableAttributeList.push(attributeAnswer[inputs[2].key]);
     }
-    continueAttributeQuestion = await confirm('Would you like to add another column?');
+    continueAttributeQuestion = await amplify.confirmPrompt('Would you like to add another column?');
   }
   answers.AttributeDefinitions = attributeAnswers;
 
@@ -232,7 +232,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
       });
       usedAttributeDefinitions.add(sortKeyName);
     }
-  } else if (await confirm('Do you want to add a sort key to your table?')) {
+  } else if (await amplify.confirmPrompt('Do you want to add a sort key to your table?')) {
     // Ask for sort key
     if (answers.AttributeDefinitions.length > 1) {
       const sortKeyQuestion = {
@@ -269,7 +269,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
 
   // Ask for GSI's
 
-  if (await confirm('Do you want to add global secondary indexes to your table?')) {
+  if (await amplify.confirmPrompt('Do you want to add global secondary indexes to your table?')) {
     let continuewithGSIQuestions = true;
     const gsiList = [];
     // Generates a clone of the attribute list
@@ -316,7 +316,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
           availableAttributes.splice(gsiPrimaryAttrIndex, 1);
         }
         if (availableAttributes.length > 0) {
-          if (await confirm('Do you want to add a sort key to your global secondary index?')) {
+          if (await amplify.confirmPrompt('Do you want to add a sort key to your global secondary index?')) {
             const sortKeyQuestion = {
               type: inputs[8].type,
               name: inputs[8].key,
@@ -332,7 +332,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
           }
         }
         gsiList.push(gsiItem);
-        continuewithGSIQuestions = await confirm('Do you want to add more global secondary indexes to your table?');
+        continuewithGSIQuestions = await amplify.confirmPrompt('Do you want to add more global secondary indexes to your table?');
       } else {
         context.print.error('You do not have any other attributes remaining to configure');
         break;
@@ -458,15 +458,6 @@ function migrate(projectPath, resourceName) {
 
   const jsonString = JSON.stringify(newCfn, null, '\t');
   fs.writeFileSync(cfnFilePath, jsonString, 'utf8');
-}
-
-async function confirm(message) {
-  const ans = await inquirer.prompt({
-    name: 'yesno',
-    message,
-    type: 'confirm',
-  });
-  return ans.yesno;
 }
 
 module.exports = { addWalkthrough, updateWalkthrough, migrate };

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -9,7 +9,7 @@ const templateFileName = 's3-cloudformation-template.json';
 
 async function addWalkthrough(context, defaultValuesFilename, serviceMetadata) {
   while (!checkIfAuthExists(context)) {
-    if (await context.prompt.confirm('You need to add auth (Amazon Cognito) to your project in order to add storage for user files. Do you want to add auth now?')) {
+    if (await context.amplify.confirmPrompt('You need to add auth (Amazon Cognito) to your project in order to add storage for user files. Do you want to add auth now?')) {
       try {
         const { add } = require('amplify-category-auth');
         await add(context);

--- a/packages/amplify-cli/src/commands/env/add.js
+++ b/packages/amplify-cli/src/commands/env/add.js
@@ -50,7 +50,7 @@ module.exports = {
     if (envFound) {
       if (context.parameters.options.yes) {
         addNewEnvConfig();
-      } else if (await context.prompt.confirm('We found an environment with the same name. Do you want to overwrite existing enviornment config?')) {
+      } else if (await context.amplify.confirmPrompt('We found an environment with the same name. Do you want to overwrite existing enviornment config?')) {
         addNewEnvConfig();
       }
     } else {

--- a/packages/amplify-cli/src/commands/env/remove.js
+++ b/packages/amplify-cli/src/commands/env/remove.js
@@ -32,7 +32,7 @@ module.exports = {
         process.exit(1);
       }
 
-      if (await context.prompt.confirm('Do you also want to remove all the resources of the environment from the cloud?')) {
+      if (await context.amplify.confirmPrompt('Do you also want to remove all the resources of the environment from the cloud?')) {
         const spinner = ora('Deleting resources from the cloud. This may take a few minutes...');
         spinner.start();
         await context.amplify.removeEnvFromCloud(context, envName);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
@@ -4,7 +4,7 @@ const { getProviderPlugins } = require('./get-provider-plugins');
 const spinner = ora('Building resources. This may take a few minutes...');
 
 function buildResources(context, category, resourceName) {
-  return context.prompt.confirm('Are you sure you want to continue building the resources?')
+  return context.amplify.confirmPrompt('Are you sure you want to continue building the resources?')
     .then((answer) => {
       if (answer) {
         const providerPlugins = getProviderPlugins(context);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/confirm-prompt.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/confirm-prompt.js
@@ -1,0 +1,14 @@
+const inquirer = require('inquirer');
+
+async function confirmPrompt(message) {
+  const ans = await inquirer.prompt({
+    name: 'yesno',
+    message,
+    type: 'confirm',
+  });
+  return ans.yesno;
+}
+
+module.exports = {
+  confirmPrompt,
+};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
@@ -3,7 +3,7 @@ const pathManager = require('./path-manager');
 const { removeEnvFromCloud } = require('./remove-env-from-cloud');
 
 async function deleteProject(context) {
-  if (await context.prompt.confirm('Are you sure you want to continue?(This would delete all the environments of the project from the cloud and wipe out all the local amplify resource files)')) {
+  if (await context.amplify.confirmPrompt('Are you sure you want to continue?(This would delete all the environments of the project from the cloud and wipe out all the local amplify resource files)')) {
     const removeEnvPromises = [];
     const allEnvs = context.amplify.getEnvDetails();
     Object.keys(allEnvs).forEach((env) => {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
@@ -39,7 +39,7 @@ async function pushResources(context, category, resourceName) {
 
   let continueToPush = context.exeInfo.inputParams.yes;
   if (!continueToPush) {
-    continueToPush = await context.prompt.confirm('Are you sure you want to continue?');
+    continueToPush = await context.amplify.confirmPrompt('Are you sure you want to continue?');
   }
 
   if (continueToPush) {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
@@ -34,7 +34,7 @@ function removeResource(context, category) {
         category,
         resourceName,
       ));
-      return context.prompt.confirm('Are you sure you want to delete the resource? This action deletes all files related to this resource from the backend directory.')
+      return context.amplify.confirmPrompt('Are you sure you want to delete the resource? This action deletes all files related to this resource from the backend directory.')
         .then(async (confirm) => {
           if (confirm) {
             const { allResources } = await context.amplify.getResourceStatus();

--- a/packages/amplify-cli/src/extensions/amplify.js
+++ b/packages/amplify-cli/src/extensions/amplify.js
@@ -4,6 +4,7 @@
 // bring in each of the constituents
 
 const constants = require('./amplify-helpers/constants');
+const confirmPrompt = require('./amplify-helpers/confirm-prompt');
 const pressEnterToContinue = require('./amplify-helpers/press-enter-to-continue');
 const { constructExeInfo } = require('./amplify-helpers/construct-exeInfo');
 const { removeResource } = require('./amplify-helpers/remove-resource');
@@ -63,6 +64,7 @@ const {
 module.exports = (context) => {
   const amplify = {
     buildResources,
+    confirmPrompt,
     constants,
     constructExeInfo,
     copyBatch,

--- a/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
@@ -157,7 +157,7 @@ async function getEnvName(context) {
     const allEnvs = context.amplify.getAllEnvs();
 
     if (allEnvs.length > 0) {
-      if (await context.prompt.confirm('Do you want to use an existing environment?')) {
+      if (await context.amplify.confirmPrompt('Do you want to use an existing environment?')) {
         const envQuestion = {
           type: 'list',
           name: 'envName',

--- a/packages/amplify-cli/src/lib/initialize-env.js
+++ b/packages/amplify-cli/src/lib/initialize-env.js
@@ -57,7 +57,7 @@ async function initializeEnv(context) {
     await sequential(categoryInitializationTasks);
 
     if (context.exeInfo.forcePush === undefined) {
-      context.exeInfo.forcePush = await context.prompt.confirm('Do you want to push your resources to the cloud for your environment?');
+      context.exeInfo.forcePush = await context.amplify.confirmPrompt('Do you want to push your resources to the cloud for your environment?');
     }
     if (context.exeInfo.forcePush) {
       context.exeInfo.projectConfig.providers.forEach((provider) => {

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -21,7 +21,7 @@ const schemaFileName = 'schema.graphql';
 
 function checkForCommonIssues(usedDirectives, opts) {
   if (usedDirectives.includes('auth') && !opts.isUserPoolEnabled) {
-    throw new Error(`You are trying to use the @auth directive without enabling Amazon Cognito user pools for your API. 
+    throw new Error(`You are trying to use the @auth directive without enabling Amazon Cognito user pools for your API.
 Run \`amplify update api\` and choose "Amazon Cognito User Pool" as the authorization type for the API.`);
   }
 }
@@ -134,7 +134,7 @@ async function transformGraphQLSchema(context, options) {
     resources which would be created for you as a
      part of the AppSync service.`);
 
-    if (await context.prompt.confirm('Do you want to use your own
+    if (await context.amplify.confirmPrompt('Do you want to use your own
       tables instead?')) {
       let continueConfiguringDyanmoTables = true;
 


### PR DESCRIPTION
prompt.confirm is unreliable and sometimes fails to take user input
create a confirm prompt helper that uses inquirer prompt instead
refactor helper defined in dynamoDb-walkthrough.js

https://github.com/aws-amplify/amplify-cli/issues/528

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.