### PR TITLE
 feat: generate s3 fragment to support autoupload in Swift

### DIFF
--- a/packages/amplify-codegen/src/utils/input-params-manager.js
+++ b/packages/amplify-codegen/src/utils/input-params-manager.js
@@ -14,6 +14,8 @@ function normalizeInputParams(context) {
         }
       }
     }
+  } else {
+    context.exeInfo = { inputParams: {} };
   }
   if (inputParams) {
     const normalizedInputParams = {};

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/generate.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/generate.test.ts
@@ -5,6 +5,7 @@ import {
   generateSubscriptions,
 } from '../../src/generator/generateAllOperations'
 import { buildClientSchema } from 'graphql'
+import { GQLDocsGenOptions } from '../../src/generator/types'
 
 jest.mock('../../src/generator/generateAllOperations')
 jest.mock('graphql')
@@ -20,7 +21,7 @@ describe('generate', () => {
     getSubscriptionType,
   }
   const maxDepth = 4
-
+  const generateOption: GQLDocsGenOptions = { useExternalFragmentForS3Object: true }
   beforeEach(() => {
     jest.resetAllMocks()
     getQueryType.mockReturnValue('QUERY_TYPE')
@@ -34,27 +35,34 @@ describe('generate', () => {
   })
 
   it('should build the client schema from schema document', () => {
-    generate(MOCK_SCHEMA_DOC)
+    generate(MOCK_SCHEMA_DOC, maxDepth, generateOption)
     expect(buildClientSchema).toHaveBeenCalledWith(MOCK_SCHEMA_DOC)
   })
 
   it('should generate operations using the helper methods', () => {
-    generate(MOCK_SCHEMA_DOC, maxDepth)
-    expect(generateQueries).toHaveBeenCalledWith(mockSchema.getQueryType(), mockSchema, maxDepth)
+    generate(MOCK_SCHEMA_DOC, maxDepth, generateOption)
+    expect(generateQueries).toHaveBeenCalledWith(
+      mockSchema.getQueryType(),
+      mockSchema,
+      maxDepth,
+      generateOption
+    )
     expect(generateMutations).toHaveBeenCalledWith(
       mockSchema.getMutationType(),
       mockSchema,
-      maxDepth
+      maxDepth,
+      generateOption
     )
     expect(generateSubscriptions).toHaveBeenCalledWith(
       mockSchema.getSubscriptionType(),
       mockSchema,
-      maxDepth
+      maxDepth,
+      generateOption
     )
   })
 
-  it('should call the individual operation gnerator and return the value from them', () => {
-    expect(generate(MOCK_SCHEMA_DOC)).toEqual({
+  it('should call the individual operation generator and return the value from them', () => {
+    expect(generate(MOCK_SCHEMA_DOC, maxDepth, generateOption)).toEqual({
       queries: 'MOCK_GENERATED_QUERY',
       subscriptions: 'MOCK_GENERATED_SUBSCRIPTION',
       mutations: 'MOCK_GENERATED_MUTATION',

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../src/generator/generateAllOperations'
 
 import generateOperation from '../../src/generator/generateOperation'
-import { GQLDocsGenOptions } from '../../src/generator/types';
+import { GQLDocsGenOptions } from '../../src/generator/types'
 
 jest.mock('../../src/generator/generateOperation')
 const mockOperationResult = {
@@ -26,7 +26,7 @@ const operations = {
 const maxDepth = 10
 
 const mockSchema = 'MOCK_SCHEMA'
-const generateOptions:GQLDocsGenOptions = {  useExternalFragmentForS3Object: true};
+const generateOptions: GQLDocsGenOptions = { useExternalFragmentForS3Object: true }
 describe('generateAllOperations', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -40,7 +40,12 @@ describe('generateAllOperations', () => {
         ...mockOperationResult,
       },
     ])
-    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions)
+    expect(generateOperation).toHaveBeenCalledWith(
+      mockFields.f1,
+      mockSchema,
+      maxDepth,
+      generateOptions
+    )
     expect(getFields).toHaveBeenCalled()
     expect(generateOperation).toHaveBeenCalledTimes(1)
     expect(getFields).toHaveBeenCalledTimes(1)
@@ -54,7 +59,12 @@ describe('generateAllOperations', () => {
         ...mockOperationResult,
       },
     ])
-    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions)
+    expect(generateOperation).toHaveBeenCalledWith(
+      mockFields.f1,
+      mockSchema,
+      maxDepth,
+      generateOptions
+    )
     expect(getFields).toHaveBeenCalled()
     expect(generateOperation).toHaveBeenCalledTimes(1)
     expect(getFields).toHaveBeenCalledTimes(1)
@@ -70,6 +80,11 @@ describe('generateAllOperations', () => {
     ])
     expect(generateOperation).toHaveBeenCalledTimes(1)
     expect(getFields).toHaveBeenCalledTimes(1)
-    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions)
+    expect(generateOperation).toHaveBeenCalledWith(
+      mockFields.f1,
+      mockSchema,
+      maxDepth,
+      generateOptions
+    )
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../../src/generator/generateAllOperations'
 
 import generateOperation from '../../src/generator/generateOperation'
+import { GQLDocsGenOptions } from '../../src/generator/types';
 
 jest.mock('../../src/generator/generateOperation')
 const mockOperationResult = {
@@ -25,42 +26,42 @@ const operations = {
 const maxDepth = 10
 
 const mockSchema = 'MOCK_SCHEMA'
-
+const generateOptions:GQLDocsGenOptions = {  useExternalFragmentForS3Object: true};
 describe('generateAllOperations', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   it('generateQueries - should call generateOperation', () => {
-    expect(generateQueries(operations, mockSchema, maxDepth)).toEqual([
+    expect(generateQueries(operations, mockSchema, maxDepth, generateOptions)).toEqual([
       {
         type: 'query',
         name: 'F1',
         ...mockOperationResult,
       },
     ])
-    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth)
+    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions)
     expect(getFields).toHaveBeenCalled()
     expect(generateOperation).toHaveBeenCalledTimes(1)
     expect(getFields).toHaveBeenCalledTimes(1)
   })
 
   it('generateMutation - should call generateOperation', () => {
-    expect(generateMutations(operations, mockSchema, maxDepth)).toEqual([
+    expect(generateMutations(operations, mockSchema, maxDepth, generateOptions)).toEqual([
       {
         type: 'mutation',
         name: 'F1',
         ...mockOperationResult,
       },
     ])
-    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth)
+    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions)
     expect(getFields).toHaveBeenCalled()
     expect(generateOperation).toHaveBeenCalledTimes(1)
     expect(getFields).toHaveBeenCalledTimes(1)
   })
 
   it('generateSubscription - should call generateOperation', () => {
-    expect(generateSubscriptions(operations, mockSchema, maxDepth)).toEqual([
+    expect(generateSubscriptions(operations, mockSchema, maxDepth, generateOptions)).toEqual([
       {
         type: 'subscription',
         name: 'F1',
@@ -69,6 +70,6 @@ describe('generateAllOperations', () => {
     ])
     expect(generateOperation).toHaveBeenCalledTimes(1)
     expect(getFields).toHaveBeenCalledTimes(1)
-    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth)
+    expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions)
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/generateOperation.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/generateOperation.test.ts
@@ -1,11 +1,13 @@
 import generateOperation from '../../src/generator/generateOperation'
 import getArgs from '../../src/generator/getArgs'
 import getBody from '../../src/generator/getBody'
+import { GQLDocsGenOptions } from '../../src/generator/types';
 
 jest.mock('../../src/generator/getArgs')
 jest.mock('../../src/generator/getBody')
 
 const maxDepth = 4
+const generateOption: GQLDocsGenOptions = { useExternalFragmentForS3Object: true }
 describe('generateOperation', () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -18,12 +20,12 @@ describe('generateOperation', () => {
       args: ['arg1'],
     }
     const doc = 'MOCK_DOCUMENT'
-    expect(generateOperation(op, 'MOCK_DOCUMENT', maxDepth)).toEqual({
+    expect(generateOperation(op, 'MOCK_DOCUMENT', maxDepth, generateOption)).toEqual({
       args: ['MOCK_ARG'],
       body: 'MOCK_BODY',
     })
 
     expect(getArgs).toHaveBeenCalledWith(op.args)
-    expect(getBody).toBeCalledWith(op, doc, maxDepth)
+    expect(getBody).toBeCalledWith(op, doc, maxDepth, generateOption)
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getBody.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getBody.test.ts
@@ -53,10 +53,10 @@ describe('getBody', () => {
 
   it('should return a list of arguments', () => {
     const query = schema.getQueryType().getFields().article
-    expect(getBody(query, schema, maxDepth)).toEqual({
+    expect(getBody(query, schema, maxDepth, { useExternalFragmentForS3Object: true})).toEqual({
       args: [{ name: 'id', value: '$id' }],
       ...mockFields,
     })
-    expect(getFields).toHaveBeenCalledWith(query, schema, maxDepth)
+    expect(getFields).toHaveBeenCalledWith(query, schema, maxDepth, { useExternalFragmentForS3Object: true})
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getFields.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getFields.test.ts
@@ -33,7 +33,7 @@ describe('getField', () => {
 
   it('should support simple scalar', () => {
     const queries = schema.getQueryType().getFields()
-    expect(getFields(queries.foo, schema, 3)).toEqual({
+    expect(getFields(queries.foo, schema, 3, {useExternalFragmentForS3Object: false})).toEqual({
       name: 'foo',
       fields: [],
       fragments: [],
@@ -44,7 +44,7 @@ describe('getField', () => {
 
   it('it should recursively resolve fields up to max depth', () => {
     const queries = schema.getQueryType().getFields()
-    expect(getFields(queries.nested, schema, 2)).toEqual({
+    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false})).toEqual({
       name: 'nested',
       fields: [
         {
@@ -74,7 +74,7 @@ describe('getField', () => {
 
   it('should not return anything for complex type when the depth is < 1', () => {
     const queries = schema.getQueryType().getFields()
-    expect(getFields(queries.nested, schema, 0)).toBeUndefined()
+    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false})).toBeUndefined()
   })
   describe('When type is an Interface', () => {
     beforeEach(() => {
@@ -118,7 +118,7 @@ describe('getField', () => {
     it('interface - should return fragments of all the implementations', () => {
       const maxDepth = 2
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes')
-      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth)
+      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, { useExternalFragmentForS3Object: false})
       expect(getPossibleTypeSpy).toHaveBeenCalled()
       expect(getFragment).toHaveBeenCalled()
 
@@ -175,7 +175,7 @@ describe('getField', () => {
     it('union - should return fragments of all the types', () => {
       const maxDepth = 2
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes')
-      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth)
+      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, { useExternalFragmentForS3Object: false})
       expect(getPossibleTypeSpy).toHaveBeenCalled()
       expect(getFragment).toHaveBeenCalled()
 

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getFragments.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getFragments.test.ts
@@ -51,6 +51,8 @@ describe('getFragments', () => {
     expect(getFragment(impl, schema, currentDepth, [])).toEqual({
       fields: [{ name: 'name' }, { name: 'length' }, { name: 'width' }],
       on: 'Rectangle',
+      external: false,
+      name: "RectangleFragment"
     })
     expect(getFields).toHaveBeenCalledTimes(3)
   })
@@ -76,6 +78,8 @@ describe('getFragments', () => {
     expect(getFragment(impl, schema, currentDepth, fieldsToFilter)).toEqual({
       fields: [{ name: 'name' }, { name: 'width' }],
       on: 'Rectangle',
+      name: "RectangleFragment",
+      external: false,
     })
   })
 

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getFragments.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getFragments.test.ts
@@ -6,7 +6,7 @@ import {
   GraphQLInt,
 } from 'graphql'
 
-import { GQLTemplateField, GQLTemplateFragment } from '../../src/generator/types'
+import { GQLTemplateField, GQLTemplateFragment, GQLDocsGenOptions } from '../../src/generator/types'
 import getFields from '../../src/generator/getFields'
 import getFragment from '../../src/generator/getFragment'
 
@@ -52,7 +52,7 @@ describe('getFragments', () => {
       fields: [{ name: 'name' }, { name: 'length' }, { name: 'width' }],
       on: 'Rectangle',
       external: false,
-      name: "RectangleFragment"
+      name: 'RectangleFragment',
     })
     expect(getFields).toHaveBeenCalledTimes(3)
   })
@@ -78,7 +78,7 @@ describe('getFragments', () => {
     expect(getFragment(impl, schema, currentDepth, fieldsToFilter)).toEqual({
       fields: [{ name: 'name' }, { name: 'width' }],
       on: 'Rectangle',
-      name: "RectangleFragment",
+      name: 'RectangleFragment',
       external: false,
     })
   })
@@ -87,5 +87,28 @@ describe('getFragments', () => {
     const impl = schema.getQueryType().getFields().simpleScalar
     const currentDepth = 3
     expect(getFragment(impl, schema, currentDepth)).toBeUndefined()
+  })
+
+  it('should use the name passed as fragment name', () => {
+    const impl = schema.getType('Rectangle')
+    const currentDepth = 3
+    const fragment = getFragment(impl, schema, currentDepth, [], 'FooFragment')
+    expect(fragment.name).toEqual('FooFragment')
+  })
+
+  it('should use the mark fragment as external when passed', () => {
+    const impl = schema.getType('Rectangle')
+    const currentDepth = 3
+    const fragment = getFragment(impl, schema, currentDepth, [], 'FooFragment', true)
+    expect(fragment.external).toEqual(true)
+  })
+
+  it('should pass the options to getFields call', () => {
+    const options: GQLDocsGenOptions = { useExternalFragmentForS3Object: true }
+    const impl = schema.getType('Rectangle')
+    const currentDepth = 3
+    const fragment = getFragment(impl, schema, currentDepth, [], 'FooFragment', false, options)
+    expect(getFields).toHaveBeenCalledTimes(3)
+    expect(getFields.mock.calls[0][3]).toEqual(options)
   })
 })

--- a/packages/amplify-graphql-docs-generator/fixtures/complex-obj.gql
+++ b/packages/amplify-graphql-docs-generator/fixtures/complex-obj.gql
@@ -1,0 +1,192 @@
+# this is an auto generated file. This will be overwritten
+query SinglePost($id: ID!) {
+  singlePost(id: $id) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+query GetPost($id: ID!) {
+  getPost(id: $id) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+query ListPosts($first: Int, $after: String) {
+  listPosts(first: $first, after: $after) {
+    items {
+      id
+      author
+      title
+      content
+      url
+      ups
+      downs
+      version
+    }
+    nextToken
+  }
+}
+mutation CreatePost($input: CreatePostInput!) {
+  createPost(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+mutation CreatePostWithFile($input: CreatePostWithFileInput!) {
+  createPostWithFile(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+mutation UpdatePost($input: UpdatePostInput!) {
+  updatePost(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+mutation DeletePost($input: DeletePostInput!) {
+  deletePost(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+subscription OnCreatePost(
+  $id: ID
+  $author: String
+  $title: String
+  $content: String
+  $url: String
+) {
+  onCreatePost(
+    id: $id
+    author: $author
+    title: $title
+    content: $content
+    url: $url
+  ) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+subscription OnUpdatePost(
+  $id: ID
+  $author: String
+  $title: String
+  $content: String
+  $url: String
+) {
+  onUpdatePost(
+    id: $id
+    author: $author
+    title: $title
+    content: $content
+    url: $url
+  ) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+subscription OnDeletePost(
+  $id: ID
+  $author: String
+  $title: String
+  $content: String
+  $url: String
+) {
+  onDeletePost(
+    id: $id
+    author: $author
+    title: $title
+    content: $content
+    url: $url
+  ) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+fragment S3Object on S3Object {
+  bucket
+  key
+  region
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/complex-obj.json
+++ b/packages/amplify-graphql-docs-generator/fixtures/complex-obj.json
@@ -1,0 +1,2078 @@
+{
+    "data": {
+        "__schema": {
+            "queryType": {
+                "name": "Query"
+            },
+            "mutationType": {
+                "name": "Mutation"
+            },
+            "subscriptionType": {
+                "name": "Subscription"
+            },
+            "types": [
+                {
+                    "kind": "OBJECT",
+                    "name": "Query",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "singlePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ID",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "getPost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ID",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "listPosts",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "first",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "after",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "PostConnection",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Post",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "file",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "S3Object",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "description": "Built-in ID",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "description": "Built-in String",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "description": "Built-in Int",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "S3Object",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "bucket",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "key",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "PostConnection",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "items",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Post",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "nextToken",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Mutation",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "createPost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "CreatePostInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "createPostWithFile",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "CreatePostWithFileInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "updatePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "UpdatePostInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deletePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "DeletePostInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreatePostInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreatePostWithFileInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "file",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "INPUT_OBJECT",
+                                    "name": "S3ObjectInput",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "S3ObjectInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "bucket",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "key",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdatePostInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DeletePostInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Subscription",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "onCreatePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "ID",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "author",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "title",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "content",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "url",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onUpdatePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "ID",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "author",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "title",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "content",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "url",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onDeletePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "ID",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "author",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "title",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "content",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "url",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Schema",
+                    "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+                    "fields": [
+                        {
+                            "name": "types",
+                            "description": "A list of all types supported by this server.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__Type",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "queryType",
+                            "description": "The type that query operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "mutationType",
+                            "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "directives",
+                            "description": "'A list of all directives supported by this server.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__Directive",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "subscriptionType",
+                            "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "kind",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "ENUM",
+                                    "name": "__TypeKind",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "fields",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Field",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "interfaces",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "possibleTypes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "enumValues",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__EnumValue",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "inputFields",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ofType",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "ENUM",
+                    "name": "__TypeKind",
+                    "description": "An enum describing what kind of type a given __Type is",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": [
+                        {
+                            "name": "SCALAR",
+                            "description": "Indicates this type is a scalar.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "OBJECT",
+                            "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INTERFACE",
+                            "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "UNION",
+                            "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM",
+                            "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_OBJECT",
+                            "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "LIST",
+                            "description": "Indicates this type is a list. `ofType` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "NON_NULL",
+                            "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "args",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__InputValue",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "defaultValue",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "description": "Built-in Boolean",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Directive",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "locations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "__DirectiveLocation",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "args",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__InputValue",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onOperation",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        },
+                        {
+                            "name": "onFragment",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        },
+                        {
+                            "name": "onField",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "description": "An enum describing valid locations where a directive can be placed",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": [
+                        {
+                            "name": "QUERY",
+                            "description": "Indicates the directive is valid on queries.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "MUTATION",
+                            "description": "Indicates the directive is valid on mutations.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FIELD",
+                            "description": "Indicates the directive is valid on fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FRAGMENT_DEFINITION",
+                            "description": "Indicates the directive is valid on fragment definitions.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FRAGMENT_SPREAD",
+                            "description": "Indicates the directive is valid on fragment spreads.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INLINE_FRAGMENT",
+                            "description": "Indicates the directive is valid on inline fragments.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SCHEMA",
+                            "description": "Indicates the directive is valid on a schema SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SCALAR",
+                            "description": "Indicates the directive is valid on a scalar SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "OBJECT",
+                            "description": "Indicates the directive is valid on an object SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FIELD_DEFINITION",
+                            "description": "Indicates the directive is valid on a field SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ARGUMENT_DEFINITION",
+                            "description": "Indicates the directive is valid on a field argument SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INTERFACE",
+                            "description": "Indicates the directive is valid on an interface SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "UNION",
+                            "description": "Indicates the directive is valid on an union SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM",
+                            "description": "Indicates the directive is valid on an enum SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM_VALUE",
+                            "description": "Indicates the directive is valid on an enum value SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_OBJECT",
+                            "description": "Indicates the directive is valid on an input object SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_FIELD_DEFINITION",
+                            "description": "Indicates the directive is valid on an input object field SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "possibleTypes": null
+                }
+            ],
+            "directives": [
+                {
+                    "name": "include",
+                    "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                        {
+                            "name": "if",
+                            "description": "Included when true.",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": true,
+                    "onField": true
+                },
+                {
+                    "name": "skip",
+                    "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                        {
+                            "name": "if",
+                            "description": "Skipped when true.",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": true,
+                    "onField": true
+                },
+                {
+                    "name": "defer",
+                    "description": "This directive allows results to be deferred during execution",
+                    "locations": [
+                        "FIELD"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": true
+                },
+                {
+                    "name": "deprecated",
+                    "description": null,
+                    "locations": [
+                        "FIELD_DEFINITION",
+                        "ENUM_VALUE"
+                    ],
+                    "args": [
+                        {
+                            "name": "reason",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": "\"No longer supported\""
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_publish",
+                    "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "subscriptions",
+                            "description": "List of subscriptions which will be published to when this mutation is called.",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_subscribe",
+                    "description": "Tells the service which mutation triggers this subscription.",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "mutations",
+                            "description": "List of mutations which will trigger this subscription when they are called.",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_auth",
+                    "description": "Directs the schema to enforce authorization on a field",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "cognito_groups",
+                            "description": "List of cognito user pool groups which have access on this field",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                }
+            ]
+        }
+    }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/foo.gql
+++ b/packages/amplify-graphql-docs-generator/fixtures/foo.gql
@@ -1,0 +1,47 @@
+# this is an auto generated file. This will be overwritten
+query GetCompleteEvent($eventId: ID!) {
+  getCompleteEvent(eventId: $eventId) {
+    _id
+    createdOn
+    en {
+      name
+      info
+      banner
+      nextVenue {
+        address
+        date
+      }
+      previousVenues {
+        address
+        date
+      }
+      previousSpeakers
+      nextSpeaker
+      gallery
+      attendees
+      alertMessage
+      eventJoinLink
+      status
+    }
+    hi {
+      name
+      info
+      banner
+      nextVenue {
+        address
+        date
+      }
+      previousVenues {
+        address
+        date
+      }
+      previousSpeakers
+      nextSpeaker
+      gallery
+      attendees
+      alertMessage
+      eventJoinLink
+      status
+    }
+  }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/foo.json
+++ b/packages/amplify-graphql-docs-generator/fixtures/foo.json
@@ -1,0 +1,1398 @@
+{
+  "data": {
+      "__schema": {
+          "queryType": {
+              "name": "Query"
+          },
+          "mutationType": null,
+          "subscriptionType": null,
+          "types": [
+              {
+                  "kind": "OBJECT",
+                  "name": "Query",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "getCompleteEvent",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "eventId",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "SCALAR",
+                                          "name": "ID",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "FullEventDetail",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "FullEventDetail",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "_id",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "ID",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "createdOn",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "en",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "EventLang",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "hi",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "EventLang",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "description": "Built-in ID",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "description": "Built-in String",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "EventLang",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "info",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "banner",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "nextVenue",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "Venue",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "previousVenues",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "Venue",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "previousSpeakers",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "SCALAR",
+                                      "name": "String",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "nextSpeaker",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "SCALAR",
+                                          "name": "String",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "gallery",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "SCALAR",
+                                      "name": "String",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "attendees",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Int",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "alertMessage",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "eventJoinLink",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "status",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "Venue",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "address",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "date",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "description": "Built-in Int",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "description": "Built-in Boolean",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "__Schema",
+                  "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+                  "fields": [
+                      {
+                          "name": "types",
+                          "description": "A list of all types supported by this server.",
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__Type",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "queryType",
+                          "description": "The type that query operations will be rooted at.",
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "__Type",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "mutationType",
+                          "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "__Type",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "directives",
+                          "description": "'A list of all directives supported by this server.",
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__Directive",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "subscriptionType",
+                          "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "__Type",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "kind",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "ENUM",
+                                  "name": "__TypeKind",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "fields",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "includeDeprecated",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Boolean",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": "false"
+                              }
+                          ],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__Field",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "interfaces",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__Type",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "possibleTypes",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__Type",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "enumValues",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "includeDeprecated",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Boolean",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": "false"
+                              }
+                          ],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__EnumValue",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "inputFields",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__InputValue",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ofType",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "__Type",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "description": "An enum describing what kind of type a given __Type is",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": [
+                      {
+                          "name": "SCALAR",
+                          "description": "Indicates this type is a scalar.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "OBJECT",
+                          "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INTERFACE",
+                          "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "UNION",
+                          "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ENUM",
+                          "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INPUT_OBJECT",
+                          "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "LIST",
+                          "description": "Indicates this type is a list. `ofType` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "NON_NULL",
+                          "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "__Field",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "args",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__InputValue",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "type",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "__Type",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "isDeprecated",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "deprecationReason",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "__InputValue",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "type",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "__Type",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "defaultValue",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "__EnumValue",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "isDeprecated",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "deprecationReason",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "__Directive",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "locations",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "ENUM",
+                                      "name": "__DirectiveLocation",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "args",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__InputValue",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "onOperation",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Boolean",
+                              "ofType": null
+                          },
+                          "isDeprecated": true,
+                          "deprecationReason": "Use `locations`."
+                      },
+                      {
+                          "name": "onFragment",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Boolean",
+                              "ofType": null
+                          },
+                          "isDeprecated": true,
+                          "deprecationReason": "Use `locations`."
+                      },
+                      {
+                          "name": "onField",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Boolean",
+                              "ofType": null
+                          },
+                          "isDeprecated": true,
+                          "deprecationReason": "Use `locations`."
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "ENUM",
+                  "name": "__DirectiveLocation",
+                  "description": "An enum describing valid locations where a directive can be placed",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": [
+                      {
+                          "name": "QUERY",
+                          "description": "Indicates the directive is valid on queries.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "MUTATION",
+                          "description": "Indicates the directive is valid on mutations.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FIELD",
+                          "description": "Indicates the directive is valid on fields.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FRAGMENT_DEFINITION",
+                          "description": "Indicates the directive is valid on fragment definitions.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FRAGMENT_SPREAD",
+                          "description": "Indicates the directive is valid on fragment spreads.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INLINE_FRAGMENT",
+                          "description": "Indicates the directive is valid on inline fragments.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "SCHEMA",
+                          "description": "Indicates the directive is valid on a schema SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "SCALAR",
+                          "description": "Indicates the directive is valid on a scalar SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "OBJECT",
+                          "description": "Indicates the directive is valid on an object SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FIELD_DEFINITION",
+                          "description": "Indicates the directive is valid on a field SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ARGUMENT_DEFINITION",
+                          "description": "Indicates the directive is valid on a field argument SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INTERFACE",
+                          "description": "Indicates the directive is valid on an interface SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "UNION",
+                          "description": "Indicates the directive is valid on an union SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ENUM",
+                          "description": "Indicates the directive is valid on an enum SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ENUM_VALUE",
+                          "description": "Indicates the directive is valid on an enum value SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INPUT_OBJECT",
+                          "description": "Indicates the directive is valid on an input object SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INPUT_FIELD_DEFINITION",
+                          "description": "Indicates the directive is valid on an input object field SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "possibleTypes": null
+              }
+          ],
+          "directives": [
+              {
+                  "name": "include",
+                  "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+                  "locations": [
+                      "FIELD",
+                      "FRAGMENT_SPREAD",
+                      "INLINE_FRAGMENT"
+                  ],
+                  "args": [
+                      {
+                          "name": "if",
+                          "description": "Included when true.",
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": true,
+                  "onField": true
+              },
+              {
+                  "name": "skip",
+                  "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+                  "locations": [
+                      "FIELD",
+                      "FRAGMENT_SPREAD",
+                      "INLINE_FRAGMENT"
+                  ],
+                  "args": [
+                      {
+                          "name": "if",
+                          "description": "Skipped when true.",
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": true,
+                  "onField": true
+              },
+              {
+                  "name": "defer",
+                  "description": "This directive allows results to be deferred during execution",
+                  "locations": [
+                      "FIELD"
+                  ],
+                  "args": [],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": true
+              },
+              {
+                  "name": "aws_publish",
+                  "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+                  "locations": [
+                      "FIELD_DEFINITION"
+                  ],
+                  "args": [
+                      {
+                          "name": "subscriptions",
+                          "description": "List of subscriptions which will be published to when this mutation is called.",
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
+              },
+              {
+                  "name": "aws_subscribe",
+                  "description": "Tells the service which mutation triggers this subscription.",
+                  "locations": [
+                      "FIELD_DEFINITION"
+                  ],
+                  "args": [
+                      {
+                          "name": "mutations",
+                          "description": "List of mutations which will trigger this subscription when they are called.",
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
+              },
+              {
+                  "name": "aws_auth",
+                  "description": "Directs the schema to enforce authorization on a field",
+                  "locations": [
+                      "FIELD_DEFINITION"
+                  ],
+                  "args": [
+                      {
+                          "name": "cognito_groups",
+                          "description": "List of cognito user pool groups which have access on this field",
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
+              },
+              {
+                  "name": "deprecated",
+                  "description": null,
+                  "locations": [
+                      "FIELD_DEFINITION",
+                      "ENUM_VALUE"
+                  ],
+                  "args": [
+                      {
+                          "name": "reason",
+                          "description": null,
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "defaultValue": "\"No longer supported\""
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
+              }
+          ]
+      }
+  }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/fragments.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/fragments.graphql
@@ -1,0 +1,6 @@
+# this is an auto generated file. This will be overwritten
+fragment S3Object on S3Object {
+  bucket
+  key
+  region
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/mutations.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/mutations.graphql
@@ -1,0 +1,61 @@
+# this is an auto generated file. This will be overwritten
+mutation CreatePost($input: CreatePostInput!) {
+  createPost(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+mutation CreatePostWithFile($input: CreatePostWithFileInput!) {
+  createPostWithFile(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+mutation UpdatePost($input: UpdatePostInput!) {
+  updatePost(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+mutation DeletePost($input: DeletePostInput!) {
+  deletePost(input: $input) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/queries.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/queries.graphql
@@ -1,0 +1,46 @@
+# this is an auto generated file. This will be overwritten
+query SinglePost($id: ID!) {
+  singlePost(id: $id) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+query GetPost($id: ID!) {
+  getPost(id: $id) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+query ListPosts($first: Int, $after: String) {
+  listPosts(first: $first, after: $after) {
+    items {
+      id
+      author
+      title
+      content
+      url
+      ups
+      downs
+      version
+    }
+    nextToken
+  }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/subscriptions.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/subscriptions.graphql
@@ -1,0 +1,82 @@
+# this is an auto generated file. This will be overwritten
+subscription OnCreatePost(
+  $id: ID
+  $author: String
+  $title: String
+  $content: String
+  $url: String
+) {
+  onCreatePost(
+    id: $id
+    author: $author
+    title: $title
+    content: $content
+    url: $url
+  ) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+subscription OnUpdatePost(
+  $id: ID
+  $author: String
+  $title: String
+  $content: String
+  $url: String
+) {
+  onUpdatePost(
+    id: $id
+    author: $author
+    title: $title
+    content: $content
+    url: $url
+  ) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}
+subscription OnDeletePost(
+  $id: ID
+  $author: String
+  $title: String
+  $content: String
+  $url: String
+) {
+  onDeletePost(
+    id: $id
+    author: $author
+    title: $title
+    content: $content
+    url: $url
+  ) {
+    id
+    author
+    title
+    content
+    url
+    ups
+    downs
+    file {
+      ...S3Object
+    }
+    version
+  }
+}

--- a/packages/amplify-graphql-docs-generator/src/cli.ts
+++ b/packages/amplify-graphql-docs-generator/src/cli.ts
@@ -47,10 +47,14 @@ export function run(argv: Array<String>): void {
           default: 2,
           normalize: true,
           type: 'number'
+        },
+        separateFiles: {
+          default: false,
+          type: 'boolean'
         }
       },
       async argv => {
-          generateAllOps(argv.schema, argv.output, { separateFiles: false, language: argv.language, maxDepth: argv.maxDepth })
+          generateAllOps(argv.schema, argv.output, { separateFiles: argv.separateFiles, language: argv.language, maxDepth: argv.maxDepth })
       }
     )
     .help()

--- a/packages/amplify-graphql-docs-generator/src/generator/generate.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/generate.ts
@@ -1,20 +1,22 @@
 import { buildClientSchema, GraphQLObjectType, GraphQLSchema, IntrospectionQuery } from 'graphql'
 
-import { generateQueries, generateMutations, generateSubscriptions } from './generateAllOperations'
-import * as types from './types'
+import { generateQueries, generateMutations, generateSubscriptions, collectExternalFragments } from './generateAllOperations'
+import { GQLDocsGenOptions, GQLAllOperations} from './types'
 export default function generate(
   schemaDocument: IntrospectionQuery,
-  maxDepth: number
-): types.GQLAllOperations {
+  maxDepth: number,
+  options: GQLDocsGenOptions
+): GQLAllOperations {
   try {
     const schemaDoc: GraphQLSchema = buildClientSchema(schemaDocument)
     const queryTypes: GraphQLObjectType = schemaDoc.getQueryType()
     const mutationType: GraphQLObjectType = schemaDoc.getMutationType()
     const subscriptionType: GraphQLObjectType = schemaDoc.getSubscriptionType()
-    const queries = generateQueries(queryTypes, schemaDoc, maxDepth) || []
-    const mutations = generateMutations(mutationType, schemaDoc, maxDepth) || []
-    const subscriptions = generateSubscriptions(subscriptionType, schemaDoc, maxDepth) || []
-    return { queries, mutations, subscriptions }
+    const queries = generateQueries(queryTypes, schemaDoc, maxDepth, options) || []
+    const mutations = generateMutations(mutationType, schemaDoc, maxDepth, options) || []
+    const subscriptions = generateSubscriptions(subscriptionType, schemaDoc, maxDepth, options) || []
+    const fragments = options.useExternalFragmentForS3Object ? collectExternalFragments([...queries, ...mutations, ...subscriptions]) : [];
+    return { queries, mutations, subscriptions, fragments }
   } catch (e) {
     throw new Error('GraphQL schema file should contain a valid GraphQL introspection query result')
   }

--- a/packages/amplify-graphql-docs-generator/src/generator/generateAllOperations.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/generateAllOperations.ts
@@ -2,18 +2,19 @@ import { GraphQLObjectType, GraphQLSchema } from 'graphql'
 const pascalCase = require('pascal-case')
 
 import generateOperation from './generateOperation'
-import { GQLTemplateOp, GQLOperationTypeEnum } from './types'
+import { GQLTemplateOp, GQLOperationTypeEnum, GQLTemplateGenericOp, GQLTemplateField, GQLTemplateFragment, GQLDocsGenOptions } from './types'
 
 export function generateQueries(
   queries: GraphQLObjectType,
   schema: GraphQLSchema,
-  maxDepth: number
+  maxDepth: number,
+  options: GQLDocsGenOptions
 ): Array<GQLTemplateOp> | undefined {
   if (queries) {
     const allQueries = queries.getFields()
     const processedQueries: Array<GQLTemplateOp> = Object.keys(allQueries).map((queryName) => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.QUERY
-      const op = generateOperation(allQueries[queryName], schema, maxDepth)
+      const op = generateOperation(allQueries[queryName], schema, maxDepth, options)
       const name: string = pascalCase(queryName)
       return { type, name, ...op }
     })
@@ -24,13 +25,15 @@ export function generateQueries(
 export function generateMutations(
   mutations: GraphQLObjectType,
   schema: GraphQLSchema,
-  maxDepth: number
+  maxDepth: number,
+  options: GQLDocsGenOptions
+
 ): Array<any> {
   if (mutations) {
     const allMutations = mutations.getFields()
     const processedMutations = Object.keys(allMutations).map((mutationName) => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.MUTATION
-      const op = generateOperation(allMutations[mutationName], schema, maxDepth)
+      const op = generateOperation(allMutations[mutationName], schema, maxDepth, options)
       const name = pascalCase(mutationName)
       return { type, name, ...op }
     })
@@ -41,16 +44,39 @@ export function generateMutations(
 export function generateSubscriptions(
   subscriptions: GraphQLObjectType,
   schema: GraphQLSchema,
-  maxDepth: number
+  maxDepth: number,
+  options: GQLDocsGenOptions
 ): Array<any> {
   if (subscriptions) {
     const allSubscriptions = subscriptions.getFields()
     const processedMutations = Object.keys(allSubscriptions).map((subscriptionName) => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.SUBSCRIPTION
-      const op = generateOperation(allSubscriptions[subscriptionName], schema, maxDepth)
+      const op = generateOperation(allSubscriptions[subscriptionName], schema, maxDepth, options)
       const name = pascalCase(subscriptionName)
       return { type, name, ...op }
     })
     return processedMutations
   }
+}
+
+export function collectExternalFragments(operations: GQLTemplateOp[] = []): GQLTemplateFragment[] {
+  const fragments = {};
+  operations.forEach((op) => {
+    getExternalFragment(op.body, fragments);
+  });
+  return Object.values(fragments);
+}
+
+function getExternalFragment(field: GQLTemplateField, externalFragments: object = {}) {
+  field.fragments.filter((fragment) =>
+    fragment.external
+  ).reduce((acc, val) => {
+    acc[val.name] = val;
+    return acc;
+  }, externalFragments);
+  field.fields.forEach((f) => {
+    getExternalFragment(f, externalFragments);
+  });
+
+  return externalFragments;
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/generateOperation.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/generateOperation.ts
@@ -2,15 +2,16 @@ import { GraphQLField, GraphQLSchema } from 'graphql'
 
 import getArgs from './getArgs'
 import getBody from './getBody'
-import { GQLTemplateGenericOp, GQLTemplateArgDeclaration, GQLTemplateOpBody } from './types'
+import { GQLTemplateGenericOp, GQLTemplateArgDeclaration, GQLTemplateOpBody, GQLDocsGenOptions } from './types'
 
 export default function generateOperation(
   operation: GraphQLField<any, any>,
   schema: GraphQLSchema,
-  maxDepth: number = 3
+  maxDepth: number = 3,
+  options: GQLDocsGenOptions
 ): GQLTemplateGenericOp {
   const args: Array<GQLTemplateArgDeclaration> = getArgs(operation.args)
-  const body: GQLTemplateOpBody = getBody(operation, schema, maxDepth)
+  const body: GQLTemplateOpBody = getBody(operation, schema, maxDepth, options)
   return {
     args,
     body,

--- a/packages/amplify-graphql-docs-generator/src/generator/getBody.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getBody.ts
@@ -1,18 +1,19 @@
 import { GraphQLField, GraphQLSchema } from 'graphql'
 
 import getFields from './getFields'
-import { GQLTemplateOpBody, GQLTemplateArgInvocation, GQLTemplateField } from './types'
+import { GQLTemplateOpBody, GQLTemplateArgInvocation, GQLTemplateField, GQLDocsGenOptions } from './types'
 
 export default function getBody(
   op: GraphQLField<any, any>,
   schema: GraphQLSchema,
-  maxDepth: number = 3
+  maxDepth: number = 3,
+  options: GQLDocsGenOptions
 ): GQLTemplateOpBody {
   const args: Array<GQLTemplateArgInvocation> = op.args.map((arg) => ({
     name: arg.name,
     value: `\$${arg.name}`,
   }))
-  const fields: GQLTemplateField = getFields(op, schema, maxDepth)
+  const fields: GQLTemplateField = getFields(op, schema, maxDepth, options)
   return {
     args,
     ...fields,

--- a/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
@@ -6,26 +6,33 @@ import {
   GraphQLSchema,
   GraphQLUnionType,
   GraphQLList,
+  isObjectType,
+  isInterfaceType,
+  isUnionType
 } from 'graphql'
 import getFragment from './getFragment'
-import { GQLConcreteType, GQLTemplateField, GQLTemplateFragment } from './types'
+import { GQLConcreteType, GQLTemplateField, GQLTemplateFragment, GQLDocsGenOptions } from './types'
 import getType from './utils/getType'
+import isS3Object from './utils/isS3Object';
 
 export default function getFields(
   field: GraphQLField<any, any>,
   schema: GraphQLSchema,
-  depth: number = 2
+  depth: number = 2,
+  options: GQLDocsGenOptions
 ): GQLTemplateField {
   const fieldType: GQLConcreteType = getType(field.type)
+  const renderS3FieldFragment = options.useExternalFragmentForS3Object && isS3Object(fieldType);
   const subFields =
-    fieldType instanceof GraphQLObjectType || fieldType instanceof GraphQLInterfaceType
+    !renderS3FieldFragment && (isObjectType(fieldType) || isInterfaceType(fieldType))
       ? fieldType.getFields()
       : []
 
-  let subFragments =
-    fieldType instanceof GraphQLInterfaceType || fieldType instanceof GraphQLUnionType
+  const subFragments: any =
+    isInterfaceType(fieldType) || isUnionType(fieldType)
       ? schema.getPossibleTypes(fieldType)
-      : []
+      : {};
+
   if (depth < 1 && !(fieldType instanceof GraphQLScalarType)) {
     return
   }
@@ -33,12 +40,19 @@ export default function getFields(
   const fields: Array<GQLTemplateField> = Object.keys(subFields)
     .map((fieldName) => {
       const subField = subFields[fieldName];
-      return getFields(subField, schema, depth - 1);
+      return getFields(subField, schema, depth - 1, options);
     })
     .filter((field) => field)
   const fragments: Array<GQLTemplateFragment> = Object.keys(subFragments)
-    .map((fragment) => getFragment(subFragments[fragment], schema, depth, fields))
+    .map((fragment) => getFragment(subFragments[fragment], schema, depth, fields, null, false, options))
     .filter((field) => field)
+
+  // Special treatment for S3 input
+  // Swift SDK needs S3 Object to have fragment
+  if (renderS3FieldFragment) {
+    fragments.push(getFragment(fieldType as GraphQLObjectType, schema, depth, [], 'S3Object', true, options));
+  }
+
   return {
     name: field.name,
     fields,

--- a/packages/amplify-graphql-docs-generator/src/generator/getFragment.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getFragment.ts
@@ -1,23 +1,28 @@
 import { GraphQLObjectType, GraphQLSchema } from 'graphql'
 
 import getFields from './getFields'
-import { GQLTemplateField, GQLTemplateFragment } from './types'
+import { GQLTemplateField, GQLTemplateFragment, GQLDocsGenOptions } from './types'
 
 export default function getFragment(
   typeObj: GraphQLObjectType,
   schema: GraphQLSchema,
   depth: number,
-  filterFields: Array<GQLTemplateField> = []
+  filterFields: Array<GQLTemplateField> = [],
+  name?: string,
+  external: boolean = false,
+  options?: GQLDocsGenOptions
 ): GQLTemplateFragment {
   const subFields = (typeObj && typeObj.getFields && typeObj.getFields()) || []
   const filterFieldNames = filterFields.map((f) => f.name)
   const fields: Array<GQLTemplateField> = Object.keys(subFields)
-    .map((field) => getFields(subFields[field], schema, depth - 1))
+    .map((field) => getFields(subFields[field], schema, depth - 1, options))
     .filter((field) => field && !filterFieldNames.includes(field.name))
   if (fields.length) {
     return {
       on: typeObj.name,
       fields,
+      external,
+      name: name || `${typeObj.name}Fragment`,
     }
   }
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/types.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/types.ts
@@ -16,8 +16,10 @@ export type GQLConcreteType =
   | GraphQLInputObjectType
 
 export type GQLTemplateFragment = {
-  on: string
-  fields: Array<GQLTemplateField>
+  on: string,
+  fields: Array<GQLTemplateField>,
+  external: boolean,
+  name: string,
 }
 
 export enum GQLOperationTypeEnum {
@@ -65,4 +67,9 @@ export type GQLAllOperations = {
   queries: Array<GQLTemplateOp>
   mutations: Array<GQLTemplateOp>
   subscriptions: Array<GQLTemplateOp>
+  fragments: Array<GQLTemplateFragment>
+}
+
+export type GQLDocsGenOptions = {
+  useExternalFragmentForS3Object: boolean
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/isS3Object.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/isS3Object.ts
@@ -1,0 +1,20 @@
+import { GraphQLType, isObjectType, isScalarType } from "graphql";
+import getType from "./getType";
+const S3_FIELD_NAMES = ['bucket', 'key', 'region' ];
+export default function isS3Object(typeObj: GraphQLType): boolean {
+  if (isObjectType(typeObj)) {
+    const fields = typeObj.getFields();
+    const fieldName = typeObj.name;
+    const hasS3Fields = S3_FIELD_NAMES.every((s3Field) => {
+      const field = fields[s3Field];
+      try {
+        const type = getType(field.type)
+        return field && isScalarType(type) && type.name === 'String';
+      } catch (e) {
+        return false;
+      }
+    });
+    return hasS3Fields && fieldName === 'S3Object';
+  }
+  return false;
+}

--- a/packages/amplify-graphql-docs-generator/src/index.ts
+++ b/packages/amplify-graphql-docs-generator/src/index.ts
@@ -12,7 +12,7 @@ import {
   IntrospectionQuery,
 } from 'graphql'
 
-import generateAllOps, { GQLTemplateOp, GQLAllOperations } from './generator'
+import generateAllOps, { GQLTemplateOp, GQLAllOperations, GQLTemplateFragment } from './generator'
 
 const TEMPLATE_DIR = path.resolve(path.join(__dirname, '../templates'))
 const FILE_EXTENSION_MAP = {
@@ -41,7 +41,10 @@ function generate(
 
   const schema: IntrospectionQuery = schemaData.data || schemaData
   const maxDepth = options.maxDepth || 3
-  const gqlOperations: GQLAllOperations = generateAllOps(schema, maxDepth)
+  const useExternalFragmentForS3Object = options.language === 'graphql'
+  const gqlOperations: GQLAllOperations = generateAllOps(schema, maxDepth, {
+    useExternalFragmentForS3Object: useExternalFragmentForS3Object,
+  })
   registerPartials()
   registerHelpers()
 
@@ -50,10 +53,15 @@ function generate(
     ['queries', 'mutations', 'subscriptions'].forEach((op) => {
       const ops = gqlOperations[op]
       if (ops.length) {
-        const gql = renderOps(gqlOperations[op], language)
+        const gql = render({ operations: gqlOperations[op], fragments: [] }, language)
         fs.writeFileSync(path.resolve(path.join(outputPath, `${op}.${fileExtension}`)), gql)
       }
     })
+
+    if (gqlOperations.fragments.length) {
+      const gql = render({ operations: [], fragments: gqlOperations.fragments }, language)
+      fs.writeFileSync(path.resolve(path.join(outputPath, `fragments.${fileExtension}`)), gql)
+    }
   } else {
     const ops = [
       ...gqlOperations.queries,
@@ -61,13 +69,16 @@ function generate(
       ...gqlOperations.subscriptions,
     ]
     if (ops.length) {
-      const gql = renderOps(ops, language)
+      const gql = render({ operations: ops, fragments: gqlOperations.fragments }, language)
       fs.writeFileSync(path.resolve(outputPath), gql)
     }
   }
 }
 
-function renderOps(operations: Array<GQLTemplateOp>, language: string = 'graphql') {
+function render(
+  doc: { operations: Array<GQLTemplateOp>; fragments?: GQLTemplateFragment[] },
+  language: string = 'graphql'
+) {
   const templateFiles = {
     javascript: 'javascript.hbs',
     graphql: 'graphql.hbs',
@@ -83,7 +94,7 @@ function renderOps(operations: Array<GQLTemplateOp>, language: string = 'graphql
     noEscape: true,
     preventIndent: true,
   })
-  const gql = template({ operations: operations })
+  const gql = template(doc)
   return format(gql, language)
 }
 

--- a/packages/amplify-graphql-docs-generator/templates/_renderExternalFragment.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderExternalFragment.hbs
@@ -1,0 +1,3 @@
+fragment {{name}} on {{ on}} {
+  {{> renderFields fields=this.fields }}
+}

--- a/packages/amplify-graphql-docs-generator/templates/_renderFragment.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderFragment.hbs
@@ -1,7 +1,11 @@
 {{#each fragments }}
   {{#if this.fields.length}}
+    {{#if this.external }}
+      ...{{this.name}}
+    {{else}}
     ...on {{this.on}} {
       {{> renderFields fields=this.fields }}
     }
+    {{/if}}
   {{/if}}
 {{/each}}

--- a/packages/amplify-graphql-docs-generator/templates/graphql.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/graphql.hbs
@@ -2,3 +2,6 @@
 {{#each operations }}
   {{> renderOp }}
 {{/each}}
+{{#each fragments }}
+  {{> renderExternalFragment }}
+{{/each}}

--- a/packages/amplify-graphql-docs-generator/tsconfig.json
+++ b/packages/amplify-graphql-docs-generator/tsconfig.json
@@ -8,8 +8,7 @@
         "emitDecoratorMetadata": true,
         "sourceRoot": "src",
         "lib": [
-            "es7",
-            "es2015",
+            "es2017",
             "dom",
             "esnext.asynciterable",
             "dom"

--- a/packages/amplify-graphql-types-generator/fixtures/complex-obj.json
+++ b/packages/amplify-graphql-types-generator/fixtures/complex-obj.json
@@ -1,0 +1,2078 @@
+{
+    "data": {
+        "__schema": {
+            "queryType": {
+                "name": "Query"
+            },
+            "mutationType": {
+                "name": "Mutation"
+            },
+            "subscriptionType": {
+                "name": "Subscription"
+            },
+            "types": [
+                {
+                    "kind": "OBJECT",
+                    "name": "Query",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "singlePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ID",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "getPost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ID",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "listPosts",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "first",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "after",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "PostConnection",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Post",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "file",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "S3Object",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "description": "Built-in ID",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "description": "Built-in String",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "description": "Built-in Int",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "S3Object",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "bucket",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "key",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "PostConnection",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "items",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Post",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "nextToken",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Mutation",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "createPost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "CreatePostInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "createPostWithFile",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "CreatePostWithFileInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "updatePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "UpdatePostInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deletePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "DeletePostInput",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreatePostInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreatePostWithFileInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "file",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "INPUT_OBJECT",
+                                    "name": "S3ObjectInput",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "S3ObjectInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "bucket",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "key",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdatePostInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "author",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "title",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "content",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "ups",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "downs",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DeletePostInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Subscription",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "onCreatePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "ID",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "author",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "title",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "content",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "url",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onUpdatePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "ID",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "author",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "title",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "content",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "url",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onDeletePost",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "ID",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "author",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "title",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "content",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "url",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Post",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Schema",
+                    "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+                    "fields": [
+                        {
+                            "name": "types",
+                            "description": "A list of all types supported by this server.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__Type",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "queryType",
+                            "description": "The type that query operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "mutationType",
+                            "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "directives",
+                            "description": "'A list of all directives supported by this server.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__Directive",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "subscriptionType",
+                            "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "kind",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "ENUM",
+                                    "name": "__TypeKind",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "fields",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Field",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "interfaces",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "possibleTypes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "enumValues",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__EnumValue",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "inputFields",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ofType",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "ENUM",
+                    "name": "__TypeKind",
+                    "description": "An enum describing what kind of type a given __Type is",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": [
+                        {
+                            "name": "SCALAR",
+                            "description": "Indicates this type is a scalar.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "OBJECT",
+                            "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INTERFACE",
+                            "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "UNION",
+                            "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM",
+                            "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_OBJECT",
+                            "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "LIST",
+                            "description": "Indicates this type is a list. `ofType` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "NON_NULL",
+                            "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "args",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__InputValue",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "defaultValue",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "description": "Built-in Boolean",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Directive",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "locations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "__DirectiveLocation",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "args",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__InputValue",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onOperation",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        },
+                        {
+                            "name": "onFragment",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        },
+                        {
+                            "name": "onField",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "description": "An enum describing valid locations where a directive can be placed",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": [
+                        {
+                            "name": "QUERY",
+                            "description": "Indicates the directive is valid on queries.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "MUTATION",
+                            "description": "Indicates the directive is valid on mutations.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FIELD",
+                            "description": "Indicates the directive is valid on fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FRAGMENT_DEFINITION",
+                            "description": "Indicates the directive is valid on fragment definitions.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FRAGMENT_SPREAD",
+                            "description": "Indicates the directive is valid on fragment spreads.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INLINE_FRAGMENT",
+                            "description": "Indicates the directive is valid on inline fragments.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SCHEMA",
+                            "description": "Indicates the directive is valid on a schema SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SCALAR",
+                            "description": "Indicates the directive is valid on a scalar SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "OBJECT",
+                            "description": "Indicates the directive is valid on an object SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FIELD_DEFINITION",
+                            "description": "Indicates the directive is valid on a field SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ARGUMENT_DEFINITION",
+                            "description": "Indicates the directive is valid on a field argument SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INTERFACE",
+                            "description": "Indicates the directive is valid on an interface SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "UNION",
+                            "description": "Indicates the directive is valid on an union SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM",
+                            "description": "Indicates the directive is valid on an enum SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM_VALUE",
+                            "description": "Indicates the directive is valid on an enum value SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_OBJECT",
+                            "description": "Indicates the directive is valid on an input object SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_FIELD_DEFINITION",
+                            "description": "Indicates the directive is valid on an input object field SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "possibleTypes": null
+                }
+            ],
+            "directives": [
+                {
+                    "name": "include",
+                    "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                        {
+                            "name": "if",
+                            "description": "Included when true.",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": true,
+                    "onField": true
+                },
+                {
+                    "name": "skip",
+                    "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                        {
+                            "name": "if",
+                            "description": "Skipped when true.",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": true,
+                    "onField": true
+                },
+                {
+                    "name": "defer",
+                    "description": "This directive allows results to be deferred during execution",
+                    "locations": [
+                        "FIELD"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": true
+                },
+                {
+                    "name": "deprecated",
+                    "description": null,
+                    "locations": [
+                        "FIELD_DEFINITION",
+                        "ENUM_VALUE"
+                    ],
+                    "args": [
+                        {
+                            "name": "reason",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": "\"No longer supported\""
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_publish",
+                    "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "subscriptions",
+                            "description": "List of subscriptions which will be published to when this mutation is called.",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_subscribe",
+                    "description": "Tells the service which mutation triggers this subscription.",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "mutations",
+                            "description": "List of mutations which will trigger this subscription when they are called.",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_auth",
+                    "description": "Directs the schema to enforce authorization on a field",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "cognito_groups",
+                            "description": "List of cognito user pool groups which have access on this field",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                }
+            ]
+        }
+    }
+}

--- a/packages/amplify-graphql-types-generator/src/swift/codeGeneration.ts
+++ b/packages/amplify-graphql-types-generator/src/swift/codeGeneration.ts
@@ -26,6 +26,7 @@ import { generateOperationId } from '../compiler/visitors/generateOperationId';
 import { collectAndMergeFields } from '../compiler/visitors/collectAndMergeFields';
 
 import '../utilities/array';
+import { isS3Field } from '../utilities/complextypes';
 
 export interface Options {
   namespace?: string;
@@ -853,7 +854,28 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     const adoptedProtocols = ['GraphQLMapConvertible'];
     const fields = Object.values(type.getFields());
 
-    const properties = fields.map(this.helpers.propertyFromInputField, this.helpers);
+    let properties = fields.map(this.helpers.propertyFromInputField, this.helpers);
+
+    // File input should have localUri and mimeType which is used only in client
+    if (isS3Field(type)) {
+      properties = [
+        ...properties,
+        {
+          propertyName: 'localUri',
+          name: 'localUri',
+          typeName: 'String',
+          isOptional: false,
+          description: '',
+        },
+        {
+          propertyName: 'mimeType',
+          name: 'mimeType',
+          typeName: 'String',
+          isOptional: false,
+          description: '',
+        },
+      ];
+    }
 
     this.structDeclaration(
       { structName, description: description || undefined, adoptedProtocols },

--- a/packages/amplify-graphql-types-generator/src/swift/helpers.ts
+++ b/packages/amplify-graphql-types-generator/src/swift/helpers.ts
@@ -167,10 +167,12 @@ export class Helpers {
   }
 
   propertyFromInputField(field: GraphQLInputField) {
-    return Object.assign({}, field, {
+    return Object.assign({}, {
       propertyName: camelCase(field.name),
       typeName: this.typeNameFromGraphQLType(field.type),
-      isOptional: !(field.type instanceof GraphQLNonNull)
+      isOptional: !(field.type instanceof GraphQLNonNull),
+      description: field.description || null,
+      name: field.name,
     });
   }
 

--- a/packages/amplify-graphql-types-generator/src/utilities/complextypes.ts
+++ b/packages/amplify-graphql-types-generator/src/utilities/complextypes.ts
@@ -1,10 +1,22 @@
 import { GraphQLType, isInputObjectType, getNamedType, isObjectType } from 'graphql';
 
-const S3_FIELD_NAMES = ['bucket', 'key', 'region', 'localUri', 'mimeType'];
+const S3_FIELD_NAMES = ['bucket', 'key', 'region' ];
 
 export function hasS3Fields(input: GraphQLType): boolean {
   if (isObjectType(input) || isInputObjectType(input)) {
+    if (isS3Field(input)) {
+      return true;
+    }
     const fields = input.getFields();
+    return Object.keys(fields)
+      .some(f => hasS3Fields((<any>fields[f]) as GraphQLType));
+  }
+  return false;
+}
+
+export function isS3Field(field: GraphQLType): boolean {
+  if (isObjectType(field) || isInputObjectType(field)) {
+    const fields = field.getFields();
     const stringFields = Object.keys(fields).filter(f => {
       const typeName = getNamedType(fields[f].type);
       return typeName.name === 'String';
@@ -13,9 +25,6 @@ export function hasS3Fields(input: GraphQLType): boolean {
     if (isS3FileField) {
       return true;
     }
-    return Object.keys(fields)
-      .filter(f => !stringFields.includes(f))
-      .some(f => hasS3Fields((<any>fields[f]) as GraphQLType));
   }
   return false;
 }


### PR DESCRIPTION
Generate s3 fragments to support complex object upload. Swift codegen requires the S3Object to be a fragment to automatically upload files to s3. Updating statement generator to render fragments when there is an S3 object

*Issue #, if available:*
re #768

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.