### PR TITLE
fix(amplify-provider-awscloudformation): ignore dot files, fixes #1135

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -328,14 +328,18 @@ function getCfnFiles(context, category, resourceName) {
    */
   if (fs.existsSync(resourceBuildDir) && fs.lstatSync(resourceBuildDir).isDirectory()) {
     const files = fs.readdirSync(resourceBuildDir);
-    const cfnFiles = files.filter(file => file.indexOf('template') !== -1);
+    const cfnFiles = files
+      .filter(file => file.indexOf('.') !== 0)
+      .filter(file => file.indexOf('template') !== -1);
     return {
       resourceDir: resourceBuildDir,
       cfnFiles,
     };
   }
   const files = fs.readdirSync(resourceDir);
-  const cfnFiles = files.filter(file => file.indexOf('template') !== -1);
+  const cfnFiles = files
+    .filter(file => file.indexOf('.') !== 0)
+    .filter(file => file.indexOf('template') !== -1);
   return {
     resourceDir,
     cfnFiles,


### PR DESCRIPTION
*Issue #, if available:* #1135

*Description of changes:* Ignores vim .swp files, or any other files starting with . when pushing to cloudformation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.