### PR TITLE
feat(graphql-dynamodb-transformer): add DyanmoDB point in time recovery

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -36,7 +36,15 @@ export class ResourceFactory {
                     'PAY_PER_REQUEST',
                     'PROVISIONED'
                 ]
-            })
+            }),
+            [ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery]: new StringParameter({
+                Description: 'Whether to enable Point in Time Recovery on the table',
+                Default: 'false',
+                AllowedValues: [
+                    'true',
+                    'false'
+                ]
+            }),
         }
     }
 
@@ -64,7 +72,10 @@ export class ResourceFactory {
                         Fn.Not(Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.APIKeyExpirationEpoch), 0))
                     ]),
                 [ResourceConstants.CONDITIONS.ShouldUsePayPerRequestBilling]:
-                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBBillingMode), 'PAY_PER_REQUEST')
+                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBBillingMode), 'PAY_PER_REQUEST'),
+
+                [ResourceConstants.CONDITIONS.ShouldUsePointInTimeRecovery]:
+                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery), 'true')
             }
         }
     }
@@ -180,6 +191,13 @@ export class ResourceFactory {
             SSESpecification: {
                 SSEEnabled: true
             },
+            PointInTimeRecoverySpecification: Fn.If(
+                ResourceConstants.CONDITIONS.ShouldUsePointInTimeRecovery,
+                {
+                    PointInTimeRecoveryEnabled: true
+                },
+                Refs.NoValue
+            ) as any,
         })
     }
 

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -35,6 +35,7 @@ export class ResourceConstants {
         DynamoDBBillingMode:   'DynamoDBBillingMode',
         DynamoDBModelTableReadIOPS: 'DynamoDBModelTableReadIOPS',
         DynamoDBModelTableWriteIOPS: 'DynamoDBModelTableWriteIOPS',
+        DynamoDBEnablePointInTimeRecovery: 'DynamoDBEnablePointInTimeRecovery',
 
         // Elasticsearch
         ElasticsearchDomainName: 'ElasticSearchDomainName',
@@ -61,7 +62,8 @@ export class ResourceConstants {
         HasEnvironmentParameter: 'HasEnvironmentParameter',
 
         // DynamoDB
-        ShouldUsePayPerRequestBilling:   'ShouldUsePayPerRequestBilling',
+        ShouldUsePayPerRequestBilling: 'ShouldUsePayPerRequestBilling',
+        ShouldUsePointInTimeRecovery: 'ShouldUsePointInTimeRecovery',
 
         // Auth
         AuthShouldCreateUserPool: 'AuthShouldCreateUserPool',

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -91,7 +91,7 @@ beforeAll(async () => {
     try {
         console.log('Creating Stack ' + STACK_NAME)
         const finishedStack = await deploy(
-            customS3Client, cf, STACK_NAME, out, {}, TMP_ROOT, BUCKET_NAME, ROOT_KEY,
+            customS3Client, cf, STACK_NAME, out, { DynamoDBEnablePointInTimeRecovery: "true" }, TMP_ROOT, BUCKET_NAME, ROOT_KEY,
             BUILD_TIMESTAMP
         )
         expect(finishedStack).toBeDefined()


### PR DESCRIPTION
*Description of changes:*
Adds an option to turn on point in time recovery for DyanmoDB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.