### PR TITLE
feat(graphql-dynamodb-transformer): support filter enums in query

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -370,7 +370,7 @@ export class ModelConnectionTransformer extends Transformer {
         }
 
         // Create the ModelXFilterInput
-        const tableXQueryFilterInput = makeModelXFilterInputObject(field)
+        const tableXQueryFilterInput = makeModelXFilterInputObject(field, ctx)
         if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
             ctx.addInput(tableXQueryFilterInput)
         }

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -7,7 +7,8 @@
     "test": "jest",
     "test-ci": "jest --ci -i",
     "build": "tsc",
-    "clean": "rm -rf ./lib"
+    "clean": "rm -rf ./lib",
+    "watch": "tsc -w"
   },
   "keywords": [
     "graphql",

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -7,7 +7,7 @@ import {
     makeCreateInputObject, makeUpdateInputObject, makeDeleteInputObject,
     makeModelScalarFilterInputObject, makeModelXFilterInputObject, makeModelSortDirectionEnumObject,
     makeModelConnectionType, makeModelConnectionField,
-    makeScalarFilterInputs, makeModelScanField, makeSubscriptionField, getNonModelObjectArray, makeNonModelInputObject, makeEnumFilterInputObject
+    makeScalarFilterInputs, makeModelScanField, makeSubscriptionField, getNonModelObjectArray, makeNonModelInputObject, makeEnumFilterInputObjects
 } from './definitions'
 import {
     blankObject, makeField, makeInputValueDefinition, makeNamedType,
@@ -412,7 +412,7 @@ export class DynamoDBModelTransformer extends Transformer {
         }
 
         // Create the Enum filters
-        const enumFilters = makeEnumFilterInputObject(def, ctx);
+        const enumFilters = makeEnumFilterInputObjects(def, ctx);
         for (const filter of enumFilters) {
             if (!this.typeExist(filter.name.value, ctx)) {
                 ctx.addInput(filter)

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -7,7 +7,7 @@ import {
     makeCreateInputObject, makeUpdateInputObject, makeDeleteInputObject,
     makeModelScalarFilterInputObject, makeModelXFilterInputObject, makeModelSortDirectionEnumObject,
     makeModelConnectionType, makeModelConnectionField,
-    makeScalarFilterInputs, makeModelScanField, makeSubscriptionField, getNonModelObjectArray, makeNonModelInputObject
+    makeScalarFilterInputs, makeModelScanField, makeSubscriptionField, getNonModelObjectArray, makeNonModelInputObject, makeEnumFilterInputObject
 } from './definitions'
 import {
     blankObject, makeField, makeInputValueDefinition, makeNamedType,
@@ -219,7 +219,11 @@ export class DynamoDBModelTransformer extends Transformer {
         ctx.addMutationFields(mutationFields)
     }
 
-    private createQueries = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+    private createQueries = (
+        def: ObjectTypeDefinitionNode,
+        directive: DirectiveNode,
+        ctx: TransformerContext,
+    ) => {
         const typeName = def.name.value
         const queryFields = []
         const directiveArguments: ModelDirectiveArgs = this.getDirectiveArgumentMap(directive)
@@ -396,7 +400,10 @@ export class DynamoDBModelTransformer extends Transformer {
         ctx.addObjectExtension(makeModelConnectionType(def.name.value))
     }
 
-    private generateFilterInputs(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {
+    private generateFilterInputs(
+        ctx: TransformerContext,
+        def: ObjectTypeDefinitionNode,
+    ): void {
         const scalarFilters = makeScalarFilterInputs()
         for (const filter of scalarFilters) {
             if (!this.typeExist(filter.name.value, ctx)) {
@@ -404,8 +411,16 @@ export class DynamoDBModelTransformer extends Transformer {
             }
         }
 
+        // Create the Enum filters
+        const enumFilters = makeEnumFilterInputObject(def, ctx);
+        for (const filter of enumFilters) {
+            if (!this.typeExist(filter.name.value, ctx)) {
+                ctx.addInput(filter)
+            }
+        }
+
         // Create the ModelXFilterInput
-        const tableXQueryFilterInput = makeModelXFilterInputObject(def)
+        const tableXQueryFilterInput = makeModelXFilterInputObject(def, ctx)
         if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
             ctx.addInput(tableXQueryFilterInput)
         }

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -337,7 +337,7 @@ export function makeModelXFilterInputObject(
     }
 }
 
-export function makeEnumFilterInputObject(
+export function makeEnumFilterInputObjects(
     obj: ObjectTypeDefinitionNode,
     ctx: TransformerContext
 ) : InputObjectTypeDefinitionNode[] {

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -18,6 +18,14 @@ export class ModelResourceIDs {
         }
         return `Model${name}FilterInput`
     }
+    static ModelFilterListInputTypeName(name: string): string {
+        const nameOverride = DEFAULT_SCALARS[name]
+        if (nameOverride) {
+            return `Model${nameOverride}ListFilterInput`
+        }
+        return `Model${name}ListFilterInput`
+    }
+
     static ModelScalarFilterInputTypeName(name: string): string {
         return `Model${name}FilterInput`
     }

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -17,6 +17,7 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
+    "amazon-cognito-identity-js": "^3.0.7",
     "axios": "^0.18.0",
     "cloudform": "^2.2.1",
     "graphql": "^0.13.2",

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -37,6 +37,7 @@ beforeAll(async () => {
         metadata: PostMetadata
         entityMetadata: EntityMetadata
         appearsIn: [Episode!]
+        episode: Episode
     }
     type Author @model {
         id: ID!
@@ -106,6 +107,32 @@ afterAll(async () => {
         }
     }
 })
+
+afterEach(async () => {
+  try {
+    // delete all the records 
+    console.log('deleting posts');
+    const response = await GRAPHQL_CLIENT.query(`
+    query {
+      listPosts {
+        items {
+          id
+        }
+      }
+    }`, {})
+    const rows = response.data.listPosts.items || [];
+    const deletePromises = [];
+    rows.forEach(row => {
+      deletePromises.push(GRAPHQL_CLIENT.query(`mutation delete{
+        deletePost(input: {id: "${row.id}"}) { id }
+      }`))
+    })
+    await Promise.all(deletePromises)
+  } catch (e) {
+    console.log(e);
+  }
+})
+
 
 /**
  * Test queries below
@@ -373,6 +400,176 @@ test('Test listPosts query with filter', async () => {
         expect(e).toBeUndefined()
     }
 })
+
+test('Test enum filters List', async () => {
+  try {
+    await GRAPHQL_CLIENT.query(
+      `mutation {
+            createPost(input: { title: "Appears in New Hope", appearsIn: [NEWHOPE], episode: NEWHOPE }) {
+                id
+                title
+                createdAt
+                updatedAt
+            }
+        }`,
+      {}
+    );
+    await GRAPHQL_CLIENT.query(
+      `mutation {
+            createPost(input: { title: "Appears in Jedi", appearsIn: [JEDI], episode: JEDI }) {
+                id
+                title
+                createdAt
+                updatedAt
+            }
+        }`,
+      {}
+    );
+    await GRAPHQL_CLIENT.query(
+        `mutation {
+              createPost(input: { title: "Appears in Empire", appearsIn: [EMPIRE], episode: EMPIRE }) {
+                  id
+                  title
+                  createdAt
+                  updatedAt
+              }
+          }`,
+        {}
+      );
+
+    await GRAPHQL_CLIENT.query(
+        `mutation {
+              createPost(input: { title: "Appears in Empire & JEDI", appearsIn: [EMPIRE, JEDI] }) {
+                  id
+                  title
+                  createdAt
+                  updatedAt
+              }
+          }`,
+        {}
+    );
+
+    // filter list of enums
+    const appearsInWithFilterResponseJedi = await GRAPHQL_CLIENT.query(
+      `query {
+            listPosts(filter: { appearsIn: {eq: [JEDI]}}) {
+                items {
+                    title
+                    id
+                }
+            }
+        }
+        `,
+      {}
+    );
+    expect(appearsInWithFilterResponseJedi.data.listPosts.items).toBeDefined();
+    const items = appearsInWithFilterResponseJedi.data.listPosts.items;
+    expect(items.length).toEqual(1);
+    expect(items[0].title).toEqual('Appears in Jedi');
+
+    const appearsInWithFilterResponseNonJedi = await GRAPHQL_CLIENT.query(
+      `query {
+            listPosts(filter: { appearsIn: {ne: [JEDI]}}) {
+                items {
+                    title
+                    id
+                }
+            }
+        }
+        `,
+      {}
+    );
+    expect(appearsInWithFilterResponseNonJedi.data.listPosts.items).toBeDefined();
+    const appearsInNonJediItems = appearsInWithFilterResponseNonJedi.data.listPosts.items;
+    expect(appearsInNonJediItems.length).toEqual(3);
+    appearsInNonJediItems.forEach((item) => {
+      expect(['Appears in Empire & JEDI', 'Appears in New Hope', 'Appears in Empire'].includes(item.title))
+        .toBeTruthy();
+    })
+
+    const appearsInContainingJedi = await GRAPHQL_CLIENT.query(
+      `query {
+            listPosts(filter: { appearsIn: {contains: JEDI }}) {
+                items {
+                    title
+                    id
+                }
+            }
+        }
+        `,
+      {}
+    );
+    expect(appearsInContainingJedi.data.listPosts.items).toBeDefined();
+    const appearsInWithJediItems = appearsInContainingJedi.data.listPosts.items;
+    expect(appearsInWithJediItems.length).toEqual(2);
+    appearsInWithJediItems.forEach((item) => {
+      expect(['Appears in Empire & JEDI', 'Appears in Jedi'].includes(item.title))
+        .toBeTruthy();
+    })
+
+    const appearsInNotContainingJedi = await GRAPHQL_CLIENT.query(
+      `query {
+            listPosts(filter: { appearsIn: {notContains: JEDI }}) {
+                items {
+                    title
+                    id
+                }
+            }
+        }
+        `,
+      {}
+    );
+    expect(appearsInNotContainingJedi.data.listPosts.items).toBeDefined();
+    const appearsInWithNonJediItems = appearsInNotContainingJedi.data.listPosts.items;
+    expect(appearsInWithNonJediItems.length).toEqual(2);
+    appearsInWithNonJediItems.forEach((item) => {
+      expect(['Appears in New Hope', 'Appears in Empire'].includes(item.title))
+        .toBeTruthy();
+    })
+
+    // enum filter
+    const jediEpisode = await GRAPHQL_CLIENT.query(
+      `query {
+            listPosts(filter: { episode: {eq: JEDI }}) {
+                items {
+                    title
+                    id
+                }
+            }
+        }
+        `,
+      {}
+    );
+    expect(jediEpisode.data.listPosts.items).toBeDefined();
+    const jediEpisodeItems = jediEpisode.data.listPosts.items;
+    expect(jediEpisodeItems.length).toEqual(1);
+    expect(jediEpisodeItems[0].title).toEqual('Appears in Jedi')
+
+    const nonJediEpisode = await GRAPHQL_CLIENT.query(
+      `query {
+            listPosts(filter: { episode: {ne: JEDI }}) {
+                items {
+                    title
+                    id
+                }
+            }
+        }
+        `,
+      {}
+    );
+    expect(nonJediEpisode.data.listPosts.items).toBeDefined();
+    const nonJediEpisodeItems = nonJediEpisode.data.listPosts.items;
+    expect(nonJediEpisodeItems.length).toEqual(3);
+    nonJediEpisodeItems.forEach((item) => {
+      expect(['Appears in New Hope', 'Appears in Empire', 'Appears in Empire & JEDI'].includes(item.title))
+        .toBeTruthy();
+    })
+  } catch (e) {
+    console.log(e);
+    // fail
+    expect(e).toBeUndefined();
+  }
+});
 
 test('Test createPost mutation with non-model types', async () => {
     try {


### PR DESCRIPTION
Enum fileds were not included in the filters generated for quries. Updated the transformer to
include filters for enum types

closes #712



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.