### PR TITLE
fix(amplify-graphql-docs-generator):prevent non-scalar fields to be t…

### DIFF
--- a/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getFields.ts
@@ -15,7 +15,7 @@ import {
 import getFragment from './getFragment'
 import { GQLConcreteType, GQLTemplateField, GQLTemplateFragment, GQLDocsGenOptions } from './types'
 import getType from './utils/getType'
-import isS3Object from './utils/isS3Object';
+import isS3Object from './utils/isS3Object'
 
 export default function getFields(
   field: GraphQLField<any, any>,
@@ -24,16 +24,14 @@ export default function getFields(
   options: GQLDocsGenOptions
 ): GQLTemplateField {
   const fieldType: GQLConcreteType = getType(field.type)
-  const renderS3FieldFragment = options.useExternalFragmentForS3Object && isS3Object(fieldType);
+  const renderS3FieldFragment = options.useExternalFragmentForS3Object && isS3Object(fieldType)
   const subFields =
     !renderS3FieldFragment && (isObjectType(fieldType) || isInterfaceType(fieldType))
       ? fieldType.getFields()
       : []
 
   const subFragments: any =
-    isInterfaceType(fieldType) || isUnionType(fieldType)
-      ? schema.getPossibleTypes(fieldType)
-      : {};
+    isInterfaceType(fieldType) || isUnionType(fieldType) ? schema.getPossibleTypes(fieldType) : {}
 
   if (depth < 1 && !(isScalarType(fieldType) || isEnumType(fieldType))) {
     return
@@ -41,18 +39,32 @@ export default function getFields(
 
   const fields: Array<GQLTemplateField> = Object.keys(subFields)
     .map((fieldName) => {
-      const subField = subFields[fieldName];
-      return getFields(subField, schema, depth - 1, options);
+      const subField = subFields[fieldName]
+      return getFields(subField, schema, depth - 1, options)
     })
     .filter((field) => field)
   const fragments: Array<GQLTemplateFragment> = Object.keys(subFragments)
-    .map((fragment) => getFragment(subFragments[fragment], schema, depth, fields, null, false, options))
+    .map((fragment) =>
+      getFragment(subFragments[fragment], schema, depth, fields, null, false, options)
+    )
     .filter((field) => field)
 
   // Special treatment for S3 input
   // Swift SDK needs S3 Object to have fragment
   if (renderS3FieldFragment) {
-    fragments.push(getFragment(fieldType as GraphQLObjectType, schema, depth, [], 'S3Object', true, options));
+    fragments.push(
+      getFragment(fieldType as GraphQLObjectType, schema, depth, [], 'S3Object', true, options)
+    )
+  }
+
+  // if the current field is an object and none of the subfields are included, don't include the field itself
+  if (
+    !(isScalarType(fieldType) || isEnumType(fieldType)) &&
+    fields.length === 0 &&
+    fragments.length === 0 &&
+    !renderS3FieldFragment
+  ) {
+    return
   }
 
   return {


### PR DESCRIPTION
…erminal field

Codegen generated statenents that would render non-scalar type without expanding them to their scalar type if depth reached to 0. Updating the code to prevent rendering non-scalar
type if none of its fields are rendered

fixes #1064

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.