### PR TITLE
fix(amplify-provider-awscloudformation): fix amplify delete error

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/delete-env.js
+++ b/packages/amplify-provider-awscloudformation/lib/delete-env.js
@@ -17,18 +17,18 @@ async function run(context, envName) {
     throw new Error('AWS credentials missing for the specified environment');
   }
 
-  const awscfn = await getConfiguredAwsCfnClient(awsConfigInfo);
+  const awscfn = await getConfiguredAwsCfnClient(context, awsConfigInfo);
 
   return new Cloudformation(context, awscfn)
     .then(cfnItem => cfnItem.deleteResourceStack(envName));
 }
 
-async function getConfiguredAwsCfnClient(awsConfigInfo) {
+async function getConfiguredAwsCfnClient(context, awsConfigInfo) {
   process.env.AWS_SDK_LOAD_CONFIG = true;
   const aws = require('aws-sdk');
   let awsconfig;
   if (awsConfigInfo.config.useProfile) {
-    awsconfig = await systemConfigManager.getProfiledAwsConfig(awsConfigInfo.config.profileName);
+    awsconfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
   } else {
     awsconfig = {
       accessKeyId: awsConfigInfo.config.accessKeyId,

--- a/packages/amplify-provider-awscloudformation/lib/delete-env.js
+++ b/packages/amplify-provider-awscloudformation/lib/delete-env.js
@@ -28,7 +28,8 @@ async function getConfiguredAwsCfnClient(context, awsConfigInfo) {
   const aws = require('aws-sdk');
   let awsconfig;
   if (awsConfigInfo.config.useProfile) {
-    awsconfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
+    awsconfig = await systemConfigManager
+      .getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
   } else {
     awsconfig = {
       accessKeyId: awsConfigInfo.config.accessKeyId,


### PR DESCRIPTION
After adding MFA support, the arity of getProfiledAwsConfig changed. Updating delete to command to use the same arity

