### PR TITLE
fix: use JSON parse instead of require in xr

### DIFF
--- a/packages/amplify-category-xr/lib/xr-manager.js
+++ b/packages/amplify-category-xr/lib/xr-manager.js
@@ -19,7 +19,7 @@ async function ensureSetup(context, resourceName) {
 
 async function setupAccess(context, resourceName) {
   let templateFilePath = path.join(__dirname, constants.TemplateFileName);
-  const template = JSON.parse(fs.readFileSync(templateFilePath));
+  const template = context.amplify.readJsonFile(templateFilePath);
 
   const answer = await inquirer.prompt({
     name: 'allowUnAuthAccess',
@@ -139,7 +139,7 @@ async function addSceneConfig(context, sceneName) {
     validate: (configFilePath) => {
       try {
         if (fs.existsSync(configFilePath)) {
-          sumerianConfig = JSON.parse(fs.readFileSync(configFilePath));
+          sumerianConfig = context.amplify.readJsonFile(configFilePath);
 
           // Sumerian config must have a url and sceneId
           if (!sumerianConfig.url || !sumerianConfig.sceneId) {

--- a/packages/amplify-category-xr/lib/xr-manager.js
+++ b/packages/amplify-category-xr/lib/xr-manager.js
@@ -139,7 +139,7 @@ async function addSceneConfig(context, sceneName) {
     validate: (configFilePath) => {
       try {
         if (fs.existsSync(configFilePath)) {
-          sumerianConfig = require(configFilePath);
+          sumerianConfig = JSON.parse(fs.readFileSync(configFilePath));
 
           // Sumerian config must have a url and sceneId
           if (!sumerianConfig.url || !sumerianConfig.sceneId) {


### PR DESCRIPTION
*Description of changes:*
- Use JSON parse instead of require to prevent file path inconsistencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.