### PR TITLE
fix: copy providerMetadata to amplify-meta during env init

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/initialize-env.js
+++ b/packages/amplify-provider-awscloudformation/lib/initialize-env.js
@@ -47,7 +47,30 @@ function run(context, providerMetadata) {
       });
     })
     .then(() => new Cloudformation(context))
-    .then(cfnItem => cfnItem.updateamplifyMetaFileWithStackOutputs(providerMetadata.StackName));
+    .then(cfnItem => cfnItem.updateamplifyMetaFileWithStackOutputs(providerMetadata.StackName))
+    .then(() => {
+      // Copy provider metadata from current-cloud-backend/amplify-meta to backend/ampliy-meta
+      console.log(context);
+      const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
+      const currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+
+      const amplifyMetafilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
+      const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetafilePath));
+
+      // Copy providerMetadata for each resource - from what is there in the cloud
+
+      Object.keys(amplifyMeta).forEach((category) => {
+        Object.keys(amplifyMeta[category]).forEach((resource) => {
+          if (currentAmplifyMeta[category][resource]) {
+            amplifyMeta[category][resource].providerMetadata =
+            currentAmplifyMeta[category][resource].providerMetadata;
+          }
+        });
+      });
+
+      const jsonString = JSON.stringify(amplifyMeta, null, 4);
+      fs.writeFileSync(amplifyMetafilePath, jsonString, 'utf8');
+    });
 }
 
 module.exports = {

--- a/packages/amplify-provider-awscloudformation/lib/initialize-env.js
+++ b/packages/amplify-provider-awscloudformation/lib/initialize-env.js
@@ -50,7 +50,6 @@ function run(context, providerMetadata) {
     .then(cfnItem => cfnItem.updateamplifyMetaFileWithStackOutputs(providerMetadata.StackName))
     .then(() => {
       // Copy provider metadata from current-cloud-backend/amplify-meta to backend/ampliy-meta
-      console.log(context);
       const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
       const currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.