### PR TITLE
feat(amplify-frontend-javascript): adding Ember config for amplify-cli

### DIFF
--- a/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
+++ b/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
@@ -37,6 +37,13 @@ const vueConfig = {
   StartCommand: `${npm} run-script serve`,
 };
 
+const emberConfig = {
+  SourceDir: '/',
+  DistributionDir: 'dist',
+  BuildCommand: `${npm} run-script build -- -e production`,
+  StartCommand: `${npm} run-script start`,
+};
+
 const defaultConfig = {
   SourceDir: 'src',
   DistributionDir: 'dist',
@@ -45,10 +52,11 @@ const defaultConfig = {
 };
 
 module.exports = {
+  angular: angularConfig,
+  ember: emberConfig,
+  ionic: ionicConfig,
   react: reactConfig,
   'react-native': reactNativeConfig,
-  angular: angularConfig,
-  ionic: ionicConfig,
   vue: vueConfig,
   none: defaultConfig,
 };


### PR DESCRIPTION
This is applying #580 to the `multienv` branch

Adds Ember to the list of frontend frameworks when running amplify init.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.