### PR TITLE
Fix null dereference when a category is removed

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
@@ -186,7 +186,7 @@ function updateamplifyMetaAfterResourceDelete(category, resourceName) {
     resourceName,
   ));
 
-  if (amplifyMeta[category][resourceName] !== undefined) {
+  if (amplifyMeta[category] && amplifyMeta[category][resourceName] !== undefined) {
     delete amplifyMeta[category][resourceName];
   }
 


### PR DESCRIPTION
When removing a category completely, say all of the lambda functions, from a project, it becomes impossible to successfully push the changes due to an error.

`Cannot read property 'lambdaFunctionName' of undefined`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.