### PR TITLE
feat(amplify-graphql-docs-generator): support multi auth

### DIFF
--- a/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -2453,6 +2453,9 @@ query SearchUser($text: String) @public {
 query UpdateSearchIndex @aws_iam {
   updateSearchIndex
 }
+query AwsAuthQuery {
+  awsAuthQuery
+}
 mutation CreateReview($episode: Episode, $review: ReviewInput!) {
   createReview(episode: $episode, review: $review) {
     episode
@@ -2964,6 +2967,10 @@ export const searchUser = \`query SearchUser($text: String) @public {
 \`;
 export const updateSearchIndex = \`query UpdateSearchIndex @aws_iam {
   updateSearchIndex
+}
+\`;
+export const awsAuthQuery = \`query AwsAuthQuery {
+  awsAuthQuery
 }
 \`;
 export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
@@ -3481,6 +3488,10 @@ export const updateSearchIndex = \`query UpdateSearchIndex @aws_iam {
   updateSearchIndex
 }
 \`;
+export const awsAuthQuery = \`query AwsAuthQuery {
+  awsAuthQuery
+}
+\`;
 export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
   createReview(episode: $episode, review: $review) {
     episode
@@ -3994,6 +4005,10 @@ export const searchUser = \`query SearchUser($text: String) @public {
 \`;
 export const updateSearchIndex = \`query UpdateSearchIndex @aws_iam {
   updateSearchIndex
+}
+\`;
+export const awsAuthQuery = \`query AwsAuthQuery {
+  awsAuthQuery
 }
 \`;
 export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {

--- a/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`end 2 end tests should generate statements 1`] = `
+exports[`end 2 end tests JSON introspection schema should generate statements 1`] = `
 "# this is an auto generated file. This will be overwritten
 query Hero($episode: Episode) {
   hero(episode: $episode) {
@@ -484,7 +484,7 @@ subscription ReviewAdded($episode: Episode) {
 "
 `;
 
-exports[`end 2 end tests should generate statements in JS 1`] = `
+exports[`end 2 end tests JSON introspection schema should generate statements in JS 1`] = `
 "// eslint-disable
 // this is an auto generated file. This will be overwritten
 
@@ -979,7 +979,7 @@ export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
 "
 `;
 
-exports[`end 2 end tests should generate statements in Typescript 1`] = `
+exports[`end 2 end tests JSON introspection schema should generate statements in Typescript 1`] = `
 "// tslint:disable
 // this is an auto generated file. This will be overwritten
 
@@ -1474,7 +1474,7 @@ export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
 "
 `;
 
-exports[`end 2 end tests should generate statements in flow 1`] = `
+exports[`end 2 end tests JSON introspection schema should generate statements in flow 1`] = `
 "// @flow
 // this is an auto generated file. This will be overwritten
 
@@ -1948,6 +1948,2052 @@ export const starship = \`query Starship($id: ID!) {
     length
     coordinates
   }
+}
+\`;
+export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+"
+`;
+
+exports[`end 2 end tests SDL schema should generate statements 1`] = `
+"# this is an auto generated file. This will be overwritten
+query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+query MyName @cognito_auth @oidc {
+  myName {
+    name
+    location
+  }
+}
+query SearchUser($text: String) @public {
+  searchUser(text: $text) {
+    items {
+      name
+      location
+    }
+  }
+}
+query UpdateSearchIndex @aws_iam {
+  updateSearchIndex
+}
+mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+"
+`;
+
+exports[`end 2 end tests SDL schema should generate statements in JS 1`] = `
+"// eslint-disable
+// this is an auto generated file. This will be overwritten
+
+export const hero = \`query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const reviews = \`query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const search = \`query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const character = \`query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const droid = \`query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+\`;
+export const human = \`query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const starship = \`query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+\`;
+export const myName = \`query MyName @cognito_auth @oidc {
+  myName {
+    name
+    location
+  }
+}
+\`;
+export const searchUser = \`query SearchUser($text: String) @public {
+  searchUser(text: $text) {
+    items {
+      name
+      location
+    }
+  }
+}
+\`;
+export const updateSearchIndex = \`query UpdateSearchIndex @aws_iam {
+  updateSearchIndex
+}
+\`;
+export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+"
+`;
+
+exports[`end 2 end tests SDL schema should generate statements in Typescript 1`] = `
+"// tslint:disable
+// this is an auto generated file. This will be overwritten
+
+export const hero = \`query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const reviews = \`query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const search = \`query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const character = \`query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const droid = \`query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+\`;
+export const human = \`query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const starship = \`query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+\`;
+export const myName = \`query MyName @cognito_auth @oidc {
+  myName {
+    name
+    location
+  }
+}
+\`;
+export const searchUser = \`query SearchUser($text: String) @public {
+  searchUser(text: $text) {
+    items {
+      name
+      location
+    }
+  }
+}
+\`;
+export const updateSearchIndex = \`query UpdateSearchIndex @aws_iam {
+  updateSearchIndex
+}
+\`;
+export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const reviewAdded = \`subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+"
+`;
+
+exports[`end 2 end tests SDL schema should generate statements in flow 1`] = `
+"// @flow
+// this is an auto generated file. This will be overwritten
+
+export const hero = \`query Hero($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const reviews = \`query Reviews($episode: Episode!) {
+  reviews(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
+}
+\`;
+export const search = \`query Search($text: String) {
+  search(text: $text) {
+    ... on Human {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+    ... on Starship {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const character = \`query Character($id: ID!) {
+  character(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    ... on Human {
+      homePlanet
+      height
+      mass
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+    ... on Droid {
+      primaryFunction
+    }
+  }
+}
+\`;
+export const droid = \`query Droid($id: ID!) {
+  droid(id: $id) {
+    id
+    name
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    primaryFunction
+  }
+}
+\`;
+export const human = \`query Human($id: ID!) {
+  human(id: $id) {
+    id
+    name
+    homePlanet
+    height
+    mass
+    friends {
+      id
+      name
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+    friendsConnection {
+      totalCount
+      edges {
+        cursor
+      }
+      friends {
+        id
+        name
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+    appearsIn
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+\`;
+export const starship = \`query Starship($id: ID!) {
+  starship(id: $id) {
+    id
+    name
+    length
+    coordinates
+  }
+}
+\`;
+export const myName = \`query MyName @cognito_auth @oidc {
+  myName {
+    name
+    location
+  }
+}
+\`;
+export const searchUser = \`query SearchUser($text: String) @public {
+  searchUser(text: $text) {
+    items {
+      name
+      location
+    }
+  }
+}
+\`;
+export const updateSearchIndex = \`query UpdateSearchIndex @aws_iam {
+  updateSearchIndex
 }
 \`;
 export const createReview = \`mutation CreateReview($episode: Episode, $review: ReviewInput!) {

--- a/packages/amplify-graphql-docs-generator/__integration__/e2e.test.ts
+++ b/packages/amplify-graphql-docs-generator/__integration__/e2e.test.ts
@@ -1,41 +1,119 @@
 import { resolve } from 'path'
-import * as fs from 'fs';
+import * as fs from 'fs'
 import generate from '../src'
 
 describe('end 2 end tests', () => {
-  const schemaPath = resolve(__dirname, '../fixtures/schema.json');
   const outputpath = resolve(__dirname, './output.graphql')
 
-  afterEach(() => {
-    // delete the generated file
-    try {
-      fs.unlinkSync(outputpath);
-    } catch (e) {
-      // CircleCI throws exception, no harm done if the file is not deleted
-    }
-  });
+  describe('JSON introspection schema', () => {
+    const schemaPath = resolve(__dirname, '../fixtures/schema.json')
+    afterEach(() => {
+      // delete the generated file
+      try {
+        fs.unlinkSync(outputpath)
+      } catch (e) {
+        // CircleCI throws exception, no harm done if the file is not deleted
+      }
+    })
 
-  it('should generate statements', () => {
-    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'graphql' });
-    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
-    expect(generatedOutput).toMatchSnapshot();
-  });
+    it('should generate statements', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'graphql',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
 
-  it('should generate statements in JS', () => {
-    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'javascript' });
-    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
-    expect(generatedOutput).toMatchSnapshot();
+    it('should generate statements in JS', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'javascript',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
+
+    it('should generate statements in Typescript', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'typescript',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
+
+    it('should generate statements in flow', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'flow',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
   })
 
-  it('should generate statements in Typescript', () => {
-    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'typescript' });
-    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
-    expect(generatedOutput).toMatchSnapshot();
-  })
+  describe('SDL schema', () => {
+    const schemaPath = resolve(__dirname, '../fixtures/schema.graphql')
+    afterEach(() => {
+      // delete the generated file
+      try {
+        fs.unlinkSync(outputpath)
+      } catch (e) {
+        // CircleCI throws exception, no harm done if the file is not deleted
+      }
+    })
 
-  it('should generate statements in flow', () => {
-    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'flow' });
-    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
-    expect(generatedOutput).toMatchSnapshot();
+    it('should generate statements', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'graphql',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
+
+    it('should generate statements in JS', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'javascript',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
+
+    it('should generate statements in Typescript', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'typescript',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
+
+    it('should generate statements in flow', () => {
+      generate(schemaPath, outputpath, {
+        separateFiles: false,
+        maxDepth: 3,
+        language: 'flow',
+        renderMultiAuthDirectives: true,
+      })
+      const generatedOutput = fs.readFileSync(outputpath, 'utf8')
+      expect(generatedOutput).toMatchSnapshot()
+    })
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/generate.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/generate.test.ts
@@ -15,11 +15,11 @@ describe('generate', () => {
   const getQueryType = jest.fn()
   const getMutationType = jest.fn()
   const getSubscriptionType = jest.fn()
-  
+
   const MOCK_GENERATED_QUERY = ['MOCK_GENERATED_QUERY'];
   const MOCK_GENERATED_MUTATION = ['MOCK_GENERATED_MUTATION']
   const MOCK_GENERATED_SUBSCRIPTION = ['MOCK_GENERATED_SUBSCRIPTION']
-  const MOCK_GENERATED_FRAGMENTS = ['MOCK_GENERATED_FRAGMENT']];
+  const MOCK_GENERATED_FRAGMENTS = ['MOCK_GENERATED_FRAGMENT'];
   const mockSchema = {
     getQueryType,
     getMutationType,

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/generateOperation.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/generateOperation.test.ts
@@ -1,10 +1,12 @@
 import generateOperation from '../../src/generator/generateOperation'
 import getArgs from '../../src/generator/getArgs'
 import getBody from '../../src/generator/getBody'
+import getDirectives from '../../src/generator/getDirectives'
 import { GQLDocsGenOptions } from '../../src/generator/types';
 
 jest.mock('../../src/generator/getArgs')
 jest.mock('../../src/generator/getBody')
+jest.mock('../../src/generator/getDirectives')
 
 const maxDepth = 4
 const generateOption: GQLDocsGenOptions = { useExternalFragmentForS3Object: true }
@@ -13,6 +15,7 @@ describe('generateOperation', () => {
     jest.resetAllMocks()
     getArgs.mockReturnValue(['MOCK_ARG'])
     getBody.mockReturnValue('MOCK_BODY')
+    getDirectives.mockReturnValue('MOCK_DIRECTIVES')
   })
 
   it('should generate operation', () => {
@@ -23,9 +26,28 @@ describe('generateOperation', () => {
     expect(generateOperation(op, 'MOCK_DOCUMENT', maxDepth, generateOption)).toEqual({
       args: ['MOCK_ARG'],
       body: 'MOCK_BODY',
+      directives: []
     })
 
     expect(getArgs).toHaveBeenCalledWith(op.args)
     expect(getBody).toBeCalledWith(op, doc, maxDepth, generateOption)
+    expect(getDirectives).not.toHaveBeenCalled()
+  })
+
+  it('should call generateDirective when renderMultiAuthDirectives option is passed', () => {
+    const op = {
+      args: ['arg1'],
+    }
+    const doc = 'MOCK_DOCUMENT'
+    const generateOption = {renderMultiAuthDirectives: true};
+    expect(generateOperation(op, 'MOCK_DOCUMENT', maxDepth, generateOption)).toEqual({
+      args: ['MOCK_ARG'],
+      body: 'MOCK_BODY',
+      directives: 'MOCK_DIRECTIVES'
+    })
+
+    expect(getArgs).toHaveBeenCalledWith(op.args)
+    expect(getBody).toBeCalledWith(op, doc, maxDepth, generateOption)
+    expect(getDirectives).toHaveBeenCalledWith(op)
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getDirectives.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getDirectives.test.ts
@@ -39,7 +39,12 @@ describe('getDirectives', () => {
         ],
       },
     }
-    expect(getDirectives(op)).toEqual([{ name: 'aws_iam', args: [] }, { name: 'oidc', args: [] }, { name: 'public', args: [] }, { name: 'cognito_auth', args: [] }])
+    expect(getDirectives(op)).toEqual([
+      { name: 'aws_iam', args: [] },
+      { name: 'oidc', args: [] },
+      { name: 'public', args: [] },
+      { name: 'cognito_auth', args: [] },
+    ])
   })
   it('should not include any directive that are not multiauth directives', () => {
     const op = {
@@ -84,14 +89,14 @@ describe('getValueFromValeNode', () => {
       fields: [
         {
           name: {
-            value: 'Foo'
+            value: 'Foo',
           },
           value: {
             kind: 'StringValue',
             value: 'bar',
-          }
+          },
         },
-      ]
+      ],
     }
     expect(getValueFromValeNode(val)).toEqual({ Foo: 'bar' })
   })
@@ -99,7 +104,7 @@ describe('getValueFromValeNode', () => {
   it('should return a number when value is FloatValue', () => {
     const val = {
       kind: 'FloatValue',
-      value: '22.2'
+      value: '22.2',
     }
     expect(getValueFromValeNode(val)).toEqual(22.2)
   })
@@ -107,7 +112,7 @@ describe('getValueFromValeNode', () => {
   it('should return a number when value is IntValue', () => {
     const val = {
       kind: 'FloatValue',
-      value: '22'
+      value: '22',
     }
     expect(getValueFromValeNode(val)).toEqual(22)
   })
@@ -115,7 +120,7 @@ describe('getValueFromValeNode', () => {
   it('should return a number when value is boolean', () => {
     const val = {
       kind: 'BooleanValue',
-      value: true
+      value: true,
     }
     expect(getValueFromValeNode(val)).toEqual(true)
   })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getDirectives.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getDirectives.test.ts
@@ -1,0 +1,89 @@
+import getDirectives, { getValueFromValeNode } from '../../src/generator/getDirectives'
+import { isType } from 'graphql'
+
+describe('getDirectives', () => {
+  it('should return an empty list if operation ast node is null', () => {
+    const op = {
+      astNode: null,
+    }
+    expect(getDirectives(op)).toEqual([])
+  })
+  it('should return directive list when operation has directives', () => {
+    const op = {
+      astNode: {
+        directives: [
+          {
+            name: {
+              value: 'directive1',
+            },
+            arguments: [],
+          },
+        ],
+      },
+    }
+    expect(getDirectives(op)).toEqual([{ name: 'directive1', args: [] }])
+  })
+})
+
+describe('getValueFromValeNode', () => {
+  it('should return null when KIND is NULL_VALUE', () => {
+    expect(
+      getValueFromValeNode({
+        kind: 'NullValue',
+      })
+    ).toBeNull()
+  })
+  it('should return a list when value is list type', () => {
+    const val = {
+      kind: 'ListValue',
+      values: [
+        {
+          kind: 'StringValue',
+          value: 'Foo',
+        },
+      ],
+    }
+    expect(getValueFromValeNode(val)).toEqual(['Foo'])
+  })
+  it('should return a Object when value is object type', () => {
+    const val = {
+      kind: 'ObjectValue',
+      fields: [
+        {
+          name: {
+            value: 'Foo'
+          },
+          value: {
+            kind: 'StringValue',
+            value: 'bar',
+          }
+        },
+      ]
+    }
+    expect(getValueFromValeNode(val)).toEqual({ Foo: 'bar' })
+  })
+
+  it('should return a number when value is FloatValue', () => {
+    const val = {
+      kind: 'FloatValue',
+      value: '22.2'
+    }
+    expect(getValueFromValeNode(val)).toEqual(22.2)
+  })
+
+  it('should return a number when value is IntValue', () => {
+    const val = {
+      kind: 'FloatValue',
+      value: '22'
+    }
+    expect(getValueFromValeNode(val)).toEqual(22)
+  })
+
+  it('should return a number when value is boolean', () => {
+    const val = {
+      kind: 'BooleanValue',
+      value: true
+    }
+    expect(getValueFromValeNode(val)).toEqual(true)
+  })
+})

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/getDirectives.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/getDirectives.test.ts
@@ -14,14 +14,47 @@ describe('getDirectives', () => {
         directives: [
           {
             name: {
-              value: 'directive1',
+              value: 'aws_iam',
+            },
+            arguments: [],
+          },
+          {
+            name: {
+              value: 'oidc',
+            },
+            arguments: [],
+          },
+          {
+            name: {
+              value: 'public',
+            },
+            arguments: [],
+          },
+          {
+            name: {
+              value: 'cognito_auth',
             },
             arguments: [],
           },
         ],
       },
     }
-    expect(getDirectives(op)).toEqual([{ name: 'directive1', args: [] }])
+    expect(getDirectives(op)).toEqual([{ name: 'aws_iam', args: [] }, { name: 'oidc', args: [] }, { name: 'public', args: [] }, { name: 'cognito_auth', args: [] }])
+  })
+  it('should not include any directive that are not multiauth directives', () => {
+    const op = {
+      astNode: {
+        directives: [
+          {
+            name: {
+              value: 'foo',
+            },
+            arguments: [],
+          },
+        ],
+      },
+    }
+    expect(getDirectives(op)).toEqual([])
   })
 })
 

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/utils/loadSchemaDocument.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/utils/loadSchemaDocument.test.ts
@@ -15,33 +15,73 @@ jest.mock('fs')
 jest.mock('graphql')
 
 describe('loadSchmeaDocument', () => {
-  const mockIntrospectionSchema = {
-    data: {
-      'foo': 'bar'
-    },
-  }
   describe('introspection schema', () => {
     beforeEach(() => {
       jest.resetAllMocks()
-      readFileSync.mockReturnValue(JSON.stringify(mockIntrospectionSchema))
     })
     it('should build client schmea if the schema file ends with .json', () => {
+      const mockIntrospectionSchema = {
+        data: {
+          foo: 'bar',
+        },
+      }
+      readFileSync.mockReturnValue(JSON.stringify(mockIntrospectionSchema))
       loadSchemaDocument('foo.json')
       expect(buildClientSchema).toHaveBeenCalledWith(mockIntrospectionSchema.data)
     })
     it('should build schema client if the there is __schema', () => {
       const mockIntrospectionSchema = {
         __schema: {
-          'foo': 'bar'
+          foo: 'bar',
         },
       }
       readFileSync.mockReturnValue(JSON.stringify(mockIntrospectionSchema))
       loadSchemaDocument('foo.json')
       expect(buildClientSchema).toHaveBeenCalledWith(mockIntrospectionSchema)
     })
+
+    it("should throw error if the introspection schema doesn't have data", () => {
+      const mockIntrospectionSchema = {}
+      readFileSync.mockReturnValue(JSON.stringify(mockIntrospectionSchema))
+      expect(() => loadSchemaDocument('foo.json')).toThrowError(
+        /GraphQL schema file should contain a valid GraphQL introspection query result/
+      )
+    })
   })
 
   describe('SDL Schema', () => {
-    
+    const mockSDLSchema = `type Foo {
+      bar: String
+    }`
+    const mockAuthDirective = `MOCK_AUTH_DIRECTIVES`
+
+    const mockAst = 'MOCK_AST'
+    const mockConcatenateAst = 'MOCK_CONCATENATE_AST'
+
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+      readFileSync.mockImplementation((path) => {
+        if (path.endsWith('aws_auth_directives.graphql')) {
+          return mockAuthDirective
+        }
+        return mockSDLSchema
+      })
+  
+    })
+
+    it('should load SDL Schema', () => {
+      parse.mockReturnValue(mockAst)
+      concatAST.mockReturnValue(mockConcatenateAst)
+      loadSchemaDocument('foo.graphql')
+
+      expect(readFileSync).toHaveBeenCalledTimes(2)
+      expect(readFileSync.mock.calls[0][0]).toEqual('foo.graphql')
+
+      expect(parse).toHaveBeenCalledTimes(2)
+      
+      expect(concatAST).toHaveBeenCalled()
+      expect(buildASTSchema).toHaveBeenCalledWith(mockConcatenateAst)
+    })
   })
 })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/utils/loadSchemaDocument.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/utils/loadSchemaDocument.test.ts
@@ -58,7 +58,6 @@ describe('loadSchmeaDocument', () => {
     const mockAst = 'MOCK_AST'
     const mockConcatenateAst = 'MOCK_CONCATENATE_AST'
 
-
     beforeEach(() => {
       jest.resetAllMocks()
       readFileSync.mockImplementation((path) => {
@@ -67,7 +66,6 @@ describe('loadSchmeaDocument', () => {
         }
         return mockSDLSchema
       })
-  
     })
 
     it('should load SDL Schema', () => {
@@ -79,7 +77,7 @@ describe('loadSchmeaDocument', () => {
       expect(readFileSync.mock.calls[0][0]).toEqual('foo.graphql')
 
       expect(parse).toHaveBeenCalledTimes(2)
-      
+
       expect(concatAST).toHaveBeenCalled()
       expect(buildASTSchema).toHaveBeenCalledWith(mockConcatenateAst)
     })

--- a/packages/amplify-graphql-docs-generator/__tests__/generator/utils/loadSchemaDocument.test.ts
+++ b/packages/amplify-graphql-docs-generator/__tests__/generator/utils/loadSchemaDocument.test.ts
@@ -1,0 +1,47 @@
+import loadSchemaDocument from '../../../src/generator/utils/loadSchemaDocument'
+import {
+  parse,
+  GraphQLSchema,
+  DocumentNode,
+  buildASTSchema,
+  concatAST,
+  Source,
+  buildClientSchema,
+  IntrospectionQuery,
+} from 'graphql'
+import { readFileSync } from 'fs'
+
+jest.mock('fs')
+jest.mock('graphql')
+
+describe('loadSchmeaDocument', () => {
+  const mockIntrospectionSchema = {
+    data: {
+      'foo': 'bar'
+    },
+  }
+  describe('introspection schema', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+      readFileSync.mockReturnValue(JSON.stringify(mockIntrospectionSchema))
+    })
+    it('should build client schmea if the schema file ends with .json', () => {
+      loadSchemaDocument('foo.json')
+      expect(buildClientSchema).toHaveBeenCalledWith(mockIntrospectionSchema.data)
+    })
+    it('should build schema client if the there is __schema', () => {
+      const mockIntrospectionSchema = {
+        __schema: {
+          'foo': 'bar'
+        },
+      }
+      readFileSync.mockReturnValue(JSON.stringify(mockIntrospectionSchema))
+      loadSchemaDocument('foo.json')
+      expect(buildClientSchema).toHaveBeenCalledWith(mockIntrospectionSchema)
+    })
+  })
+
+  describe('SDL Schema', () => {
+    
+  })
+})

--- a/packages/amplify-graphql-docs-generator/appsync_custom_directives.graphql
+++ b/packages/amplify-graphql-docs-generator/appsync_custom_directives.graphql
@@ -1,4 +1,9 @@
+# MultiAuth directives
 directive @cognito_auth(cognito_groups: [String]) on OBJECT| FIELD_DEFINITION
 directive @public on OBJECT | FIELD_DEFINITION
 directive @oidc on OBJECT | FIELD_DEFINITION
 directive @aws_iam on OBJECT | FIELD_DEFINITION
+
+# Other custom AWS directives
+directive @aws_subscribe(mutations: [String]) on FIELD_DEFINITION
+directive @aws_auth(cognito_groups: [String]) on FIELD_DEFINITION

--- a/packages/amplify-graphql-docs-generator/aws_auth_directives.graphql
+++ b/packages/amplify-graphql-docs-generator/aws_auth_directives.graphql
@@ -1,0 +1,4 @@
+directive @cognito_auth(cognito_groups: [String]) on OBJECT| FIELD_DEFINITION
+directive @public on OBJECT | FIELD_DEFINITION
+directive @oidc on OBJECT | FIELD_DEFINITION
+directive @aws_iam on OBJECT | FIELD_DEFINITION

--- a/packages/amplify-graphql-docs-generator/fixtures/multiauth-result.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/multiauth-result.graphql
@@ -1,0 +1,19 @@
+# this is an auto generated file. This will be overwritten
+query AllBlogs @aws_iam @cognito_auth {
+  allBlogs {
+    CreatedAt
+    Description
+    Id
+    User
+  }
+}
+query AllPosts @cognito_auth {
+  allPosts {
+    Id
+  }
+}
+query GetPost {
+  getPost {
+    Id
+  }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/multiauth.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/multiauth.graphql
@@ -1,0 +1,20 @@
+schema {
+  query: Query
+}
+ 
+type Blog {
+  CreatedAt: String @oidc
+  Description: String @public
+  Id: ID
+  User: String @cognito_auth(cognito_groups : ["Admin"])
+}
+ 
+type Post @public {
+  Id: ID
+}
+ 
+type Query {
+  allBlogs: Blog @aws_iam @cognito_auth(cognito_groups : ["Admin"])
+  allPosts: Post @cognito_auth(cognito_groups : ["Admin"])
+  getPost: Post
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/multiauth.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/multiauth.graphql
@@ -1,20 +1,20 @@
 schema {
   query: Query
 }
- 
+
 type Blog {
   CreatedAt: String @oidc
   Description: String @public
   Id: ID
   User: String @cognito_auth(cognito_groups : ["Admin"])
 }
- 
+
 type Post @public {
   Id: ID
 }
- 
+
 type Query {
   allBlogs: Blog @aws_iam @cognito_auth(cognito_groups : ["Admin"])
   allPosts: Post @cognito_auth(cognito_groups : ["Admin"])
-  getPost: Post
+  getPost: Post @aws_auth
 }

--- a/packages/amplify-graphql-docs-generator/fixtures/multiauth.json
+++ b/packages/amplify-graphql-docs-generator/fixtures/multiauth.json
@@ -1,0 +1,1100 @@
+{
+  "data" : {
+    "__schema" : {
+      "queryType" : {
+        "name" : "Query"
+      },
+      "mutationType" : null,
+      "subscriptionType" : null,
+      "types" : [ {
+        "kind" : "OBJECT",
+        "name" : "Query",
+        "description" : null,
+        "fields" : [ {
+          "name" : "allPosts",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Post",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : [ {
+            "name" : "aws_auth",
+            "args" : [ {
+              "name" : "cognito_groups",
+              "value" : [ "Admin" ],
+              "treatValueAsString" : false
+            } ]
+          } ]
+        }, {
+          "name" : "getPost",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Post",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "allBlogs",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Blog",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : [ {
+            "name" : "iam_auth",
+            "args" : null
+          } ]
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "Post",
+        "description" : null,
+        "fields" : [ {
+          "name" : "Id",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : [ {
+          "name" : "unauth",
+          "args" : null
+        } ]
+      }, {
+        "kind" : "SCALAR",
+        "name" : "ID",
+        "description" : "Built-in ID",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "Blog",
+        "description" : null,
+        "fields" : [ {
+          "name" : "Id",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "User",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : [ {
+            "name" : "aws_auth",
+            "args" : [ {
+              "name" : "cognito_groups",
+              "value" : [ "Admin" ],
+              "treatValueAsString" : false
+            } ]
+          } ]
+        }, {
+          "name" : "Description",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : [ {
+            "name" : "api_key_auth",
+            "args" : null
+          } ]
+        }, {
+          "name" : "CreatedAt",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : [ {
+            "name" : "oidc_auth",
+            "args" : null
+          } ]
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "SCALAR",
+        "name" : "String",
+        "description" : "Built-in String",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "__Schema",
+        "description" : "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+        "fields" : [ {
+          "name" : "types",
+          "description" : "A list of all types supported by this server.",
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "NON_NULL",
+                "name" : null,
+                "ofType" : {
+                  "kind" : "OBJECT",
+                  "name" : "__Type",
+                  "ofType" : null
+                }
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "queryType",
+          "description" : "The type that query operations will be rooted at.",
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "__Type",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "mutationType",
+          "description" : "If this server supports mutation, the type that mutation operations will be rooted at.",
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "__Type",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "directives",
+          "description" : "'A list of all directives supported by this server.",
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "NON_NULL",
+                "name" : null,
+                "ofType" : {
+                  "kind" : "OBJECT",
+                  "name" : "__Directive",
+                  "ofType" : null
+                }
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "subscriptionType",
+          "description" : "'If this server support subscription, the type that subscription operations will be rooted at.",
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "__Type",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "__Type",
+        "description" : null,
+        "fields" : [ {
+          "name" : "kind",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "__TypeKind",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "name",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "description",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "fields",
+          "description" : null,
+          "args" : [ {
+            "name" : "includeDeprecated",
+            "description" : null,
+            "type" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            },
+            "defaultValue" : "false"
+          } ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "OBJECT",
+                "name" : "__Field",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "interfaces",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "OBJECT",
+                "name" : "__Type",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "possibleTypes",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "OBJECT",
+                "name" : "__Type",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "enumValues",
+          "description" : null,
+          "args" : [ {
+            "name" : "includeDeprecated",
+            "description" : null,
+            "type" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            },
+            "defaultValue" : "false"
+          } ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "OBJECT",
+                "name" : "__EnumValue",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "inputFields",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "OBJECT",
+                "name" : "__InputValue",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "ofType",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "__Type",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "ENUM",
+        "name" : "__TypeKind",
+        "description" : "An enum describing what kind of type a given __Type is",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : [ {
+          "name" : "SCALAR",
+          "description" : "Indicates this type is a scalar.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "OBJECT",
+          "description" : "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INTERFACE",
+          "description" : "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "UNION",
+          "description" : "Indicates this type is a union. `possibleTypes` is a valid field.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "ENUM",
+          "description" : "Indicates this type is an enum. `enumValues` is a valid field.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INPUT_OBJECT",
+          "description" : "Indicates this type is an input object. `inputFields` is a valid field.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "LIST",
+          "description" : "Indicates this type is a list. `ofType` is a valid field.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "NON_NULL",
+          "description" : "Indicates this type is a non-null. `ofType` is a valid field.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "__Field",
+        "description" : null,
+        "fields" : [ {
+          "name" : "name",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "description",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "args",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "NON_NULL",
+                "name" : null,
+                "ofType" : {
+                  "kind" : "OBJECT",
+                  "name" : "__InputValue",
+                  "ofType" : null
+                }
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "type",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "__Type",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "isDeprecated",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "deprecationReason",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "__InputValue",
+        "description" : null,
+        "fields" : [ {
+          "name" : "name",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "description",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "type",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "__Type",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "defaultValue",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "SCALAR",
+        "name" : "Boolean",
+        "description" : "Built-in Boolean",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "__EnumValue",
+        "description" : null,
+        "fields" : [ {
+          "name" : "name",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "description",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "isDeprecated",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "deprecationReason",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "__Directive",
+        "description" : null,
+        "fields" : [ {
+          "name" : "name",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "description",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "locations",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "ENUM",
+                "name" : "__DirectiveLocation",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "args",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "NON_NULL",
+                "name" : null,
+                "ofType" : {
+                  "kind" : "OBJECT",
+                  "name" : "__InputValue",
+                  "ofType" : null
+                }
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null,
+          "directives" : null
+        }, {
+          "name" : "onOperation",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "isDeprecated" : true,
+          "deprecationReason" : "Use `locations`.",
+          "directives" : null
+        }, {
+          "name" : "onFragment",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "isDeprecated" : true,
+          "deprecationReason" : "Use `locations`.",
+          "directives" : null
+        }, {
+          "name" : "onField",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "isDeprecated" : true,
+          "deprecationReason" : "Use `locations`.",
+          "directives" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null,
+        "directives" : null
+      }, {
+        "kind" : "ENUM",
+        "name" : "__DirectiveLocation",
+        "description" : "An enum describing valid locations where a directive can be placed",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : [ {
+          "name" : "QUERY",
+          "description" : "Indicates the directive is valid on queries.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "MUTATION",
+          "description" : "Indicates the directive is valid on mutations.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "FIELD",
+          "description" : "Indicates the directive is valid on fields.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "FRAGMENT_DEFINITION",
+          "description" : "Indicates the directive is valid on fragment definitions.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "FRAGMENT_SPREAD",
+          "description" : "Indicates the directive is valid on fragment spreads.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INLINE_FRAGMENT",
+          "description" : "Indicates the directive is valid on inline fragments.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "SCHEMA",
+          "description" : "Indicates the directive is valid on a schema SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "SCALAR",
+          "description" : "Indicates the directive is valid on a scalar SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "OBJECT",
+          "description" : "Indicates the directive is valid on an object SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "FIELD_DEFINITION",
+          "description" : "Indicates the directive is valid on a field SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "ARGUMENT_DEFINITION",
+          "description" : "Indicates the directive is valid on a field argument SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INTERFACE",
+          "description" : "Indicates the directive is valid on an interface SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "UNION",
+          "description" : "Indicates the directive is valid on an union SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "ENUM",
+          "description" : "Indicates the directive is valid on an enum SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "ENUM_VALUE",
+          "description" : "Indicates the directive is valid on an enum value SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INPUT_OBJECT",
+          "description" : "Indicates the directive is valid on an input object SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INPUT_FIELD_DEFINITION",
+          "description" : "Indicates the directive is valid on an input object field SDL definition.",
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "possibleTypes" : null,
+        "directives" : null
+      } ],
+      "directives" : [ {
+        "name" : "include",
+        "description" : "Directs the executor to include this field or fragment only when the `if` argument is true",
+        "locations" : [ "FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT" ],
+        "args" : [ {
+          "name" : "if",
+          "description" : "Included when true.",
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : true,
+        "onField" : true
+      }, {
+        "name" : "skip",
+        "description" : "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+        "locations" : [ "FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT" ],
+        "args" : [ {
+          "name" : "if",
+          "description" : "Skipped when true.",
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : true,
+        "onField" : true
+      }, {
+        "name" : "defer",
+        "description" : "This directive allows results to be deferred during execution",
+        "locations" : [ "FIELD" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : true
+      }, {
+        "name" : "aws_publish",
+        "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+        "locations" : [ "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "subscriptions",
+          "description" : "List of subscriptions which will be published to when this mutation is called.",
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_subscribe",
+        "description" : "Tells the service which mutation triggers this subscription.",
+        "locations" : [ "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "mutations",
+          "description" : "List of mutations which will trigger this subscription when they are called.",
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "args" : [ {
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_auth",
+        "description" : "Directs the schema to enforce authorization on a field",
+        "locations" : [ "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "cognito_groups",
+          "description" : "List of cognito user pool groups which have access on this field",
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      } ]
+    }
+  }
+}

--- a/packages/amplify-graphql-docs-generator/fixtures/schema.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/schema.graphql
@@ -70,13 +70,28 @@ type PageInfo {
 }
 
 type Query {
-	hero(episode: Episode): Character
+	hero(episode: Episode): Character 
 	reviews(episode: Episode!): [Review]
 	search(text: String): [SearchResult]
 	character(id: ID!): Character
 	droid(id: ID!): Droid
 	human(id: ID!): Human
 	starship(id: ID!): Starship
+	myName: User @cognito_auth(cognito_groups: ["user"]) @oidc
+	searchUser(text: String): UserResult @public
+	updateSearchIndex: Boolean @aws_iam
+
+}
+
+type User {
+	name: String
+	location: String
+}
+
+type UserResult {
+	items: [
+		User
+	]
 }
 
 # Represents a review for a movie

--- a/packages/amplify-graphql-docs-generator/fixtures/schema.graphql
+++ b/packages/amplify-graphql-docs-generator/fixtures/schema.graphql
@@ -70,7 +70,7 @@ type PageInfo {
 }
 
 type Query {
-	hero(episode: Episode): Character 
+	hero(episode: Episode): Character
 	reviews(episode: Episode!): [Review]
 	search(text: String): [SearchResult]
 	character(id: ID!): Character
@@ -80,7 +80,7 @@ type Query {
 	myName: User @cognito_auth(cognito_groups: ["user"]) @oidc
 	searchUser(text: String): UserResult @public
 	updateSearchIndex: Boolean @aws_iam
-
+	awsAuthQuery: Boolean @aws_auth
 }
 
 type User {
@@ -107,7 +107,7 @@ input ReviewInput {
 	favorite_color: ColorInput
 }
 
-union SearchResult = Human | Droid | Starship 
+union SearchResult = Human | Droid | Starship
 
 type Starship {
 	id: ID!

--- a/packages/amplify-graphql-docs-generator/fixtures/schema.json
+++ b/packages/amplify-graphql-docs-generator/fixtures/schema.json
@@ -1,2228 +1,2259 @@
 {
   "data": {
-    "__schema": {
-      "queryType": {
-        "name": "Query"
-      },
-      "mutationType": {
-        "name": "Mutation"
-      },
-      "subscriptionType": {
-        "name": "Subscription"
-      },
-      "types": [
-        {
-          "kind": "OBJECT",
-          "name": "Query",
-          "description": null,
-          "fields": [
-            {
-              "name": "hero",
-              "description": null,
-              "args": [
-                {
-                  "name": "episode",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "Episode",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Character",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "reviews",
-              "description": null,
-              "args": [
-                {
-                  "name": "episode",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "Episode",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
+      "__schema": {
+          "queryType": {
+              "name": "Query"
+          },
+          "mutationType": {
+              "name": "Mutation"
+          },
+          "subscriptionType": {
+              "name": "Subscription"
+          },
+          "types": [
+              {
                   "kind": "OBJECT",
-                  "name": "Review",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "search",
-              "description": null,
-              "args": [
-                {
-                  "name": "text",
+                  "name": "Query",
                   "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "UNION",
-                  "name": "SearchResult",
-                  "ofType": null
-                }
+                  "fields": [
+                      {
+                          "name": "hero",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "episode",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "ENUM",
+                                      "name": "Episode",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "INTERFACE",
+                              "name": "Character",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "reviews",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "episode",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "ENUM",
+                                          "name": "Episode",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "Review",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "search",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "text",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "String",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "UNION",
+                                  "name": "SearchResult",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "character",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "id",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "SCALAR",
+                                          "name": "ID",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "INTERFACE",
+                              "name": "Character",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "droid",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "id",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "SCALAR",
+                                          "name": "ID",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "Droid",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "human",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "id",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "SCALAR",
+                                          "name": "ID",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "Human",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "starship",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "id",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "SCALAR",
+                                          "name": "ID",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "Starship",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "character",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Character",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "droid",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Droid",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "human",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Human",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "starship",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Starship",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INTERFACE",
-          "name": "Character",
-          "description": null,
-          "fields": [
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friends",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "INTERFACE",
                   "name": "Character",
-                  "ofType": null
-                }
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "id",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "ID",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friends",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "INTERFACE",
+                                  "name": "Character",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friendsConnection",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "first",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Int",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              },
+                              {
+                                  "name": "after",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "ID",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "FriendsConnection",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "appearsIn",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "ENUM",
+                                      "name": "Episode",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": [
+                      {
+                          "kind": "OBJECT",
+                          "name": "Human",
+                          "ofType": null
+                      },
+                      {
+                          "kind": "OBJECT",
+                          "name": "Droid",
+                          "ofType": null
+                      }
+                  ]
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friendsConnection",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "description": "Built-in ID",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "description": "Built-in String",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
                   "kind": "OBJECT",
                   "name": "FriendsConnection",
-                  "ofType": null
-                }
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "totalCount",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Int",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "edges",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "FriendsEdge",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friends",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "INTERFACE",
+                                  "name": "Character",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "pageInfo",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "PageInfo",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "appearsIn",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "Episode",
-                    "ofType": null
-                  }
-                }
+              {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "description": "Built-in Int",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": [
-            {
-              "kind": "OBJECT",
-              "name": "Human",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "Droid",
-              "ofType": null
-            }
-          ]
-        },
-        {
-          "kind": "SCALAR",
-          "name": "ID",
-          "description": "Built-in ID",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "String",
-          "description": "Built-in String",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "FriendsConnection",
-          "description": null,
-          "fields": [
-            {
-              "name": "totalCount",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "edges",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "OBJECT",
                   "name": "FriendsEdge",
-                  "ofType": null
-                }
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "cursor",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "ID",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "node",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "INTERFACE",
+                              "name": "Character",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friends",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "Character",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "OBJECT",
                   "name": "PageInfo",
-                  "ofType": null
-                }
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "startCursor",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "ID",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "endCursor",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "ID",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "hasNextPage",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "Built-in Int",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "FriendsEdge",
-          "description": null,
-          "fields": [
-            {
-              "name": "cursor",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Character",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "PageInfo",
-          "description": null,
-          "fields": [
-            {
-              "name": "startCursor",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "endCursor",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasNextPage",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
-                }
+                  "description": "Built-in Boolean",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": "Built-in Boolean",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "Episode",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "NEWHOPE",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EMPIRE",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "JEDI",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Review",
-          "description": "  Represents a review for a movie",
-          "fields": [
-            {
-              "name": "episode",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "ENUM",
-                "name": "Episode",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "stars",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "commentary",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "UNION",
-          "name": "SearchResult",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": [
-            {
-              "kind": "OBJECT",
-              "name": "Human",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "Droid",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "Starship",
-              "ofType": null
-            }
-          ]
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Human",
-          "description": "  A humanoid creature from the Star Wars universe",
-          "fields": [
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "homePlanet",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "height",
-              "description": null,
-              "args": [
-                {
-                  "name": "unit",
+              {
+                  "kind": "ENUM",
+                  "name": "Episode",
                   "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "LengthUnit",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": [
+                      {
+                          "name": "NEWHOPE",
+                          "description": null,
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "EMPIRE",
+                          "description": null,
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "JEDI",
+                          "description": null,
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "mass",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friends",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "Character",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friendsConnection",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "OBJECT",
-                  "name": "FriendsConnection",
-                  "ofType": null
-                }
+                  "name": "Review",
+                  "description": "  Represents a review for a movie",
+                  "fields": [
+                      {
+                          "name": "episode",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "ENUM",
+                              "name": "Episode",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "stars",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Int",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "commentary",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "appearsIn",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "Episode",
-                    "ofType": null
-                  }
-                }
+              {
+                  "kind": "UNION",
+                  "name": "SearchResult",
+                  "description": null,
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": [
+                      {
+                          "kind": "OBJECT",
+                          "name": "Human",
+                          "ofType": null
+                      },
+                      {
+                          "kind": "OBJECT",
+                          "name": "Droid",
+                          "ofType": null
+                      },
+                      {
+                          "kind": "OBJECT",
+                          "name": "Starship",
+                          "ofType": null
+                      }
+                  ]
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "starships",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
+              {
+                  "kind": "OBJECT",
+                  "name": "Human",
+                  "description": "  A humanoid creature from the Star Wars universe",
+                  "fields": [
+                      {
+                          "name": "id",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "ID",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "homePlanet",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "height",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "unit",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "ENUM",
+                                      "name": "LengthUnit",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Float",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "mass",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Float",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friends",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "INTERFACE",
+                                  "name": "Character",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friendsConnection",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "first",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Int",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              },
+                              {
+                                  "name": "after",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "ID",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "FriendsConnection",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "appearsIn",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "ENUM",
+                                      "name": "Episode",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "starships",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "Starship",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [
+                      {
+                          "kind": "INTERFACE",
+                          "name": "Character",
+                          "ofType": null
+                      }
+                  ],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "description": "Built-in Float",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "ENUM",
+                  "name": "LengthUnit",
+                  "description": "  Units of height",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": [
+                      {
+                          "name": "METER",
+                          "description": null,
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FOOT",
+                          "description": null,
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "possibleTypes": null
+              },
+              {
                   "kind": "OBJECT",
                   "name": "Starship",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Character",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": "Built-in Float",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "LengthUnit",
-          "description": "  Units of height",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "METER",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FOOT",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Starship",
-          "description": null,
-          "fields": [
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "length",
-              "description": null,
-              "args": [
-                {
-                  "name": "unit",
                   "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "LengthUnit",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "coordinates",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "Float"
+                  "fields": [
+                      {
+                          "name": "id",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "ID",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "length",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "unit",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "ENUM",
+                                      "name": "LengthUnit",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Float",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "coordinates",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "LIST",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "NON_NULL",
+                                          "name": null,
+                                          "ofType": {
+                                              "kind": "SCALAR",
+                                              "name": "Float",
+                                              "ofType": null
+                                          }
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
                       }
-                    }
-                  }
-                }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Droid",
-          "description": null,
-          "fields": [
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friends",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "Character",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "friendsConnection",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "OBJECT",
-                  "name": "FriendsConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "appearsIn",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "Episode",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "primaryFunction",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Character",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Mutation",
-          "description": "  The mutation type, represents all updates we can make to our data",
-          "fields": [
-            {
-              "name": "createReview",
-              "description": null,
-              "args": [
-                {
-                  "name": "episode",
+                  "name": "Droid",
                   "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "Episode",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "review",
+                  "fields": [
+                      {
+                          "name": "id",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "ID",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friends",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "INTERFACE",
+                                  "name": "Character",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "friendsConnection",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "first",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Int",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              },
+                              {
+                                  "name": "after",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "ID",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "FriendsConnection",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "appearsIn",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "ENUM",
+                                      "name": "Episode",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "primaryFunction",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [
+                      {
+                          "kind": "INTERFACE",
+                          "name": "Character",
+                          "ofType": null
+                      }
+                  ],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "OBJECT",
+                  "name": "Mutation",
+                  "description": "  The mutation type, represents all updates we can make to our data",
+                  "fields": [
+                      {
+                          "name": "createReview",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "episode",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "ENUM",
+                                      "name": "Episode",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              },
+                              {
+                                  "name": "review",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "INPUT_OBJECT",
+                                          "name": "ReviewInput",
+                                          "ofType": null
+                                      }
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "Review",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ReviewInput",
                   "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "ReviewInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Review",
-                "ofType": null
+                  "fields": null,
+                  "inputFields": [
+                      {
+                          "name": "stars",
+                          "description": null,
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Int",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      },
+                      {
+                          "name": "commentary",
+                          "description": null,
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "defaultValue": null
+                      },
+                      {
+                          "name": "favorite_color",
+                          "description": null,
+                          "type": {
+                              "kind": "INPUT_OBJECT",
+                              "name": "ColorInput",
+                              "ofType": null
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "ReviewInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "stars",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "commentary",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "favorite_color",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ColorInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "ColorInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "red",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "green",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "blue",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Subscription",
-          "description": "  The subscription type, represents all subscriptions we can make to our data",
-          "fields": [
-            {
-              "name": "reviewAdded",
-              "description": null,
-              "args": [
-                {
-                  "name": "episode",
+              {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ColorInput",
                   "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "Episode",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Review",
-                "ofType": null
+                  "fields": null,
+                  "inputFields": [
+                      {
+                          "name": "red",
+                          "description": null,
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Int",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      },
+                      {
+                          "name": "green",
+                          "description": null,
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Int",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      },
+                      {
+                          "name": "blue",
+                          "description": null,
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Int",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "interfaces": null,
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__Schema",
-          "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
-          "fields": [
-            {
-              "name": "types",
-              "description": "A list of all types supported by this server.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__Type"
-                    }
-                  }
-                }
+              {
+                  "kind": "OBJECT",
+                  "name": "Subscription",
+                  "description": "  The subscription type, represents all subscriptions we can make to our data",
+                  "fields": [
+                      {
+                          "name": "reviewAdded",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "episode",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "ENUM",
+                                      "name": "Episode",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": null
+                              }
+                          ],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "Review",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "queryType",
-              "description": "The type that query operations will be rooted at.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
+                  "kind": "OBJECT",
+                  "name": "__Schema",
+                  "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+                  "fields": [
+                      {
+                          "name": "types",
+                          "description": "A list of all types supported by this server.",
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__Type",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "queryType",
+                          "description": "The type that query operations will be rooted at.",
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "__Type",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "mutationType",
+                          "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "__Type",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "directives",
+                          "description": "'A list of all directives supported by this server.",
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__Directive",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "subscriptionType",
+                          "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "__Type",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null
-                }
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "kind",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "ENUM",
+                                  "name": "__TypeKind",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "fields",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "includeDeprecated",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Boolean",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": "false"
+                              }
+                          ],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__Field",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "interfaces",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__Type",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "possibleTypes",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__Type",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "enumValues",
+                          "description": null,
+                          "args": [
+                              {
+                                  "name": "includeDeprecated",
+                                  "description": null,
+                                  "type": {
+                                      "kind": "SCALAR",
+                                      "name": "Boolean",
+                                      "ofType": null
+                                  },
+                                  "defaultValue": "false"
+                              }
+                          ],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__EnumValue",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "inputFields",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "OBJECT",
+                                      "name": "__InputValue",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ofType",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "OBJECT",
+                              "name": "__Type",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "mutationType",
-              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "directives",
-              "description": "'A list of all directives supported by this server.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__Directive"
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "subscriptionType",
-              "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__Type",
-          "description": null,
-          "fields": [
-            {
-              "name": "kind",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "ENUM",
                   "name": "__TypeKind",
-                  "ofType": null
-                }
+                  "description": "An enum describing what kind of type a given __Type is",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": [
+                      {
+                          "name": "SCALAR",
+                          "description": "Indicates this type is a scalar.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "OBJECT",
+                          "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INTERFACE",
+                          "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "UNION",
+                          "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ENUM",
+                          "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INPUT_OBJECT",
+                          "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "LIST",
+                          "description": "Indicates this type is a list. `ofType` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "NON_NULL",
+                          "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "fields",
-              "description": null,
-              "args": [
-                {
-                  "name": "includeDeprecated",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                }
-              ],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Field",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "interfaces",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "possibleTypes",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "enumValues",
-              "description": null,
-              "args": [
-                {
-                  "name": "includeDeprecated",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                }
-              ],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__EnumValue",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "inputFields",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__InputValue",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ofType",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "__TypeKind",
-          "description": "An enum describing what kind of type a given __Type is",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "SCALAR",
-              "description": "Indicates this type is a scalar.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OBJECT",
-              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INTERFACE",
-              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UNION",
-              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM",
-              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_OBJECT",
-              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LIST",
-              "description": "Indicates this type is a list. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NON_NULL",
-              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__Field",
-          "description": null,
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "args",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__InputValue"
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
+                  "name": "__Field",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "args",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__InputValue",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "type",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "__Type",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "isDeprecated",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "deprecationReason",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isDeprecated",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deprecationReason",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__InputValue",
-          "description": null,
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
+              {
                   "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
+                  "name": "__InputValue",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "type",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "OBJECT",
+                                  "name": "__Type",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "defaultValue",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "defaultValue",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+              {
+                  "kind": "OBJECT",
+                  "name": "__EnumValue",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "isDeprecated",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "deprecationReason",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
+              {
+                  "kind": "OBJECT",
+                  "name": "__Directive",
+                  "description": null,
+                  "fields": [
+                      {
+                          "name": "name",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "description",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "locations",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "NON_NULL",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "ENUM",
+                                      "name": "__DirectiveLocation",
+                                      "ofType": null
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "args",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "LIST",
+                                  "name": null,
+                                  "ofType": {
+                                      "kind": "NON_NULL",
+                                      "name": null,
+                                      "ofType": {
+                                          "kind": "OBJECT",
+                                          "name": "__InputValue",
+                                          "ofType": null
+                                      }
+                                  }
+                              }
+                          },
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "onOperation",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Boolean",
+                              "ofType": null
+                          },
+                          "isDeprecated": true,
+                          "deprecationReason": "Use `locations`."
+                      },
+                      {
+                          "name": "onFragment",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Boolean",
+                              "ofType": null
+                          },
+                          "isDeprecated": true,
+                          "deprecationReason": "Use `locations`."
+                      },
+                      {
+                          "name": "onField",
+                          "description": null,
+                          "args": [],
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "Boolean",
+                              "ofType": null
+                          },
+                          "isDeprecated": true,
+                          "deprecationReason": "Use `locations`."
+                      }
+                  ],
+                  "inputFields": null,
+                  "interfaces": [],
+                  "enumValues": null,
+                  "possibleTypes": null
+              },
+              {
+                  "kind": "ENUM",
+                  "name": "__DirectiveLocation",
+                  "description": "An enum describing valid locations where a directive can be placed",
+                  "fields": null,
+                  "inputFields": null,
+                  "interfaces": null,
+                  "enumValues": [
+                      {
+                          "name": "QUERY",
+                          "description": "Indicates the directive is valid on queries.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "MUTATION",
+                          "description": "Indicates the directive is valid on mutations.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FIELD",
+                          "description": "Indicates the directive is valid on fields.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FRAGMENT_DEFINITION",
+                          "description": "Indicates the directive is valid on fragment definitions.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FRAGMENT_SPREAD",
+                          "description": "Indicates the directive is valid on fragment spreads.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INLINE_FRAGMENT",
+                          "description": "Indicates the directive is valid on inline fragments.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "SCHEMA",
+                          "description": "Indicates the directive is valid on a schema SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "SCALAR",
+                          "description": "Indicates the directive is valid on a scalar SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "OBJECT",
+                          "description": "Indicates the directive is valid on an object SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "FIELD_DEFINITION",
+                          "description": "Indicates the directive is valid on a field SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ARGUMENT_DEFINITION",
+                          "description": "Indicates the directive is valid on a field argument SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INTERFACE",
+                          "description": "Indicates the directive is valid on an interface SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "UNION",
+                          "description": "Indicates the directive is valid on an union SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ENUM",
+                          "description": "Indicates the directive is valid on an enum SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "ENUM_VALUE",
+                          "description": "Indicates the directive is valid on an enum value SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INPUT_OBJECT",
+                          "description": "Indicates the directive is valid on an input object SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      },
+                      {
+                          "name": "INPUT_FIELD_DEFINITION",
+                          "description": "Indicates the directive is valid on an input object field SDL definition.",
+                          "isDeprecated": false,
+                          "deprecationReason": null
+                      }
+                  ],
+                  "possibleTypes": null
+              }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__EnumValue",
-          "description": null,
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+          "directives": [
+              {
+                  "name": "include",
+                  "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+                  "locations": [
+                      "FIELD",
+                      "FRAGMENT_SPREAD",
+                      "INLINE_FRAGMENT"
+                  ],
+                  "args": [
+                      {
+                          "name": "if",
+                          "description": "Included when true.",
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": true,
+                  "onField": true
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+              {
+                  "name": "skip",
+                  "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+                  "locations": [
+                      "FIELD",
+                      "FRAGMENT_SPREAD",
+                      "INLINE_FRAGMENT"
+                  ],
+                  "args": [
+                      {
+                          "name": "if",
+                          "description": "Skipped when true.",
+                          "type": {
+                              "kind": "NON_NULL",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "Boolean",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": true,
+                  "onField": true
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isDeprecated",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+              {
+                  "name": "defer",
+                  "description": "This directive allows results to be deferred during execution",
+                  "locations": [
+                      "FIELD"
+                  ],
+                  "args": [],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": true
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deprecationReason",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+              {
+                  "name": "deprecated",
+                  "description": null,
+                  "locations": [
+                      "FIELD_DEFINITION",
+                      "ENUM_VALUE"
+                  ],
+                  "args": [
+                      {
+                          "name": "reason",
+                          "description": null,
+                          "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                          },
+                          "defaultValue": "\"No longer supported\""
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__Directive",
-          "description": null,
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+              {
+                  "name": "aws_publish",
+                  "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+                  "locations": [
+                      "FIELD_DEFINITION"
+                  ],
+                  "args": [
+                      {
+                          "name": "subscriptions",
+                          "description": "List of subscriptions which will be published to when this mutation is called.",
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+              {
+                  "name": "aws_auth",
+                  "description": "Directs the schema to enforce authorization on a field",
+                  "locations": [
+                      "FIELD_DEFINITION"
+                  ],
+                  "args": [
+                      {
+                          "name": "cognito_groups",
+                          "description": "List of cognito user pool groups which have access on this field",
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "locations",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "__DirectiveLocation",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "args",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__InputValue"
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "onOperation",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
-            },
-            {
-              "name": "onFragment",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
-            },
-            {
-              "name": "onField",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "__DirectiveLocation",
-          "description": "An enum describing valid locations where a directive can be placed",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "QUERY",
-              "description": "Indicates the directive is valid on queries.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MUTATION",
-              "description": "Indicates the directive is valid on mutations.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FIELD",
-              "description": "Indicates the directive is valid on fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FRAGMENT_DEFINITION",
-              "description": "Indicates the directive is valid on fragment definitions.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FRAGMENT_SPREAD",
-              "description": "Indicates the directive is valid on fragment spreads.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INLINE_FRAGMENT",
-              "description": "Indicates the directive is valid on inline fragments.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SCHEMA",
-              "description": "Indicates the directive is valid on a schema SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SCALAR",
-              "description": "Indicates the directive is valid on a scalar SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OBJECT",
-              "description": "Indicates the directive is valid on an object SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FIELD_DEFINITION",
-              "description": "Indicates the directive is valid on a field SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ARGUMENT_DEFINITION",
-              "description": "Indicates the directive is valid on a field argument SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INTERFACE",
-              "description": "Indicates the directive is valid on an interface SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UNION",
-              "description": "Indicates the directive is valid on an union SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM",
-              "description": "Indicates the directive is valid on an enum SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM_VALUE",
-              "description": "Indicates the directive is valid on an enum value SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_OBJECT",
-              "description": "Indicates the directive is valid on an input object SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_FIELD_DEFINITION",
-              "description": "Indicates the directive is valid on an input object field SDL definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        }
-      ],
-      "directives": [
-        {
-          "name": "include",
-          "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
-          "args": [
-            {
-              "name": "if",
-              "description": "Included when true.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": true,
-          "onField": true
-        },
-        {
-          "name": "skip",
-          "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
-          "args": [
-            {
-              "name": "if",
-              "description": "Skipped when true.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": true,
-          "onField": true
-        },
-        {
-          "name": "defer",
-          "description": "This directive allows results to be deferred during execution",
-          "args": [],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": true
-        },
-        {
-          "name": "deprecated",
-          "description": null,
-          "args": [
-            {
-              "name": "reason",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": "\"No longer supported\""
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_auth",
-          "description": "Directs the schema to enforce authorization on a field",
-          "args": [
-            {
-              "name": "cognito_groups",
-              "description": "List of cognito user pool groups which have access on this field",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_publish",
-          "description": "Tells the service which subscriptions will be published to when this mutation is called.",
-          "args": [
-            {
-              "name": "subscriptions",
-              "description": "List of subscriptions which will be published to when this mutation is called.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_subscribe",
-          "description": "Tells the service which mutation triggers this subscription.",
-          "args": [
-            {
-              "name": "mutations",
-              "description": "List of mutations which will trigger this subscription when they are called.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        }
-      ]
-    }
+              {
+                  "name": "aws_subscribe",
+                  "description": "Tells the service which mutation triggers this subscription.",
+                  "locations": [
+                      "FIELD_DEFINITION"
+                  ],
+                  "args": [
+                      {
+                          "name": "mutations",
+                          "description": "List of mutations which will trigger this subscription when they are called.",
+                          "type": {
+                              "kind": "LIST",
+                              "name": null,
+                              "ofType": {
+                                  "kind": "SCALAR",
+                                  "name": "String",
+                                  "ofType": null
+                              }
+                          },
+                          "defaultValue": null
+                      }
+                  ],
+                  "onOperation": false,
+                  "onFragment": false,
+                  "onField": false
+              }
+          ]
+      }
   }
 }

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -26,10 +26,9 @@
     "format": "prettier --write ./src/**/*.ts ./__tests__/**/*.ts"
   },
   "devDependencies": {
-    "@types/ejs": "^2.6.0",
     "@types/graphql": "^14.2.0",
     "@types/handlebars": "4.1.0",
-    "@types/jest": "23.3.1",
+    "@types/jest": "^23.3.1",
     "@types/node": "8.0.28",
     "@types/prettier": "^1.13.2",
     "jest": "^23.1.0",
@@ -39,12 +38,8 @@
   },
   "dependencies": {
     "camel-case": "^3.0.0",
-    "commander": "^2.9.0",
-    "fetch": "^1.1.0",
     "graphql": "^14.2.1",
     "handlebars": "^4.1.1",
-    "lodash": "^4.17.4",
-    "node-fetch": "^1.6.3",
     "pascal-case": "^2.0.1",
     "prettier": "1.16.4",
     "yargs": "^13.2.2"

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -27,27 +27,27 @@
   },
   "devDependencies": {
     "@types/ejs": "^2.6.0",
-    "@types/graphql": "^0.13.1",
-    "@types/handlebars": "4.0.39",
+    "@types/graphql": "^14.2.0",
+    "@types/handlebars": "4.1.0",
     "@types/jest": "23.3.1",
     "@types/node": "8.0.28",
     "@types/prettier": "^1.13.2",
     "jest": "^23.1.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.4.1"
   },
   "dependencies": {
     "camel-case": "^3.0.0",
     "commander": "^2.9.0",
     "fetch": "^1.1.0",
-    "graphql": "^0.13.2",
-    "handlebars": "4.0.11",
+    "graphql": "^14.2.1",
+    "handlebars": "^4.1.1",
     "lodash": "^4.17.4",
     "node-fetch": "^1.6.3",
     "pascal-case": "^2.0.1",
     "prettier": "1.16.4",
-    "yargs": "^12.0.1"
+    "yargs": "^13.2.2"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-docs-generator/src/cli.ts
+++ b/packages/amplify-graphql-docs-generator/src/cli.ts
@@ -51,10 +51,14 @@ export function run(argv: Array<String>): void {
         separateFiles: {
           default: false,
           type: 'boolean'
+        },
+        renderMultiAuthDirectives: {
+          default: false,
+          type: 'boolean'
         }
       },
       async argv => {
-          generateAllOps(argv.schema, argv.output, { separateFiles: argv.separateFiles, language: argv.language, maxDepth: argv.maxDepth })
+        generateAllOps(argv.schema, argv.output, { separateFiles: argv.separateFiles, language: argv.language, maxDepth: argv.maxDepth, renderMultiAuthDirectives: argv.renderMultiAuthDirectives, })
       }
     )
     .help()

--- a/packages/amplify-graphql-docs-generator/src/generator/generate.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/generate.ts
@@ -1,23 +1,31 @@
 import { buildClientSchema, GraphQLObjectType, GraphQLSchema, IntrospectionQuery } from 'graphql'
 
-import { generateQueries, generateMutations, generateSubscriptions, collectExternalFragments } from './generateAllOperations'
-import { GQLDocsGenOptions, GQLAllOperations} from './types'
+import {
+  generateQueries,
+  generateMutations,
+  generateSubscriptions,
+  collectExternalFragments,
+} from './generateAllOperations'
+import { GQLDocsGenOptions, GQLAllOperations } from './types'
 export default function generate(
-  schemaDocument: IntrospectionQuery,
+  schemaDoc: GraphQLSchema,
   maxDepth: number,
   options: GQLDocsGenOptions
 ): GQLAllOperations {
   try {
-    const schemaDoc: GraphQLSchema = buildClientSchema(schemaDocument)
     const queryTypes: GraphQLObjectType = schemaDoc.getQueryType()
     const mutationType: GraphQLObjectType = schemaDoc.getMutationType()
     const subscriptionType: GraphQLObjectType = schemaDoc.getSubscriptionType()
     const queries = generateQueries(queryTypes, schemaDoc, maxDepth, options) || []
     const mutations = generateMutations(mutationType, schemaDoc, maxDepth, options) || []
-    const subscriptions = generateSubscriptions(subscriptionType, schemaDoc, maxDepth, options) || []
-    const fragments = options.useExternalFragmentForS3Object ? collectExternalFragments([...queries, ...mutations, ...subscriptions]) : [];
+    const subscriptions =
+      generateSubscriptions(subscriptionType, schemaDoc, maxDepth, options) || []
+    const fragments = options.useExternalFragmentForS3Object
+      ? collectExternalFragments([...queries, ...mutations, ...subscriptions])
+      : []
     return { queries, mutations, subscriptions, fragments }
   } catch (e) {
-    throw new Error('GraphQL schema file should contain a valid GraphQL introspection query result')
+    throw e;
+    // throw new Error('GraphQL schema file should contain a valid GraphQL introspection query result')
   }
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/generateOperation.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/generateOperation.ts
@@ -1,8 +1,9 @@
-import { GraphQLField, GraphQLSchema } from 'graphql'
+import { GraphQLField, GraphQLSchema, GraphQLDirective, } from 'graphql'
 
 import getArgs from './getArgs'
 import getBody from './getBody'
 import { GQLTemplateGenericOp, GQLTemplateArgDeclaration, GQLTemplateOpBody, GQLDocsGenOptions } from './types'
+import getDirectives from './getDirectives';
 
 export default function generateOperation(
   operation: GraphQLField<any, any>,
@@ -12,8 +13,10 @@ export default function generateOperation(
 ): GQLTemplateGenericOp {
   const args: Array<GQLTemplateArgDeclaration> = getArgs(operation.args)
   const body: GQLTemplateOpBody = getBody(operation, schema, maxDepth, options)
+  const directives = options.renderMultiAuthDirectives ? getDirectives(operation) : [];
   return {
     args,
     body,
+    directives,
   }
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/getDirectives.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getDirectives.ts
@@ -1,0 +1,60 @@
+import {
+  GraphQLDirective,
+  GraphQLField,
+  getDirectiveValues,
+  getNamedType,
+  DirectiveDefinitionNode,
+  DirectiveNode,
+  GraphQLNonNull,
+  NameNode,
+  ArgumentNode,
+  ValueNode,
+} from 'graphql'
+import getArgs from './getArgs'
+import getType from './utils/getType'
+
+export default function getDirectives(operation: GraphQLField<any, any>) {
+  const astNode = operation.astNode
+  if (!astNode) {
+    return []
+  }
+  const directiveNode = astNode.directives
+  const d = directiveNode.map((dNode: DirectiveNode) => {
+    return {
+      name: dNode.name.value,
+      args: getArguments(dNode.arguments),
+    }
+  })
+  return d
+}
+
+export function getNameFromNameNode(name: NameNode) {
+  return name.value
+}
+
+export function getArguments(args: ReadonlyArray<ArgumentNode>) {
+  return args.map((arg) => ({
+    name: getNameFromNameNode(arg.name),
+    value: JSON.stringify(getValueFromValeNode(arg.value)),
+  }))
+}
+
+export function getValueFromValeNode(val: any) {
+  switch (val.kind) {
+    case 'NullValue':
+      return null
+    case 'ListValue':
+      return val.values.map((v) => getValueFromValeNode(v))
+    case 'ObjectValue':
+      const obj = {}
+      val.fields.reduce((acc, f) => {
+        acc[getNameFromNameNode(f.name)] = getValueFromValeNode(f.value)
+      }, obj)
+      return obj
+    case 'FloatValue':
+    case 'IntValue':
+      return Number(val.value)
+    default:
+      return val.value
+  }
+}

--- a/packages/amplify-graphql-docs-generator/src/generator/getDirectives.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/getDirectives.ts
@@ -13,6 +13,8 @@ import {
 import getArgs from './getArgs'
 import getType from './utils/getType'
 
+const APPSYNC_MULTI_AUTH_DIRECTIVES = ['cognito_auth', 'public', 'oidc', 'aws_iam'];
+
 export default function getDirectives(operation: GraphQLField<any, any>) {
   const astNode = operation.astNode
   if (!astNode) {
@@ -24,7 +26,7 @@ export default function getDirectives(operation: GraphQLField<any, any>) {
       name: dNode.name.value,
       args: getArguments(dNode.arguments),
     }
-  })
+  }).filter(d => APPSYNC_MULTI_AUTH_DIRECTIVES.includes(d.name))
   return d
 }
 

--- a/packages/amplify-graphql-docs-generator/src/generator/types.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/types.ts
@@ -55,7 +55,8 @@ export type GQLTemplateOpBody = GQLTemplateField & {
 
 export type GQLTemplateGenericOp = {
   args: Array<GQLTemplateArgDeclaration>
-  body: GQLTemplateOpBody
+  body: GQLTemplateOpBody,
+  directives: Array<Object>
 }
 
 export type GQLTemplateOp = GQLTemplateGenericOp & {
@@ -71,5 +72,6 @@ export type GQLAllOperations = {
 }
 
 export type GQLDocsGenOptions = {
-  useExternalFragmentForS3Object: boolean
+  useExternalFragmentForS3Object: boolean,
+  renderMultiAuthDirectives: boolean
 }

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/loadSchemaDocument.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/loadSchemaDocument.ts
@@ -5,7 +5,7 @@ import { join, extname } from 'path';
 function loadSchemaFromSDL(file: string): GraphQLSchema {
   const schemaDoc = new Source(readFileSync(file, 'utf8'), file)
   const authDirectives = new Source(
-    readFileSync(join(__dirname, '..', '..', '..', 'aws_auth_directives.graphql'), 'utf8')
+    readFileSync(join(__dirname, '..', '..', '..', 'appsync_custom_directives.graphql'), 'utf8')
   )
   const doc = concatAST([schemaDoc, authDirectives].map((source) => parse(source)))
   return buildASTSchema(doc);

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/loadSchemaDocument.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/loadSchemaDocument.ts
@@ -1,0 +1,31 @@
+import { parse, GraphQLSchema, DocumentNode, buildASTSchema, concatAST, Source, buildClientSchema, IntrospectionQuery } from 'graphql'
+import { readFileSync } from 'fs'
+import { join, extname } from 'path';
+
+function loadSchemaFromSDL(file: string): GraphQLSchema {
+  const schemaDoc = new Source(readFileSync(file, 'utf8'), file)
+  const authDirectives = new Source(
+    readFileSync(join(__dirname, '..', '..', '..', 'aws_auth_directives.graphql'), 'utf8')
+  )
+  const doc = concatAST([schemaDoc, authDirectives].map((source) => parse(source)))
+  return buildASTSchema(doc);
+}
+
+function loadSchemaFromIntrospection(file: string): GraphQLSchema {
+  const schemaContent = readFileSync(file, 'utf8').trim()
+  const schemaData = JSON.parse(schemaContent)
+  if (!schemaData.data && !schemaData.__schema) {
+    // tslint:disable-line
+    throw new Error('GraphQL schema file should contain a valid GraphQL introspection query result')
+  }
+  const schema: IntrospectionQuery = schemaData.data || schemaData
+  return buildClientSchema(schema);
+}
+
+export default function getSchema(file: string): GraphQLSchema {
+  const ext = extname(file);
+  if (ext === '.json') {
+    return loadSchemaFromIntrospection(file)
+  }
+  return loadSchemaFromSDL(file)
+}

--- a/packages/amplify-graphql-docs-generator/src/generator/utils/loadSchemaDocument.ts
+++ b/packages/amplify-graphql-docs-generator/src/generator/utils/loadSchemaDocument.ts
@@ -15,7 +15,6 @@ function loadSchemaFromIntrospection(file: string): GraphQLSchema {
   const schemaContent = readFileSync(file, 'utf8').trim()
   const schemaData = JSON.parse(schemaContent)
   if (!schemaData.data && !schemaData.__schema) {
-    // tslint:disable-line
     throw new Error('GraphQL schema file should contain a valid GraphQL introspection query result')
   }
   const schema: IntrospectionQuery = schemaData.data || schemaData

--- a/packages/amplify-graphql-docs-generator/templates/_renderDirectives.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderDirectives.hbs
@@ -1,0 +1,5 @@
+{{#if directives.length}}
+  {{#each directives}}
+    @{{name}}{{#unless @last}} {{/unless}}
+  {{/each}}
+{{/if}}

--- a/packages/amplify-graphql-docs-generator/templates/_renderOp.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/_renderOp.hbs
@@ -1,4 +1,4 @@
-{{type}} {{name}} {{>renderArgDeclaration args=args}}{
+{{type}} {{name}} {{>renderArgDeclaration args=args}} {{>renderDirectives directives=directives}} {
     {{body.name}}{{> renderCallArgs args=body.args}} 
     {{#if body.hasBody}} {
       {{> renderFields fields=body.fields}}

--- a/packages/amplify-graphql-docs-generator/tsconfig.json
+++ b/packages/amplify-graphql-docs-generator/tsconfig.json
@@ -6,20 +6,21 @@
         "outDir": "lib",
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "sourceRoot": "src",
         "lib": [
             "es2017",
             "dom",
             "esnext.asynciterable",
             "dom"
         ],
+        "types": ["jest"]
     },
     "exclude": [
         "node_modules",
         "lib",
-        "__tests__"
+        "__tests__",
+        "__integration__"
     ],
     "include": [
-        "src/"
+        "src/**/*.ts"
     ]
 }

--- a/packages/amplify-graphql-docs-generator/tsconfig.json
+++ b/packages/amplify-graphql-docs-generator/tsconfig.json
@@ -12,7 +12,7 @@
             "esnext.asynciterable",
             "dom"
         ],
-        "types": ["jest"]
+        "types": ["jest", "node"]
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Add support for rendering of auth directives in the generated document. The rendered auth directive
will be use by JS sdk to infer the auth needed to support multi auth.

A graphql schema can override auth mode for a field. The codegen will read those overrides and add them in the generated statements
```graphql
# Schema
schema {
  query: Query
}
 
type Blog {
  CreatedAt: String @oidc
  Description: String @public
  Id: ID
  User: String @cognito_auth(cognito_groups : ["Admin"])
}
 
type Post @public {
  Id: ID
}
 
type Query {
  allBlogs: Blog @aws_iam @cognito_auth(cognito_groups : ["Admin"])
  allPosts: Post @cognito_auth(cognito_groups : ["Admin"])
  getPost: Post
}
```
The generated statements will look like
```graphql
# this is an auto generated file. This will be overwritten
query AllBlogs @aws_iam @cognito_auth {
  allBlogs {
    CreatedAt
    Description
    Id
    User
  }
}
query AllPosts @cognito_auth {
  allPosts {
    Id
  }
}
query GetPost {
  getPost {
    Id
  }
}

```