### PR TITLE
feat(amplify-provider-awscloudformation): append env name

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -14,8 +14,9 @@ async function run(context) {
   if (!context.exeInfo || (context.exeInfo.isNewEnv)) {
     const awscfn = await getConfiguredAwsCfnClient(context);
     const initTemplateFilePath = path.join(__dirname, 'rootStackTemplate.json');
-    const timeStamp = `-${moment().format('YYYYMMDDHHmmss')}`;
-    const stackName = normalizeStackName(context.exeInfo.projectConfig.projectName + timeStamp);
+    const timeStamp = `${moment().format('YYYYMMDDHHmmss')}`;
+    const { envName = '' } = context.exeInfo.localEnvInfo;
+    const stackName = normalizeStackName(`${context.exeInfo.projectConfig.projectName}-${envName}-${timeStamp}`);
     const deploymentBucketName = `${stackName}-deployment`;
     const authRoleName = `${stackName}-authRole`;
     const unauthRoleName = `${stackName}-unauthRole`;


### PR DESCRIPTION
Adding env name to stack name and bucket to easily distinguish them

closes #1340

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.