### PR TITLE
Changed the `ResponseCode` of the error pages in the template

### DIFF
--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
@@ -29,7 +29,7 @@
                         "ShouldNotCreateEnvResources",
                         {
                            "Ref": "bucketName"
-                        }, 
+                        },
                         {
                             "Fn::Join": [
                                 "",
@@ -43,7 +43,7 @@
                                   }
                                 ]
                             ]
-                        }      
+                        }
                     ]
                 },
                 "AccessControl": "PublicRead",
@@ -145,7 +145,7 @@
             ],
             "Properties" : {
                 "DistributionConfig" : {
-                    "Origins" : [ 
+                    "Origins" : [
                         {
                             "DomainName" :  {"Fn::GetAtt": ["S3Bucket", "DomainName"]},
                             "Id" : "hostingS3Bucket",
@@ -166,35 +166,35 @@
                     ],
                     "Enabled" : "true",
                     "DefaultCacheBehavior" : {
-                        "AllowedMethods" : [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ],  
+                        "AllowedMethods" : [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ],
                         "TargetOriginId" : "hostingS3Bucket",
                         "ForwardedValues" : {
                             "QueryString" : "false"
                         },
-                        "ViewerProtocolPolicy" : "redirect-to-https", 
+                        "ViewerProtocolPolicy" : "redirect-to-https",
                         "DefaultTTL" : 86400,
                         "MaxTTL" : 31536000,
                         "MinTTL" : 60,
                         "Compress" : true
-                    }, 
+                    },
                     "DefaultRootObject" : "index.html",
                     "CustomErrorResponses" : [
                         {
                             "ErrorCachingMinTTL" : 300,
                             "ErrorCode" : 400,
-                            "ResponseCode" : 200,
+                            "ResponseCode" : 400,
                             "ResponsePagePath" : "/"
-                        }, 
+                        },
                         {
                             "ErrorCachingMinTTL" : 300,
                             "ErrorCode" : 403,
-                            "ResponseCode" : 200,
+                            "ResponseCode" : 403,
                             "ResponsePagePath" : "/"
-                        }, 
+                        },
                         {
                             "ErrorCachingMinTTL" : 300,
                             "ErrorCode" : 404,
-                            "ResponseCode" : 200,
+                            "ResponseCode" : 404,
                             "ResponsePagePath" : "/"
                         }
                     ]
@@ -209,7 +209,7 @@
             }
         },
         "HostingBucketName": {
-            "Description": "Hosting bucket name", 
+            "Description": "Hosting bucket name",
             "Value":  {"Ref": "S3Bucket"}
         },
         "WebsiteURL": {
@@ -229,7 +229,7 @@
                 ]
             },
             "Description": "Name of S3 bucket to hold website content"
-        }, 
+        },
         "CloudFrontDistributionID": {
             "Value": { "Ref": "CloudFrontDistribution"}
         },


### PR DESCRIPTION
Changed the `ResponseCode` of the error pages to the corresponding and equivalent `ErrorCode`values.

I have a setting in my VS code that removes empty space on save. I just noticed it did that here. If you want me to undo those changes I can.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/608

*Description of changes:*
I changed the Response codes from `200`s to the `4xx`s

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.