### PR TITLE
feat: add support for ap-northeast-2

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/aws-regions.js
+++ b/packages/amplify-provider-awscloudformation/lib/aws-regions.js
@@ -6,6 +6,7 @@ const regionMappings = {
   'eu-west-2': 'EU (London)',
   'eu-central-1': 'EU (Frankfurt)',
   'ap-northeast-1': 'Asia Pacific (Tokyo)',
+  'ap-northeast-2': 'Asia Pacific (Seoul)',
   'ap-southeast-1': 'Asia Pacific (Singapore)',
   'ap-southeast-2': 'Asia Pacific (Sydney)',
   'ap-south-1': 'Asia Pacific (Mumbai)',


### PR DESCRIPTION
Since Amplify console in ap-northeast-2 was opened but not CLI.

Reference: https://aws.amazon.com/about-aws/whats-new/2019/04/amplify-console-now-available-in-five-additional-regions