### PR TITLE
Revert "ci: use team account's NPM_TOKEN"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
             - amplify-cli-npm-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:
           name: Authenticate with npm
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN_TEAM_ACCT" > ~/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run:
           name: "Publish Amplify CLI"
           command: |


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#929

Tokens not allowed to publish 