### PR TITLE
    fix(amplify-codegen): fix codegen external add error

### DIFF
--- a/packages/amplify-codegen/commands/codegen/add.js
+++ b/packages/amplify-codegen/commands/codegen/add.js
@@ -1,4 +1,5 @@
 const codeGen = require('../../src/index');
+const constants = require('../../src/constants');
 
 const featureName = 'add';
 
@@ -6,6 +7,14 @@ module.exports = {
   name: featureName,
   run: async (context) => {
     try {
+      const { options } = context.parameters;
+      const keys = Object.keys(options);
+      if (keys.length && !keys.includes('apiId')) {
+        const paramMsg = keys.length > 1 ? 'Invalid Parameters ' : 'Invalid parameter ';
+        context.print.info(`${paramMsg} ${keys.join(', ')}`);
+        context.print.info(constants.INFO_MESSAGE_ADD_ERROR);
+        return;
+      }
       const apiId = context.parameters.options.apiId || null;
       await codeGen.add(context, apiId);
     } catch (ex) {

--- a/packages/amplify-codegen/commands/codegen/add.js
+++ b/packages/amplify-codegen/commands/codegen/add.js
@@ -7,10 +7,10 @@ module.exports = {
   name: featureName,
   run: async (context) => {
     try {
-      const { options } = context.parameters;
+      const { options = {} } = context.parameters;
       const keys = Object.keys(options);
       if (keys.length && !keys.includes('apiId')) {
-        const paramMsg = keys.length > 1 ? 'Invalid Parameters ' : 'Invalid parameter ';
+        const paramMsg = keys.length > 1 ? 'Invalid parameters ' : 'Invalid parameter ';
         context.print.info(`${paramMsg} ${keys.join(', ')}`);
         context.print.info(constants.INFO_MESSAGE_ADD_ERROR);
         return;

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -56,4 +56,5 @@ module.exports = {
   INFO_MESSAGE_DOWNLOAD_ERROR: 'Downloading schema failed',
   INFO_MESSAGE_OPS_GEN: 'Generating GraphQL operations',
   INFO_MESSAGE_OPS_GEN_SUCCESS: 'Generated GraphQL operations successfully and saved at ',
+  INFO_MESSAGE_ADD_ERROR: 'amplify codegen add takes only apiId as parameter. \n$ amplify codegen add [--apiId <API_ID>]',
 };

--- a/packages/amplify-codegen/src/utils/input-params-manager.js
+++ b/packages/amplify-codegen/src/utils/input-params-manager.js
@@ -2,7 +2,7 @@ const constants = require('../constants');
 
 function normalizeInputParams(context) {
   let inputParams;
-  if (context.exeInfo.inputParams) {
+  if (context.exeInfo && context.exeInfo.inputParams) {
     if (context.exeInfo.inputParams[constants.Label]) {
       inputParams = context.exeInfo.inputParams[constants.Label];
     } else {

--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -19,10 +19,9 @@ const {
 const DEFAULT_EXCLUDE_PATTERNS = ['./amplify/**'];
 
 async function addWalkThrough(context, skip = []) {
-  normalizeInputParams(context);
   let inputParams;
   let yesFlag = false;
-  if (context.exeInfo.inputParams) {
+  if (context.exeInfo && context.exeInfo.inputParams) {
     normalizeInputParams(context);
     inputParams = context.exeInfo.inputParams[constants.Label];
     yesFlag = context.exeInfo.inputParams.yes;


### PR DESCRIPTION
Codegen external api add failed due to a missing null check and failed with error "Cannot convert
undefined or null to object". Fixing this error.

Added parameter validation logic to codegen add

#726 