### PR TITLE
fix:skip inclusion node_modules form current_cloud_backend.zip

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const path = require('path');
-const archiver = require('archiver');
+const archiver = require('../src/utils/archiver');
 const fs = require('fs-extra');
 const ora = require('ora');
 const Cloudformation = require('../src/aws-utils/aws-cfn');
@@ -114,21 +114,7 @@ function storeCurrentCloudBackend(context) {
   }
 
   const zipFilePath = path.normalize(path.join(tempDir, zipFilename));
-  const output = fs.createWriteStream(zipFilePath);
-
-  return new Promise((resolve, reject) => {
-    output.on('close', () => {
-      resolve({ zipFilePath, zipFilename });
-    });
-    output.on('error', () => {
-      reject(new Error('Failed to zip code.'));
-    });
-
-    const zip = archiver.create('zip', {});
-    zip.pipe(output);
-    zip.directory(currentCloudBackendDir, false);
-    zip.finalize();
-  })
+  return archiver.run(currentCloudBackendDir, zipFilePath)
     .then((result) => {
       const s3Key = `${result.zipFilename}`;
       return new S3(context)

--- a/packages/amplify-provider-awscloudformation/src/utils/archiver.js
+++ b/packages/amplify-provider-awscloudformation/src/utils/archiver.js
@@ -1,0 +1,34 @@
+const archiver = require('archiver');
+const path = require('path');
+const fs = require('fs-extra');
+
+const DEFAULT_IGNORE_PATTERN = ['*/*/build/**', '*/*/dist/**', 'function/*/src/node_modules/**'];
+
+function run(folder, zipFilePath, ignorePattern = DEFAULT_IGNORE_PATTERN) {
+  const zipFileFolder = path.dirname(zipFilePath);
+  const zipFilename = path.basename(zipFilePath);
+
+  fs.ensureDir(zipFileFolder);
+  const output = fs.createWriteStream(zipFilePath);
+  return new Promise((resolve, reject) => {
+    output.on('close', () => {
+      resolve({ zipFilePath, zipFilename });
+    });
+    output.on('error', () => {
+      reject(new Error('Failed to zip code.'));
+    });
+
+    const zip = archiver.create('zip', {});
+    zip.pipe(output);
+    zip.glob('**', {
+      cwd: folder,
+      ignore: ignorePattern,
+      dot: true,
+    });
+    zip.finalize();
+  });
+}
+
+module.exports = {
+  run,
+};


### PR DESCRIPTION
Current cloud backend included Lambda functions node_modules. This can cause errors when checking
out an env where node_modules has reference to local node_package. By skipping node_modules folder
the size of current_cloud_backend.zip file size reduces and also fixes the error when referencing
local packages

fixes #1077

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.