### PR TITLE
feat(amplify-category-storage): add s3 multipart upload to cfn

### DIFF
--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json
@@ -101,7 +101,8 @@
 							"ExposedHeaders": [
 								"x-amz-server-side-encryption",
 								"x-amz-request-id",
-								"x-amz-id-2"
+								"x-amz-id-2",
+								"ETag"
 							],
 							"Id": "S3CORSRuleId1",
 							"MaxAge": "3000"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/61

*Description of changes:*
to enable s3 multipart (and files larger than 5MB), ETag is added to the CORS configuration for the bucket

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.