### PR TITLE
 fix(amplify-provider-awscloudformation): add session token

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/system-config-manager.js
@@ -130,8 +130,10 @@ function normalizeKeys(config) {
   if (config) {
     config.accessKeyId = config.accessKeyId || config.aws_access_key_id;
     config.secretAccessKey = config.secretAccessKey || config.aws_secret_access_key;
+    config.sessionToken = config.sessionToken || config.aws_session_token;
     delete config.aws_access_key_id;
     delete config.aws_secret_access_key;
+    delete config.aws_session_token;
   }
   return config;
 }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/user-agent.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/user-agent.js
@@ -7,7 +7,7 @@ function formUserAgentParam(context, userAgentAction) {
   const projectConfig = context.exeInfo ?
     context.exeInfo.projectConfig : amplify.getProjectConfig();
 
-  let framework = projectConfig.frontend;
+  let framework = Object.keys(projectConfig.frontendHandler)[0];
 
   if (framework === 'javascript') {
     ({ framework } = projectConfig.javascript);


### PR DESCRIPTION
*Issue #, if available:*
#709 
#719

*Description of changes:*
Allows the user to directly manage the session of a temp credential until a more comprehensive solution is found.
The possible temp credentials expiration during an amplify push can happen, but the user should be able to push again after updating the credentials.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.