### PR TITLE
fix(graphql-dynamodb-transformer): always output datasource name

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -129,6 +129,7 @@ export class DynamoDBModelTransformer extends Transformer {
         const typeName = def.name.value
         const tableLogicalID = ModelResourceIDs.ModelTableResourceID(typeName)
         const iamRoleLogicalID = ModelResourceIDs.ModelTableIAMRoleID(typeName)
+        const dataSourceRoleLogicalID = ModelResourceIDs.ModelTableDataSourceID(typeName)
         ctx.setResource(
             tableLogicalID,
             this.resources.makeModelTable(typeName, undefined, undefined)
@@ -138,8 +139,12 @@ export class DynamoDBModelTransformer extends Transformer {
             this.resources.makeIAMRole(typeName)
         )
         ctx.setResource(
-            ModelResourceIDs.ModelTableDataSourceID(typeName),
+            dataSourceRoleLogicalID,
             this.resources.makeDynamoDBDataSource(tableLogicalID, iamRoleLogicalID, typeName)
+        )
+        ctx.setOutput(
+            `GetAtt${dataSourceRoleLogicalID}Name`,
+            this.resources.makeDataSourceOutput(dataSourceRoleLogicalID)
         )
         ctx.setOutput(
             `GetAtt${tableLogicalID}Name`,

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -115,6 +115,16 @@ export class ResourceFactory {
         }
     }
 
+    public makeDataSourceOutput(resourceId: string): Output {
+        return {
+            Description: "Your model DataSource name.",
+            Value: Fn.GetAtt(resourceId, "Name"),
+            Export: {
+                Name: Fn.Join(':', [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), "GetAtt", resourceId, "Name"])
+            }
+        }
+    }
+
     public makeTableNameOutput(resourceId: string): Output {
         return {
             Description: "Your DynamoDB table name.",


### PR DESCRIPTION
fix #982 
fix #1030 
fix #1141 

*Description of changes:*
By **always** exporting the **DataSource** name output, it prevents `amplify push` to fails if a **@connection** directive or a model with a **@connection** is removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.