### PR TITLE
Viewer Transformer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,13 @@ $ npm install -g @aws-amplify/cli
 $ amplify configure
 ```
 
- - Warning: Please don't use `yarn` for installing the CLI. It has known issues. Use `npm` instead as advised above.
+### Beta
+For [multiple environment and team workflow support](https://aws-amplify.github.io/docs/cli/multienv?sdk=js), install and configure the Amplify CLI as follows:
+
+```bash
+$ npm install -g @aws-amplify/cli@multienv
+$ amplify configure
+```
 
 ## Commands Summary
 

--- a/packages/amplify-cli/CHANGELOG.md
+++ b/packages/amplify-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.1.35"></a>
+## [0.1.35](https://github.com/aws-amplify/amplify-cli/compare/@aws-amplify/cli@0.1.34...@aws-amplify/cli@0.1.35) (2018-11-21)
+
+
+
+
+**Note:** Version bump only for package @aws-amplify/cli
+
 <a name="0.1.34"></a>
 ## [0.1.34](https://github.com/aws-amplify/amplify-cli/compare/@aws-amplify/cli@0.1.34-beta.0...@aws-amplify/cli@0.1.34) (2018-11-13)
 

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/cli",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Amplify CLI",
   "bin": {
     "amplify": "bin/amplify"
@@ -28,11 +28,11 @@
     "amplify-category-interactions": "^0.1.33",
     "amplify-category-notifications": "^0.1.33",
     "amplify-category-storage": "^0.1.33",
-    "amplify-codegen": "^0.1.34",
+    "amplify-codegen": "^0.1.35",
     "amplify-frontend-android": "^0.1.33",
     "amplify-frontend-ios": "^0.1.33",
     "amplify-frontend-javascript": "^0.1.33",
-    "amplify-provider-awscloudformation": "^0.1.34",
+    "amplify-provider-awscloudformation": "^0.1.35",
     "cfonts": "^2.1.2",
     "chalk": "^2.0.1",
     "eslint": "^4.19.1",

--- a/packages/amplify-codegen/CHANGELOG.md
+++ b/packages/amplify-codegen/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.1.35"></a>
+## [0.1.35](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.34...amplify-codegen@0.1.35) (2018-11-21)
+
+
+
+
+**Note:** Version bump only for package amplify-codegen
+
 <a name="0.1.34"></a>
 ## [0.1.34](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.34-beta.0...amplify-codegen@0.1.34) (2018-11-13)
 

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-codegen",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "amplify code generator",
   "main": "src/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "amplify-graphql-docs-generator": "^0.1.33",
-    "amplify-graphql-types-generator": "^0.1.1",
+    "amplify-graphql-types-generator": "^0.1.2",
     "aws-appsync-codegen": "^0.17.4",
     "chalk": "^2.4.1",
     "eslint": "^4.9.0",

--- a/packages/amplify-graphql-types-generator/CHANGELOG.md
+++ b/packages/amplify-graphql-types-generator/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.1.2"></a>
+## [0.1.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-graphql-types-generator@0.1.1...amplify-graphql-types-generator@0.1.2) (2018-11-21)
+
+
+### Bug Fixes
+
+* **amplify-graphql-types-generator:** nullable parameter order in angular serivce ([53c5c3d](https://github.com/aws-amplify/amplify-cli/commit/53c5c3d))
+
+
+
+
 <a name="0.1.1"></a>
 ## [0.1.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-graphql-types-generator@0.1.1-beta.0...amplify-graphql-types-generator@0.1.1) (2018-11-09)
 

--- a/packages/amplify-graphql-types-generator/package.json
+++ b/packages/amplify-graphql-types-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-graphql-types-generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Generate API code or type annotations based on a GraphQL schema and statements",
   "main": "./lib/index.js",
   "bin": "./lib/cli.js",

--- a/packages/amplify-provider-awscloudformation/CHANGELOG.md
+++ b/packages/amplify-provider-awscloudformation/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.1.35"></a>
+## [0.1.35](https://github.com/aws-amplify/amplify-cli/compare/amplify-provider-awscloudformation@0.1.34...amplify-provider-awscloudformation@0.1.35) (2018-11-21)
+
+
+
+
+**Note:** Version bump only for package amplify-provider-awscloudformation
+
 <a name="0.1.34"></a>
 ## [0.1.34](https://github.com/aws-amplify/amplify-cli/compare/amplify-provider-awscloudformation@0.1.34-beta.0...amplify-provider-awscloudformation@0.1.34) (2018-11-13)
 

--- a/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
@@ -42,7 +42,7 @@ function run(context) {
           default: `amplify-${context.amplify.makeId()}`,
         }]);
     }).then((answers) => {
-      const deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', answers.userName).replace('{region}', answers.region);
+      const deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', answers.userName).replace('{region}', awsConfig.region);
       context.print.info('Complete the user creation using the AWS console');
       context.print.info(chalk.green(deepLinkURL));
       opn(deepLinkURL, { wait: false });

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -1,13 +1,13 @@
 {
   "name": "amplify-provider-awscloudformation",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "AWS CloudFormation Provider",
   "main": "index.js",
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
     "amplify-category-storage": "^0.1.33",
-    "amplify-codegen": "^0.1.34",
+    "amplify-codegen": "^0.1.35",
     "archiver": "^2.1.1",
     "aws-sdk": "^2.250.1",
     "cfn-lint": "^1.7.2",

--- a/packages/graphql-viewer-transformer/package.json
+++ b/packages/graphql-viewer-transformer/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "graphql-viewer-transformer",
+  "version": "1.0.33",
+  "description": "A GraphQL transform that adds a viewer field to a query for a @model type.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "jest",
+    "test-ci": "jest --ci -i",
+    "build": "tsc",
+    "clean": "rm -rf ./lib"
+  },
+  "keywords": [
+    "graphql",
+    "appsync",
+    "aws"
+  ],
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "cloudform": "^2.2.1",
+    "graphql": "^0.13.2",
+    "graphql-mapping-template": "^1.0.33",
+    "graphql-transformer-common": "^1.0.33",
+    "graphql-transformer-core": "^1.0.33"
+  },
+  "devDependencies": {
+    "@types/graphql": "^0.13.1",
+    "@types/jest": "^23.1.1",
+    "@types/node": "^10.3.4",
+    "aws-sdk": "^2.259.1",
+    "graphql-appsync-transformer": "^1.0.33",
+    "graphql-dynamodb-transformer": "^1.0.33",
+    "jest": "^23.1.0",
+    "ts-jest": "^22.4.6",
+    "tslint": "^5.10.0",
+    "typescript": "^2.8.3"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testURL": "http://localhost",
+    "testRegex": "(src/__tests__/.*.test.*)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  }
+}

--- a/packages/graphql-viewer-transformer/src/ViewerTransformer.ts
+++ b/packages/graphql-viewer-transformer/src/ViewerTransformer.ts
@@ -1,0 +1,91 @@
+import { Transformer, TransformerContext, InvalidDirectiveError } from "graphql-transformer-core";
+import {
+    ObjectTypeDefinitionNode,
+    DirectiveNode,
+} from "graphql";
+import { ResourceFactory } from './resources'
+import {
+    ResolverResourceIDs,
+    makeNamedType,
+    makeField,
+    ModelResourceIDs
+} from "graphql-transformer-common";
+import Table from "cloudform/types/glue/table";
+
+interface ViewerDirectiveArgs {
+    // Name of the viewer field appearing in the Query
+    viewerField?: string,
+    // Field to use for searching on the model
+    modelField?: string,
+    // Field to use in the $ctx.identity obj for searching (eg: sub or username)
+    identityField?: string,
+}
+
+export class ViewerTransformer extends Transformer {
+
+    resources: ResourceFactory
+
+    constructor() {
+        super(
+            'ViewerTransformer',
+            'directive @viewer(viewerField: String = "viewer") on OBJECT'
+        )
+        this.resources = new ResourceFactory();
+    }
+
+    /**
+     * When a type is annotated with @viewer it appends to the query as a viewer.
+     *
+     * Usage:
+     *
+     * type User @model @viewer(viewerField: "viewer", modelField: "email", identityField: "username") {
+     *   id: ID!
+     *   name: String
+     * }
+     * 
+     * type Query {
+     *   viewer: User
+     * }
+     *
+     * Enabling viewer queries
+     * 
+     */
+    public object = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
+        // @viewer may only be used on types that are also @model
+        const modelDirective = def.directives.find((dir) => dir.name.value === 'model')
+        if (!modelDirective) {
+            throw new InvalidDirectiveError('Types annotated with @viewer must also be annotated with @model.')
+        }
+
+        this.createViewerQuery(def, directive, ctx)
+    }
+
+    private createViewerQuery = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        const typeName = def.name.value
+        const queryFields = []
+        const directiveArguments: ViewerDirectiveArgs = this.getDirectiveArgumentMap(directive)
+
+        const viewerField = directiveArguments.viewerField || "viewer";
+        const modelField = directiveArguments.modelField || "email";
+        const identityField = directiveArguments.identityField || "username";
+
+        const viewerResolver = this.resources.makeViewerResolver(typeName, viewerField,
+            modelField,
+            identityField,
+            ctx.getQueryTypeName())
+        // Create the index
+
+        const tableLogicalId = ModelResourceIDs.ModelTableResourceID(typeName)
+        const table = ctx.getResource(tableLogicalId) as Table
+        const updated = this.resources.updateTableForConnection(table, viewerField, modelField, null)
+
+        ctx.setResource(tableLogicalId, updated)
+        ctx.setResource("ViewerResolver", viewerResolver)
+        queryFields.push(makeField(
+            viewerField,
+            [],
+            makeNamedType(def.name.value)
+        ))
+        ctx.addQueryFields(queryFields)
+    }
+}

--- a/packages/graphql-viewer-transformer/src/__tests__/ViewerTransformer.test.ts
+++ b/packages/graphql-viewer-transformer/src/__tests__/ViewerTransformer.test.ts
@@ -1,0 +1,80 @@
+import {
+    ObjectTypeDefinitionNode, parse, DocumentNode,
+    Kind, InputObjectTypeDefinitionNode
+} from 'graphql'
+import GraphQLTransform from 'graphql-transformer-core'
+import { ResourceConstants } from 'graphql-transformer-common'
+import { ViewerTransformer } from '../ViewerTransformer'
+import AppSyncTransformer from 'graphql-appsync-transformer'
+import DynamoDBModelTransformer from 'graphql-dynamodb-transformer'
+
+const getType = (schemaDoc: DocumentNode) => (name: string): ObjectTypeDefinitionNode =>
+    schemaDoc.definitions.find(d => d.kind !== Kind.SCHEMA_DEFINITION ? d.name.value === name : false) as ObjectTypeDefinitionNode
+const getField = (input: ObjectTypeDefinitionNode, field: string) => input.fields.find(f => f.name.value === field)
+
+test('Test VersionedModelTransformer validation happy case', () => {
+    const validSchema = `
+    type User @model @viewer {
+        id: ID!
+        name: String!
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new AppSyncTransformer(),
+            new DynamoDBModelTransformer(),
+            new ViewerTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    // tslint:disable-next-line
+    const schemaDoc = parse(out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID].Properties.Definition)
+
+    expect(out).toBeDefined()
+    expect(getField(getType(schemaDoc)('Query'), 'viewer')).toBeDefined()
+    // Use e2e tests to test resolver logic.
+});
+
+
+test('Test ViewerModelTransformer validation fails when provided viewer field of wrong type.', () => {
+    const validSchema = `
+    type User @model @viewer {
+        id: ID!
+        name: String!
+    }
+    `
+    try {
+        const transformer = new GraphQLTransform({
+            transformers: [
+                new AppSyncTransformer(),
+                new DynamoDBModelTransformer(),
+                new ViewerTransformer()
+            ]
+        })
+        const out = transformer.transform(validSchema);
+    } catch (e) {
+        expect(e.name).toEqual('TransformerContractError')
+    }
+});
+
+test('Test VersionedModelTransformer version field replaced by non-null if provided as nullable.', () => {
+    const validSchema = `
+    type User @model @viewer {
+        id: ID!
+        name: String!
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new AppSyncTransformer(),
+            new DynamoDBModelTransformer(),
+            new ViewerTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    const sdl = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID].Properties.Definition
+    const schemaDoc = parse(sdl)
+    const viewerField = getField(getType(schemaDoc)('Query'), 'viewer')
+    expect(viewerField).toBeDefined()
+    // expect(versionField.type.kind).toEqual(Kind.NON_NULL_TYPE)
+});

--- a/packages/graphql-viewer-transformer/src/index.ts
+++ b/packages/graphql-viewer-transformer/src/index.ts
@@ -1,0 +1,3 @@
+import { ViewerTransformer } from './ViewerTransformer'
+export * from './ViewerTransformer'
+export default ViewerTransformer

--- a/packages/graphql-viewer-transformer/src/resources.ts
+++ b/packages/graphql-viewer-transformer/src/resources.ts
@@ -1,0 +1,131 @@
+import Template from 'cloudform/types/template'
+import { Fn, AppSync } from 'cloudform'
+import {
+  str, print, ref, obj, nul, ifElse,
+  compoundExpression, bool, equals, raw, DynamoDBMappingTemplate, int,
+} from 'graphql-mapping-template'
+import { ResourceConstants, ModelResourceIDs, DEFAULT_SCALARS } from 'graphql-transformer-common'
+import Table, { GlobalSecondaryIndex, KeySchema, Projection, AttributeDefinition, ProvisionedThroughput } from 'cloudform/types/dynamoDb/table';
+import { InvalidDirectiveError } from 'graphql-transformer-core';
+
+export class ResourceFactory {
+
+  public makeParams() {
+    return {}
+  }
+
+  /**
+   * Creates the barebones template for an application.
+   */
+  public initTemplate(): Template {
+    return {
+      Parameters: this.makeParams(),
+      Resources: {},
+      Outputs: {}
+    }
+  }
+
+  /**
+ * Add a GSI for the connection if one does not already exist.
+ * @param table The table to add the GSI to.
+ */
+  public updateTableForConnection(table: Table,
+    fieldName: string,
+    fieldAttributeName: string,
+    sortField: { name: string, type: string } = null
+  ): Table {
+    const gsis = table.Properties.GlobalSecondaryIndexes || [] as GlobalSecondaryIndex[]
+    if (gsis.length >= 5) {
+      throw new InvalidDirectiveError(
+        `Cannot create connection ${fieldName}. Table ${table.Properties.TableName} out of GSI capacity.`
+      )
+    }
+    const connectionGSIName = `gsi-${fieldName}`
+
+    // If the GSI does not exist yet then add it.
+    const existingGSI = gsis.find(gsi => gsi.IndexName === connectionGSIName)
+    if (!existingGSI) {
+      const keySchema = [new KeySchema({ AttributeName: fieldAttributeName, KeyType: 'HASH' })]
+      if (sortField) {
+        keySchema.push(new KeySchema({ AttributeName: sortField.name, KeyType: 'RANGE' }))
+      }
+      gsis.push(new GlobalSecondaryIndex({
+        IndexName: connectionGSIName,
+        KeySchema: keySchema,
+        Projection: new Projection({
+          ProjectionType: 'ALL'
+        }),
+        ProvisionedThroughput: new ProvisionedThroughput({
+          ReadCapacityUnits: Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS),
+          WriteCapacityUnits: Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS)
+        }),
+      }))
+    }
+
+    // If the attribute definition does not exist yet, add it.
+    const attributeDefinitions = table.Properties.AttributeDefinitions as AttributeDefinition[]
+    const existingAttribute = attributeDefinitions.find(attr => attr.AttributeName === fieldAttributeName)
+    if (!existingAttribute) {
+      attributeDefinitions.push(new AttributeDefinition({
+        AttributeName: fieldAttributeName,
+        AttributeType: 'S'
+      }))
+    }
+
+    // If the attribute definition does not exist yet, add it.
+    if (sortField) {
+      const existingSortAttribute = attributeDefinitions.find(attr => attr.AttributeName === sortField.name)
+      if (!existingSortAttribute) {
+        const scalarType = DEFAULT_SCALARS[sortField.type]
+        const attributeType = scalarType === 'String' ? 'S' : 'N'
+        attributeDefinitions.push(new AttributeDefinition({ AttributeName: sortField.name, AttributeType: attributeType }))
+      }
+    }
+
+    table.Properties.GlobalSecondaryIndexes = gsis
+    table.Properties.AttributeDefinitions = attributeDefinitions
+    return table
+  }
+
+  /**
+  * Create a resolver that creates an item in DynamoDB.
+  * @param type
+  */
+  public makeViewerResolver(type: string, fieldName: string, modelField: string = "email", identityField: string = "username", queryTypeName: string = 'Query') {
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: queryTypeName,
+      RequestMappingTemplate: print(
+        compoundExpression([
+          DynamoDBMappingTemplate.query({
+            query: obj({
+              'expression': str('#fieldName = :fieldName'),
+              'expressionNames': obj({
+                '#fieldName': str(modelField)
+              }),
+              'expressionValues': obj({
+                ':fieldName': obj({
+                  'S': str(`$ctx.identity.${identityField}`)
+                })
+              })
+            }),
+            index: str(`gsi-${fieldName}`),
+            scanIndexForward: nul(),
+            filter: nul(),
+            nextToken: nul(),
+            limit: int(1)
+          })
+        ])
+      ),
+      ResponseMappingTemplate: print(
+        ifElse(
+          raw('$ctx.result.items.size() > 0'),
+          raw('$util.toJson($ctx.result.items[0]'),
+          nul()
+        )
+      )
+    }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID)
+  }
+}

--- a/packages/graphql-viewer-transformer/src/run.ts
+++ b/packages/graphql-viewer-transformer/src/run.ts
@@ -1,0 +1,28 @@
+import GraphQLTransform from "graphql-transformer-core";
+import { ViewerTransformer } from "./ViewerTransformer";
+import AppSyncTransformer from 'graphql-appsync-transformer';
+import DynamoDBModelTransformer from 'graphql-dynamodb-transformer';
+
+import fs = require('fs');
+
+const validSchema = `
+type User @model @viewer {
+    id: ID!
+    name: String!
+}
+`;
+
+const transformer = new GraphQLTransform({
+    transformers: [
+        new AppSyncTransformer(),
+        new DynamoDBModelTransformer(),
+        new ViewerTransformer()
+    ]
+});
+const out = transformer.transform(validSchema);
+fs.writeFile('cf.out.json', JSON.stringify(out, null, 4), (err) => {
+    if (err) {
+        throw err;
+    }
+    console.log('SUCCESS!');
+});

--- a/packages/graphql-viewer-transformer/tsconfig.json
+++ b/packages/graphql-viewer-transformer/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "sourceMap": true,
+        "outDir": "lib",
+        "lib": [
+            "es2015",
+            "es2016.array.include",
+            "esnext.asynciterable",
+            "dom"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
+}

--- a/packages/graphql-viewer-transformer/tslint.json
+++ b/packages/graphql-viewer-transformer/tslint.json
@@ -1,0 +1,64 @@
+{
+    "rules": {
+        "class-name": true,
+        "curly": true,
+        "eofline": false,
+        "forin": true,
+        "indent": false,
+        "label-position": true,
+        "max-line-length": [
+            true,
+            150
+        ],
+        "no-arg": true,
+        "no-bitwise": true,
+        "no-console": false,
+        "no-construct": true,
+        "no-constructor-vars": false,
+        "no-debugger": true,
+        "no-duplicate-variable": true,
+        "no-empty": true,
+        "no-eval": true,
+        "no-string-literal": true,
+        "no-switch-case-fall-through": true,
+        "no-trailing-whitespace": true,
+        "no-unused-expression": true,
+        "no-unused-variable": false,
+        "no-use-before-declare": true,
+        "no-var-requires": false,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-catch",
+            "check-else",
+            "check-whitespace"
+        ],
+        "semicolon": false,
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "typedef": [
+            true,
+            "callSignature",
+            "indexSignature",
+            "parameter",
+            "propertySignature",
+            "variableDeclarator",
+            "memberVariableDeclarator"
+        ],
+        "use-strict": false,
+        "variable-name": [
+            true,
+            "allow-leading-underscore"
+        ],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}


### PR DESCRIPTION
Issue: #740

*Description of changes:*

I needed a custom transformer for adding a viewer to a schema and adding it manually each time would get erased after every gql-compile. Could I get some guidance on the implementation and directions for contributing back a custom transformer?

Directive:
```gql
directive @viewer(viewerField: "viewer", modelField: "email", identityField: "username") on OBJECT
```

Sample Schema:
```gql
type User @model @viewer {
    id: ID!
    name: String!
}
```

Cloudformation output:
```json
"UserTable": {
    "Type": "AWS::DynamoDB::Table",
    "Properties": {
        "TableName": "(Intentionally truncated)",
        "KeySchema": [
            {
                "AttributeName": "id",
                "KeyType": "HASH"
            }
        ],
        "AttributeDefinitions": [
            {
                "AttributeName": "id",
                "AttributeType": "S"
            },
            {
                "AttributeName": "email",
                "AttributeType": "S"
            }
        ],
        "GlobalSecondaryIndexes": [
            {
                "IndexName": "gsi-viewer",
                "KeySchema": [
                    {
                        "AttributeName": "email",
                        "KeyType": "HASH"
                    }
                ],
                "Projection": {
                    "ProjectionType": "ALL"
                },
                "ProvisionedThroughput": {
                    "ReadCapacityUnits": {
                        "Ref": "DynamoDBModelTableReadIOPS"
                    },
                    "WriteCapacityUnits": {
                        "Ref": "DynamoDBModelTableWriteIOPS"
                    }
                }
            }
        ]
    }
},
...
"ViewerResolver": {
    "Type": "AWS::AppSync::Resolver",
    "Properties": {
        "ApiId": {
            "Fn::GetAtt": [
                "GraphQLAPI",
                "ApiId"
            ]
        },
        "DataSourceName": {
            "Fn::GetAtt": [
                "UserDataSource",
                "Name"
            ]
        },
        "FieldName": "viewer",
        "TypeName": "Query",
        "RequestMappingTemplate": "{\n  \"version\": \"2017-02-28\",\n  \"operation\": \"Query\",\n  \"query\": {\n      \"expression\": \"#fieldName = :fieldName\",\n      \"expressionNames\": {\n          \"#fieldName\": \"email\"\n    },\n      \"expressionValues\": {\n          \":fieldName\": {\n              \"S\": \"$ctx.identity.username\"\n      }\n    }\n  },\n  \"scanIndexForward\": null,\n  \"filter\": null,\n  \"limit\": 1,\n  \"nextToken\": null,\n  \"index\": \"gsi-viewer\"\n}",
        "ResponseMappingTemplate": "#if( $ctx.result.items.size() > 0 )\n  $util.toJson($ctx.result.items[0]\n#else\nnull\n#end"
    },
    "DependsOn": "GraphQLSchema"
}
```

Expanded request:
```vtl
{
  "version": "2017-02-28",
  "operation": "Query",
  "query": {
      "expression": "#fieldName = :fieldName",
      "expressionNames": {
          "#fieldName": "email"
    },
      "expressionValues": {
          ":fieldName": {
              "S": "$ctx.identity.username"
      }
    }
  },
  "scanIndexForward": null,
  "filter": null,
  "limit": 1,
  "nextToken": null,
  "index": "gsi-viewer"
}
```

Expanded Response:
```vtl
#if( $ctx.result.items.size() > 0 )
  $util.toJson($ctx.result.items[0]
#else
null
#end
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.