### PR TITLE
Increase GSI limit from 5 to 20, per the DynamoDB Docs

### DIFF
--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -38,7 +38,7 @@ export class ResourceFactory {
         sortField: { name: string, type: string } = null
     ): Table {
         const gsis = table.Properties.GlobalSecondaryIndexes || [] as GlobalSecondaryIndex[]
-        if (gsis.length >= 5) {
+        if (gsis.length >= 20) {
             throw new InvalidDirectiveError(
                 `Cannot create connection ${connectionName}. Table ${table.Properties.TableName} out of GSI capacity.`
             )


### PR DESCRIPTION
To my [reading](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-secondary-indexes), GSI limit is 20, not 5 — also, this works for adding more indicies when changed thusly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.