### PR TITLE
fix(amplify-provider-awscloudformation): batch cfn status polling

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -161,9 +161,13 @@ class CloudFormation {
 
         return nestedstackEvents;
       })
-      .catch(() =>
-        // ignore. We dont fail if we can't get the nested stack status
-        ({}));
+      .catch((e) => {
+        if (e && e.code === 'Throttling') {
+          return {};
+        }
+
+        Promise.reject(e);
+      });
   }
 
   updateResourceStack(dir, cfnFile) {

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -120,7 +120,11 @@ class CloudFormation {
             nestedStackQueue = [...nestedStackQueue, ...newStacks];
           }
 
-          for (let i = 0; i < Math.min(CFN_MAX_CONCURRENT_REQUEST, nestedStackQueue.length); i++) {
+          for (
+            let i = 0;
+            i < Math.min(CFN_MAX_CONCURRENT_REQUEST, nestedStackQueue.length);
+            i += 1
+          ) {
             nestedStackEventPromises.push(self.getNestedStackEvents(nestedStackQueue[0]));
             if (nestedStackQueue.length > 1) {
               nestedStackQueue.shift();


### PR DESCRIPTION
Cloud formation provider polls cloud formation to get the list of events to show when pushing the
stack. When a project has more than 20 resources, this causes throtlling. Fixing this issue by
batching the polling

#705 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.