### PR TITLE
Returnhook

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
@@ -15,8 +15,8 @@ function onCategoryOutputsChange(context) {
   const pluginNames = Object.keys(context.amplify.getCategoryPlugins(context));
   pluginNames.forEach((pluginName) => {
     const pluginInstance = context.amplify.getPluginInstance(context, pluginName);
-    if (pluginInstance && typeof pluginInstance.callback === 'function') {
-      pluginInstance.callback(context);
+    if (pluginInstance && typeof pluginInstance.onAmplifyCategoryOutputChange === 'function') {
+      pluginInstance.onAmplifyCategoryOutputChange(context);
     }
   });
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
@@ -11,6 +11,14 @@ function onCategoryOutputsChange(context) {
       require(frontendPlugins[projectConfig.frontend]);
     frontendHandlerModule.createFrontendConfigs(context, getResourceOutputs());
   }
+
+  const pluginNames = Object.keys(context.amplify.getCategoryPlugins(context));
+  pluginNames.forEach((pluginName) => {
+    const pluginInstance = context.amplify.getPluginInstance(context, pluginName);
+    if (pluginInstance && typeof pluginInstance.callback === 'function') {
+      pluginInstance.callback(context);
+    }
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
*Issue #, if available:* #748 

*Description of changes:* Adds functionality for callbacks to be implemented by any plugin that amplify supports (both 3rd party and 1st party plugins can be supported with this). This just builds on top of the callback for frontend development and adds support for the categories.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.