### PR TITLE
feat: allow custom frontend configs

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-resource-outputs.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-resource-outputs.js
@@ -1,9 +1,11 @@
 const fs = require('fs');
 const pathManager = require('./path-manager');
 
-function getResourceOutputs() {
-  const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+function getResourceOutputs(amplifyMeta) {
+  if (!amplifyMeta) {
+    const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
+    amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  }
 
   // Build the provider object
   const outputsByProvider = {};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
@@ -2,21 +2,34 @@ const fs = require('fs');
 const pathManager = require('./path-manager');
 const { getResourceOutputs } = require('./get-resource-outputs');
 
-async function onCategoryOutputsChange(context) {
+
+async function onCategoryOutputsChange(context, cloudAmplifyMeta) {
+  if (!cloudAmplifyMeta) {
+    const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
+    if (fs.existsSync(currentAmplifyMetafilePath)) {
+      cloudAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+    } else {
+      cloudAmplifyMeta = {};
+    }
+  }
+
   const projectConfigFilePath = pathManager.getProjectConfigFilePath();
   const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
   if (projectConfig.frontend) {
     const frontendPlugins = context.amplify.getFrontendPlugins(context);
     const frontendHandlerModule =
       require(frontendPlugins[projectConfig.frontend]);
-    await frontendHandlerModule.createFrontendConfigs(context, getResourceOutputs());
+    await frontendHandlerModule.createFrontendConfigs(
+      context,
+      getResourceOutputs(), getResourceOutputs(cloudAmplifyMeta),
+    );
   }
 
   const pluginNames = Object.keys(context.amplify.getCategoryPlugins(context));
   pluginNames.forEach((pluginName) => {
     const pluginInstance = context.amplify.getPluginInstance(context, pluginName);
     if (pluginInstance && typeof pluginInstance.onAmplifyCategoryOutputChange === 'function') {
-      pluginInstance.onAmplifyCategoryOutputChange(context);
+      pluginInstance.onAmplifyCategoryOutputChange(context, cloudAmplifyMeta);
     }
   });
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
@@ -50,8 +50,12 @@ async function pushResources(context, category, resourceName) {
 
   if (continueToPush) {
     try {
+      // Get current-cloud-backend's amplify-meta
+      const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
+      const currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+
       await providersPush(context);
-      await onCategoryOutputsChange(context);
+      await onCategoryOutputsChange(context, currentAmplifyMeta);
     } catch (err) {
       // Handle the errors and print them nicely for the user.
       context.print.error(`\n${err.message}`);

--- a/packages/amplify-cli/src/lib/config-steps/c1-configFrontend.js
+++ b/packages/amplify-cli/src/lib/config-steps/c1-configFrontend.js
@@ -1,6 +1,5 @@
 const inquirer = require('inquirer');
 const { getFrontendPlugins } = require('../../extensions/amplify-helpers/get-frontend-plugins');
-const { getResourceOutputs } = require('../../extensions/amplify-helpers/get-resource-outputs');
 const { normalizeFrontendHandlerName } = require('../input-params-manager');
 
 async function run(context) {
@@ -12,8 +11,7 @@ async function run(context) {
   if (selectedFrontend !== frontend) {
     delete context.exeInfo.projectConfig[frontend];
     const frontendModule = require(frontendPlugins[selectedFrontend]);
-    await frontendModule.init(context)
-      .then(() => frontendModule.createFrontendConfigs(context, getResourceOutputs()));
+    await frontendModule.init(context);
     context.exeInfo.projectConfig.frontend = selectedFrontend;
   } else {
     const frontendModule = require(frontendPlugins[selectedFrontend]);

--- a/packages/amplify-cli/src/lib/config-steps/c9-onSuccess.js
+++ b/packages/amplify-cli/src/lib/config-steps/c9-onSuccess.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const { print } = require('gluegun/print');
 
-function run(context) {
+async function run(context) {
   const { projectPath } = context.exeInfo;
   const { amplify } = context;
 
@@ -12,6 +12,8 @@ function run(context) {
   jsonString = JSON.stringify(context.exeInfo.localEnvInfo, null, 4);
   const envFilePath = context.amplify.pathManager.getLocalEnvFilePath();
   fs.writeFileSync(envFilePath, jsonString, 'utf8');
+
+  await context.amplify.onCategoryOutputsChange(context);
 
   printWelcomeMessage();
 }

--- a/packages/amplify-frontend-android/index.js
+++ b/packages/amplify-frontend-android/index.js
@@ -16,11 +16,13 @@ function onInitSuccessful(context) {
   return initializer.onInitSuccessful(context);
 }
 
-function createFrontendConfigs(context, amplifyResources) {
-  const { outputsForFrontend } = amplifyResources;
+function createFrontendConfigs(context, amplifyResources, amplifyCloudResources) {
+  const newOutputsForFrontend = amplifyResources.outputsForFrontend;
+  const cloudOutputsForFrontend = amplifyCloudResources.outputsForFrontend;
   // createAmplifyConfig(context, outputsByCategory);
-  return createAWSConfig(context, outputsForFrontend);
+  return createAWSConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
 }
+
 
 function configure(context) {
   return configManager.configure(context);

--- a/packages/amplify-frontend-ios/index.js
+++ b/packages/amplify-frontend-ios/index.js
@@ -16,12 +16,12 @@ function onInitSuccessful(context) {
   return initializer.onInitSuccessful(context);
 }
 
-function createFrontendConfigs(context, amplifyResources) {
-  const { outputsForFrontend } = amplifyResources;
+function createFrontendConfigs(context, amplifyResources, amplifyCloudResources) {
+  const newOutputsForFrontend = amplifyResources.outputsForFrontend;
+  const cloudOutputsForFrontend = amplifyCloudResources.outputsForFrontend;
   // createAmplifyConfig(context, outputsByCategory);
-  return createAWSConfig(context, outputsForFrontend);
+  return createAWSConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
 }
-
 function configure(context) {
   return configManager.configure(context);
 }

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -16,7 +16,20 @@ function createAmplifyConfig(context, amplifyResources) {
   }
 }
 
-function createAWSConfig(context, amplifyResources) {
+function createAWSConfig(context, amplifyResources, cloudAmplifyResources) {
+  const newAWSConfig = getAWSConfigObject(amplifyResources);
+  const cloudAWSConfig = getAWSConfigObject(cloudAmplifyResources);
+  const currentAWSConfig = getCurrentAWSConfig(context);
+
+  const customConfigs = getCustomConfigs(cloudAWSConfig, currentAWSConfig);
+
+  Object.assign(newAWSConfig, customConfigs);
+
+  generateAWSConfigFile(context, newAWSConfig);
+  return context;
+}
+
+function getAWSConfigObject(amplifyResources) {
   const { serviceResourceMapping } = amplifyResources;
   const configOutput = {
     UserAgent: 'aws-amplify/cli',
@@ -45,8 +58,34 @@ function createAWSConfig(context, amplifyResources) {
       default: break;
     }
   });
-  generateAWSConfigFile(context, configOutput);
-  return context;
+
+  return configOutput;
+}
+
+function getCurrentAWSConfig(context) {
+  const { amplify } = context;
+  const projectPath = context.exeInfo ?
+    context.exeInfo.localEnvInfo.projectPath : amplify.getEnvInfo().projectPath;
+  const srcDirPath = path.join(projectPath);
+  const targetFilePath = path.join(srcDirPath, constants.awsConfigFilename);
+
+  let awsConfig = {};
+
+  if (fs.existsSync(targetFilePath)) {
+    awsConfig = JSON.parse(fs.readFileSync(targetFilePath));
+  }
+  return awsConfig;
+}
+
+
+function getCustomConfigs(cloudAWSConfig, currentAWSConfig) {
+  const customConfigs = {};
+  Object.keys(currentAWSConfig).forEach((key) => {
+    if (!cloudAWSConfig[key]) {
+      customConfigs[key] = currentAWSConfig[key];
+    }
+  });
+  return customConfigs;
 }
 
 function generateAWSConfigFile(context, configOutput) {

--- a/packages/amplify-frontend-javascript/index.js
+++ b/packages/amplify-frontend-javascript/index.js
@@ -18,10 +18,11 @@ function onInitSuccessful(context) {
   return initializer.onInitSuccessful(context);
 }
 
-function createFrontendConfigs(context, amplifyResources) {
-  const { outputsForFrontend } = amplifyResources;
+async function createFrontendConfigs(context, amplifyResources, amplifyCloudResources) {
+  const newOutputsForFrontend = amplifyResources.outputsForFrontend;
+  const cloudOutputsForFrontend = amplifyCloudResources.outputsForFrontend;
   // createAmplifyConfig(context, outputsByCategory);
-  return createAWSExports(context, outputsForFrontend);
+  return await createAWSExports(context, newOutputsForFrontend, cloudOutputsForFrontend);
 }
 
 function configure(context) {

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -32,11 +32,33 @@ function createAmplifyConfig(context, amplifyResources) {
   }
 }
 
-async function createAWSExports(context, amplifyResources) {
-  const { serviceResourceMapping } = amplifyResources;
+async function createAWSExports(context, amplifyResources, cloudAmplifyResources) {
+  const newAWSExports = getAWSExportsObject(amplifyResources);
+  const cloudAWSExports = getAWSExportsObject(cloudAmplifyResources);
+  const currentAWSExports = await getCurrentAWSExports(context);
+
+  const customConfigs = getCustomConfigs(cloudAWSExports, currentAWSExports);
+
+  Object.assign(newAWSExports, customConfigs);
+  generateAWSExportsFile(context, newAWSExports);
+  return context;
+}
+
+function getCustomConfigs(cloudAWSExports, currentAWSExports) {
+  const customConfigs = {};
+  Object.keys(currentAWSExports).forEach((key) => {
+    if (!cloudAWSExports[key]) {
+      customConfigs[key] = currentAWSExports[key];
+    }
+  });
+  return customConfigs;
+}
+
+function getAWSExportsObject(resources) {
+  const { serviceResourceMapping } = resources;
   const configOutput = {};
 
-  const projectRegion = amplifyResources.metadata.Region;
+  const projectRegion = resources.metadata.Region;
   configOutput.aws_project_region = projectRegion;
 
   Object.keys(serviceResourceMapping).forEach((service) => {
@@ -60,8 +82,29 @@ async function createAWSExports(context, amplifyResources) {
       default: break;
     }
   });
-  await generateAWSExportsFile(context, configOutput);
-  return context;
+
+  return configOutput;
+}
+
+async function getCurrentAWSExports(context) {
+  const { amplify } = context;
+  const projectPath = context.exeInfo ?
+    context.exeInfo.localEnvInfo.projectPath : amplify.getEnvInfo().projectPath;
+  const projectConfig = context.exeInfo ?
+    context.exeInfo.projectConfig[constants.Label] : amplify.getProjectConfig()[constants.Label];
+  const frontendConfig = projectConfig.config;
+  const srcDirPath = path.join(projectPath, frontendConfig.SourceDir);
+
+  const targetFilePath = path.join(srcDirPath, constants.exportsFilename);
+  let awsExports = {};
+
+  if (fs.existsSync(targetFilePath)) {
+    await context.patching.replace(targetFilePath, 'export default awsmobile;\n', 'module.exports = {awsmobile};\n');
+    awsExports = require(targetFilePath).awsmobile;
+    await context.patching.replace(targetFilePath, 'module.exports = {awsmobile};\n', 'export default awsmobile;\n');
+  }
+
+  return awsExports;
 }
 
 async function generateAWSExportsFile(context, configOutput) {


### PR DESCRIPTION
re #419


*Issue #, if available:*
#419
*Description of changes:*

Previously, the CLI didn't respect user provided custom keys as a part of the awsconfiguration.json and aws_exports.js files (it used to overwrite the custom contents after an 'amplify push'). This PR, allows users t0 provide custom config keys for aws_exports.js (for javascript projects) and awsconfiguration.json(for native projects) which the CLI won't blow up on a push.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.