### PR TITLE
fix: conditonally create AppSync API Key

### DIFF
--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "23.1.1",
     "@types/node": "^10.3.4",
     "cloudform": "^3.5.0",
-    "graphql-dynamodb-transformer": "^2.0.0-multienv.2",
+    "graphql-dynamodb-transformer": "^3.0.7",
     "jest": "^23.1.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -65,7 +65,7 @@ export class ResourceConstants {
 
         // Auth
         AuthShouldCreateUserPool: 'AuthShouldCreateUserPool',
-        APIKeyExpirationEpochIsNotNegOne: 'APIKeyExpirationEpochIsNotNegOne',
+        ShouldCreateAPIKey: 'ShouldCreateAPIKey',
         APIKeyExpirationEpochIsPositive: 'APIKeyExpirationEpochIsPositive',
     }
     public static OUTPUTS = {

--- a/packages/graphql-transformers-e2e-tests/src/deployNestedStacks.ts
+++ b/packages/graphql-transformers-e2e-tests/src/deployNestedStacks.ts
@@ -124,7 +124,7 @@ export async function deploy(
         console.error(`Error cleaning up build directory: ${e}`)
     }
     try {
-        console.log('Adding APIKey to deployment') 
+        console.log('Adding APIKey to deployment')
         addAPIKeys(deploymentResources);
         console.log('Finished adding APIKey to deployment')
 
@@ -166,7 +166,6 @@ export async function deploy(
 }
 
 function addAPIKeys(stack: DeploymentResources) {
-    console.log(stack)
     if (!stack.rootStack.Resources.GraphQLAPIKey) {
         stack.rootStack.Resources.GraphQLAPIKey = {
             "Type": "AWS::AppSync::ApiKey",
@@ -188,19 +187,6 @@ function addAPIKeys(stack: DeploymentResources) {
                     "GraphQLAPIKey",
                     "ApiKey"
                 ]
-            },
-            "Export": {
-                "Name": {
-                    "Fn::Join": [
-                        ":",
-                        [
-                            {
-                                "Ref": "AWS::StackName"
-                            },
-                            "GraphQLApiKey"
-                        ]
-                    ]
-                }
             },
         }
     }


### PR DESCRIPTION
GraphQL transformer created AppSync API key even if the user had selected Cognito user pool as
authorization type for API. These API keys expire after 7 days and when they do expire, users cant
push changes using cloud formation. Updated transformer not to generate an API key when using
Cognito User Pool

fix #954

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.