### PR TITLE
Fix issue where if a GraphQL API is deployed with `@model`

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -49,45 +49,48 @@ function uploadAppSyncFiles(context, resources) {
       ));
     }
 
-    const resolverFiles = fs.readdirSync(resolverDir);
-    const resolverBucket = getProjectBucket(context);
+      const resolverBucket = getProjectBucket(context);
 
-    resolverFiles.forEach((file) => {
-      const resolverFilePath = path.join(resolverDir, file);
+      if (fs.existsSync(resolverDir)) {
+          const resolverFiles = fs.readdirSync(resolverDir);
 
-      uploadFilePromises.push(uploadAppSyncResolver(
-        context, file,
-        resolverFilePath, buildTimeStamp,
-      ));
-    });
+          resolverFiles.forEach((file) => {
+              const resolverFilePath = path.join(resolverDir, file);
 
-    return Promise.all(uploadFilePromises)
-      .then(() => {
-        const parametersFilePath = path.join(backEndDir, category, resourceName, 'parameters.json');
-        let currentParameters;
+              uploadFilePromises.push(uploadAppSyncResolver(
+                  context, file,
+                  resolverFilePath, buildTimeStamp,
+              ));
+          });
+      }
 
-        if (fs.existsSync(parametersFilePath)) {
-          try {
-            currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
-            // Clear the parameters cache
-            currentParameters = {
-              AppSyncApiName: currentParameters.AppSyncApiName,
-              AuthCognitoUserPoolId: currentParameters.AuthCognitoUserPoolId,
-            };
-          } catch (e) {
-            currentParameters = {};
-          }
-        }
+      return Promise.all(uploadFilePromises)
+          .then(() => {
+              const parametersFilePath = path.join(backEndDir, category, resourceName, 'parameters.json');
+              let currentParameters;
 
-        Object.assign(currentParameters, s3LocationMap);
-        Object.assign(currentParameters, {
-          ResolverBucket: resolverBucket,
-          ResolverRootKey: ROOT_APPSYNC_S3_KEY,
-          DeploymentTimestamp: buildTimeStamp,
-        });
-        const jsonString = JSON.stringify(currentParameters, null, 4);
-        fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
-      });
+              if (fs.existsSync(parametersFilePath)) {
+                  try {
+                      currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
+                      // Clear the parameters cache
+                      currentParameters = {
+                          AppSyncApiName: currentParameters.AppSyncApiName,
+                          AuthCognitoUserPoolId: currentParameters.AuthCognitoUserPoolId,
+                      };
+                  } catch (e) {
+                      currentParameters = {};
+                  }
+              }
+
+              Object.assign(currentParameters, s3LocationMap);
+              Object.assign(currentParameters, {
+                  ResolverBucket: resolverBucket,
+                  ResolverRootKey: ROOT_APPSYNC_S3_KEY,
+                  DeploymentTimestamp: buildTimeStamp,
+              });
+              const jsonString = JSON.stringify(currentParameters, null, 4);
+              fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
+          });
   }
 }
 

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -49,48 +49,48 @@ function uploadAppSyncFiles(context, resources) {
       ));
     }
 
-      const resolverBucket = getProjectBucket(context);
+    const resolverBucket = getProjectBucket(context);
 
-      if (fs.existsSync(resolverDir)) {
-          const resolverFiles = fs.readdirSync(resolverDir);
+    if (fs.existsSync(resolverDir)) {
+      const resolverFiles = fs.readdirSync(resolverDir);
 
-          resolverFiles.forEach((file) => {
-              const resolverFilePath = path.join(resolverDir, file);
+      resolverFiles.forEach((file) => {
+        const resolverFilePath = path.join(resolverDir, file);
 
-              uploadFilePromises.push(uploadAppSyncResolver(
-                  context, file,
-                  resolverFilePath, buildTimeStamp,
-              ));
-          });
-      }
+        uploadFilePromises.push(uploadAppSyncResolver(
+          context, file,
+          resolverFilePath, buildTimeStamp,
+        ));
+      });
+    }
 
-      return Promise.all(uploadFilePromises)
-          .then(() => {
-              const parametersFilePath = path.join(backEndDir, category, resourceName, 'parameters.json');
-              let currentParameters;
+    return Promise.all(uploadFilePromises)
+      .then(() => {
+        const parametersFilePath = path.join(backEndDir, category, resourceName, 'parameters.json');
+        let currentParameters;
 
-              if (fs.existsSync(parametersFilePath)) {
-                  try {
-                      currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
-                      // Clear the parameters cache
-                      currentParameters = {
-                          AppSyncApiName: currentParameters.AppSyncApiName,
-                          AuthCognitoUserPoolId: currentParameters.AuthCognitoUserPoolId,
-                      };
-                  } catch (e) {
-                      currentParameters = {};
-                  }
-              }
+        if (fs.existsSync(parametersFilePath)) {
+          try {
+            currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
+            // Clear the parameters cache
+            currentParameters = {
+              AppSyncApiName: currentParameters.AppSyncApiName,
+              AuthCognitoUserPoolId: currentParameters.AuthCognitoUserPoolId,
+            };
+          } catch (e) {
+            currentParameters = {};
+          }
+        }
 
-              Object.assign(currentParameters, s3LocationMap);
-              Object.assign(currentParameters, {
-                  ResolverBucket: resolverBucket,
-                  ResolverRootKey: ROOT_APPSYNC_S3_KEY,
-                  DeploymentTimestamp: buildTimeStamp,
-              });
-              const jsonString = JSON.stringify(currentParameters, null, 4);
-              fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
-          });
+        Object.assign(currentParameters, s3LocationMap);
+        Object.assign(currentParameters, {
+          ResolverBucket: resolverBucket,
+          ResolverRootKey: ROOT_APPSYNC_S3_KEY,
+          DeploymentTimestamp: buildTimeStamp,
+        });
+        const jsonString = JSON.stringify(currentParameters, null, 4);
+        fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
+      });
   }
 }
 


### PR DESCRIPTION
and then those `@model` directives are removed, a file not found
error is thrown and the stack is unable to be deployed.

*Issue #, if available:* N/A

*Description of changes:* Checked for existence of `resolvers` folder when calling uploadAppSyncFiles.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.