### PR TITLE
feat(amplify-codegen): add support for max-depth for statements

### DIFF
--- a/packages/amplify-codegen/commands/codegen/codegen.js
+++ b/packages/amplify-codegen/commands/codegen/codegen.js
@@ -7,16 +7,16 @@ module.exports = {
   name: featureName,
   run: async (context) => {
     if (context.parameters.options.help) {
-      const header = `amplify ${featureName} [subcommand] \nDescriptions:
+      const header = `amplify ${featureName} [subcommand] [[--nodownload] [--max-depth <number>]]\nDescriptions:
       Generates GraphQL statements(queries, mutations and subscriptions) and type annotations. \nSub Commands:`;
 
       const commands = [
         {
-          name: 'types',
+          name: 'types [--nodownload]',
           description: constants.CMD_DESCRIPTION_GENERATE_TYPES,
         },
         {
-          name: 'statments',
+          name: 'statments [--nodownload] [--max-depth]',
           description: constants.CMD_DESCRIPTION_GENERATE_STATEMENTS,
         },
         {
@@ -38,7 +38,8 @@ module.exports = {
     
     try {
       const forceDownloadSchema = !context.parameters.options.nodownload;
-      await codeGen.generate(context, forceDownloadSchema);
+      const { maxDepth } = context.parameters.options;
+      await codeGen.generate(context, forceDownloadSchema, maxDepth);
     } catch (e) {
       context.print.info(e.message);
       process.exit(1);

--- a/packages/amplify-codegen/commands/codegen/statements.js
+++ b/packages/amplify-codegen/commands/codegen/statements.js
@@ -7,7 +7,8 @@ module.exports = {
   run: async (context) => {
     try {
       const forceDownloadSchema = !context.parameters.options.nodownload;
-      await codeGen.generateStatements(context, forceDownloadSchema);
+      const { maxDepth } = context.parameters.options;
+      await codeGen.generateStatements(context, forceDownloadSchema, maxDepth);
     } catch (ex) {
       context.print.info(ex.message);
       process.exit(1);

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -89,6 +89,9 @@ async function add(context, apiId = null) {
     endpoint: apiDetails.endpoint,
   };
 
+  if (answer.maxDepth) {
+    newProject.amplifyExtension.maxDepth = answer.maxDepth;
+  }
   config.addProject(newProject);
   if (answer.shouldGenerateDocs) {
     await generateStatements(context, false);

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -7,7 +7,7 @@ const loadConfig = require('../codegen-config');
 const constants = require('../constants');
 const { downloadIntrospectionSchemaWithProgress, isAppSyncApiPendingPush } = require('../utils');
 
-async function generateStatementsAndTypes(context, forceDownloadSchema) {
+async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
   if (!projects.length) {
@@ -24,7 +24,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema) {
     );
     await Promise.all(downloadPromises);
   }
-  await generateStatements(context, false);
+  await generateStatements(context, false, maxDepth);
   await generateTypes(context, false);
   const pendingPush = await isAppSyncApiPendingPush(context);
   if (pendingPush) {

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -7,7 +7,7 @@ const loadConfig = require('../codegen-config');
 const constants = require('../constants');
 const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require('../utils');
 
-async function generateStatements(context, forceDownloadSchema) {
+async function generateStatements(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
   if (!projects.length) {
@@ -32,7 +32,11 @@ async function generateStatements(context, forceDownloadSchema) {
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
     opsGenSpinner.start();
     jetpack.dir(opsGenDirectory);
-    await statementsGen(schema, opsGenDirectory, { separateFiles: true, language });
+    await statementsGen(schema, opsGenDirectory, {
+      separateFiles: true,
+      language,
+      maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
+    });
     opsGenSpinner.succeed(
       constants.INFO_MESSAGE_OPS_GEN_SUCCESS + path.relative(path.resolve('.'), opsGenDirectory),
     );

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -11,24 +11,28 @@ module.exports = {
   PROMPT_MSG_GQL_FILE_PATTERN:
     'Enter the file name pattern of graphql queries, mutations and subscriptions',
   PROMPT_MSG_GENERATE_CODE: 'Do you want to generate code for your newly created GraphQL API',
-  PROMPT_MSG_UPDATE_STATEMENTS: 'Do you want to generate GraphQL statements (queries, mutations and subscription) based on your schema types? This will overwrite your current graphql queries, mutations and subscriptions',
+  PROMPT_MSG_UPDATE_STATEMENTS:
+    'Do you want to generate GraphQL statements (queries, mutations and subscription) based on your schema types? This will overwrite your current graphql queries, mutations and subscriptions',
   PROMPT_MSG_CHANGE_REGION: 'Do you want to choose a different region',
   PROMPT_MSG_UPDATE_CODE: 'Do you want to update code for your updated GraphQL API',
+  PROMPT_MSG_MAX_DEPTH: 'Enter the maximum depth of statements to be generated',
   PROMPT_MSG_GENERATE_OPS:
     'Do you want to generate/update all possible GraphQL operations - queries, mutations and subscriptions',
   PROMPT_MSG_SELECT_PROJECT: 'Choose the AppSync API',
   PROMPT_MSG_SELECT_REGION: 'Choose AWS Region',
   ERROR_CODEGEN_TARGET_NOT_SUPPORTED: 'is not supported by codegen plugin',
   ERROR_CODEGEN_FRONTEND_NOT_SUPPORTED: 'The project frontend is not supported by codegen',
+  ERROR_MSG_MAX_DEPTH: 'Depth should be a integer greater than 0',
   ERROR_CODEGEN_NO_API_AVAILABLE:
     'There are no GraphQL APIs available.\nAdd by running $amplify api add',
-  ERROR_CODEGEN_NO_API_KEY_AVAILABLE: "Security mode is set to API Key but coudn't find any API Keys. Please add an API Key to your AppSync API using the AWS AppSync console",
+  ERROR_CODEGEN_NO_API_KEY_AVAILABLE:
+    "Security mode is set to API Key but coudn't find any API Keys. Please add an API Key to your AppSync API using the AWS AppSync console",
   ERROR_CODEGEN_ALL_APIS_ALREADY_ADDED: 'All enabled AppSync APIs are already added',
   ERROR_CODEGEN_SUPPORT_MAX_ONE_API: 'Codegen support only one GraphQL API per project',
   CMD_DESCRIPTION_ADD:
     'Generate API code or type annotations based on a GraphQL schema and query documents',
   CMD_DESCRIPTION_GENERATE_TYPES:
-    "Generate API code or type annotations based on a GraphQL schema and statements.\nIf don't want to download schema before generating code pass --nodownload flag",
+    "Generate API code or type annotations based on a GraphQL schema and statements.\nIf don't want to download schema before generating code pass --nodownload flag.",
   CMD_DESCRIPTION_GENERATE_STATEMENTS:
     "Generate GraphQL statements(query, mutations and subscriptions) from schema.\nIf don't want to download schema before generating code pass --nodownload flag",
   ERROR_NOT_CONFIGURED: '',
@@ -56,5 +60,6 @@ module.exports = {
   INFO_MESSAGE_DOWNLOAD_ERROR: 'Downloading schema failed',
   INFO_MESSAGE_OPS_GEN: 'Generating GraphQL operations',
   INFO_MESSAGE_OPS_GEN_SUCCESS: 'Generated GraphQL operations successfully and saved at ',
-  INFO_MESSAGE_ADD_ERROR: 'amplify codegen add takes only apiId as parameter. \n$ amplify codegen add [--apiId <API_ID>]',
+  INFO_MESSAGE_ADD_ERROR:
+    'amplify codegen add takes only apiId as parameter. \n$ amplify codegen add [--apiId <API_ID>]',
 };

--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -4,6 +4,7 @@ const askCodeGenQueryFilePattern = require('./questions/queryFilePattern');
 const askTargetFileName = require('./questions/generatedFileName');
 const askShouldGenerateCode = require('./questions/generateCode');
 const askShouldGenerateDocs = require('./questions/generateDocs');
+const askMaxDepth = require('./questions/maxDepth');
 const { normalizeInputParams } = require('../utils/input-params-manager');
 const constants = require('../constants');
 const { getOutputFileName } = require('../utils');
@@ -58,6 +59,11 @@ async function addWalkThrough(context, skip = []) {
     answers.shouldGenerateDocs =
     await determineValue(inputParams, yesFlag, 'generateDocs', true, () => askShouldGenerateDocs());
     answers.docsFilePath = getGraphQLDocPath(frontend, schemaLocation);
+  }
+
+  if (answers.shouldGenerateDocs && !skip.includes('maxDepth')) {
+    answers.maxDepth =
+    await determineValue(inputParams, yesFlag, 'maxDepth', true, askMaxDepth);
   }
 
   if (!(frontend === 'android' || answers.target === 'javascript')) {

--- a/packages/amplify-codegen/src/walkthrough/configure.js
+++ b/packages/amplify-codegen/src/walkthrough/configure.js
@@ -4,6 +4,7 @@ const askForGraphQLAPIResource = require('./questions/selectProject');
 const askCodeGenTargetLanguage = require('./questions/languageTarget');
 const askCodeGeneQueryFilePattern = require('./questions/queryFilePattern');
 const askTargetFileName = require('./questions/generatedFileName');
+const askMaxDepth = require('./questions/maxDepth');
 const { getFrontEndHandler, getIncludePattern } = require('../utils/');
 
 function deepCopy(obj) {
@@ -53,6 +54,10 @@ async function configureProjectWalkThrough(context, amplifyConfig) {
     amplifyExtension.generatedFileName = '';
   }
   amplifyExtension.codeGenTarget = targetLanguage;
+
+  amplifyExtension.maxDepth = await askMaxDepth(
+    amplifyExtension.maxDepth,
+  );
 
   return selectedProjectConfig;
 }

--- a/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
@@ -1,0 +1,24 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askMaxDepth(defaultDepth = 2) {
+  const answer = await inquirer.prompt([
+    {
+      name: 'maxDepth',
+      message: constants.PROMPT_MSG_MAX_DEPTH,
+      type: 'input',
+      validate: (val) => {
+        const num = Number.parseInt(val, 10);
+        return Number.isInteger(num) && Number.isFinite(num) && num > 0
+          ? true
+          : constants.ERROR_MSG_MAX_DEPTH;
+      },
+      default: defaultDepth,
+    },
+  ]);
+
+  return Number.parseInt(answer.maxDepth, 10);
+}
+
+module.exports = askMaxDepth;

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -54,7 +54,7 @@ describe('command - generateStatementsAndTypes', () => {
     const forceDownload = false;
     await generateStatementsAndTypes(MOCK_CONTEXT, forceDownload);
     expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT);
-    expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false, undefined);
     expect(generateTypes).toHaveBeenCalledWith(MOCK_CONTEXT, false);
   });
 

--- a/packages/amplify-codegen/tests/walkthrough/add.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/add.test.js
@@ -3,7 +3,7 @@ const askCodegneQueryFilePattern = require('../../src/walkthrough/questions/quer
 const askGeneratedFileName = require('../../src/walkthrough/questions/generatedFileName');
 const askGenerateCode = require('../../src/walkthrough/questions/generateCode');
 const askShouldGenerateDocs = require('../../src/walkthrough/questions/generateDocs');
-
+const askMaxDepth = require('../../src/walkthrough/questions/maxDepth');
 const {
   getGraphQLDocPath,
   getSchemaDownloadLocation,
@@ -18,6 +18,7 @@ jest.mock('../../src/walkthrough/questions/generatedFileName');
 jest.mock('../../src/utils');
 jest.mock('../../src/walkthrough/questions/generateCode');
 jest.mock('../../src/walkthrough/questions/generateDocs');
+jest.mock('../../src/walkthrough/questions/maxDepth');
 
 describe('Add walk-through', () => {
   const MOCK_TARGET_LANGUAGE = 'MOCK_TARGET_LANGUAGE';
@@ -30,6 +31,7 @@ describe('Add walk-through', () => {
   const MOCK_DOWNLOAD_LOCATION = 'MOCK_SCHEMA_DIR/graphql/schema.json';
   const MOCK_DOCS_FILE_PATH = 'mockDocFilesPath';
   const MOCK_FRONTEND_HANDLER = 'mockFrontEndHandler';
+  const MOCK_MAX_DEPTH = 20;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -45,6 +47,7 @@ describe('Add walk-through', () => {
       graphQLDirectory: 'src/graphql',
       graphQLExtension: '*.js',
     });
+    askMaxDepth.mockReturnValue(MOCK_MAX_DEPTH);
   });
 
   it('should show questions in walkthrough', async () => {
@@ -62,6 +65,7 @@ describe('Add walk-through', () => {
       schemaLocation: MOCK_DOWNLOAD_LOCATION,
       docsFilePath: MOCK_DOCS_FILE_PATH,
       shouldGenerateDocs: true,
+      maxDepth: MOCK_MAX_DEPTH,
     });
   });
 
@@ -77,6 +81,7 @@ describe('Add walk-through', () => {
       schemaLocation: MOCK_DOWNLOAD_LOCATION,
       docsFilePath: MOCK_DOCS_FILE_PATH,
       shouldGenerateDocs: true,
+      maxDepth: MOCK_MAX_DEPTH,
     });
   });
 

--- a/packages/amplify-codegen/tests/walkthrough/configure.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/configure.test.js
@@ -3,6 +3,7 @@ const selectProject = require('../../src/walkthrough/questions/selectProject');
 const askCodegenTargetLanguage = require('../../src/walkthrough/questions/languageTarget');
 const askCodegneQueryFilePattern = require('../../src/walkthrough/questions/queryFilePattern');
 const askGeneratedFileName = require('../../src/walkthrough/questions/generatedFileName');
+const askMaxDepth = require('../../src/walkthrough/questions/maxDepth');
 const configure = require('../../src/walkthrough/configure');
 const { getIncludePattern } = require('../../src/utils');
 
@@ -10,6 +11,7 @@ jest.mock('../../src/walkthrough/questions/selectProject');
 jest.mock('../../src/walkthrough/questions/languageTarget');
 jest.mock('../../src/walkthrough/questions/queryFilePattern');
 jest.mock('../../src/walkthrough/questions/generatedFileName');
+jest.mock('../../src/walkthrough/questions/maxDepth');
 jest.mock('../../src/utils');
 
 describe('configure walk-through', () => {
@@ -20,6 +22,7 @@ describe('configure walk-through', () => {
   const mockGeneratedFileName = 'MOCK_FILE_NAME.ts';
   const mockGraphQLDirectory = 'MOCK_GQL_DIR';
   const mockGraphQLExtension = 'MOCK_GQL_EXTENSION';
+  const MOCK_MAX_DEPTH = 'MOCK_MAX_DEPTH';
 
   const mockConfigs = [
     {
@@ -29,6 +32,7 @@ describe('configure walk-through', () => {
         graphQLApiId: 'one',
         generatedFileName: 'one-1.ts',
         codeGenTarget: 'language-one',
+        maxDepth: 5,
       },
     },
     {
@@ -36,7 +40,7 @@ describe('configure walk-through', () => {
       includes: ['two/**/*.gql', 'two/**/*.graohql'],
       amplifyExtension: {
         graphQLApiId: 'two',
-
+        maxDepth: 10,
         generatedFileName: 'two-2.ts',
         codeGenTarget: 'language-two',
       },
@@ -49,6 +53,7 @@ describe('configure walk-through', () => {
     askCodegenTargetLanguage.mockReturnValue(mockTargetLanguage);
     askCodegneQueryFilePattern.mockReturnValue(mockIncludes);
     askGeneratedFileName.mockReturnValue(mockGeneratedFileName);
+    askMaxDepth.mockReturnValue(MOCK_MAX_DEPTH);
     getIncludePattern.mockReturnValue({
       graphQLDirectory: mockGraphQLDirectory,
       graphQLExtension: mockGraphQLExtension,
@@ -72,11 +77,14 @@ describe('configure walk-through', () => {
       mockContext,
       mockConfigs[1].amplifyExtension.codeGenTarget,
     );
-    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith([join(mockGraphQLDirectory, '**', mockGraphQLExtension)]);
+    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith([
+      join(mockGraphQLDirectory, '**', mockGraphQLExtension),
+    ]);
     expect(askGeneratedFileName).toHaveBeenCalledWith(
       mockConfigs[1].amplifyExtension.generatedFileName,
       mockTargetLanguage,
     );
+    expect(askMaxDepth).toHaveBeenCalledWith(10);
     expect(results).toEqual({
       projectName: mockConfigs[1].projectName,
       includes: mockIncludes,
@@ -84,6 +92,7 @@ describe('configure walk-through', () => {
         graphQLApiId: mockConfigs[1].amplifyExtension.graphQLApiId,
         generatedFileName: mockGeneratedFileName,
         codeGenTarget: mockTargetLanguage,
+        maxDepth: MOCK_MAX_DEPTH,
       },
     });
   });


### PR DESCRIPTION
codegen had hardcode max depth of 2 for the statement generation. Exposed a new configuration and
flag (--max-depth) to configure the maximum level that an object needs to expand when generating statements

re #715 #745 #638 #775