### PR TITLE
fix(amplify-graphql-types-generator): underscore support in swift

### DIFF
--- a/packages/amplify-graphql-types-generator/src/swift/codeGeneration.ts
+++ b/packages/amplify-graphql-types-generator/src/swift/codeGeneration.ts
@@ -913,18 +913,18 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           );
         });
 
-        for (const { propertyName, typeName, description } of properties) {
+        for (const { name, propertyName, typeName, description } of properties) {
           this.printNewlineIfNeeded();
           this.comment(description || undefined);
           this.printOnNewline(`public var ${escapeIdentifierIfNeeded(propertyName)}: ${typeName}`);
           this.withinBlock(() => {
             this.printOnNewline('get');
             this.withinBlock(() => {
-              this.printOnNewline(`return graphQLMap["${propertyName}"] as! ${typeName}`);
+              this.printOnNewline(`return graphQLMap["${name}"] as! ${typeName}`);
             });
             this.printOnNewline('set');
             this.withinBlock(() => {
-              this.printOnNewline(`graphQLMap.updateValue(newValue, forKey: "${propertyName}")`);
+              this.printOnNewline(`graphQLMap.updateValue(newValue, forKey: "${name}")`);
             });
           });
         }

--- a/packages/amplify-graphql-types-generator/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/packages/amplify-graphql-types-generator/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -1493,10 +1493,10 @@ public struct ReviewInput: GraphQLMapConvertible {
   /// Favorite color, optional
   public var favoriteColor: ColorInput? {
     get {
-      return graphQLMap[\\"favoriteColor\\"] as! ColorInput?
+      return graphQLMap[\\"favorite_color\\"] as! ColorInput?
     }
     set {
-      graphQLMap.updateValue(newValue, forKey: \\"favoriteColor\\")
+      graphQLMap.updateValue(newValue, forKey: \\"favorite_color\\")
     }
   }
 }"


### PR DESCRIPTION
Swift codegen did not handle underscores field names. The generated code used undescore name for mapbut getters/setters used camelCase name similar to the name of the property. Udated code to use
underscore name for gettters and setters

fix #643

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.