### PR TITLE
feat(graphql-dynamodb-transformer): always output stream arn

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -143,6 +143,10 @@ export class DynamoDBModelTransformer extends Transformer {
             this.resources.makeDynamoDBDataSource(tableLogicalID, iamRoleLogicalID, typeName)
         )
         ctx.setOutput(
+            ModelResourceIDs.ModelTableStreamArn(typeName),
+            this.resources.makeTableStreamArnOutput(tableLogicalID)
+        )
+        ctx.setOutput(
             `GetAtt${dataSourceRoleLogicalID}Name`,
             this.resources.makeDataSourceOutput(dataSourceRoleLogicalID)
         )

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -101,8 +101,6 @@ export class DynamoDBModelTransformer extends Transformer {
                 ".*" + def.name.value + "Model",
                 ".*" + def.name.value + "DataSource",
                 ".*" + def.name.value + "IAMRole",
-                // Backward compatibility map addition to prevent breaking current deploys.
-                "^GetAtt" + def.name.value + "Table",
                 // All resolvers except the search resolver.
                 "^[^S].*" + def.name.value + "Resolver",
                 "^" + def.name.value + ".+Resolver",

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -101,6 +101,8 @@ export class DynamoDBModelTransformer extends Transformer {
                 ".*" + def.name.value + "Model",
                 ".*" + def.name.value + "DataSource",
                 ".*" + def.name.value + "IAMRole",
+                // Backward compatibility map addition to prevent breaking current deploys.
+                "^GetAtt" + def.name.value + "Table",
                 // All resolvers except the search resolver.
                 "^[^S].*" + def.name.value + "Resolver",
                 "^" + def.name.value + ".+Resolver",
@@ -143,7 +145,8 @@ export class DynamoDBModelTransformer extends Transformer {
             this.resources.makeDynamoDBDataSource(tableLogicalID, iamRoleLogicalID, typeName)
         )
         ctx.setOutput(
-            ModelResourceIDs.ModelTableStreamArn(typeName),
+            // "GetAtt" is a backward compatibility addition to prevent breaking current deploys.
+            `GetAtt${ModelResourceIDs.ModelTableStreamArn(typeName)}`,
             this.resources.makeTableStreamArnOutput(tableLogicalID)
         )
         ctx.setOutput(

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -115,6 +115,16 @@ export class ResourceFactory {
         }
     }
 
+    public makeTableStreamArnOutput(resourceId: string): Output {
+        return {
+            Description: "Your DynamoDB table StreamArn.",
+            Value: Fn.GetAtt(resourceId, "StreamArn"),
+            Export: {
+                Name: Fn.Join(':', [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), "GetAtt", resourceId, "StreamArn"])
+            }
+        }
+    }
+
     public makeDataSourceOutput(resourceId: string): Output {
         return {
             Description: "Your model DataSource name.",

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -165,7 +165,12 @@ export class ResourceFactory {
         return new Lambda.EventSourceMapping({
             BatchSize: 1,
             Enabled: true,
-            EventSourceArn: Fn.GetAtt(ModelResourceIDs.ModelTableResourceID(typeName), 'StreamArn'),
+            EventSourceArn: Fn.ImportValue(
+                Fn.Join(
+                    ':',
+                    [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), "GetAtt", ModelResourceIDs.ModelTableResourceID(typeName), "StreamArn"]
+                )
+            ),
             FunctionName: Fn.GetAtt(ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaFunctionLogicalID, 'Arn'),
             StartingPosition: 'LATEST'
         }).dependsOn([

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -6,6 +6,9 @@ export class ModelResourceIDs {
     static ModelTableResourceID(typeName: string): string {
         return `${typeName}Table`
     }
+    static ModelTableStreamArn(typeName: string): string {
+        return `${typeName}TableStreamArn`
+    }
     static ModelTableDataSourceID(typeName: string): string {
         return `${typeName}DataSource`
     }


### PR DESCRIPTION
solve #987 and fix #980

*Description of changes:*
Modify the **graphql-dynamodb-transformer** to **always** output and export the DynamoDB table `StreamArn`. It will prevent that removing the **@searchable** directive from a model makes the `amplify push` fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.