### PR TITLE
fix(graphql-dynamodb-transformer): generate filters for connection

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -293,10 +293,9 @@ export class DynamoDBModelTransformer extends Transformer {
             const listResolver = this.resources.makeListResolver(def.name.value, listFieldNameOverride, ctx.getQueryTypeName())
             ctx.setResource(ResolverResourceIDs.DynamoDBListResolverResourceID(typeName), listResolver)
 
-            this.generateFilterInputs(ctx, def)
-
             queryFields.push(makeModelScanField(listResolver.Properties.FieldName, def.name.value))
         }
+        this.generateFilterInputs(ctx, def)
 
         ctx.addQueryFields(queryFields)
     }


### PR DESCRIPTION
 DyanmoDBTransformer generates filter input type if and only if queries are enbled for a type. This used to work fine
 when transformer did not support enum filters. ID, String, Int, Float are not unique to a schema and are generated all the time. With EnumFilter if the Type does not have queries enabled, these filter input types never gets generated  but they may gets referenced in connections queries. Updated code to generate Filters even when queries are disabled.

fixes #865

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.