### PR TITLE
fix(amplify-provider-awscloudformation): trim profile name

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
@@ -89,7 +89,7 @@ function run(context) {
           },
         ]);
 
-        profileName = answer.pn;
+        profileName = answer.pn.trim();
 
         systemConfigManager.setProfile(awsConfig, profileName);
         context.newUserInfo = {


### PR DESCRIPTION
AWS profile name can not contain empty chars at the begining or end. Trimming the profile name
before saving it to disk

#542

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.