### PR TITLE
ci: run e2e test in multienv branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,7 @@ workflows:
             branches:
               only:
                 - master
+                - multienv
           requires:
             - build
       - integration_test:

--- a/packages/graphql-transformers-e2e-tests/src/CloudFormationClient.ts
+++ b/packages/graphql-transformers-e2e-tests/src/CloudFormationClient.ts
@@ -45,6 +45,13 @@ export class CloudFormationClient {
             })
         }
 
+        // add env info to template
+        template.Parameters.env = {
+            "Type": "String",
+            "Description": "env name",
+            "Default": "NONE"
+        };
+
         return await promisify<CloudFormation.Types.CreateStackInput, CloudFormation.Types.CreateStackOutput>(
             this.client.createStack,
             {


### PR DESCRIPTION
GraphQL Transformer has e2e test which does not run in
multienv branch. Updating configuration to run the
test in multienv branch and updating e2e tests
 to include the env name in the CFN document

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.