### PR TITLE
fix(amplify-provider-awscloudformation): delete project without profile

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/delete-env.js
+++ b/packages/amplify-provider-awscloudformation/lib/delete-env.js
@@ -1,44 +1,9 @@
-const path = require('path');
-const fs = require('fs-extra');
-const constants = require('./constants');
 const Cloudformation = require('../src/aws-utils/aws-cfn');
-const systemConfigManager = require('./system-config-manager');
+
 
 async function run(context, envName) {
-  const dotConfigDirPath = context.amplify.pathManager.getDotConfigDirPath();
-  const configInfoFilePath = path.join(dotConfigDirPath, constants.LocalAWSInfoFileName);
-
-  const awsConfigInfo = {};
-  if (fs.existsSync(configInfoFilePath)) {
-    awsConfigInfo.config = JSON.parse(fs.readFileSync(configInfoFilePath))[envName];
-  }
-
-  if (!awsConfigInfo.config) {
-    throw new Error('AWS credentials missing for the specified environment');
-  }
-
-  const awscfn = await getConfiguredAwsCfnClient(context, awsConfigInfo);
-
-  return new Cloudformation(context, awscfn)
+  return new Cloudformation(context)
     .then(cfnItem => cfnItem.deleteResourceStack(envName));
-}
-
-async function getConfiguredAwsCfnClient(context, awsConfigInfo) {
-  process.env.AWS_SDK_LOAD_CONFIG = true;
-  const aws = require('aws-sdk');
-  let awsconfig;
-  if (awsConfigInfo.config.useProfile) {
-    awsconfig = await systemConfigManager
-      .getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
-  } else {
-    awsconfig = {
-      accessKeyId: awsConfigInfo.config.accessKeyId,
-      secretAccessKey: awsConfigInfo.config.secretAccessKey,
-      region: awsConfigInfo.config.region,
-    };
-  }
-  aws.config.update(awsconfig);
-  return aws;
 }
 
 module.exports = {


### PR DESCRIPTION
Amplify project can be initialized with access key and secrete key (without profile). When a project
is configured without profile and user does not have default profile, running amplify delete of the
project threw Missing region in config error. This update fixes it by using default configuration
loader

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.