### PR TITLE
build: pin the version of @types/jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
-    "lerna": "^2.11.0"
+    "lerna": "^3.10.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.1.2",

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -29,7 +29,7 @@
     "@types/ejs": "^2.6.0",
     "@types/graphql": "^0.13.1",
     "@types/handlebars": "^4.0.39",
-    "@types/jest": "^23.3.1",
+    "@types/jest": "23.3.1",
     "@types/node": "^8.0.28",
     "@types/prettier": "^1.13.2",
     "jest": "^23.1.0",

--- a/packages/amplify-graphql-types-generator/package.json
+++ b/packages/amplify-graphql-types-generator/package.json
@@ -32,7 +32,7 @@
     "@types/glob": "^5.0.30",
     "@types/graphql": "^14.0.3",
     "@types/inflected": "^1.1.29",
-    "@types/jest": "^20.0.6",
+    "@types/jest": "20.0.6",
     "@types/mkdirp": "^0.5.0",
     "@types/node-fetch": "^1.6.7",
     "@types/yargs": "12.0.1",

--- a/packages/graphql-appsync-transformer/package.json
+++ b/packages/graphql-appsync-transformer/package.json
@@ -24,7 +24,7 @@
     "graphql-transformer-core": "^2.0.1-multienv.0"
   },
   "devDependencies": {
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "jest": "^23.1.0",
     "ts-jest": "^22.4.6",

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "graphql-appsync-transformer": "^2.0.0-multienv.1",
     "graphql-dynamodb-transformer": "^2.0.0-multienv.2",

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "aws-sdk": "^2.259.1",
     "graphql-appsync-transformer": "^2.0.0-multienv.1",

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "aws-sdk": "^2.259.1",
     "graphql-appsync-transformer": "^2.0.0-multienv.1",

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -23,7 +23,7 @@
     "graphql-transformer-core": "^2.0.1-multienv.0"
   },
   "devDependencies": {
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "bestzip": "^2.0.0",
     "graphql-dynamodb-transformer": "^2.0.0-multienv.2",

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "aws-sdk": "^2.259.1",
     "graphql-appsync-transformer": "^2.0.0-multienv.1",

--- a/packages/graphql-mapping-template/package.json
+++ b/packages/graphql-mapping-template/package.json
@@ -19,7 +19,7 @@
     "cloudform": "^2.2.1"
   },
   "devDependencies": {
-    "@types/jest": "^22.2.3",
+    "@types/jest": "22.2.3",
     "jest": "^23.0.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "aws-sdk": "^2.259.1",
     "jest": "^23.1.0",

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.0",
+    "@types/jest": "23.1.0",
     "jest": "^23.0.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "aws-amplify": "^1.1.4",
     "aws-sdk": "^2.259.1",

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.1",
-    "@types/jest": "^23.1.1",
+    "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "aws-sdk": "^2.259.1",
     "graphql-appsync-transformer": "^2.0.0-multienv.1",


### PR DESCRIPTION
Pinned the version of @types/jest to ensure that it works with typescript v2.x.x

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.