### PR TITLE
Improve error message for ManyToMany within GQL Compile

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -160,7 +160,7 @@ export class ModelConnectionTransformer extends Transformer {
         if (leftConnectionIsList && rightConnectionIsList) {
             // 1. TODO.
             // Use an intermediary table or other strategy like embedded string sets for many to many.
-            throw new InvalidDirectiveError(`Many to Many connections are not yet supported.`)
+            throw new InvalidDirectiveError(`Invalid Connection (${connectionName}): Many to Many connections are not yet supported.`)
         } else if (leftConnectionIsList && rightConnectionIsList === false) {
             // 2. [] to {} when the association exists. Note: false and undefined are not equal.
             // Store a foreign key on the related table and wire up a Query resolver.


### PR DESCRIPTION
Provide connection name when throwing an error for a ManyToMany connection type being unsupported

*Issue #, if available:* N/A

*Description of changes:* Change to an error message text to provide more useful feedback to developers


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.