### PR TITLE
fix(graphql-relational-schema-transformer fixes) fix rds import issues

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/AuroraServerlessMySQLDatabaseReader.ts
+++ b/packages/graphql-relational-schema-transformer/src/AuroraServerlessMySQLDatabaseReader.ts
@@ -139,13 +139,20 @@ export class AuroraServerlessMySQLDatabaseReader implements IRelationalDBReader 
         }
 
         // Add foreign key for this table
-        let tablesWithRef = await this.getTableForeignKeyReferences(tableName)
-        for (const tableWithRef of tablesWithRef) {
-            if (tableWithRef && tableWithRef.length > 0) {
-                const baseType = getNamedType(`${tableWithRef}Connection`)
-                fields.push(getFieldDefinition(`${tableWithRef}`, baseType))
-            }
-        }
+
+        // NOTE from @mikeparisstuff: It would be great to re-enable this such that foreign key relationships are
+        // resolver automatically. This code was breaking compilation because it was not
+        // creating XConnection types correctly. This package also does not yet support
+        // wiring up the resolvers (or ideally selection set introspection & automatic JOINs)
+        // so there is not point in creating these connection fields anyway. Disabling until
+        // supported.
+        // let tablesWithRef = await this.getTableForeignKeyReferences(tableName)
+        // for (const tableWithRef of tablesWithRef) {
+        //     if (tableWithRef && tableWithRef.length > 0) {
+        //         const baseType = getNamedType(`${tableWithRef}Connection`)
+        //         fields.push(getFieldDefinition(`${tableWithRef}`, baseType))
+        //     }
+        // }
 
         return new TableContext(getTypeDefinition(fields, tableName), getInputTypeDefinition(createFields, `Create${tableName}Input`),
                 getInputTypeDefinition(updateFields, `Update${tableName}Input`), primaryKey, primaryKeyType, stringFieldList, intFieldList)

--- a/packages/graphql-relational-schema-transformer/src/__tests__/AuroraServerlessMySQLDBReader.test.ts
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/AuroraServerlessMySQLDBReader.test.ts
@@ -93,7 +93,7 @@ function describeTableTestCommon(tableName: string, fieldLength: number, isForei
      *   comments: CommentConnection
      * }
     */ 
-    expect(tableContext.tableTypeDefinition.fields.length).toEqual(isForeignKey ? fieldLength+1 : fieldLength)
+    expect(tableContext.tableTypeDefinition.fields.length).toEqual(fieldLength)
     expect(tableContext.updateTypeDefinition.fields.length).toEqual(fieldLength)
     expect(tableContext.createTypeDefinition.fields.length).toEqual(fieldLength)
 }


### PR DESCRIPTION
Two fixes that I found in the new RDS tool.

1. Disabling broken connection fields inferred from foreign keys. There was no support at the resolver level any way and this was breaking tables with foreign keys.
2. Disabling importing tables with no explicit primary keys. This was breaking. The tool now warns that it is skipping a table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.