### PR TITLE
Update codegen to hide warnings

### DIFF
--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -26,6 +26,10 @@ async function generateTypes(context, forceDownloadSchema) {
       const schema = path.resolve(cfg.schema);
       const output = cfg.amplifyExtension.generatedFileName;
       const target = cfg.amplifyExtension.codeGenTarget;
+
+      if (!output || output === '') {
+        return;
+      }
       if (forceDownloadSchema || jetpack.exists(schema) !== 'file') {
         await downloadIntrospectionSchemaWithProgress(
           context,

--- a/packages/amplify-graphql-docs-generator/src/index.ts
+++ b/packages/amplify-graphql-docs-generator/src/index.ts
@@ -111,7 +111,7 @@ function registerHelpers() {
 
 function format(str: string, language: string = 'graphql'): string {
   const parserMap = {
-    javascript: 'babylon',
+    javascript: 'babel',
     graphql: 'graphql',
     typescript: 'typescript',
     flow: 'flow',


### PR DESCRIPTION
### fix(amplify-graphql-docs-generator): change prettier parser to babel

Prettier has deprecated use of babylon parser to parse JS files. Updating the config to user babel

### fix(amplify-codegen): hide types gen message for JS

Hide the types generated status message if there is no types to be generated. This happens when the output type is either JS or graphql.