### PR TITLE
fix(graphql-auth-transformer): conditional group expression

### DIFF
--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -315,7 +315,7 @@ export class ResourceFactory {
                     raw(`$util.qr($groupAuthExpressions.add("contains(#${groupsAttributeName}, :${groupName}$foreach.count)"))`),
                     raw(`$util.qr($groupAuthExpressionValues.put(":${groupName}$foreach.count", { "S": $userGroup }))`),
                 ]),
-                raw(`$util.qr($groupAuthExpressionNames.put("#${groupsAttributeName}", "${groupsAttribute}"))`),
+                iff(raw('$userGroups.size() > 0'), raw(`$util.qr($groupAuthExpressionNames.put("#${groupsAttributeName}", "${groupsAttribute}"))`)),
             )
             ruleNumber++
         }
@@ -579,6 +579,6 @@ export class ResourceFactory {
     }
 
     public setUserGroups(): SetNode {
-        return set(ref('userGroups'), ref('ctx.identity.claims.get("cognito:groups")'));
+        return set(ref('userGroups'), raw('$util.defaultIfNull($ctx.identity.claims.get("cognito:groups"), [])'));
     }
 }


### PR DESCRIPTION
Transformer added group auth expression even when the auth had an empty group. This caused DynamoDB to error. Adding auth expression only if there is a group specified.
*Issue #, if available:*

fixes #360 

*Description of changes:*

Adds a missing check in generated update & delete resolver to fix an issue caused when the logged in user is not enrolled in any Cognito User Pools groups.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.