### PR TITLE
fix: ignore file starting with a dot when compiling configs

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -205,7 +205,7 @@ function validateCfnTemplates(context, resourcesToBeUpdated) {
     const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
     const files = fs.readdirSync(resourceDir);
     // Fetch all the Cloudformation templates for the resource (can be json or yml)
-    const cfnFiles = files.filter(file => file.indexOf('template') !== -1);
+    const cfnFiles = files.filter(file => file.indexOf('template') !== -1 && file.indexOf('.') !== 0);
     for (let j = 0; j < cfnFiles.length; j += 1) {
       const filePath = path.normalize(path.join(resourceDir, cfnFiles[j]));
       try {

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -201,6 +201,10 @@ export async function readProjectConfiguration(projectDirectory: string): Promis
     if (resolverDirExists) {
         const resolverFiles = await readDir(resolverDirectory)
         for (const resolverFile of resolverFiles) {
+            if (resolverFile.indexOf('.') === 0) {
+                continue;
+            }
+
             const resolverFilePath = path.join(resolverDirectory, resolverFile)
             resolvers[resolverFile] = await readFile(resolverFilePath)
         }
@@ -223,6 +227,10 @@ export async function readProjectConfiguration(projectDirectory: string): Promis
     if (stacksDirExists) {
         const stackFiles = await readDir(stacksDirectory)
         for (const stackFile of stackFiles) {
+            if (stackFile.indexOf('.') === 0) {
+                continue;
+            }
+
             const stackFilePath = path.join(stacksDirectory, stackFile)
             throwIfNotJSON(stackFile);
             const stackBuffer = await readFile(stackFilePath);
@@ -395,6 +403,10 @@ async function readSchemaDocuments(schemaDirectoryPath: string): Promise<string[
     const files = await readDir(schemaDirectoryPath);
     let schemaDocuments = [];
     for (const fileName of files) {
+        if (fileName.indexOf('.') === 0) {
+            continue;
+        }
+
         const fullPath = `${schemaDirectoryPath}/${fileName}`;
         const stats = await lstat(fullPath);
         if (stats.isDirectory()) {


### PR DESCRIPTION
*Description of changes:*

When generating files during a push, amplify-cli is iterating through various directories in ```amplify```. It currently lists all files. If you have something open in your editor which generates a temp file e.g. .filename.swp amplify tries to run cfn-lint on it as well and you get an error.

This commit ignores all files starting with a ```.```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.