### PR TITLE
fix(amplify-codegen): make codegen multienv aware

### DIFF
--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -20,8 +20,6 @@ async function postPushCallback(context, graphQLConfig) {
   const schema = await downloadIntrospectionSchema(context, api.id, schemaLocation);
 
   const newProject = graphQLConfig.gqlConfig;
-  newProject.amplifyExtension.graphQLApiId = api.id;
-  newProject.endpoint = api.endpoint;
   newProject.schema = schema;
 
   config.addProject(newProject);

--- a/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
+++ b/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
@@ -50,9 +50,7 @@ class AmplifyCodeGenConfig {
     if (project.amplifyExtension && Object.keys(project.amplifyExtension).length) {
       extensions.amplify = project.amplifyExtension;
     }
-    if (project.endpoint) {
-      extensions.endpoints = { prod: project.endpoint };
-    }
+
     if (Object.keys(extensions).length) {
       newProject.extensions = extensions;
     }

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -80,13 +80,11 @@ async function add(context, apiId = null) {
     excludes: answer.excludePattern,
     schema,
     amplifyExtension: {
-      graphQLApiId: apiDetails.id,
       codeGenTarget: answer.target || '',
       generatedFileName: answer.generatedFileName || '',
       docsFilePath: answer.docsFilePath,
       region,
     },
-    endpoint: apiDetails.endpoint,
   };
 
   if (answer.maxDepth) {

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -6,20 +6,23 @@ const generateTypes = require('./types');
 const generateStatements = require('./statements');
 const loadConfig = require('../codegen-config');
 const constants = require('../constants');
-const { downloadIntrospectionSchemaWithProgress, isAppSyncApiPendingPush } = require('../utils');
+const { downloadIntrospectionSchemaWithProgress, isAppSyncApiPendingPush, getAppSyncAPIDetails } = require('../utils');
 
 async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
+
   const { projectPath } = context.amplify.getEnvInfo();
-  if (!projects.length) {
+  const apis = getAppSyncAPIDetails(context);
+  if (!projects.length || !apis.length) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
   }
+
   if (forceDownloadSchema) {
     const downloadPromises = projects.map(async cfg =>
       downloadIntrospectionSchemaWithProgress(
         context,
-        cfg.amplifyExtension.graphQLApiId,
+        apis[0].id,
         join(projectPath, cfg.schema),
         cfg.amplifyExtension.region,
       ),

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -5,13 +5,14 @@ const statementsGen = require('amplify-graphql-docs-generator').default;
 
 const loadConfig = require('../codegen-config');
 const constants = require('../constants');
-const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require('../utils');
+const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 
 async function generateStatements(context, forceDownloadSchema, maxDepth) {
   const config = loadConfig(context);
   const projects = config.getProjects();
+  const apis = getAppSyncAPIDetails(context);
   const { projectPath } = context.amplify.getEnvInfo();
-  if (!projects.length) {
+  if (!projects.length || !apis.length) {
     context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
     return;
   }
@@ -24,7 +25,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth) {
     if (forceDownloadSchema || jetpack.exists(schemaPath) !== 'file') {
       await downloadIntrospectionSchemaWithProgress(
         context,
-        cfg.amplifyExtension.graphQLApiId,
+        apis[0].id,
         schemaPath,
         cfg.amplifyExtension.region,
       );

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -6,15 +6,15 @@ const jetpack = require('fs-jetpack');
 
 const constants = require('../constants');
 const loadConfig = require('../codegen-config');
-const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require('../utils');
+const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 
 async function generateTypes(context, forceDownloadSchema) {
   const frontend = getFrontEndHandler(context);
   if (frontend !== 'android') {
     const config = loadConfig(context);
     const projects = config.getProjects();
-
-    if (!projects.length) {
+    const apis = getAppSyncAPIDetails(context);
+    if (!projects.length || !apis.length) {
       context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
       return;
     }
@@ -39,7 +39,7 @@ async function generateTypes(context, forceDownloadSchema) {
       if (forceDownloadSchema || jetpack.exists(schemaPath) !== 'file') {
         await downloadIntrospectionSchemaWithProgress(
           context,
-          cfg.amplifyExtension.graphQLApiId,
+          apis[0].id,
           schemaPath,
           cfg.amplifyExtension.region,
         );

--- a/packages/amplify-codegen/tests/callbacks/postPushCallback.test.js
+++ b/packages/amplify-codegen/tests/callbacks/postPushCallback.test.js
@@ -66,10 +66,8 @@ describe('Callback - Post Push update AppSync API', () => {
       ...MOCK_GRAPHQL_CONFIG.gqlConfig,
       amplifyExtension: {
         ...MOCK_GRAPHQL_CONFIG.gqlConfig.amplifyExtension,
-        graphQLApiId: MOCK_API_ID,
       },
       schema: MOCK_SCHEMA_DOWNLOAD_PATH,
-      endpoint: MOCK_API_ENDPOINT,
     });
   });
 

--- a/packages/amplify-codegen/tests/commands/add.test.js
+++ b/packages/amplify-codegen/tests/commands/add.test.js
@@ -89,11 +89,9 @@ describe('command - add', () => {
     expect(newProjectConfig.includes).toEqual(MOCK_INCLUDE_PATTERN);
     expect(newProjectConfig.excludes).toEqual(MOCK_EXCLUDE_PATTERN);
     expect(newProjectConfig.schema).toEqual(MOCK_DOWNLOADED_SCHEMA_LOCATION);
-    expect(newProjectConfig.amplifyExtension.graphQLApiId).toEqual(MOCK_API_ID);
     expect(newProjectConfig.amplifyExtension.codeGenTarget).toEqual(MOCK_TARGET);
     expect(newProjectConfig.amplifyExtension.generatedFileName).toEqual(MOCK_GENERATED_FILE_NAME);
     expect(newProjectConfig.amplifyExtension.docsFilePath).toEqual(MOCK_DOCS_FILE_PATH);
-    expect(newProjectConfig.endpoint).toEqual(MOCK_ENDPOINT);
 
     expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false);
     expect(generateTypes).toHaveBeenCalledWith(MOCK_CONTEXT, false);

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const {
   downloadIntrospectionSchemaWithProgress,
   isAppSyncApiPendingPush,
+  getAppSyncAPIDetails,
 } = require('../../src/utils');
 
 const MOCK_CONTEXT = {
@@ -40,11 +41,15 @@ const MOCK_PROJECT = {
   amplifyExtension: {
     generatedFileName: MOCK_GENERATED_FILE_NAME,
     codeGenTarget: MOCK_TARGET,
-    graphQLApiId: MOCK_API_ID,
     docsFilePath: MOCK_STATEMENTS_PATH,
     region: MOCK_REGION,
   },
 };
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
 
 describe('command - generateStatementsAndTypes', () => {
   beforeEach(() => {
@@ -54,6 +59,7 @@ describe('command - generateStatementsAndTypes', () => {
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
     MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
   });
 
   it('should generate statements and types', async () => {

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -5,7 +5,12 @@ const jetpack = require('fs-jetpack');
 const loadConfig = require('../../src/codegen-config');
 const generateStatements = require('../../src/commands/statements');
 const constants = require('../../src/constants');
-const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require('../../src/utils');
+const {
+  downloadIntrospectionSchemaWithProgress,
+  getFrontEndHandler,
+  getAppSyncAPIDetails,
+} = require('../../src/utils');
+
 
 const MOCK_CONTEXT = {
   print: {
@@ -30,6 +35,11 @@ const MOCK_API_ID = 'MOCK_API_ID';
 const MOCK_REGION = 'MOCK_AWS_REGION';
 const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
 
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
 const MOCK_PROJECT = {
   includes: [MOCK_INCLUDE_PATH],
   schema: MOCK_SCHEMA,
@@ -53,6 +63,7 @@ describe('command - statements', () => {
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
     MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
   });
 
   it('should generate statements', async () => {

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -6,7 +6,11 @@ const jetpack = require('fs-jetpack');
 const loadConfig = require('../../src/codegen-config');
 const generateTypes = require('../../src/commands/types');
 const constants = require('../../src/constants');
-const { downloadIntrospectionSchemaWithProgress, getFrontEndHandler } = require('../../src/utils');
+const {
+  downloadIntrospectionSchemaWithProgress,
+  getFrontEndHandler,
+  getAppSyncAPIDetails,
+} = require('../../src/utils');
 
 const MOCK_CONTEXT = {
   print: {
@@ -45,6 +49,11 @@ const MOCK_PROJECT = {
   },
 };
 sync.mockReturnValue(MOCK_QUERIES);
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
 
 getFrontEndHandler.mockReturnValue('javascript');
 
@@ -57,6 +66,7 @@ describe('command - types', () => {
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
     MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
   });
 
   it('should generate types', async () => {


### PR DESCRIPTION
Amplify codegen relied graphql config file to figure out the AppSync API ID to download the
introspection schema. With the introduction of multienv, the API ID changes based on the current
environment. Updated codegen to use the API ID from amplify meta to make codegen multienv aware

fix #1243

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.