### PR TITLE
fix(amplify-graphql-docs-generator): render enums like scalar fields

### DIFF
--- a/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -12,6 +12,7 @@ query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -48,6 +49,7 @@ query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -101,6 +103,7 @@ query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -137,6 +140,7 @@ query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -169,6 +173,7 @@ query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -205,6 +210,7 @@ query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -241,6 +247,7 @@ query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -277,6 +284,7 @@ query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -319,6 +327,7 @@ query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -355,6 +364,7 @@ query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -387,6 +397,7 @@ query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -423,6 +434,7 @@ query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -486,6 +498,7 @@ export const hero = \`query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -522,6 +535,7 @@ export const hero = \`query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -577,6 +591,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -613,6 +628,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -645,6 +661,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -681,6 +698,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -718,6 +736,7 @@ export const character = \`query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -754,6 +773,7 @@ export const character = \`query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -797,6 +817,7 @@ export const droid = \`query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -833,6 +854,7 @@ export const droid = \`query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -866,6 +888,7 @@ export const human = \`query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -902,6 +925,7 @@ export const human = \`query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -969,6 +993,7 @@ export const hero = \`query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1005,6 +1030,7 @@ export const hero = \`query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1060,6 +1086,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1096,6 +1123,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1128,6 +1156,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1164,6 +1193,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1201,6 +1231,7 @@ export const character = \`query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1237,6 +1268,7 @@ export const character = \`query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1280,6 +1312,7 @@ export const droid = \`query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1316,6 +1349,7 @@ export const droid = \`query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1349,6 +1383,7 @@ export const human = \`query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1385,6 +1420,7 @@ export const human = \`query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1452,6 +1488,7 @@ export const hero = \`query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1488,6 +1525,7 @@ export const hero = \`query Hero($episode: Episode) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1543,6 +1581,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1579,6 +1618,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1611,6 +1651,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1647,6 +1688,7 @@ export const search = \`query Search($text: String) {
         friends {
           id
           name
+          appearsIn
           ... on Human {
             homePlanet
             height
@@ -1684,6 +1726,7 @@ export const character = \`query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1720,6 +1763,7 @@ export const character = \`query Character($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1763,6 +1807,7 @@ export const droid = \`query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1799,6 +1844,7 @@ export const droid = \`query Droid($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1832,6 +1878,7 @@ export const human = \`query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height
@@ -1868,6 +1915,7 @@ export const human = \`query Human($id: ID!) {
       friends {
         id
         name
+        appearsIn
         ... on Human {
           homePlanet
           height

--- a/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
@@ -8,7 +8,9 @@ import {
   GraphQLList,
   isObjectType,
   isInterfaceType,
-  isUnionType
+  isUnionType,
+  isEnumType,
+  isScalarType,
 } from 'graphql'
 import getFragment from './getFragment'
 import { GQLConcreteType, GQLTemplateField, GQLTemplateFragment, GQLDocsGenOptions } from './types'
@@ -33,7 +35,7 @@ export default function getFields(
       ? schema.getPossibleTypes(fieldType)
       : {};
 
-  if (depth < 1 && !(fieldType instanceof GraphQLScalarType)) {
+  if (depth < 1 && !(isScalarType(fieldType) || isEnumType(fieldType))) {
     return
   }
 


### PR DESCRIPTION
statement generation skipped enum type when traversing fields and when the depth reached 0. It
treated enums similar to that of a field which has subfield. Updating code to treat enums like a
scalar.

fix #623

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.