### PR TITLE
fix(cli): added global windows npm path to plugin import

### DIFF
--- a/packages/amplify-cli/src/lib/global-prefix.js
+++ b/packages/amplify-cli/src/lib/global-prefix.js
@@ -9,6 +9,9 @@ function getGlobalNodeModuleDirPath() {
   if (__dirname.includes(yarnPrefix)) {
     return path.join(yarnPrefix, 'node_modules');
   }
+  if (process.platform === 'win32') {
+    return path.join(getNpmPrefix(), 'node_modules');
+  }
   return path.join(getNpmPrefix(), 'lib', 'node_modules');
 }
 


### PR DESCRIPTION
Global Plugins were not found under windows because the default path for node_modules is not inside a lib folder.

*Description of changes:*
I have added an OS check. If on windows, it returns the correct path (without lib subdirectory).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.