### PR TITLE
Limit to allow "development" environment name

### DIFF
--- a/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
@@ -123,7 +123,7 @@ async function getEnvName(context) {
   const isEnvNameValid = (inputEnvName) => {
     let valid = true;
 
-    if (inputEnvName.length > 10 || inputEnvName.length < 2 || /[^a-z]/g.test(inputEnvName)) {
+    if (inputEnvName.length > 11 || inputEnvName.length < 2 || /[^a-z]/g.test(inputEnvName)) {
       valid = false;
     }
     return valid;


### PR DESCRIPTION
**Issue #, if available:**

Limit on environment name doesn't allow for "development", which is a common environment name.

**Description of changes:**

Extended the limit on environment name from 10 to 11 characters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.