### PR TITLE
fix: (amplify init) change default destribution folder

### DIFF
--- a/packages/amplify-cli/sample-headless-scripts/headless_configure_project.sh
+++ b/packages/amplify-cli/sample-headless-scripts/headless_configure_project.sh
@@ -4,7 +4,7 @@ IFS='|'
 
 REACTCONFIG="{\
 \"SourceDir\":\"src\",\
-\"DistributionDir\":\"build\",\
+\"DistributionDir\":\"dist\",\
 \"BuildCommand\":\"npm run-script build\",\
 \"StartCommand\":\"npm run-script start\"\
 }"

--- a/packages/amplify-cli/sample-headless-scripts/headless_init_new_project.sh
+++ b/packages/amplify-cli/sample-headless-scripts/headless_init_new_project.sh
@@ -4,7 +4,7 @@ IFS='|'
 
 REACTCONFIG="{\
 \"SourceDir\":\"src\",\
-\"DistributionDir\":\"build\",\
+\"DistributionDir\":\"dist\",\
 \"BuildCommand\":\"npm run-script build\",\
 \"StartCommand\":\"npm run-script start\"\
 }"

--- a/packages/amplify-cli/tests/amplify-helpers/headless-config.sh
+++ b/packages/amplify-cli/tests/amplify-helpers/headless-config.sh
@@ -4,7 +4,7 @@ IFS='|'
 
 REACTCONFIG="{\
 \"SourceDir\":\"src\",\
-\"DistributionDir\":\"build\",\
+\"DistributionDir\":\"dist\",\
 \"BuildCommand\":\"npm run-script build\",\
 \"StartCommand\":\"npm run-script start\"\
 }"

--- a/packages/amplify-cli/tests/amplify-helpers/headless-init.sh
+++ b/packages/amplify-cli/tests/amplify-helpers/headless-init.sh
@@ -4,7 +4,7 @@ IFS='|'
 
 REACTCONFIG="{\
 \"SourceDir\":\"src\",\
-\"DistributionDir\":\"build\",\
+\"DistributionDir\":\"dist\",\
 \"BuildCommand\":\"npm run-script build\",\
 \"StartCommand\":\"npm run-script start\"\
 }"

--- a/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
+++ b/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
@@ -4,7 +4,7 @@ const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
 
 const reactConfig = {
   SourceDir: 'src',
-  DistributionDir: 'build',
+  DistributionDir: 'dist',
   BuildCommand: `${npm} run-script build`,
   StartCommand: `${npm} run-script start`,
 };


### PR DESCRIPTION
*Issue #1307, if available:*
#1307 

*Description of changes:*
set default distribution folder of the Getting started of react from build to dist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.