### PR TITLE
Fixing #939

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -153,13 +153,6 @@ export class DynamoDBModelTransformer extends Transformer {
         nonModelArray: ObjectTypeDefinitionNode[]
     ) => {
         const typeName = def.name.value
-        // Create the input types.
-        const createInput = makeCreateInputObject(def, nonModelArray, ctx)
-        const updateInput = makeUpdateInputObject(def, nonModelArray, ctx)
-        const deleteInput = makeDeleteInputObject(def)
-        ctx.addInput(createInput)
-        ctx.addInput(updateInput)
-        ctx.addInput(deleteInput)
 
         const mutationFields = [];
         // Get any name overrides provided by the user. If an empty map it provided
@@ -200,6 +193,10 @@ export class DynamoDBModelTransformer extends Transformer {
 
         // Create the mutations.
         if (shouldMakeCreate) {
+            const createInput = makeCreateInputObject(def, nonModelArray, ctx)
+            if (!ctx.getType(createInput.name.value)) {
+                ctx.addInput(createInput)
+            }
             const createResolver = this.resources.makeCreateResolver(def.name.value, createFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName), createResolver)
             mutationFields.push(makeField(
@@ -210,6 +207,10 @@ export class DynamoDBModelTransformer extends Transformer {
         }
 
         if (shouldMakeUpdate) {
+            const updateInput = makeUpdateInputObject(def, nonModelArray, ctx)
+            if (!ctx.getType(updateInput.name.value)) {
+                ctx.addInput(updateInput)
+            }
             const updateResolver = this.resources.makeUpdateResolver(def.name.value, updateFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName), updateResolver)
             mutationFields.push(makeField(
@@ -220,6 +221,10 @@ export class DynamoDBModelTransformer extends Transformer {
         }
 
         if (shouldMakeDelete) {
+            const deleteInput = makeDeleteInputObject(def)
+            if (!ctx.getType(deleteInput.name.value)) {
+                ctx.addInput(deleteInput)
+            }
             const deleteResolver = this.resources.makeDeleteResolver(def.name.value, deleteFieldNameOverride)
             ctx.setResource(ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName), deleteResolver)
             mutationFields.push(makeField(

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -40,7 +40,6 @@ test('Test DynamoDBModelTransformer with query overrides', () => {
     })
     const out = transformer.transform(validSchema)
     expect(out).toBeDefined()
-    console.log(JSON.stringify(out, null, 4))
     const definition = out.schema
     expect(definition).toBeDefined()
     const parsed = parse(definition);
@@ -49,7 +48,6 @@ test('Test DynamoDBModelTransformer with query overrides', () => {
     // This id should always be optional.
     // aka a named type node aka name.value would not be set if it were a non null node
     const idField = createPostInput.fields.find(f => f.name.value === 'id')
-    console.log(idField)
     expect((idField.type as NamedTypeNode).name.value).toEqual('ID');
     const queryType = getObjectType(parsed, 'Query')
     expect(queryType).toBeDefined()
@@ -311,7 +309,6 @@ test('Test DynamoDBModelTransformer with advanced subscriptions', () => {
     expect(subField.directives.length).toEqual(1)
     expect(subField.directives[0].name.value).toEqual('aws_subscribe')
     const mutationsList = subField.directives[0].arguments.find(a => a.name.value === 'mutations').value as ListValueNode
-    console.log(mutationsList.values)
     const mutList = mutationsList.values.map((v: any) => v.value)
     expect(mutList.length).toEqual(3)
     expect(mutList).toContain('createPost')
@@ -352,7 +349,6 @@ test('Test DynamoDBModelTransformer with non-model types and enums', () => {
 
     const definition = out.schema
     expect(definition).toBeDefined()
-    console.log(`OUTPUT SCHEMA\n${definition}`)
     const parsed = parse(definition);
 
     const postMetaDataInputType = getInputType(parsed, 'PostMetadataInput')
@@ -374,6 +370,77 @@ test('Test DynamoDBModelTransformer with non-model types and enums', () => {
 
     expect(verifyInputCount(parsed, 'PostMetadataInput', 1)).toBeTruthy();
     expect(verifyInputCount(parsed, 'TagInput', 1)).toBeTruthy();
+});
+
+test('Test DynamoDBModelTransformer with mutation input overrides when mutations are disabled', () => {
+    const validSchema = `type Post @model(mutations: null) {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    input CreatePostInput {
+        different: String
+    }
+    input UpdatePostInput {
+        different2: String
+    }
+    input DeletePostInput {
+        different3: String
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema)
+    expect(out).toBeDefined()
+    const definition = out.schema
+    expect(definition).toBeDefined()
+    const parsed = parse(definition);
+    const createPostInput = getInputType(parsed, 'CreatePostInput')
+    expectFieldsOnInputType(createPostInput, ['different'])
+    const updatePostInput = getInputType(parsed, 'UpdatePostInput')
+    expectFieldsOnInputType(updatePostInput, ['different2'])
+    const deletePostInput = getInputType(parsed, 'DeletePostInput')
+    expectFieldsOnInputType(deletePostInput, ['different3'])
+});
+
+test('Test DynamoDBModelTransformer with mutation input overrides when mutations are enabled', () => {
+    const validSchema = `type Post @model {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    # User defined types always take precedence.
+    input CreatePostInput {
+        different: String
+    }
+    input UpdatePostInput {
+        different2: String
+    }
+    input DeletePostInput {
+        different3: String
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema)
+    expect(out).toBeDefined()
+    const definition = out.schema
+    expect(definition).toBeDefined()
+    const parsed = parse(definition);
+    const createPostInput = getInputType(parsed, 'CreatePostInput')
+    expectFieldsOnInputType(createPostInput, ['different'])
+    const updatePostInput = getInputType(parsed, 'UpdatePostInput')
+    expectFieldsOnInputType(updatePostInput, ['different2'])
+    const deletePostInput = getInputType(parsed, 'DeletePostInput')
+    expectFieldsOnInputType(deletePostInput, ['different3'])
 });
 
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {


### PR DESCRIPTION
*Issue #, if available:*
#939

*Description of changes:*

This no longer generated mutation inputs when mutations are disabled. It also adds a check to make sure the transform does not override any user created inputs that may have the same name as the auto-generated inputs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.