### PR TITLE
fix(update-amplify-meta): allow update value to be other types

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
@@ -13,14 +13,16 @@ function updateAwsMetaFile(filePath, category, resourceName, attribute, value, t
   } else if (!amplifyMeta[category][resourceName]) {
     amplifyMeta[category][resourceName] = {};
   }
-  if (!amplifyMeta[category][resourceName][attribute]) {
-    amplifyMeta[category][resourceName][attribute] = {};
-  }
-  if (Array.isArray(amplifyMeta[category][resourceName][attribute])) {
-    amplifyMeta[category][resourceName][attribute] = value;
-  } else {
+  
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    if (!amplifyMeta[category][resourceName][attribute]) {
+      amplifyMeta[category][resourceName][attribute] = {};
+    }
     Object.assign(amplifyMeta[category][resourceName][attribute], value);
+  } else {
+    amplifyMeta[category][resourceName][attribute] = value;
   }
+  
   if (timeStamp) {
     amplifyMeta[category][resourceName].lastPushTimeStamp = timeStamp;
   }


### PR DESCRIPTION
fix(update-amplify-meta): Allow update value to be other types other then dictionary or an array.

*Issue #, if available:* N/A

*Description of changes:*
Allows users to use updateamplifyMetaAfterResourceUpdate to update a value that is not a dictionary or array (as they were already present).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.