### PR TITLE
Fixing #591

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -202,7 +202,7 @@ export class ResourceFactory {
                 AwsRegion: Fn.Select(3, Fn.Split(':', Fn.GetAtt(tableId, 'Arn'))),
                 TableName: Fn.Ref(tableId)
             }
-        }).dependsOn(tableId).dependsOn(iamRoleLogicalID)
+        }).dependsOn([tableId, iamRoleLogicalID])
     }
 
     /**

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -152,8 +152,10 @@ export class ResourceFactory {
                 }
             }
         })
-            .dependsOn(ResourceConstants.RESOURCES.ElasticSearchStreamingLambdaIAMRoleLogicalID)
-            .dependsOn(ResourceConstants.RESOURCES.ElasticSearchDomainLogicalID)
+            .dependsOn([
+                ResourceConstants.RESOURCES.ElasticSearchStreamingLambdaIAMRoleLogicalID,
+                ResourceConstants.RESOURCES.ElasticSearchDomainLogicalID
+            ])
     }
 
     public makeDynamoDBStreamEventSourceMapping(typeName: string) {
@@ -164,8 +166,10 @@ export class ResourceFactory {
             FunctionName: Fn.GetAtt(ResourceConstants.RESOURCES.ElasticSearchStreamingLambdaFunctionLogicalID, 'Arn'),
             StartingPosition: 'LATEST'
         })
-            .dependsOn(ModelResourceIDs.ModelTableResourceID(typeName))
-            .dependsOn(ResourceConstants.RESOURCES.ElasticSearchStreamingLambdaFunctionLogicalID)
+            .dependsOn([
+                ModelResourceIDs.ModelTableResourceID(typeName),
+                ResourceConstants.RESOURCES.ElasticSearchStreamingLambdaFunctionLogicalID
+            ])
     }
 
     /**
@@ -481,7 +485,9 @@ export class ResourceFactory {
                 ])
             )
         })
-            .dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID)
-            .dependsOn(ResourceConstants.RESOURCES.ElasticSearchDataSourceLogicalID)
+            .dependsOn([
+                ResourceConstants.RESOURCES.GraphQLSchemaLogicalID,
+                ResourceConstants.RESOURCES.ElasticSearchDataSourceLogicalID
+            ])
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

#591

*Description of changes:*

This change fixes a bug with how the transformed template's dependsOn statements are configured. Previously the code was trying to chain `dependsOn()` from the `cloudform` library when it was really supposed to be passed a list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.