### PR TITLE
build: avoid removing package-lock files in production-build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "lerna run lint",
     "lint-fix": "lerna run lint-fix",
     "clean": "rm -rf node_modules && lerna clean --yes",
-    "production-build": "lerna exec -- rm -f package-lock.json && lerna bootstrap --hoist && lerna run build",
+    "production-build": "lerna bootstrap --hoist && lerna run build",
     "setup-dev": "lerna exec -- rm -f package-lock.json && lerna bootstrap && cd packages/amplify-cli && rm -f -- package-lock.json && npm link && cd ../.. && lerna run build",
     "setup-dev-win": "lerna exec -- del /f package-lock.json && lerna bootstrap && cd packages/amplify-cli && del /f package-lock.json && npm link && cd ../.. && lerna run build",
     "publish:master": "lerna publish --canary --yes  --preid=alpha --message 'chore(release): Publish [ci skip]' --no-git-tag-version --no-push",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.