### PR TITLE
fix: update CLI to handle UTF8 BOM

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/index.js
@@ -1,7 +1,6 @@
-const fs = require('fs');
 
 function addResource(context, category, service) {
-  const serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  const serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
 
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;

--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
@@ -33,7 +33,7 @@ function configure(context, defaultValuesFilename, serviceMetadata, resourceName
     inputs = inputs.filter(input => input.key !== 'resourceName');
     const resourceDirPath = path.join(projectBackendDirPath, category, resourceName);
     const parametersFilePath = path.join(resourceDirPath, parametersFileName);
-    const parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    const parameters = context.amplify.readJsonFile(parametersFilePath);
     parameters.resourceName = resourceName;
     Object.assign(defaultValues, parameters);
   }
@@ -178,7 +178,7 @@ function writeCfnFile(context, resourceDirPath, force = false) {
   const templateFilePath = path.join(resourceDirPath, templateFileName);
   if (!fs.existsSync(templateFilePath) || force) {
     const templateSourceFilePath = `${__dirname}/../cloudformation-templates/${templateFileName}`;
-    const templateSource = JSON.parse(fs.readFileSync(templateSourceFilePath));
+    const templateSource = context.amplify.readJsonFile(templateSourceFilePath);
     templateSource.Mappings = getTemplateMappings(context);
     const jsonString = JSON.stringify(templateSource, null, 4);
     fs.writeFileSync(templateFilePath, jsonString, 'utf8');
@@ -214,14 +214,14 @@ function migrate(context) {
   const { analytics = {} } = amplifyMeta;
   Object.keys(analytics).forEach((resourceName) => {
     const resourcePath = path.join(projectBackendDirPath, category, resourceName);
-    const cfn = JSON.parse(fs.readFileSync(path.join(resourcePath, 'pinpoint-cloudformation-template.json')));
+    const cfn = context.amplify.readJsonFile(path.join(resourcePath, 'pinpoint-cloudformation-template.json'));
     const updatedCfn = migrateCFN(cfn);
 
     fs.ensureDirSync(resourcePath);
     const templateFilePath = path.join(resourcePath, templateFileName);
     fs.writeFileSync(templateFilePath, JSON.stringify(updatedCfn, null, 4), 'utf8');
 
-    const parameters = JSON.parse(fs.readFileSync(path.join(resourcePath, 'parameters.json')));
+    const parameters = context.amplify.readJsonFile(path.join(resourcePath, 'parameters.json'));
     const updatedParams = migrateParams(context, parameters);
     const parametersFilePath = path.join(resourcePath, parametersFileName);
     fs.writeFileSync(parametersFilePath, JSON.stringify(updatedParams, null, 4), 'utf8');

--- a/packages/amplify-category-api/commands/api/add-datasource.js
+++ b/packages/amplify-category-api/commands/api/add-datasource.js
@@ -49,7 +49,7 @@ module.exports = {
          */
         const currEnv = amplify.getEnvInfo().envName;
         const teamProviderInfoFilePath = amplify.pathManager.getProviderInfoFilePath();
-        const teamProviderInfo = JSON.parse(fs.readFileSync(teamProviderInfoFilePath));
+        const teamProviderInfo = context.amplify.readJsonFile(teamProviderInfoFilePath);
 
         if (!teamProviderInfo[currEnv][categories]) {
           teamProviderInfo[currEnv][categories] = {};
@@ -75,7 +75,7 @@ module.exports = {
         fs.writeFileSync(teamProviderInfoFilePath, JSON.stringify(teamProviderInfo, null, 4));
 
         const backendConfigFilePath = amplify.pathManager.getBackendConfigFilePath();
-        const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+        const backendConfig = context.amplify.readJsonFile(backendConfigFilePath);
 
         backendConfig[category][resourceName][rdsInit] = true;
 

--- a/packages/amplify-category-api/index.js
+++ b/packages/amplify-category-api/index.js
@@ -57,7 +57,7 @@ async function initEnv(context) {
    * configured an RDS datasource
    */
   const backendConfigFilePath = amplify.pathManager.getBackendConfigFilePath();
-  const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendConfig = context.amplify.readJsonFile(backendConfigFilePath);
 
   let resourceName;
   const apis = Object.keys(backendConfig[category]);
@@ -90,7 +90,7 @@ async function initEnv(context) {
    */
   const currEnv = amplify.getEnvInfo().envName;
   const teamProviderInfoFilePath = amplify.pathManager.getProviderInfoFilePath();
-  const teamProviderInfo = JSON.parse(fs.readFileSync(teamProviderInfoFilePath));
+  const teamProviderInfo = context.amplify.readJsonFile(teamProviderInfoFilePath);
   if (teamProviderInfo[currEnv][categories]
     && teamProviderInfo[currEnv][categories][category]
     && teamProviderInfo[currEnv][categories][category][resourceName]

--- a/packages/amplify-category-api/index.js
+++ b/packages/amplify-category-api/index.js
@@ -57,7 +57,7 @@ async function initEnv(context) {
    * configured an RDS datasource
    */
   const backendConfigFilePath = amplify.pathManager.getBackendConfigFilePath();
-  const backendConfig = context.amplify.readJsonFile(backendConfigFilePath);
+  const backendConfig = amplify.readJsonFile(backendConfigFilePath);
 
   let resourceName;
   const apis = Object.keys(backendConfig[category]);
@@ -90,7 +90,7 @@ async function initEnv(context) {
    */
   const currEnv = amplify.getEnvInfo().envName;
   const teamProviderInfoFilePath = amplify.pathManager.getProviderInfoFilePath();
-  const teamProviderInfo = context.amplify.readJsonFile(teamProviderInfoFilePath);
+  const teamProviderInfo = amplify.readJsonFile(teamProviderInfoFilePath);
   if (teamProviderInfo[currEnv][categories]
     && teamProviderInfo[currEnv][categories][category]
     && teamProviderInfo[currEnv][categories][category][resourceName]

--- a/packages/amplify-category-api/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/index.js
@@ -33,7 +33,7 @@ function copyCfnTemplate(context, category, options, cfnFilename) {
 
 
 function console(context, service) {
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { openConsole } = require(serviceWalkthroughSrc);
@@ -48,7 +48,7 @@ function console(context, service) {
 
 function addResource(context, category, service, options) {
   let answers;
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   let { cfnFilename } = serviceMetadata;
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
@@ -101,7 +101,7 @@ function addResource(context, category, service, options) {
 
 async function updateResource(context, category, service) {
   let answers;
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   let { cfnFilename } = serviceMetadata;
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
@@ -151,7 +151,7 @@ async function updateResource(context, category, service) {
 }
 
 async function migrateResource(context, projectPath, service, resourceName) {
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { migrate } = require(serviceWalkthroughSrc);
@@ -165,7 +165,7 @@ async function migrateResource(context, projectPath, service, resourceName) {
 }
 
 function addDatasource(context, category, datasource) {
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-datasources.json`))[datasource];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-datasources.json`)[datasource];
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   return serviceQuestions(context, defaultValuesFilename, serviceWalkthroughFilename);
 }

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.js
@@ -67,7 +67,7 @@ async function updateWalkthrough(context, defaultValuesFilename) {
   const parametersFilePath = pathLib.join(resourceDirPath, parametersFileName);
   let parameters;
   try {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    parameters = context.amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     parameters = {};
   }
@@ -578,7 +578,7 @@ async function migrate(context, projectPath, resourceName) {
   const parametersFilePath = pathLib.join(resourceDirPath, parametersFileName);
   let parameters;
   try {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    parameters = context.amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     context.print.error(`Error reading api-params.json file for ${resourceName} resource`);
     throw e;

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.js
@@ -578,7 +578,7 @@ async function migrate(context, projectPath, resourceName) {
   const parametersFilePath = pathLib.join(resourceDirPath, parametersFileName);
   let parameters;
   try {
-    parameters = context.amplify.readJsonFile(parametersFilePath);
+    parameters = amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     context.print.error(`Error reading api-params.json file for ${resourceName} resource`);
     throw e;

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -261,7 +261,7 @@ async function updateWalkthrough(context) {
   let parameters = {};
 
   try {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    parameters = context.amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     context.print.error('Parameters file not found');
     context.print.info(e.stack);
@@ -270,14 +270,14 @@ async function updateWalkthrough(context) {
   const authType = await askSecurityQuestions(context, parameters);
 
   const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
 
   amplifyMeta[category][resourceName].output.securityType = authType;
   let jsonString = JSON.stringify(amplifyMeta, null, '\t');
   fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
 
   const backendConfigFilePath = context.amplify.pathManager.getBackendConfigFilePath();
-  const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendConfig = context.amplify.readJsonFile(backendConfigFilePath);
 
   backendConfig[category][resourceName].output.securityType = authType;
   jsonString = JSON.stringify(backendConfig, null, '\t');

--- a/packages/amplify-category-auth/commands/auth/enable.js
+++ b/packages/amplify-category-auth/commands/auth/enable.js
@@ -9,7 +9,7 @@ module.exports = {
   alias: ['add'],
   run: async (context) => {
     const { amplify } = context;
-    const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
 
     const existingAuth = amplify.getProjectDetails().amplifyMeta.auth || {};
 

--- a/packages/amplify-category-auth/commands/auth/enable.js
+++ b/packages/amplify-category-auth/commands/auth/enable.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const { messages } = require('../../provider-utils/awscloudformation/assets/string-maps');
 
 const subcommand = 'enable';
@@ -10,7 +9,7 @@ module.exports = {
   alias: ['add'],
   run: async (context) => {
     const { amplify } = context;
-    const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
+    const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
 
     const existingAuth = amplify.getProjectDetails().amplifyMeta.auth || {};
 

--- a/packages/amplify-category-auth/commands/auth/update.js
+++ b/packages/amplify-category-auth/commands/auth/update.js
@@ -10,7 +10,7 @@ module.exports = {
   alias: ['update'],
   run: async (context) => {
     const { amplify } = context;
-    const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     const existingAuth = amplify.getProjectDetails().amplifyMeta.auth || {};
 
     if (!Object.keys(existingAuth).length > 0) {

--- a/packages/amplify-category-auth/commands/auth/update.js
+++ b/packages/amplify-category-auth/commands/auth/update.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const { messages } = require('../../provider-utils/awscloudformation/assets/string-maps');
 
 
@@ -11,7 +10,7 @@ module.exports = {
   alias: ['update'],
   run: async (context) => {
     const { amplify } = context;
-    const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
+    const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     const existingAuth = amplify.getProjectDetails().amplifyMeta.auth || {};
 
     if (!Object.keys(existingAuth).length > 0) {

--- a/packages/amplify-category-auth/index.js
+++ b/packages/amplify-category-auth/index.js
@@ -14,7 +14,7 @@ const {
 // this function is being kept for temporary compatability.
 async function add(context) {
   const { amplify } = context;
-  const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
+  const servicesMetadata = amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
 
   const existingAuth = amplify.getProjectDetails().amplifyMeta.auth || {};
 
@@ -54,7 +54,7 @@ async function add(context) {
 
 async function externalAuthEnable(context, externalCategory, resourceName, requirements) {
   const { amplify } = context;
-  const serviceMetadata = context.amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
+  const serviceMetadata = amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
   const { cfnFilename, provider } = serviceMetadata.Cognito;
   const authExists =
     amplify.getProjectDetails().amplifyMeta.auth &&
@@ -164,7 +164,7 @@ async function checkRequirements(requirements, context) {
   let authParameters;
 
   if (existingAuth && Object.keys(existingAuth).length > 0) {
-    authParameters = context.amplify.readJsonFile(`${amplify.pathManager.getBackendDirPath()}/auth/${
+    authParameters = amplify.readJsonFile(`${amplify.pathManager.getBackendDirPath()}/auth/${
       Object.keys(existingAuth)[0]
     }/parameters.json`);
   } else {
@@ -209,7 +209,7 @@ async function initEnv(context) {
 
 async function console(context) {
   const { amplify } = context;
-  const supportedServices = context.amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
+  const supportedServices = amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
   const amplifyMeta = amplify.getProjectMeta();
 
   if (!amplifyMeta.auth || Object.keys(amplifyMeta.auth).length === 0) {

--- a/packages/amplify-category-auth/index.js
+++ b/packages/amplify-category-auth/index.js
@@ -1,5 +1,4 @@
 const category = 'auth';
-const fs = require('fs');
 const _ = require('lodash');
 const uuid = require('uuid');
 const sequential = require('promise-sequential');
@@ -15,7 +14,7 @@ const {
 // this function is being kept for temporary compatability.
 async function add(context) {
   const { amplify } = context;
-  const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/provider-utils/supported-services.json`));
+  const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
 
   const existingAuth = amplify.getProjectDetails().amplifyMeta.auth || {};
 
@@ -55,7 +54,7 @@ async function add(context) {
 
 async function externalAuthEnable(context, externalCategory, resourceName, requirements) {
   const { amplify } = context;
-  const serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/provider-utils/supported-services.json`));
+  const serviceMetadata = context.amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
   const { cfnFilename, provider } = serviceMetadata.Cognito;
   const authExists =
     amplify.getProjectDetails().amplifyMeta.auth &&
@@ -165,9 +164,9 @@ async function checkRequirements(requirements, context) {
   let authParameters;
 
   if (existingAuth && Object.keys(existingAuth).length > 0) {
-    authParameters = JSON.parse(fs.readFileSync(`${amplify.pathManager.getBackendDirPath()}/auth/${
+    authParameters = context.amplify.readJsonFile(`${amplify.pathManager.getBackendDirPath()}/auth/${
       Object.keys(existingAuth)[0]
-    }/parameters.json`));
+    }/parameters.json`);
   } else {
     return { authEnabled: false };
   }
@@ -210,7 +209,7 @@ async function initEnv(context) {
 
 async function console(context) {
   const { amplify } = context;
-  const supportedServices = JSON.parse(fs.readFileSync(`${__dirname}/provider-utils/supported-services.json`));
+  const supportedServices = context.amplify.readJsonFile(`${__dirname}/provider-utils/supported-services.json`);
   const amplifyMeta = amplify.getProjectMeta();
 
   if (!amplifyMeta.auth || Object.keys(amplifyMeta.auth).length === 0) {

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -332,7 +332,7 @@ async function migrate(context) {
   if (!Object.keys(existingAuth).length > 0) {
     return;
   }
-  const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
+  const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
   const { provider, cfnFilename, defaultValuesFilename } = servicesMetadata.Cognito;
   const defaultValuesSrc = `${__dirname}/assets/${defaultValuesFilename}`;
 

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const inquirer = require('inquirer');
 const opn = require('opn');
 const _ = require('lodash');
@@ -124,7 +123,7 @@ function saveResourceParameters(
 
 async function addResource(context, category, service) {
   let props = {};
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const {
     cfnFilename,
     defaultValuesFilename,
@@ -170,7 +169,7 @@ async function addResource(context, category, service) {
 async function updateResource(context, category, serviceResult) {
   const { service, resourceName } = serviceResult;
   let props = {};
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const {
     cfnFilename,
     defaultValuesFilename,
@@ -250,7 +249,7 @@ async function updateResource(context, category, serviceResult) {
 }
 
 async function updateConfigOnEnvInit(context, category, service) {
-  const srvcMetaData = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))
+  const srvcMetaData = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)
     .Cognito;
   const { defaultValuesFilename, stringMapFilename, serviceWalkthroughFilename } = srvcMetaData;
 
@@ -333,7 +332,7 @@ async function migrate(context) {
   if (!Object.keys(existingAuth).length > 0) {
     return;
   }
-  const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
+  const servicesMetadata = context.amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
   const { provider, cfnFilename, defaultValuesFilename } = servicesMetadata.Cognito;
   const defaultValuesSrc = `${__dirname}/assets/${defaultValuesFilename}`;
 

--- a/packages/amplify-category-auth/tests/commands/enable.test.js
+++ b/packages/amplify-category-auth/tests/commands/enable.test.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const add = require('../../commands/auth/enable');
 const { messages } = require('../../provider-utils/awscloudformation/assets/string-maps');
 
@@ -12,6 +13,7 @@ describe('auth enable: ', () => {
       executeProviderUtils: mockExecuteProviderUtils,
       getProjectDetails: mockGetProjectDetails,
       serviceSelectionPrompt: mockSelectionPrompt,
+      readJsonFile: jest.fn(path => JSON.parse(fs.readFileSync(path))),
     },
     print: {
       warning: jest.fn(),

--- a/packages/amplify-category-auth/tests/commands/update.test.js
+++ b/packages/amplify-category-auth/tests/commands/update.test.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const update = require('../../commands/auth/update');
 const { messages } = require('../../provider-utils/awscloudformation/assets/string-maps');
 
@@ -10,6 +11,7 @@ describe('auth update: ', () => {
   const mockGetProjectDetails = jest.fn();
   const mockSelectionPrompt = jest.fn(() => Promise.reject(new Error()));
   const mockProjectPath = '/User/someone/Documents/Project/amplify-test';
+
   const mockPluginInstance = { loadResourceParameters: jest.fn() };
   const mockContext = {
     amplify: {
@@ -17,6 +19,7 @@ describe('auth update: ', () => {
       getProjectDetails: mockGetProjectDetails,
       serviceSelectionPrompt: mockSelectionPrompt,
       getPluginInstance: jest.fn().mockReturnValue(mockPluginInstance),
+      readJsonFile: jest.fn(path => JSON.parse(fs.readFileSync(path))),
       pathManager: {
         getBackendDirPath: jest.fn(),
       },

--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -99,7 +99,7 @@ function copyCfnTemplate(context, category, options, cfnFilename) {
 
 async function addResource(context, category, service, options) {
   let answers;
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { cfnFilename, defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
 
   const result = await serviceQuestions(context, defaultValuesFilename, serviceWalkthroughFilename);
@@ -142,7 +142,7 @@ async function openEditor(context, category, options) {
 
 async function invoke(context, category, service, resourceName) {
   const { amplify } = context;
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { inputs } = serviceMetadata;
   const resourceQuestions = [
     {
@@ -200,7 +200,7 @@ async function invoke(context, category, service, resourceName) {
 }
 
 function migrateResource(context, projectPath, service, resourceName) {
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { migrate } = require(serviceWalkthroughSrc);
@@ -210,7 +210,7 @@ function migrateResource(context, projectPath, service, resourceName) {
     return;
   }
 
-  return migrate(projectPath, resourceName);
+  return migrate(context, projectPath, resourceName);
 }
 
 

--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -142,7 +142,7 @@ async function openEditor(context, category, options) {
 
 async function invoke(context, category, service, resourceName) {
   const { amplify } = context;
-  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
+  serviceMetadata = amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { inputs } = serviceMetadata;
   const resourceQuestions = [
     {

--- a/packages/amplify-category-function/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.js
@@ -106,7 +106,7 @@ async function getTableParameters(context, dynamoAnswers) {
   const parametersFilePath = path.join(resourceDirPath, parametersFileName);
   let parameters;
   try {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    parameters = context.amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     parameters = {};
   }
@@ -207,10 +207,10 @@ async function askDynamoDBQuestions(context, inputs) {
   }
 }
 
-function migrate(projectPath, resourceName) {
+function migrate(context, projectPath, resourceName) {
   const resourceDirPath = path.join(projectPath, 'amplify', 'backend', category, resourceName);
   const cfnFilePath = path.join(resourceDirPath, `${resourceName}-cloudformation-template.json`);
-  const oldCfn = JSON.parse(fs.readFileSync(cfnFilePath, 'utf8'));
+  const oldCfn = context.amplify.readJsonFile(cfnFilePath, 'utf8');
   const newCfn = {};
   Object.assign(newCfn, oldCfn);
 

--- a/packages/amplify-category-function/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.js
@@ -210,7 +210,7 @@ async function askDynamoDBQuestions(context, inputs) {
 function migrate(context, projectPath, resourceName) {
   const resourceDirPath = path.join(projectPath, 'amplify', 'backend', category, resourceName);
   const cfnFilePath = path.join(resourceDirPath, `${resourceName}-cloudformation-template.json`);
-  const oldCfn = context.amplify.readJsonFile(cfnFilePath, 'utf8');
+  const oldCfn = context.amplify.readJsonFile(cfnFilePath);
   const newCfn = {};
   Object.assign(newCfn, oldCfn);
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -1,4 +1,3 @@
-const fs = require('fs-extra');
 const path = require('path');
 const inquirer = require('inquirer');
 
@@ -18,7 +17,7 @@ const originErrorCodes = {
 
 async function configure(context) {
   const templateFilePath = path.join(__dirname, '../template.json');
-  const originalTemplate = JSON.parse(fs.readFileSync(templateFilePath));
+  const originalTemplate = context.amplify.readJsonFile(templateFilePath);
   if (!context.exeInfo.template.Resources.CloudFrontDistribution) {
     context.print.info('CloudFront is NOT in the current hosting');
     const answer = await inquirer.prompt({

--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/index.js
@@ -47,7 +47,7 @@ function copyCfnTemplate(context, category, options, cfnFilename) {
 
 async function addResource(context, category, service, options) {
   await authHelper.ensureAuth(context);
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { cfnFilename } = serviceMetadata;
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
@@ -92,7 +92,7 @@ async function addResource(context, category, service, options) {
 }
 
 function updateResource(context, category, service) {
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { cfnFilename } = serviceMetadata;
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
@@ -120,7 +120,7 @@ function updateResource(context, category, service) {
 }
 
 async function migrateResource(context, projectPath, service, resourceName) {
-  serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { migrate } = require(serviceWalkthroughSrc);

--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
@@ -153,7 +153,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
       const resourceDirPath = path.join(projectBackendDirPath, category, resourceName);
       const parametersFilePath = path.join(resourceDirPath, parametersFileName);
       try {
-        parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+        parameters = context.amplify.readJsonFile(parametersFilePath);
       } catch (e) {
         parameters = {};
       }
@@ -722,7 +722,7 @@ async function migrate(context, projectPath, resourceName) {
 
   let parameters;
   try {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    parameters = context.amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     context.print.error(`Error reading api-params.json file for ${resourceName} resource`);
     throw e;

--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
@@ -722,7 +722,7 @@ async function migrate(context, projectPath, resourceName) {
 
   let parameters;
   try {
-    parameters = context.amplify.readJsonFile(parametersFilePath);
+    parameters = amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     context.print.error(`Error reading api-params.json file for ${resourceName} resource`);
     throw e;

--- a/packages/amplify-category-notifications/lib/multi-env-manager.js
+++ b/packages/amplify-category-notifications/lib/multi-env-manager.js
@@ -44,7 +44,7 @@ async function constructPinpointNotificationsMeta(context) {
   }
 
   const backendConfigFilePath = context.amplify.pathManager.getBackendConfigFilePath();
-  const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendConfig = context.amplify.readJsonFile(backendConfigFilePath);
   if (backendConfig[constants.CategoryName]) {
     const categoryConfig = backendConfig[constants.CategoryName];
     const services = Object.keys(categoryConfig);
@@ -209,10 +209,18 @@ async function writeData(context) {
   }
   // TODO: move writing to files logic to the cli core when those are ready
   writeTeamProviderInfo(pinpointMeta, context);
-  writeBackendConfig(pinpointMeta, context.amplify.pathManager.getBackendConfigFilePath());
-  writeBackendConfig(pinpointMeta, context.amplify.pathManager.getCurrentBackendConfigFilePath());
-  writeAmplifyMeta(categoryMeta, context.amplify.pathManager.getAmplifyMetaFilePath());
-  writeAmplifyMeta(categoryMeta, context.amplify.pathManager.getCurentAmplifyMetaFilePath());
+  writeBackendConfig(context, pinpointMeta, context.amplify.pathManager.getBackendConfigFilePath());
+  writeBackendConfig(
+    context,
+    pinpointMeta,
+    context.amplify.pathManager.getCurrentBackendConfigFilePath(),
+  );
+  writeAmplifyMeta(context, categoryMeta, context.amplify.pathManager.getAmplifyMetaFilePath());
+  writeAmplifyMeta(
+    context,
+    categoryMeta,
+    context.amplify.pathManager.getCurentAmplifyMetaFilePath(),
+  );
   await context.amplify.onCategoryOutputsChange(context);
 }
 
@@ -220,7 +228,7 @@ function writeTeamProviderInfo(pinpointMeta, context) {
   const teamProviderInfoFilepath = context.amplify.pathManager.getProviderInfoFilePath();
   if (fs.existsSync(teamProviderInfoFilepath)) {
     const { envName } = context.exeInfo.localEnvInfo;
-    const teamProviderInfo = JSON.parse(fs.readFileSync(teamProviderInfoFilepath));
+    const teamProviderInfo = context.amplify.readJsonFile(teamProviderInfoFilepath);
     teamProviderInfo[envName] = teamProviderInfo[envName] || {};
     teamProviderInfo[envName].categories = teamProviderInfo[envName].categories || {};
     teamProviderInfo[envName].categories[constants.CategoryName] =
@@ -236,9 +244,9 @@ function writeTeamProviderInfo(pinpointMeta, context) {
   }
 }
 
-function writeBackendConfig(pinpointMeta, backendConfigFilePath) {
+function writeBackendConfig(context, pinpointMeta, backendConfigFilePath) {
   if (fs.existsSync(backendConfigFilePath)) {
-    const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+    const backendConfig = context.amplify.readJsonFile(backendConfigFilePath);
     backendConfig[constants.CategoryName] = backendConfig[constants.CategoryName] || {};
 
     const services = Object.keys(backendConfig[constants.CategoryName]);
@@ -261,9 +269,9 @@ function writeBackendConfig(pinpointMeta, backendConfigFilePath) {
   }
 }
 
-function writeAmplifyMeta(categoryMeta, amplifyMetaFilePath) {
+function writeAmplifyMeta(context, categoryMeta, amplifyMetaFilePath) {
   if (fs.existsSync(amplifyMetaFilePath)) {
-    const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+    const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
     amplifyMeta[constants.CategoryName] = categoryMeta;
     const jsonString = JSON.stringify(amplifyMeta, null, '\t');
     fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/index.js
@@ -1,7 +1,6 @@
-const fs = require('fs');
 
 function addResource(context, category, service, options) {
-  const serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  const serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { addWalkthrough } = require(serviceWalkthroughSrc);
@@ -18,7 +17,7 @@ function addResource(context, category, service, options) {
 }
 
 function updateResource(context, category, service) {
-  const serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  const serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { defaultValuesFilename, serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { updateWalkthrough } = require(serviceWalkthroughSrc);
@@ -32,7 +31,7 @@ function updateResource(context, category, service) {
 }
 
 function migrateResource(context, projectPath, service, resourceName) {
-  const serviceMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../supported-services.json`))[service];
+  const serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const { serviceWalkthroughFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { migrate } = require(serviceWalkthroughSrc);
@@ -42,7 +41,7 @@ function migrateResource(context, projectPath, service, resourceName) {
     return;
   }
 
-  return migrate(projectPath, resourceName);
+  return migrate(context, projectPath, resourceName);
 }
 
 

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -73,7 +73,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
     const parametersFilePath = path.join(resourceDirPath, parametersFileName);
     let parameters;
     try {
-      parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+      parameters = context.amplify.readJsonFile(parametersFilePath);
     } catch (e) {
       parameters = {};
     }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -73,7 +73,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
     const resourceDirPath = path.join(projectBackendDirPath, category, resourceName);
     const parametersFilePath = path.join(resourceDirPath, parametersFileName);
     try {
-      parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+      parameters = context.amplify.readJsonFile(parametersFilePath);
     } catch (e) {
       parameters = {};
     }
@@ -287,13 +287,13 @@ function checkIfAuthExists(context) {
   return authExists;
 }
 
-function migrate(projectPath, resourceName) {
+function migrate(context, projectPath, resourceName) {
   const resourceDirPath = path.join(projectPath, 'amplify', 'backend', category, resourceName);
 
   // Change CFN file
 
   const cfnFilePath = path.join(resourceDirPath, 's3-cloudformation-template.json');
-  const oldCfn = JSON.parse(fs.readFileSync(cfnFilePath, 'utf8'));
+  const oldCfn = context.amplify.readJsonFile(cfnFilePath, 'utf8');
   const newCfn = {};
   Object.assign(newCfn, oldCfn);
 
@@ -349,7 +349,7 @@ function migrate(projectPath, resourceName) {
 
   // Change Parameters file
   const parametersFilePath = path.join(resourceDirPath, parametersFileName);
-  const oldParameters = JSON.parse(fs.readFileSync(parametersFilePath, 'utf8'));
+  const oldParameters = context.amplify.readJsonFile(parametersFilePath, 'utf8');
   const newParameters = {};
   Object.assign(newParameters, oldParameters);
 

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -73,7 +73,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
     const resourceDirPath = path.join(projectBackendDirPath, category, resourceName);
     const parametersFilePath = path.join(resourceDirPath, parametersFileName);
     try {
-      parameters = context.amplify.readJsonFile(parametersFilePath);
+      parameters = amplify.readJsonFile(parametersFilePath);
     } catch (e) {
       parameters = {};
     }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -293,7 +293,7 @@ function migrate(context, projectPath, resourceName) {
   // Change CFN file
 
   const cfnFilePath = path.join(resourceDirPath, 's3-cloudformation-template.json');
-  const oldCfn = context.amplify.readJsonFile(cfnFilePath, 'utf8');
+  const oldCfn = context.amplify.readJsonFile(cfnFilePath);
   const newCfn = {};
   Object.assign(newCfn, oldCfn);
 

--- a/packages/amplify-category-xr/index.js
+++ b/packages/amplify-category-xr/index.js
@@ -1,6 +1,5 @@
 const xrManager = require('./lib/xr-manager');
 const inquirer = require('inquirer');
-const fs = require('fs-extra');
 
 const SUMERIAN_SERVICE_NAME = 'Sumerian';
 const XR_CATEGORY_NAME = 'xr';
@@ -57,7 +56,7 @@ async function initEnv(context) {
     }
   }
 
-  const backendConfig = JSON.parse(fs.readFileSync(context.amplify.pathManager.getBackendConfigFilePath()));
+  const backendConfig = context.amplify.readJsonFile(context.amplify.pathManager.getBackendConfigFilePath());
   const xrResources = Object.keys(backendConfig.xr);
 
   if (xrResources.length > 0) {

--- a/packages/amplify-cli/src/commands/env/checkout.js
+++ b/packages/amplify-cli/src/commands/env/checkout.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const sequential = require('promise-sequential');
 const { initializeEnv } = require('../../lib/initialize-env');
 const { getProviderPlugins } = require('../../extensions/amplify-helpers/get-provider-plugins');
+const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 module.exports = {
   name: 'checkout',
@@ -19,7 +20,7 @@ module.exports = {
     // Set the current env to the environment name provided
 
     const localEnvFilePath = context.amplify.pathManager.getLocalEnvFilePath();
-    const localEnvInfo = JSON.parse(fs.readFileSync(localEnvFilePath));
+    const localEnvInfo = readJsonFile(localEnvFilePath);
     localEnvInfo.envName = envName;
     const jsonString = JSON.stringify(localEnvInfo, null, 4);
     fs.writeFileSync(localEnvFilePath, jsonString, 'utf8');

--- a/packages/amplify-cli/src/commands/env/import.js
+++ b/packages/amplify-cli/src/commands/env/import.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
+const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 module.exports = {
   name: 'import',
@@ -47,7 +48,7 @@ module.exports = {
 
       let envAwsInfo = {};
       if (fs.existsSync(configInfoFilePath)) {
-        envAwsInfo = JSON.parse(fs.readFileSync(configInfoFilePath));
+        envAwsInfo = readJsonFile(configInfoFilePath);
       }
 
       envAwsInfo[envName] = awsInfo;

--- a/packages/amplify-cli/src/commands/env/remove.js
+++ b/packages/amplify-cli/src/commands/env/remove.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const ora = require('ora');
+const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 module.exports = {
   name: 'remove',
@@ -47,7 +48,7 @@ module.exports = {
       // Remove entry from aws-info
       const dotConfigDirPath = context.amplify.pathManager.getDotConfigDirPath();
       const awsInfoFilePath = path.join(dotConfigDirPath, 'local-aws-info.json');
-      const awsInfo = JSON.parse(fs.readFileSync(awsInfoFilePath));
+      const awsInfo = readJsonFile(awsInfoFilePath);
       if (awsInfo[envName]) {
         delete awsInfo[envName];
         jsonString = JSON.stringify(awsInfo, null, '\t');

--- a/packages/amplify-cli/src/extensions/amplify-helpers/envResourceParams.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/envResourceParams.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const pathManager = require('./path-manager');
 const { getEnvInfo } = require('./get-env-info');
+const { readJsonFile } = require('./read-json-file');
 
 const CATEGORIES = 'categories';
 
@@ -22,7 +23,7 @@ function loadAllResourceParameters(context) {
     }
     const teamProviderInfoFilePath = pathManager.getProviderInfoFilePath();
     if (fs.existsSync(teamProviderInfoFilePath)) {
-      return JSON.parse(fs.readFileSync(teamProviderInfoFilePath));
+      return readJsonFile(teamProviderInfoFilePath);
     }
   } catch (e) {
     return {};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-all-envs.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-all-envs.js
@@ -1,11 +1,12 @@
 const fs = require('fs-extra');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function getAllEnvs() {
   let allEnvs = [];
-  const teamProviderInfoFilepath = pathManager.getProviderInfoFilePath();
-  if (fs.existsSync(teamProviderInfoFilepath)) {
-    const envInfo = JSON.parse(fs.readFileSync(teamProviderInfoFilepath));
+  const teamProviderInfoFilePath = pathManager.getProviderInfoFilePath();
+  if (fs.existsSync(teamProviderInfoFilePath)) {
+    const envInfo = readJsonFile(teamProviderInfoFilePath);
     allEnvs = Object.keys(envInfo);
   }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-env-details.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-env-details.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function getEnvDetails() {
-  const envProviderFilepath = pathManager.getProviderInfoFilePath();
+  const envProviderFilePath = pathManager.getProviderInfoFilePath();
   let envProviderInfo = {};
-  if (fs.existsSync(envProviderFilepath)) {
-    envProviderInfo = JSON.parse(fs.readFileSync(envProviderFilepath));
+  if (fs.existsSync(envProviderFilePath)) {
+    envProviderInfo = readJsonFile(envProviderFilePath);
   }
 
   return envProviderInfo;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function getEnvInfo() {
-  const envFilepath = pathManager.getLocalEnvFilePath();
+  const envFilePath = pathManager.getLocalEnvFilePath();
   let envInfo = {};
-  if (fs.existsSync(envFilepath)) {
-    envInfo = JSON.parse(fs.readFileSync(envFilepath));
+  if (fs.existsSync(envFilePath)) {
+    envInfo = readJsonFile(envFilePath);
   }
 
   return envInfo;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-project-config.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-project-config.js
@@ -1,9 +1,9 @@
-const fs = require('fs');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function getProjectConfig() {
   const projectConfigFilePath = pathManager.getProjectConfigFilePath();
-  const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+  const projectConfig = readJsonFile(projectConfigFilePath);
   return projectConfig;
 }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-project-details.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-project-details.js
@@ -1,26 +1,27 @@
 const fs = require('fs-extra');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function getProjectDetails() {
   const projectConfigFilePath = pathManager.getProjectConfigFilePath();
-  const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+  const projectConfig = readJsonFile(projectConfigFilePath);
 
   let amplifyMeta = {};
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
   if (fs.existsSync(amplifyMetaFilePath)) {
-    amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+    amplifyMeta = readJsonFile(amplifyMetaFilePath);
   }
 
   let localEnvInfo = {};
-  const envFilepath = pathManager.getLocalEnvFilePath();
-  if (fs.existsSync(envFilepath)) {
-    localEnvInfo = JSON.parse(fs.readFileSync(envFilepath));
+  const envFilePath = pathManager.getLocalEnvFilePath();
+  if (fs.existsSync(envFilePath)) {
+    localEnvInfo = readJsonFile(envFilePath);
   }
 
   let teamProviderInfo = {};
   const teamProviderFilePath = pathManager.getProviderInfoFilePath();
   if (fs.existsSync(teamProviderFilePath)) {
-    teamProviderInfo = JSON.parse(fs.readFileSync(teamProviderFilePath));
+    teamProviderInfo = readJsonFile(teamProviderFilePath);
   }
 
   return {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-project-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-project-meta.js
@@ -1,9 +1,10 @@
-const fs = require('fs');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
+
 
 function getProjectMeta() {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   return amplifyMeta;
 }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-resource-outputs.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-resource-outputs.js
@@ -1,10 +1,10 @@
-const fs = require('fs');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function getResourceOutputs(amplifyMeta) {
   if (!amplifyMeta) {
     const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-    amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+    amplifyMeta = readJsonFile(amplifyMetaFilePath);
   }
 
   // Build the provider object

--- a/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/on-category-outputs-change.js
@@ -1,20 +1,20 @@
 const fs = require('fs');
 const pathManager = require('./path-manager');
 const { getResourceOutputs } = require('./get-resource-outputs');
-
+const { readJsonFile } = require('./read-json-file');
 
 async function onCategoryOutputsChange(context, cloudAmplifyMeta) {
   if (!cloudAmplifyMeta) {
     const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
     if (fs.existsSync(currentAmplifyMetafilePath)) {
-      cloudAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+      cloudAmplifyMeta = readJsonFile(currentAmplifyMetafilePath);
     } else {
       cloudAmplifyMeta = {};
     }
   }
 
   const projectConfigFilePath = pathManager.getProjectConfigFilePath();
-  const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+  const projectConfig = readJsonFile(projectConfigFilePath);
   if (projectConfig.frontend) {
     const frontendPlugins = context.amplify.getFrontendPlugins(context);
     const frontendHandlerModule =

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
@@ -4,6 +4,7 @@ const { showResourceTable } = require('./resource-status');
 const { onCategoryOutputsChange } = require('./on-category-outputs-change');
 const { initializeEnv } = require('../../lib/initialize-env');
 const { getProviderPlugins } = require('./get-provider-plugins');
+const { readJsonFile } = require('./read-json-file');
 
 async function pushResources(context, category, resourceName) {
   if (context.parameters.options.env) {
@@ -14,10 +15,10 @@ async function pushResources(context, category, resourceName) {
       context.exeInfo.forcePush = false;
       const projectConfigFilePath = context.amplify.pathManager.getProjectConfigFilePath();
       if (fs.existsSync(projectConfigFilePath)) {
-        context.exeInfo.projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+        context.exeInfo.projectConfig = readJsonFile(projectConfigFilePath);
       }
       const envFilePath = context.amplify.pathManager.getLocalEnvFilePath();
-      context.exeInfo.localEnvInfo = JSON.parse(fs.readFileSync(envFilePath));
+      context.exeInfo.localEnvInfo = readJsonFile(envFilePath);
 
       if (context.exeInfo.localEnvInfo.envName !== envName) {
         context.exeInfo.localEnvInfo.envName = envName;
@@ -52,8 +53,8 @@ async function pushResources(context, category, resourceName) {
   if (continueToPush) {
     try {
       // Get current-cloud-backend's amplify-meta
-      const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
-      const currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+      const currentAmplifyMetaFilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
+      const currentAmplifyMeta = readJsonFile(currentAmplifyMetaFilePath);
 
       await providersPush(context);
       await onCategoryOutputsChange(context, currentAmplifyMeta);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
@@ -6,10 +6,11 @@ const {
   updateBackendConfigAfterResourceRemove,
 } = require('./update-backend-config');
 const { removeResourceParameters } = require('./envResourceParams');
+const { readJsonFile } = require('./read-json-file');
 
 function removeResource(context, category) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
 
   if (!amplifyMeta[category] || Object.keys(amplifyMeta[category]).length === 0) {
     context.print.error('No resources added for this category');

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -6,6 +6,7 @@ const { hashElement } = require('folder-hash');
 const pathManager = require('./path-manager');
 const { getEnvInfo } = require('./get-env-info');
 const _ = require('lodash');
+const { readJsonFile } = require('./read-json-file');
 
 async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPushTimeStamp) {
   // Pushing the resource for the first time hence no lastPushTimeStamp
@@ -204,10 +205,10 @@ async function asyncForEach(array, callback) {
 
 async function getResourceStatus(category, resourceName, providerName) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
 
   const currentamplifyMetaFilePath = pathManager.getCurentAmplifyMetaFilePath();
-  const currentamplifyMeta = JSON.parse(fs.readFileSync(currentamplifyMetaFilePath));
+  const currentamplifyMeta = readJsonFile(currentamplifyMetaFilePath);
 
   let resourcesToBeCreated = getResourcesToBeCreated(
     amplifyMeta,

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
@@ -7,9 +7,10 @@ const {
   updateBackendConfigAfterResourceAdd,
   updateBackendConfigDependsOn,
 } = require('./update-backend-config');
+const { readJsonFile } = require('./read-json-file');
 
 function updateAwsMetaFile(filePath, category, resourceName, attribute, value, timeStamp) {
-  const amplifyMeta = JSON.parse(fs.readFileSync(filePath));
+  const amplifyMeta = readJsonFile(filePath);
 
   if (!amplifyMeta[category]) {
     amplifyMeta[category] = {};
@@ -71,7 +72,7 @@ function moveBackendResourcesToCurrentCloudBackend(resources) {
 
 function updateamplifyMetaAfterResourceAdd(category, resourceName, options) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   if (!amplifyMeta[category]) {
     amplifyMeta[category] = {};
   }
@@ -88,7 +89,7 @@ function updateamplifyMetaAfterResourceAdd(category, resourceName, options) {
 function updateProvideramplifyMeta(providerName, options) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
 
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   if (!amplifyMeta.providers) {
     amplifyMeta.providers = {};
     amplifyMeta.providers[providerName] = {};
@@ -125,7 +126,7 @@ function updateamplifyMetaAfterResourceUpdate(category, resourceName, attribute,
 
 async function updateamplifyMetaAfterPush(resources) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
 
   const currentTimestamp = new Date();
   let sourceDir;
@@ -162,7 +163,7 @@ function getHashForResourceDir(dirPath) {
 
 function updateamplifyMetaAfterBuild(resource) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   const currentTimestamp = new Date();
   /*eslint-disable */
   amplifyMeta[resource.category][resource.resourceName].lastBuildTimeStamp = currentTimestamp;
@@ -174,7 +175,7 @@ function updateamplifyMetaAfterBuild(resource) {
 
 function updateAmplifyMetaAfterPackage(resource, zipFilename) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   const currentTimestamp = new Date();
   /*eslint-disable */
   amplifyMeta[resource.category][resource.resourceName].lastPackageTimeStamp = currentTimestamp;
@@ -188,7 +189,7 @@ function updateAmplifyMetaAfterPackage(resource, zipFilename) {
 
 function updateamplifyMetaAfterResourceDelete(category, resourceName) {
   const amplifyMetaFilePath = pathManager.getCurentAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
 
   const resourceDir = path.normalize(path.join(
     pathManager.getCurrentCloudBackendDirPath(),

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-backend-config.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-backend-config.js
@@ -1,9 +1,10 @@
 const fs = require('fs-extra');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function updateBackendConfigAfterResourceAdd(category, resourceName, options) {
   const backendConfigFilePath = pathManager.getBackendConfigFilePath();
-  const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendConfig = readJsonFile(backendConfigFilePath);
   if (!backendConfig[category]) {
     backendConfig[category] = {};
   }
@@ -17,7 +18,7 @@ function updateBackendConfigAfterResourceAdd(category, resourceName, options) {
 
 function updateBackendConfigDependsOn(category, resourceName, value) {
   const backendConfigFilePath = pathManager.getBackendConfigFilePath();
-  const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendConfig = readJsonFile(backendConfigFilePath);
 
   if (!backendConfig[category]) {
     backendConfig[category] = {};
@@ -34,7 +35,7 @@ function updateBackendConfigDependsOn(category, resourceName, value) {
 
 function updateBackendConfigAfterResourceRemove(category, resourceName) {
   const backendConfigFilePath = pathManager.getBackendConfigFilePath();
-  const backendConfig = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendConfig = readJsonFile(backendConfigFilePath);
 
   if (backendConfig[category][resourceName] !== undefined) {
     delete backendConfig[category][resourceName];

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-project-config.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-project-config.js
@@ -1,11 +1,12 @@
 const fs = require('fs-extra');
 const pathManager = require('./path-manager');
+const { readJsonFile } = require('./read-json-file');
 
 function updateProjectConfig(projectPath, label, data) {
   let projectConfig;
   const projectConfigFilePath = pathManager.getProjectConfigFilePath(projectPath);
   if (fs.existsSync(projectConfigFilePath)) {
-    projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+    projectConfig = readJsonFile(projectConfigFilePath);
   } else {
     projectConfig = {};
   }

--- a/packages/amplify-cli/src/lib/config-steps/c0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/config-steps/c0-analyzeProject.js
@@ -4,14 +4,15 @@ const inquirer = require('inquirer');
 const { normalizeEditorCode, editorSelection } =
   require('../../extensions/amplify-helpers/editor-selection');
 const { makeId } = require('../../extensions/amplify-helpers/make-id');
+const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 async function run(context) {
   const projectConfigFilePath = context.amplify.pathManager.getProjectConfigFilePath();
   if (fs.existsSync(projectConfigFilePath)) {
-    context.exeInfo.projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+    context.exeInfo.projectConfig = readJsonFile(projectConfigFilePath);
   }
   const envFilePath = context.amplify.pathManager.getLocalEnvFilePath();
-  context.exeInfo.localEnvInfo = JSON.parse(fs.readFileSync(envFilePath));
+  context.exeInfo.localEnvInfo = readJsonFile(envFilePath);
 
   const projectPath = process.cwd();
   Object.assign(context.exeInfo.localEnvInfo, { projectPath });

--- a/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
@@ -5,6 +5,7 @@ const { normalizeEditorCode, editorSelection } =
   require('../../extensions/amplify-helpers/editor-selection');
 const { makeId } = require('../../extensions/amplify-helpers/make-id');
 const { PROJECT_CONFIG_VERSION } = require('../../extensions/amplify-helpers/constants');
+const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 async function run(context) {
   context.print.warning('Note: It is recommended to run this command from the root of your app directory');
@@ -55,7 +56,7 @@ async function getProjectName(context) {
   const projectPath = process.cwd();
   if (!context.exeInfo.isNewProject) {
     const projectConfigFilePath = context.amplify.pathManager.getProjectConfigFilePath(projectPath);
-    ({ projectName } = JSON.parse(fs.readFileSync(projectConfigFilePath)));
+    ({ projectName } = readJsonFile(projectConfigFilePath));
     return projectName;
   }
 
@@ -183,7 +184,7 @@ function isNewEnv(context, envName) {
   const providerInfoFilePath = context.amplify.pathManager.getProviderInfoFilePath(projectPath);
 
   if (fs.existsSync(providerInfoFilePath)) {
-    const envProviderInfo = JSON.parse(fs.readFileSync(providerInfoFilePath));
+    const envProviderInfo = readJsonFile(providerInfoFilePath);
     if (envProviderInfo[envName]) {
       newEnv = false;
     }
@@ -207,7 +208,7 @@ function getDefaultEditor(context) {
   const projectPath = process.cwd();
   const localEnvFilePath = context.amplify.pathManager.getLocalEnvFilePath(projectPath);
   if (fs.existsSync(localEnvFilePath)) {
-    ({ defaultEditor } = JSON.parse(fs.readFileSync(localEnvFilePath)));
+    ({ defaultEditor } = readJsonFile(localEnvFilePath));
   }
 
   return defaultEditor;

--- a/packages/amplify-cli/src/lib/init-steps/s9-onSuccess.js
+++ b/packages/amplify-cli/src/lib/init-steps/s9-onSuccess.js
@@ -5,6 +5,7 @@ const { getProviderPlugins } = require('../../extensions/amplify-helpers/get-pro
 const gitManager = require('../../extensions/amplify-helpers/git-manager');
 const { print } = require('gluegun/print');
 const { initializeEnv } = require('../initialize-env');
+const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 async function run(context) {
   const { projectPath } = context.exeInfo.localEnvInfo;
@@ -26,7 +27,7 @@ async function run(context) {
   let currentAmplifyMeta = {};
 
   if (fs.existsSync(currentAmplifyMetafilePath)) {
-    currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+    currentAmplifyMeta = readJsonFile(currentAmplifyMetafilePath);
   }
 
   const providerPlugins = getProviderPlugins(context);
@@ -101,7 +102,7 @@ function generateProviderInfoFile(context) {
   let teamProviderInfo = {};
   const providerInfoFilePath = context.amplify.pathManager.getProviderInfoFilePath(projectPath);
   if (fs.existsSync(providerInfoFilePath)) {
-    teamProviderInfo = JSON.parse(fs.readFileSync(providerInfoFilePath));
+    teamProviderInfo = readJsonFile(providerInfoFilePath);
     Object.assign(teamProviderInfo, context.exeInfo.teamProviderInfo);
   } else {
     ({ teamProviderInfo } = context.exeInfo);

--- a/packages/amplify-cli/src/lib/initialize-env.js
+++ b/packages/amplify-cli/src/lib/initialize-env.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const sequential = require('promise-sequential');
 const ora = require('ora');
+const { readJsonFile } = require('../extensions/amplify-helpers/read-json-file');
 
 const spinner = ora('');
 
@@ -12,14 +13,14 @@ async function initializeEnv(context, currentAmplifyMeta) {
     const { projectPath } = context.exeInfo.localEnvInfo;
     const providerInfoFilePath = context.amplify.pathManager.getProviderInfoFilePath(projectPath);
     const amplifyMeta = {};
-    amplifyMeta.providers = JSON.parse(fs.readFileSync(providerInfoFilePath))[currentEnv];
+    amplifyMeta.providers = readJsonFile(providerInfoFilePath)[currentEnv];
 
     if (!currentAmplifyMeta) {
       // Get current-cloud-backend's amplify-meta
       const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
 
       if (fs.existsSync(currentAmplifyMetafilePath)) {
-        currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+        currentAmplifyMeta = readJsonFile(currentAmplifyMetafilePath);
       }
     }
 
@@ -89,7 +90,7 @@ function populateAmplifyMeta(context, amplifyMeta) {
 
   const backendConfigFilePath = context.amplify.pathManager.getBackendConfigFilePath(projectPath);
 
-  const backendResourceInfo = JSON.parse(fs.readFileSync(backendConfigFilePath));
+  const backendResourceInfo = readJsonFile(backendConfigFilePath);
 
   Object.assign(amplifyMeta, backendResourceInfo);
 

--- a/packages/amplify-cli/src/lib/migrate-project.js
+++ b/packages/amplify-cli/src/lib/migrate-project.js
@@ -5,6 +5,7 @@ const ora = require('ora');
 const { makeId } = require('../extensions/amplify-helpers/make-id');
 const constants = require('../extensions/amplify-helpers/constants');
 const gitManager = require('../extensions/amplify-helpers/git-manager');
+const { readJsonFile } = require('../extensions/amplify-helpers/read-json-file');
 
 const spinner = ora('');
 const { prompt } = require('gluegun/prompt');
@@ -39,7 +40,7 @@ async function migrateProject(context) {
   }
 
   const projectConfigFilePath = getProjectConfigFilePath(projectPath);
-  const projectConfig = JSON.parse(fs.readFileSync(projectConfigFilePath));
+  const projectConfig = readJsonFile(projectConfigFilePath);
   // First level check
   // New projects also don't have projectPaths
   if (!projectConfig.projectPath) {
@@ -183,7 +184,7 @@ function persistMigrationContext(migrationInfo) {
 
 function getAmplifyMeta(projectPath) {
   const amplifyMetafilePath = getAmplifyMetaFilePath(projectPath);
-  return JSON.parse(fs.readFileSync(amplifyMetafilePath));
+  return readJsonFile(amplifyMetafilePath);
 }
 
 function persistAmplifyMeta(amplifyMeta, projectPath) {
@@ -196,7 +197,7 @@ function persistAmplifyMeta(amplifyMeta, projectPath) {
 
 function getCurrentAmplifyMeta(projectPath) {
   const currentAmplifyMetafilePath = getCurentAmplifyMetaFilePath(projectPath);
-  return JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+  return readJsonFile(currentAmplifyMetafilePath);
 }
 
 function persistCurrentAmplifyMeta(currentAmplifyMeta, projectPath) {
@@ -267,7 +268,7 @@ function generateLocalAwsInfo(projectPath) {
   const dotConfigDirPath = getDotConfigDirPath(projectPath);
   const awsInfoFilePath = path.join(dotConfigDirPath, 'aws-info.json');
   if (fs.existsSync(awsInfoFilePath)) {
-    const awsInfo = JSON.parse(fs.readFileSync(awsInfoFilePath));
+    const awsInfo = readJsonFile(awsInfoFilePath);
     awsInfo.configLevel = 'project'; // Old version didn't support "General" configuation
     newAwsInfo = { NONE: awsInfo };
     fs.removeSync(awsInfoFilePath);

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -74,7 +74,7 @@ function getCurrentAWSConfig(context) {
   let awsConfig = {};
 
   if (fs.existsSync(targetFilePath)) {
-    awsConfig = context.amplify.readJsonFile(targetFilePath);
+    awsConfig = amplify.readJsonFile(targetFilePath);
   }
   return awsConfig;
 }

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -74,7 +74,7 @@ function getCurrentAWSConfig(context) {
   let awsConfig = {};
 
   if (fs.existsSync(targetFilePath)) {
-    awsConfig = JSON.parse(fs.readFileSync(targetFilePath));
+    awsConfig = context.amplify.readJsonFile(targetFilePath);
   }
   return awsConfig;
 }

--- a/packages/amplify-frontend-javascript/lib/configuration-manager.js
+++ b/packages/amplify-frontend-javascript/lib/configuration-manager.js
@@ -6,7 +6,7 @@ const constants = require('./constants');
 
 async function init(context) {
   normalizeInputParams(context);
-  const framework = guessFramework(context.exeInfo.localEnvInfo.projectPath);
+  const framework = guessFramework(context, context.exeInfo.localEnvInfo.projectPath);
   const config = frameworkConfigMapping[framework];
   context.exeInfo.projectConfig[constants.Label] = {
     framework,
@@ -135,12 +135,12 @@ async function confirmFrameworkConfiguration(context) {
   }
 }
 
-function guessFramework(projectPath) {
+function guessFramework(context, projectPath) {
   let frameWork = 'none';
   try {
     const packageJsonFilePath = path.join(projectPath, 'package.json');
     if (fs.existsSync(packageJsonFilePath)) {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath, 'utf8'));
+      const packageJson = context.amplify.readJsonFile(packageJsonFilePath, 'utf8');
       if (packageJson && packageJson.dependencies) {
         if (packageJson.dependencies.react) {
           frameWork = 'react';

--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -45,7 +45,7 @@ function doesAwsConfigExists(context) {
   const { envName } = context.exeInfo ? context.exeInfo.localEnvInfo : context.amplify.getEnv();
 
   if (fs.existsSync(configInfoFilePath)) {
-    const envAwsInfo = JSON.parse(fs.readFileSync(configInfoFilePath));
+    const envAwsInfo = context.amplify.readJsonFile(configInfoFilePath);
     if (envAwsInfo[envName]) {
       configExists = true;
     }
@@ -413,7 +413,7 @@ function persistLocalEnvConfig(context) {
 
   let envAwsInfo = {};
   if (fs.existsSync(configInfoFilePath)) {
-    envAwsInfo = JSON.parse(fs.readFileSync(configInfoFilePath));
+    envAwsInfo = context.amplify.readJsonFile(configInfoFilePath);
   }
 
   envAwsInfo[envName] = awsInfo;
@@ -434,14 +434,14 @@ function getCurrentConfig(context) {
   if (fs.existsSync(configInfoFilePath)) {
     try {
       const { envName } = context.amplify.getEnvInfo();
-      const configInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'))[envName];
+      const configInfo = context.amplify.readJsonFile(configInfoFilePath, 'utf8')[envName];
 
       if (configInfo && configInfo.configLevel !== 'general') {
         if (configInfo.useProfile && configInfo.profileName) {
           projectConfigInfo.config.useProfile = configInfo.useProfile;
           projectConfigInfo.config.profileName = configInfo.profileName;
         } else if (configInfo.awsConfigFilePath && fs.existsSync(configInfo.awsConfigFilePath)) {
-          const awsSecrets = JSON.parse(fs.readFileSync(configInfo.awsConfigFilePath, 'utf8'));
+          const awsSecrets = context.amplify.readJsonFile(configInfo.awsConfigFilePath, 'utf8');
           projectConfigInfo.config.useProfile = false;
           projectConfigInfo.config.awsConfigFilePath = configInfo.awsConfigFilePath;
           projectConfigInfo.config.accessKeyId = awsSecrets.accessKeyId;
@@ -470,7 +470,7 @@ function removeProjectConfig(context) {
   const configInfoFilePath = path.join(dotConfigDirPath, constants.LocalAWSInfoFileName);
   if (fs.existsSync(configInfoFilePath)) {
     const { envName } = context.amplify.getEnvInfo();
-    const configInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'));
+    const configInfo = context.amplify.readJsonFile(configInfoFilePath, 'utf8');
     if (configInfo[envName]) {
       if (configInfo[envName].awsConfigFilePath &&
         fs.existsSync(configInfo[envName].awsConfigFilePath)) {
@@ -590,7 +590,7 @@ function getConfigLevel(context) {
     const configInfoFilePath = path.join(dotConfigDirPath, constants.LocalAWSInfoFileName);
     if (fs.existsSync(configInfoFilePath)) {
       const { envName } = context.amplify.getEnvInfo();
-      const envConfigInfo = JSON.parse(fs.readFileSync(configInfoFilePath, 'utf8'))[envName];
+      const envConfigInfo = context.amplify.readJsonFile(configInfoFilePath)[envName];
       if (envConfigInfo) {
         // configLevel is 'general' only when it's explicitly set so
         if (envConfigInfo.configLevel === 'general') {

--- a/packages/amplify-provider-awscloudformation/lib/initialize-env.js
+++ b/packages/amplify-provider-awscloudformation/lib/initialize-env.js
@@ -51,10 +51,10 @@ function run(context, providerMetadata) {
     .then(() => {
       // Copy provider metadata from current-cloud-backend/amplify-meta to backend/ampliy-meta
       const currentAmplifyMetafilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
-      const currentAmplifyMeta = JSON.parse(fs.readFileSync(currentAmplifyMetafilePath));
+      const currentAmplifyMeta = context.amplify.readJsonFile(currentAmplifyMetafilePath);
 
       const amplifyMetafilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-      const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetafilePath));
+      const amplifyMeta = context.amplify.readJsonFile(amplifyMetafilePath);
 
       // Copy providerMetadata for each resource - from what is there in the cloud
 

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -242,7 +242,7 @@ function packageResources(context, resources) {
         const cfnFile = cfnFiles[0];
         const cfnFilePath = path.normalize(path.join(resourceDir, cfnFile));
 
-        const cfnMeta = JSON.parse(fs.readFileSync(cfnFilePath));
+        const cfnMeta = context.amplify.readJsonFile(cfnFilePath);
 
         cfnMeta.Resources.LambdaFunction.Properties.Code = {
           S3Bucket: s3Bucket,
@@ -390,7 +390,7 @@ function uploadTemplateToS3(context, resourceDir, cfnFile, category, resourceNam
 /* eslint-disable */
 function formNestedStack(context, projectDetails, categoryName, resourceName, serviceName, skipEnv) {
 /* eslint-enable */
-  const nestedStack = JSON.parse(fs.readFileSync(`${__dirname}/rootStackTemplate.json`));
+  const nestedStack = context.amplify.readJsonFile(`${__dirname}/rootStackTemplate.json`);
 
   const { amplifyMeta } = projectDetails;
 

--- a/packages/amplify-provider-awscloudformation/lib/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/system-config-manager.js
@@ -151,7 +151,7 @@ function cacheRoleCredentials(context, roleArn, sessionName, credentials) {
   let cacheContents = {};
   const cacheFilePath = getCacheFilePath(context);
   if (fs.existsSync(cacheFilePath)) {
-    cacheContents = JSON.parse(fs.readFileSync(cacheFilePath, 'utf-8'));
+    cacheContents = context.amplify.readJsonFile(cacheFilePath, 'utf-8');
   }
   cacheContents[roleArn] = cacheContents[roleArn] || {};
   cacheContents[roleArn][sessionName] = credentials;
@@ -163,7 +163,7 @@ function getCachedRoleCredentials(context, roleArn, sessionName) {
   let roleCredentials;
   const cacheFilePath = getCacheFilePath(context);
   if (fs.existsSync(cacheFilePath)) {
-    const cacheContents = JSON.parse(fs.readFileSync(cacheFilePath, 'utf-8'));
+    const cacheContents = context.amplify.readJsonFile(cacheFilePath, 'utf-8');
     if (cacheContents[roleArn]) {
       roleCredentials = cacheContents[roleArn][sessionName];
       roleCredentials = validateCachedCredentials(roleCredentials) ? roleCredentials : undefined;
@@ -203,7 +203,7 @@ async function resetCache(context, profileName) {
   const profileConfig = getProfileConfig(profileName);
   const cacheFilePath = getCacheFilePath(context);
   if (profileConfig && profileConfig.role_arn && fs.existsSync(cacheFilePath)) {
-    const cacheContents = JSON.parse(fs.readFileSync(cacheFilePath, 'utf-8'));
+    const cacheContents = context.amplify.readJsonFile(cacheFilePath, 'utf-8');
     if (cacheContents[profileConfig.role_arn]) {
       delete cacheContents[profileConfig.role_arn];
       const jsonString = JSON.stringify(cacheContents, null, 4);

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -139,7 +139,7 @@ async function transformGraphQLSchema(context, options) {
 
   if (!parameters && fs.existsSync(parametersFilePath)) {
     try {
-      parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+      parameters = context.amplify.readJsonFile(parametersFilePath);
     } catch (e) {
       parameters = {};
     }

--- a/packages/amplify-provider-awscloudformation/src/resourceParams.js
+++ b/packages/amplify-provider-awscloudformation/src/resourceParams.js
@@ -40,9 +40,9 @@ function loadResourceParameters(context, category, resource) {
   const parametersBuildFilePath = path.join(resourceDirPath, 'build', 'parameters.json');
   const parametersFilePath = path.join(resourceDirPath, 'parameters.json');
   if (fs.existsSync(parametersBuildFilePath)) {
-    parameters = JSON.parse(fs.readFileSync(parametersBuildFilePath));
+    parameters = context.amplify.readJsonFile(parametersBuildFilePath);
   } else if (fs.existsSync(parametersFilePath)) {
-    parameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    parameters = context.amplify.readJsonFile(parametersFilePath);
   }
   const envSpecificParams = context.amplify.loadEnvResourceParameters(context, category, resource);
   return { ...parameters, ...envSpecificParams };


### PR DESCRIPTION
Some editors and platforms can add UTF BOM at the begining of the file. Node JSON.parse doesn't
handle the BOM enchoding very well and chokes the CLI. Updating the CLI to use a util method which
can handle the BOM chars

fix #1355 and fix #1122

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.