### PR TITLE
fix(cli): check BOM in json read

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/read-json-file.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/read-json-file.js
@@ -1,0 +1,16 @@
+const fs = require('fs-extra');
+
+function stripBOM(content) {
+  if (content.charCodeAt(0) === 0xFEFF) {
+    content = content.slice(1);
+  }
+  return content;
+}
+
+function readJsonFile(jsonFilePath, encoding = 'utf8') {
+  return JSON.parse(stripBOM(fs.readFileSync(jsonFilePath, encoding)));
+}
+
+module.exports = {
+  readJsonFile,
+};

--- a/packages/amplify-cli/src/extensions/amplify.js
+++ b/packages/amplify-cli/src/extensions/amplify.js
@@ -29,6 +29,7 @@ const { sharedQuestions } = require('./amplify-helpers/shared-questions.js');
 const { inputValidation } = require('./amplify-helpers/input-validation');
 const { copyBatch } = require('./amplify-helpers/copy-batch');
 const { listCategories } = require('./amplify-helpers/list-categories');
+const { readJsonFile } = require('./amplify-helpers/read-json-file');
 const pathManager = require('./amplify-helpers/path-manager');
 const { makeId } = require('./amplify-helpers/make-id');
 const { openEditor } = require('./amplify-helpers/open-editor');
@@ -95,6 +96,7 @@ module.exports = (context) => {
     pathManager,
     pressEnterToContinue,
     pushResources,
+    readJsonFile,
     removeEnvFromCloud,
     removeResource,
     sharedQuestions,

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -81,7 +81,7 @@ function getCurrentAWSConfig(context) {
   let awsConfig = {};
 
   if (fs.existsSync(targetFilePath)) {
-    awsConfig = JSON.parse(fs.readFileSync(targetFilePath));
+    awsConfig = amplify.readJsonFile(targetFilePath);
   }
   return awsConfig;
 }


### PR DESCRIPTION
*Issue #, if available:*
fix #1280

*Description of changes:*

Certain text editors insert a BOM character in front of the file contents, and JSON.parse(.) can not handle it, JSON.parse(.) throws "SyntaxError: Unexpected token ﻿ in JSON at position 0" when the argument string contains the BOM character. This was logged as a [node issue](https://github.com/nodejs/node/issues/20649)

This PR adds an utility method `readJsonFile` in the amplify extension to read json files, and it has built in logic to handle the BOM character. 
In this PR, the`readJsonFile` utility method is only used in the amplify-frontend-android's frontend-config-creator to fix issue #1280, its usage should be extended to other places where JSON.parse(fs.readFileSync(.)) is directly used. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.