### PR TITLE
fix(cli): remove calls to gluegun's prompt.confirm

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
@@ -94,7 +94,7 @@ function configure(context, defaultValuesFilename, serviceMetadata, resourceName
 
       if (foundUnmetRequirements) {
         context.print.warning('Adding analytics would add the Auth category to the project if not already added.');
-        if (await context.prompt.confirm('Apps need authorization to send analytics events. Do you want to allow guests and unauthenticated users to send analytics events? (we recommend you allow this when getting started)')) {
+        if (await amplify.confirmPrompt.run('Apps need authorization to send analytics events. Do you want to allow guests and unauthenticated users to send analytics events? (we recommend you allow this when getting started)')) {
           try {
             await externalAuthEnable(context, 'api', answers.resourceName, apiRequirements);
           } catch (e) {

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -116,7 +116,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
 
   // The user doesn't have an annotated schema file
 
-  if (!await context.prompt.confirm('Do you want a guided schema creation?')) {
+  if (!await amplify.confirmPrompt.run('Do you want a guided schema creation?')) {
     // Copy the most basic schema onto the users resource dir and transform that
 
     const targetSchemaFilePath = `${resourceDir}/${schemaFileName}`;

--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -125,7 +125,7 @@ async function addResource(context, category, service, options) {
 
 async function openEditor(context, category, options) {
   const targetDir = context.amplify.pathManager.getBackendDirPath();
-  if (await context.prompt.confirm('Do you want to edit the local lambda function now?')) {
+  if (await context.amplify.confirmPrompt.run('Do you want to edit the local lambda function now?')) {
     switch (options.functionTemplate) {
       case 'helloWorld':
         await context.amplify.openEditor(context, `${targetDir}/${category}/${options.resourceName}/src/index.js`);

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -149,7 +149,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
         AttributeType: defaultValues.sortKeyType,
       },
     );
-    continueAttributeQuestion = await confirm('Would you like to add another column?');
+    continueAttributeQuestion = await amplify.confirmPrompt.run('Would you like to add another column?');
   }
   const indexableAttributeList = [];
 
@@ -158,7 +158,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
 
     if (attributeAnswers.findIndex(attribute => attribute.AttributeName
       === attributeAnswer[inputs[2].key]) !== -1) {
-      continueAttributeQuestion = await confirm('This attribute was already added. Do you want to add another attribute?');
+      continueAttributeQuestion = await amplify.confirmPrompt.run('This attribute was already added. Do you want to add another attribute?');
       continue;
     }
 
@@ -170,7 +170,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
     if (attributeTypes[attributeAnswer[inputs[3].key]].indexable) {
       indexableAttributeList.push(attributeAnswer[inputs[2].key]);
     }
-    continueAttributeQuestion = await confirm('Would you like to add another column?');
+    continueAttributeQuestion = await amplify.confirmPrompt.run('Would you like to add another column?');
   }
   answers.AttributeDefinitions = attributeAnswers;
 
@@ -232,7 +232,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
       });
       usedAttributeDefinitions.add(sortKeyName);
     }
-  } else if (await confirm('Do you want to add a sort key to your table?')) {
+  } else if (await amplify.confirmPrompt.run('Do you want to add a sort key to your table?')) {
     // Ask for sort key
     if (answers.AttributeDefinitions.length > 1) {
       const sortKeyQuestion = {
@@ -269,7 +269,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
 
   // Ask for GSI's
 
-  if (await confirm('Do you want to add global secondary indexes to your table?')) {
+  if (await amplify.confirmPrompt.run('Do you want to add global secondary indexes to your table?')) {
     let continuewithGSIQuestions = true;
     const gsiList = [];
     // Generates a clone of the attribute list
@@ -316,7 +316,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
           availableAttributes.splice(gsiPrimaryAttrIndex, 1);
         }
         if (availableAttributes.length > 0) {
-          if (await confirm('Do you want to add a sort key to your global secondary index?')) {
+          if (await amplify.confirmPrompt.run('Do you want to add a sort key to your global secondary index?')) {
             const sortKeyQuestion = {
               type: inputs[8].type,
               name: inputs[8].key,
@@ -332,7 +332,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
           }
         }
         gsiList.push(gsiItem);
-        continuewithGSIQuestions = await confirm('Do you want to add more global secondary indexes to your table?');
+        continuewithGSIQuestions = await amplify.confirmPrompt.run('Do you want to add more global secondary indexes to your table?');
       } else {
         context.print.error('You do not have any other attributes remaining to configure');
         break;
@@ -386,16 +386,7 @@ function copyCfnTemplate(context, categoryName, resourceName, options) {
   ];
 
   // copy over the files
-  return context.amplify.copyBatch(context, copyJobs, options);
-}
-
-async function confirm(message) {
-  const ans = await inquirer.prompt({
-    name: 'yesno',
-    message,
-    type: 'confirm',
-  });
-  return ans.yesno;
+  return amplify.copyBatch(context, copyJobs, options);
 }
 
 module.exports = { addWalkthrough, updateWalkthrough };

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -9,7 +9,7 @@ const templateFileName = 's3-cloudformation-template.json';
 
 async function addWalkthrough(context, defaultValuesFilename, serviceMetadata) {
   while (!checkIfAuthExists(context)) {
-    if (await context.prompt.confirm('You need to add auth (Amazon Cognito) to your project in order to add storage for user files. Do you want to add auth now?')) {
+    if (await context.amplify.confirmPrompt.run('You need to add auth (Amazon Cognito) to your project in order to add storage for user files. Do you want to add auth now?')) {
       try {
         const { add } = require('amplify-category-auth');
         await add(context);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
@@ -4,7 +4,7 @@ const { getProviderPlugins } = require('./get-provider-plugins');
 const spinner = ora('Building resources. This may take a few minutes...');
 
 function buildResources(context, category, resourceName) {
-  return context.prompt.confirm('Are you sure you want to continue building the resources?')
+  return context.amplify.confirmPrompt.run('Are you sure you want to continue building the resources?')
     .then((answer) => {
       if (answer) {
         const providerPlugins = getProviderPlugins(context);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/confirm-prompt.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/confirm-prompt.js
@@ -1,0 +1,14 @@
+const inquirer = require('inquirer');
+
+async function run(message) {
+  const ans = await inquirer.prompt({
+    name: 'yesno',
+    message,
+    type: 'confirm',
+  });
+  return ans.yesno;
+}
+
+module.exports = {
+  run,
+};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
@@ -6,7 +6,7 @@ const pathManager = require('./path-manager');
 const spinner = ora('Deleting resources from the cloud. This may take a few minutes...');
 
 async function deleteProject(context) {
-  return context.prompt.confirm('Are you sure you want to continue?(This would delete all the project from the cloud and wipe out all the local amplify resource files)')
+  return context.amplify.confirmPrompt.run('Are you sure you want to continue?(This would delete all the project from the cloud and wipe out all the local amplify resource files)')
     .then((answer) => {
       if (answer) {
         const { providers } = getProjectConfig();

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
@@ -5,7 +5,7 @@ const { onCategoryOutputsChange } = require('./on-category-outputs-change');
 async function pushResources(context, category, resourceName) {
   await showResourceTable(category, resourceName);
 
-  return context.prompt.confirm('Are you sure you want to continue?')
+  return context.amplify.confirmPrompt.run('Are you sure you want to continue?')
     .then((answer) => {
       if (answer) {
         const { providers } = getProjectConfig();

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
@@ -30,7 +30,7 @@ function removeResource(context, category) {
         category,
         resourceName,
       ));
-      return context.prompt.confirm('Are you sure you want to delete the resource? This action deletes all files related to this resource from the backend directory.')
+      return context.amplify.confirmPrompt.run('Are you sure you want to delete the resource? This action deletes all files related to this resource from the backend directory.')
         .then(async (confirm) => {
           if (confirm) {
             const { allResources } = await context.amplify.getResourceStatus();

--- a/packages/amplify-cli/src/extensions/amplify.js
+++ b/packages/amplify-cli/src/extensions/amplify.js
@@ -4,6 +4,7 @@
 // bring in each of the constituents
 
 const constants = require('./amplify-helpers/constants');
+const confirmPrompt = require('./amplify-helpers/confirm-prompt');
 const pressEnterToContinue = require('./amplify-helpers/press-enter-to-continue');
 const { removeResource } = require('./amplify-helpers/remove-resource');
 const { pushResources } = require('./amplify-helpers/push-resources');
@@ -47,6 +48,7 @@ const { showHelpfulProviderLinks } = require('./amplify-helpers/show-helpful-pro
 module.exports = (context) => {
   const amplify = {
     buildResources,
+    confirmPrompt,
     constants,
     copyBatch,
     deleteProject,

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -129,7 +129,7 @@ async function transformGraphQLSchema(context, options) {
     resources which would be created for you as a
      part of the AppSync service.`);
 
-    if (await context.prompt.confirm('Do you want to use your own
+    if (await context.amplify.confirmPrompt.run('Do you want to use your own
       tables instead?')) {
       let continueConfiguringDyanmoTables = true;
 


### PR DESCRIPTION
prompt.confirm is unreliable and sometimes fails to take user input
create a confirm prompt helper that uses inquirer prompt instead
refactor helper defined in dynamoDb-walkthrough.js

https://github.com/aws-amplify/amplify-cli/issues/528

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.