### PR TITLE
build: run lint during pre-push

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "npm run test-changed"
+      "pre-push": "npm run lint && npm run test-changed"
     }
   },
   "author": "Amazon Web Services",


### PR DESCRIPTION
*Description of changes:*
- Run lint during pre-push to eliminate CI lint failure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.