### PR TITLE
Allowing e2e errors to bubble up for circle ci debugging

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
@@ -208,8 +208,8 @@ afterAll(async () => {
             expect(true).toEqual(true)
             console.log('Successfully deleted stack ' + STACK_NAME)
         } else {
-            console.error(e)
-            expect(true).toEqual(false)
+            console.error(e);
+            throw e;
         }
     }
     try {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
@@ -216,7 +216,7 @@ afterAll(async () => {
             console.log('Successfully deleted stack ' + STACK_NAME)
         } else {
             console.error(e)
-            expect(true).toEqual(false)
+            throw e;
         }
     }
     try {


### PR DESCRIPTION
A quick change to let errors bubble up so we can debug circle ci.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.