### PR TITLE
fix(amplify-codegen): use path relative to project root for codegen

### DIFF
--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -11,7 +11,7 @@ const { downloadIntrospectionSchemaWithProgress, isAppSyncApiPendingPush } = req
 async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
-  const projectRoot = context.amplify.pathManager.searchProjectRootPath();
+  const { projectPath } = context.amplify.getEnvInfo();
   if (!projects.length) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
   }
@@ -20,7 +20,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
       downloadIntrospectionSchemaWithProgress(
         context,
         cfg.amplifyExtension.graphQLApiId,
-        join(projectRoot, cfg.schema),
+        join(projectPath, cfg.schema),
         cfg.amplifyExtension.region,
       ),
     );

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -1,3 +1,4 @@
+const { join } = require('path');
 const {
   AmplifyCodeGenNoAppSyncAPIAvailableError: NoAppSyncAPIAvailableError,
 } = require('../errors');
@@ -10,6 +11,7 @@ const { downloadIntrospectionSchemaWithProgress, isAppSyncApiPendingPush } = req
 async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
+  const projectRoot = context.amplify.pathManager.searchProjectRootPath();
   if (!projects.length) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
   }
@@ -18,7 +20,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
       downloadIntrospectionSchemaWithProgress(
         context,
         cfg.amplifyExtension.graphQLApiId,
-        cfg.schema,
+        join(projectRoot, cfg.schema),
         cfg.amplifyExtension.region,
       ),
     );

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -10,17 +10,17 @@ const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require(
 async function generateStatements(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
-  const projectRoot = context.amplify.pathManager.searchProjectRootPath();
+  const { projectPath } = context.amplify.getEnvInfo();
   if (!projects.length) {
     context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
     return;
   }
   projects.forEach(async (cfg) => {
-    const includeFiles = path.join(projectRoot, cfg.includes[0]);
+    const includeFiles = path.join(projectPath, cfg.includes[0]);
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath
-      ? path.join(projectRoot, cfg.amplifyExtension.docsFilePath)
+      ? path.join(projectPath, cfg.amplifyExtension.docsFilePath)
       : path.dirname(path.dirname(includeFiles));
-    const schema = path.join(projectRoot, cfg.schema);
+    const schema = path.join(projectPath, cfg.schema);
     if (forceDownloadSchema || jetpack.exists(schema) !== 'file') {
       await downloadIntrospectionSchemaWithProgress(
         context,

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -20,12 +20,12 @@ async function generateStatements(context, forceDownloadSchema, maxDepth) {
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath
       ? path.join(projectPath, cfg.amplifyExtension.docsFilePath)
       : path.dirname(path.dirname(includeFiles));
-    const schema = path.join(projectPath, cfg.schema);
-    if (forceDownloadSchema || jetpack.exists(schema) !== 'file') {
+    const schemaPath = path.join(projectPath, cfg.schema);
+    if (forceDownloadSchema || jetpack.exists(schemaPath) !== 'file') {
       await downloadIntrospectionSchemaWithProgress(
         context,
         cfg.amplifyExtension.graphQLApiId,
-        schema,
+        schemaPath,
         cfg.amplifyExtension.region,
       );
     }
@@ -34,7 +34,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth) {
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
     opsGenSpinner.start();
     jetpack.dir(opsGenDirectory);
-    await statementsGen(schema, opsGenDirectory, {
+    await statementsGen(schemaPath, opsGenDirectory, {
       separateFiles: true,
       language,
       maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -10,20 +10,22 @@ const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require(
 async function generateStatements(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
+  const projectRoot = context.amplify.pathManager.searchProjectRootPath();
   if (!projects.length) {
     context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
     return;
   }
   projects.forEach(async (cfg) => {
-    const includeFiles = cfg.includes[0];
-    const opsGenDirectory =
-      cfg.amplifyExtension.docsFilePath || path.dirname(path.dirname(includeFiles));
-    const schema = path.resolve(cfg.schema);
+    const includeFiles = path.join(projectRoot, cfg.includes[0]);
+    const opsGenDirectory = cfg.amplifyExtension.docsFilePath
+      ? path.join(projectRoot, cfg.amplifyExtension.docsFilePath)
+      : path.dirname(path.dirname(includeFiles));
+    const schema = path.join(projectRoot, cfg.schema);
     if (forceDownloadSchema || jetpack.exists(schema) !== 'file') {
       await downloadIntrospectionSchemaWithProgress(
         context,
         cfg.amplifyExtension.graphQLApiId,
-        cfg.schema,
+        schema,
         cfg.amplifyExtension.region,
       );
     }

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -19,31 +19,34 @@ async function generateTypes(context, forceDownloadSchema) {
       return;
     }
 
+    const projectRoot = context.amplify.pathManager.searchProjectRootPath();
+
     projects.forEach(async (cfg) => {
       const excludes = cfg.excludes.map(pattern => `!${pattern}`);
       const includeFiles = cfg.includes;
-      const queries = glob.sync([...includeFiles, ...excludes]);
-      const schema = path.resolve(cfg.schema);
+      const queries = glob.sync([...includeFiles, ...excludes], { cwd: projectRoot });
+      const schema = path.join(projectRoot, cfg.schema);
       const output = cfg.amplifyExtension.generatedFileName;
       const target = cfg.amplifyExtension.codeGenTarget;
 
       if (!output || output === '') {
         return;
       }
+      const outputPath = path.join(projectRoot, output);
       if (forceDownloadSchema || jetpack.exists(schema) !== 'file') {
         await downloadIntrospectionSchemaWithProgress(
           context,
           cfg.amplifyExtension.graphQLApiId,
-          cfg.schema,
+          schema,
           cfg.amplifyExtension.region,
         );
       }
       const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
       codeGenSpinner.start();
-      generate(queries, schema, output, '', target, '', {
+      generate(queries, schema, path.join(projectRoot, output), '', target, '', {
         addTypename: true,
       });
-      codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${output}`);
+      codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${path.relative(path.resolve('.'), outputPath)}`);
     });
   }
 }

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -28,7 +28,7 @@ async function generateTypes(context, forceDownloadSchema) {
         cwd: projectPath,
         absolute: true,
       });
-      const schema = path.join(projectPath, cfg.schema);
+      const schemaPath = path.join(projectPath, cfg.schema);
       const output = cfg.amplifyExtension.generatedFileName;
       const target = cfg.amplifyExtension.codeGenTarget;
 
@@ -36,17 +36,17 @@ async function generateTypes(context, forceDownloadSchema) {
         return;
       }
       const outputPath = path.join(projectPath, output);
-      if (forceDownloadSchema || jetpack.exists(schema) !== 'file') {
+      if (forceDownloadSchema || jetpack.exists(schemaPath) !== 'file') {
         await downloadIntrospectionSchemaWithProgress(
           context,
           cfg.amplifyExtension.graphQLApiId,
-          schema,
+          schemaPath,
           cfg.amplifyExtension.region,
         );
       }
       const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
       codeGenSpinner.start();
-      generate(queries, schema, path.join(projectPath, output), '', target, '', {
+      generate(queries, schemaPath, path.join(projectPath, output), '', target, '', {
         addTypename: true,
       });
       codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${path.relative(path.resolve('.'), outputPath)}`);

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -29,13 +29,13 @@ async function generateTypes(context, forceDownloadSchema) {
         absolute: true,
       });
       const schemaPath = path.join(projectPath, cfg.schema);
-      const output = cfg.amplifyExtension.generatedFileName;
+      const { generatedFileName } = cfg.amplifyExtension;
       const target = cfg.amplifyExtension.codeGenTarget;
 
-      if (!output || output === '') {
+      if (!generatedFileName || generatedFileName === '') {
         return;
       }
-      const outputPath = path.join(projectPath, output);
+      const outputPath = path.join(projectPath, generatedFileName);
       if (forceDownloadSchema || jetpack.exists(schemaPath) !== 'file') {
         await downloadIntrospectionSchemaWithProgress(
           context,
@@ -46,7 +46,7 @@ async function generateTypes(context, forceDownloadSchema) {
       }
       const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
       codeGenSpinner.start();
-      generate(queries, schemaPath, path.join(projectPath, output), '', target, '', {
+      generate(queries, schemaPath, path.join(projectPath, generatedFileName), '', target, '', {
         addTypename: true,
       });
       codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${path.relative(path.resolve('.'), outputPath)}`);

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -4,6 +4,7 @@ const generateTypes = require('../../src/commands/types');
 const generateStatementsAndTypes = require('../../src/commands/generateStatementsAndType');
 const { AmplifyCodeGenNoAppSyncAPIAvailableError } = require('../../src/errors');
 const constants = require('../../src/constants');
+const path = require('path');
 
 const {
   downloadIntrospectionSchemaWithProgress,
@@ -13,6 +14,11 @@ const {
 const MOCK_CONTEXT = {
   print: {
     info: jest.fn(),
+  },
+  amplify: {
+    pathManager: {
+      searchProjectRootPath: jest.fn(),
+    },
   },
 };
 
@@ -28,6 +34,7 @@ const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
 const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
 
 const MOCK_PROJECT = {
   includes: [MOCK_INCLUDE_PATH],
@@ -48,6 +55,7 @@ describe('command - generateStatementsAndTypes', () => {
     loadConfig.mockReturnValue({
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
+    MOCK_CONTEXT.amplify.pathManager.searchProjectRootPath.mockReturnValue(MOCK_PROJECT_ROOT);
   });
 
   it('should generate statements and types', async () => {
@@ -64,7 +72,7 @@ describe('command - generateStatementsAndTypes', () => {
     expect(downloadIntrospectionSchemaWithProgress).toHaveBeenCalledWith(
       MOCK_CONTEXT,
       MOCK_API_ID,
-      MOCK_SCHEMA,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_REGION,
     );
   });

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -16,9 +16,7 @@ const MOCK_CONTEXT = {
     info: jest.fn(),
   },
   amplify: {
-    pathManager: {
-      searchProjectRootPath: jest.fn(),
-    },
+    getEnvInfo: jest.fn(),
   },
 };
 
@@ -55,7 +53,7 @@ describe('command - generateStatementsAndTypes', () => {
     loadConfig.mockReturnValue({
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
-    MOCK_CONTEXT.amplify.pathManager.searchProjectRootPath.mockReturnValue(MOCK_PROJECT_ROOT);
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
   });
 
   it('should generate statements and types', async () => {

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -11,6 +11,11 @@ const MOCK_CONTEXT = {
   print: {
     info: jest.fn(),
   },
+  amplify: {
+    pathManager: {
+      searchProjectRootPath: jest.fn(),
+    },
+  },
 };
 
 jest.mock('amplify-graphql-docs-generator');
@@ -25,6 +30,7 @@ const MOCK_TARGET_LANGUAGE = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
 const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
 
 const MOCK_PROJECT = {
   includes: [MOCK_INCLUDE_PATH],
@@ -48,6 +54,7 @@ describe('command - statements', () => {
     loadConfig.mockReturnValue({
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
+    MOCK_CONTEXT.amplify.pathManager.searchProjectRootPath.mockReturnValue(MOCK_PROJECT_ROOT);
   });
 
   it('should generate statements', async () => {
@@ -56,10 +63,10 @@ describe('command - statements', () => {
     expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
     expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT);
 
-    expect(jetpack.exists).toHaveBeenCalledWith(path.resolve(MOCK_SCHEMA));
+    expect(jetpack.exists).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA));
     expect(generate).toHaveBeenCalledWith(
-      path.resolve(MOCK_SCHEMA),
-      MOCK_STATEMENTS_PATH,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH),
       { separateFiles: true, language: MOCK_TARGET_LANGUAGE },
     );
   });
@@ -69,8 +76,8 @@ describe('command - statements', () => {
     const forceDownload = false;
     await generateStatements(MOCK_CONTEXT, forceDownload);
     expect(generate).toHaveBeenCalledWith(
-      path.resolve(MOCK_SCHEMA),
-      MOCK_STATEMENTS_PATH,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH),
       { separateFiles: true, language: 'graphql' },
     );
   });
@@ -81,7 +88,7 @@ describe('command - statements', () => {
     expect(downloadIntrospectionSchemaWithProgress).toHaveBeenCalledWith(
       MOCK_CONTEXT,
       MOCK_API_ID,
-      MOCK_SCHEMA,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_REGION,
     );
   });
@@ -93,7 +100,7 @@ describe('command - statements', () => {
     expect(downloadIntrospectionSchemaWithProgress).toHaveBeenCalledWith(
       MOCK_CONTEXT,
       MOCK_API_ID,
-      MOCK_SCHEMA,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_REGION,
     );
   });

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -12,9 +12,7 @@ const MOCK_CONTEXT = {
     info: jest.fn(),
   },
   amplify: {
-    pathManager: {
-      searchProjectRootPath: jest.fn(),
-    },
+    getEnvInfo: jest.fn(),
   },
 };
 
@@ -54,7 +52,7 @@ describe('command - statements', () => {
     loadConfig.mockReturnValue({
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
-    MOCK_CONTEXT.amplify.pathManager.searchProjectRootPath.mockReturnValue(MOCK_PROJECT_ROOT);
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
   });
 
   it('should generate statements', async () => {

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -12,6 +12,11 @@ const MOCK_CONTEXT = {
   print: {
     info: jest.fn(),
   },
+  amplify: {
+    pathManager: {
+      searchProjectRootPath: jest.fn(),
+    },
+  },
 };
 
 jest.mock('glob-all');
@@ -28,6 +33,7 @@ const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
 const MOCK_GENERATED_FILE_NAME = 'API.TS';
 const MOCK_API_ID = 'MOCK_API_ID';
 const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
 
 const MOCK_PROJECT = {
   excludes: [MOCK_EXCLUDE_PATH],
@@ -52,18 +58,20 @@ describe('command - types', () => {
     loadConfig.mockReturnValue({
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
+    MOCK_CONTEXT.amplify.pathManager.searchProjectRootPath.mockReturnValue(MOCK_PROJECT_ROOT);
   });
+
   it('should generate types', async () => {
     const forceDownload = false;
     await generateTypes(MOCK_CONTEXT, forceDownload);
     expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
     expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT);
-    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`]);
-    expect(jetpack.exists).toHaveBeenCalledWith(path.resolve(MOCK_SCHEMA));
+    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`], { cwd: MOCK_PROJECT_ROOT });
+    expect(jetpack.exists).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA));
     expect(generate).toHaveBeenCalledWith(
       MOCK_QUERIES,
-      path.resolve(MOCK_SCHEMA),
-      MOCK_GENERATED_FILE_NAME,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      path.join(MOCK_PROJECT_ROOT, MOCK_GENERATED_FILE_NAME),
       '',
       MOCK_TARGET,
       '',
@@ -84,7 +92,7 @@ describe('command - types', () => {
     expect(downloadIntrospectionSchemaWithProgress).toHaveBeenCalledWith(
       MOCK_CONTEXT,
       MOCK_API_ID,
-      MOCK_SCHEMA,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_REGION,
     );
   });
@@ -96,7 +104,7 @@ describe('command - types', () => {
     expect(downloadIntrospectionSchemaWithProgress).toHaveBeenCalledWith(
       MOCK_CONTEXT,
       MOCK_API_ID,
-      MOCK_SCHEMA,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_REGION,
     );
   });

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -13,9 +13,7 @@ const MOCK_CONTEXT = {
     info: jest.fn(),
   },
   amplify: {
-    pathManager: {
-      searchProjectRootPath: jest.fn(),
-    },
+    getEnvInfo: jest.fn(),
   },
 };
 
@@ -58,7 +56,7 @@ describe('command - types', () => {
     loadConfig.mockReturnValue({
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
-    MOCK_CONTEXT.amplify.pathManager.searchProjectRootPath.mockReturnValue(MOCK_PROJECT_ROOT);
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
   });
 
   it('should generate types', async () => {
@@ -66,7 +64,7 @@ describe('command - types', () => {
     await generateTypes(MOCK_CONTEXT, forceDownload);
     expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
     expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT);
-    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`], { cwd: MOCK_PROJECT_ROOT });
+    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`], { cwd: MOCK_PROJECT_ROOT, absolute: true });
     expect(jetpack.exists).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA));
     expect(generate).toHaveBeenCalledWith(
       MOCK_QUERIES,


### PR DESCRIPTION
Updated codegen to generate statements and types to be written to files relative to project root
instead of current working directory

fixes #886

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.