### PR TITLE
perf: speed up push

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
@@ -35,7 +35,13 @@ async function pushResources(context, category, resourceName) {
   }
 
 
-  await showResourceTable(category, resourceName);
+  const hasChanges = await showResourceTable(category, resourceName);
+
+  // no changes detected
+  if (!hasChanges && !context.exeInfo.forcePush) {
+    context.print.info('\nNo changes detected');
+    return context;
+  }
 
   let continueToPush = context.exeInfo.inputParams.yes;
   if (!continueToPush) {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -314,6 +314,10 @@ async function showResourceTable(category, resourceName) {
     tableOptions,
     { format: 'markdown' },
   );
+
+  const changedResourceCount =
+    resourcesToBeCreated.length + resourcesToBeUpdated.length + resourcesToBeDeleted.length;
+  return changedResourceCount;
 }
 
 module.exports = {

--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const fsExtra = require('fs-extra');
+const fs = require('fs-extra');
 const path = require('path');
 const moment = require('moment');
 const archiver = require('archiver');
@@ -97,10 +96,11 @@ function removeOutdatedPackage(currentBuildFile) {
       .readdirSync(distDir)
       .map(p => path.join(distDir, p))
       .filter(p => currentBuildFile !== p)
-      .map(p => fsExtra.remove(p));
+      .map(p => fs.remove(p));
     return Promise.all(deletePromises);
   } catch (e) {
     // nothing to do here
+    console.log(`Failed to clean up outdated packages ${e.message}`);
   }
 }
 

--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const fsExtra = require('fs-extra');
 const path = require('path');
 const moment = require('moment');
 const archiver = require('archiver');
@@ -24,16 +25,20 @@ function buildResource(context, resource) {
   let zipFilename = resource.distZipFilename;
   let zipFilePath = zipFilename ? path.normalize(path.join(distDir, zipFilename)) : '';
 
-
-  if (!resource.lastBuildTimeStamp ||
-    new Date(packageJsonMeta.mtime) > new Date(resource.lastBuildTimeStamp)) {
+  if (
+    !resource.lastBuildTimeStamp ||
+    new Date(packageJsonMeta.mtime) > new Date(resource.lastBuildTimeStamp)
+  ) {
     const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
     require('child_process').spawnSync(npm, ['install'], { cwd: resourceDir });
     context.amplify.updateamplifyMetaAfterBuild(resource);
   }
 
-  if (!resource.lastPackageTimeStamp || !resource.distZipFilename ||
-    isPackageOutdated(resourceDir, resource.lastPackageTimeStamp)) {
+  if (
+    !resource.lastPackageTimeStamp ||
+    !resource.distZipFilename ||
+    isPackageOutdated(resourceDir, resource.lastPackageTimeStamp)
+  ) {
     zipFilename = `${resourceName}-${moment().unix()}-latest-build.zip`;
 
     if (!fs.existsSync(distDir)) {
@@ -46,7 +51,8 @@ function buildResource(context, resource) {
     return new Promise((resolve, reject) => {
       output.on('close', () => {
         context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename);
-        resolve({ zipFilePath, zipFilename });
+        removeOutdatedPackage(zipFilePath).then(() =>
+          resolve({ zipFilePath, zipFilename }));
       });
       output.on('error', () => {
         reject(new Error('Failed to zip code.'));
@@ -82,6 +88,20 @@ function getSourceFiles(dir, ignoredDir) {
     }
     return acc.concat(getSourceFiles(path.join(dir, f)));
   }, []);
+}
+
+function removeOutdatedPackage(currentBuildFile) {
+  try {
+    const distDir = path.dirname(currentBuildFile);
+    const deletePromises = fs
+      .readdirSync(distDir)
+      .map(p => path.join(distDir, p))
+      .filter(p => currentBuildFile !== p)
+      .map(p => fsExtra.remove(p));
+    return Promise.all(deletePromises);
+  } catch (e) {
+    // nothing to do here
+  }
 }
 
 module.exports = {

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -179,7 +179,14 @@ function storeCurrentCloudBackend(context) {
 
     const zip = archiver.create('zip', {});
     zip.pipe(output);
-    zip.directory(currentCloudBackendDir, false);
+    zip.glob(
+      '**',
+      {
+        cwd: currentCloudBackendDir,
+        ignore: ['*/*/build/**', '*/*/dist/**', '*/*/node_modules/**'],
+        dot: true,
+      },
+    );
     zip.finalize();
   })
     .then((result) => {


### PR DESCRIPTION
Make push performant by
1. Deleting older function builds which were retained in the dist folder of function category.
 With this change only the latest build package is maintained
2. Excluding build/dist/node_modules from getting included in the current-cloud snapshot. This decreases the size of the snapshot substantially (when functions are included in the project) and decreases the upload time
3. Bail quickly if there are no resources to be update

closes #914

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.