### PR TITLE
fix(amplify-category-api):add-graphql-datasource use selected profile

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/AuroraDataAPIClient.ts
+++ b/packages/graphql-relational-schema-transformer/src/AuroraDataAPIClient.ts
@@ -13,8 +13,8 @@ export class AuroraDataAPIClient {
         this.RDS = rdsClient
     }
 
-    constructor(databaseRegion: string, awsSecretStoreArn: string, dbClusterOrInstanceArn: string, database: string) {
-        this.AWS = require('aws-sdk')
+    constructor(databaseRegion: string, awsSecretStoreArn: string, dbClusterOrInstanceArn: string, database: string, aws: any) {
+        this.AWS = aws
         this.AWS.config.update({
             region: databaseRegion
         })

--- a/packages/graphql-relational-schema-transformer/src/AuroraServerlessMySQLDatabaseReader.ts
+++ b/packages/graphql-relational-schema-transformer/src/AuroraServerlessMySQLDatabaseReader.ts
@@ -20,9 +20,9 @@ export class AuroraServerlessMySQLDatabaseReader implements IRelationalDBReader 
         this.auroraClient = auroraClient
     }
 
-    constructor(dbRegion: string, awsSecretStoreArn: string, dbClusterOrInstanceArn: string, database: string) {
+    constructor(dbRegion: string, awsSecretStoreArn: string, dbClusterOrInstanceArn: string, database: string, aws:any) {
         this.auroraClient = new AuroraDataAPIClient(dbRegion, awsSecretStoreArn,
-             dbClusterOrInstanceArn, database)
+             dbClusterOrInstanceArn, database, aws)
         this.dbRegion = dbRegion
         this.awsSecretStoreArn = awsSecretStoreArn
         this.dbClusterOrInstanceArn = dbClusterOrInstanceArn

--- a/packages/graphql-relational-schema-transformer/src/__tests__/AuroraDataAPIClient.test.ts
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/AuroraDataAPIClient.test.ts
@@ -69,7 +69,10 @@ test('Test list tables', async () => {
          throw new Error('Incorrect SQL given.')
       })
    }))
-   const testClient = new AuroraDataAPIClient(region, secretStoreArn, clusterArn, databaseName)
+
+   const aws = require('aws-sdk')
+
+   const testClient = new AuroraDataAPIClient(region, secretStoreArn, clusterArn, databaseName, aws)
    const mockRDS = new MockRDSClient()
    testClient.setRDSClient(mockRDS)
 
@@ -147,7 +150,9 @@ test('Test foreign key lookup', async() => {
          throw new Error('Incorrect SQL given.')
       })
    }))
-   const testClient = new AuroraDataAPIClient(region, secretStoreArn, clusterArn, databaseName)
+
+   const aws = require('aws-sdk')
+   const testClient = new AuroraDataAPIClient(region, secretStoreArn, clusterArn, databaseName, aws)
    const mockRDS = new MockRDSClient()
    testClient.setRDSClient(mockRDS)
 
@@ -478,7 +483,9 @@ test('Test describe table', async() => {
          throw new Error('Incorrect SQL given.')
       })
    }))
-   const testClient = new AuroraDataAPIClient(region, secretStoreArn, clusterArn, databaseName)
+
+   const aws = require('aws-sdk')
+   const testClient = new AuroraDataAPIClient(region, secretStoreArn, clusterArn, databaseName, aws)
    const mockRDS = new MockRDSClient()
    testClient.setRDSClient(mockRDS)
 

--- a/packages/graphql-relational-schema-transformer/src/__tests__/AuroraServerlessMySQLDBReader.test.ts
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/AuroraServerlessMySQLDBReader.test.ts
@@ -11,8 +11,9 @@ const tableAName = 'a'
 const tableBName = 'b'
 const tableCName = 'c'
 const tableDName = 'd'     
+const aws = require('aws-sdk')
 
-const dummyReader = new AuroraServerlessMySQLDatabaseReader(dbRegion, secretStoreArn, clusterArn, testDBName)
+const dummyReader = new AuroraServerlessMySQLDatabaseReader(dbRegion, secretStoreArn, clusterArn, testDBName, aws)
 
 test('Test describe table', async () => {
     const MockAuroraClient = jest.fn<AuroraDataAPIClient>(() => ({


### PR DESCRIPTION
- RDS import plugin did not use the configured AWS credentials form the Amplify Project. Updated to use the configured profile
- RDS import plugin showed only 10 secrets. Added fetching all the results 
closes: #1314 and #1315

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.