### PR TITLE
Adding support for KeyConditionInput types

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -10,13 +10,14 @@ import {
     makeModelConnectionType,
     makeModelConnectionField,
     makeScalarFilterInputs,
+    makeScalarKeyConditionInputs,
     makeModelXFilterInputObject,
     makeModelSortDirectionEnumObject,
 } from 'graphql-dynamodb-transformer'
 import {
     getBaseType, isListType, getDirectiveArgument, blankObject,
     isScalar, STANDARD_SCALARS,
-    toCamelCase, isNonNullType
+    toCamelCase, isNonNullType, attributeTypeFromScalar
 } from 'graphql-transformer-common'
 import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common'
 import { updateCreateInputWithConnectionField, updateUpdateInputWithConnectionField } from './definitions';
@@ -151,6 +152,18 @@ export class ModelConnectionTransformer extends Transformer {
             }
         }
 
+        // This grabs the definition of the sort field when it lives on the foreign model.
+        // We use this to configure key condition arguments for the resolver on the many side of the @connection.
+        const foreignAssociatedSortField = associatedSortFieldName &&
+            relatedType.fields.find((f: FieldDefinitionNode) => f.name.value === associatedSortFieldName);
+        const sortKeyInfo = foreignAssociatedSortField ?
+            {
+                fieldName: foreignAssociatedSortField.name.value,
+                attributeType: attributeTypeFromScalar(foreignAssociatedSortField.type),
+                typeName: getBaseType(foreignAssociatedSortField.type)
+            } :
+            undefined;
+
         // Relationship Cardinalities:
         // 1. [] to []
         // 2. [] to {}
@@ -177,11 +190,13 @@ export class ModelConnectionTransformer extends Transformer {
                 fieldName,
                 relatedTypeName,
                 connectionAttributeName,
-                connectionName
+                connectionName,
+                // If there is a sort field for this connection query then use
+                sortKeyInfo
             )
             ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver)
 
-            this.extendTypeWithConnection(ctx, parent, field, relatedType)
+            this.extendTypeWithConnection(ctx, parent, field, relatedType, sortKeyInfo)
         } else if (!leftConnectionIsList && rightConnectionIsList) {
             // 3. {} to [] when the association exists.
             // Store foreign key on this table and wire up a GetItem resolver.
@@ -253,11 +268,12 @@ export class ModelConnectionTransformer extends Transformer {
                 fieldName,
                 relatedTypeName,
                 connectionAttributeName,
-                connectionName
+                connectionName,
+                sortKeyInfo
             )
             ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver)
 
-            this.extendTypeWithConnection(ctx, parent, field, relatedType)
+            this.extendTypeWithConnection(ctx, parent, field, relatedType, sortKeyInfo)
 
             // Update the create & update input objects for the related type
             const createInputName = ModelResourceIDs.ModelCreateInputObjectName(relatedTypeName)
@@ -329,7 +345,8 @@ export class ModelConnectionTransformer extends Transformer {
         ctx: TransformerContext,
         parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
         field: FieldDefinitionNode,
-        returnType: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode
+        returnType: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+        sortKeyInfo?: { fieldName: string, typeName: string }
     ) {
         this.generateModelXConnectionType(ctx, returnType)
 
@@ -344,7 +361,7 @@ export class ModelConnectionTransformer extends Transformer {
             const newFields = type.fields.map(
                 (f: FieldDefinitionNode) => {
                     if (f.name.value === field.name.value) {
-                        const updated = makeModelConnectionField(field.name.value, returnType.name.value)
+                        const updated = makeModelConnectionField(field.name.value, returnType.name.value, sortKeyInfo)
                         updated.directives = f.directives
                         return updated
                     }
@@ -362,13 +379,13 @@ export class ModelConnectionTransformer extends Transformer {
                 ctx.addEnum(modelSortDirection)
             }
 
-            this.generateFilterInputs(ctx, returnType)
+            this.generateFilterAndKeyConditionInputs(ctx, returnType)
         } else {
             throw new InvalidDirectiveError(`Could not find a object or interface type named ${parent.name.value}.`)
         }
     }
 
-    private generateFilterInputs(ctx: TransformerContext, field: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode): void {
+    private generateFilterAndKeyConditionInputs(ctx: TransformerContext, field: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode): void {
         const scalarFilters = makeScalarFilterInputs()
         for (const filter of scalarFilters) {
             if (!this.typeExist(filter.name.value, ctx)) {
@@ -380,6 +397,14 @@ export class ModelConnectionTransformer extends Transformer {
         const tableXQueryFilterInput = makeModelXFilterInputObject(field, ctx)
         if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
             ctx.addInput(tableXQueryFilterInput)
+        }
+
+        // Create sort key condition inputs for valid sort key types
+        const sortKeyConditionInputs = makeScalarKeyConditionInputs()
+        for (const keyCondition of sortKeyConditionInputs) {
+            if (!this.typeExist(keyCondition.name.value, ctx)) {
+                ctx.addInput(keyCondition)
+            }
         }
     }
 }

--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -5,7 +5,7 @@ import { Fn, Refs } from 'cloudform-types'
 import {
     DynamoDBMappingTemplate, str, print,
     ref, obj, set, nul,
-    ifElse, compoundExpression, bool, equals, iff, raw
+    ifElse, compoundExpression, bool, equals, iff, raw, comment, qref, Expression, block
 } from 'graphql-mapping-template'
 import { ResourceConstants, ModelResourceIDs, DEFAULT_SCALARS, NONE_VALUE } from 'graphql-transformer-common'
 import { InvalidDirectiveError } from 'graphql-transformer-core';
@@ -124,8 +124,29 @@ export class ResourceFactory {
      * Create a resolver that queries an item in DynamoDB.
      * @param type
      */
-    public makeQueryConnectionResolver(type: string, field: string, relatedType: string, connectionAttribute: string, connectionName: string) {
+    public makeQueryConnectionResolver(
+        type: string, field: string, relatedType: string, 
+        connectionAttribute: string, connectionName: string, 
+        sortKeyInfo?: { fieldName: string, attributeType: 'S' | 'B' | 'N' }
+    ) {
         const defaultPageLimit = 10
+        const setup: Expression[] = [
+            set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
+            set(ref('query'), obj({
+                'expression': str('#connectionAttribute = :connectionAttribute'),
+                'expressionNames': obj({
+                    '#connectionAttribute': str(connectionAttribute)
+                }),
+                'expressionValues': obj({
+                    ':connectionAttribute': obj({
+                        'S': str('$context.source.id')
+                    })
+                })
+            }))
+        ];
+        if (sortKeyInfo) {
+            setup.push(this.applyKeyConditionExpression(sortKeyInfo.fieldName, sortKeyInfo.attributeType, 'query'));
+        }
         return new Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(relatedType), 'Name'),
@@ -133,19 +154,9 @@ export class ResourceFactory {
             TypeName: type,
             RequestMappingTemplate: print(
                 compoundExpression([
-                    set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
+                    ...setup,
                     DynamoDBMappingTemplate.query({
-                        query: obj({
-                            'expression': str('#connectionAttribute = :connectionAttribute'),
-                            'expressionNames': obj({
-                                '#connectionAttribute': str(connectionAttribute)
-                            }),
-                            'expressionValues': obj({
-                                ':connectionAttribute': obj({
-                                    'S': str('$context.source.id')
-                                })
-                            })
-                        }),
+                        query: raw('$util.toJson($query)'),
                         scanIndexForward: ifElse(
                             ref('context.args.sortDirection'),
                             ifElse(
@@ -177,5 +188,84 @@ export class ResourceFactory {
                 ])
             )
         }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID)
+    }
+
+    /**
+     * Key conditions materialize as instances of ModelXKeyConditionInput passed via $ctx.args.
+     * If the arguments with the given sortKey name exists, create a DynamoDB expression that
+     * implements its logic. Possible operators: eq, le, lt, ge, gt, beginsWith, and between.
+     * @param argName The name of the argument containing the sort key condition object.
+     */
+    private applyKeyConditionExpression(argName: string, attributeType: 'S' | 'N' | 'B' = 'S', queryExprReference: string = 'query') {
+        return block("Applying Key Condition", [
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.beginsWith)`),
+                compoundExpression([
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND begins_with(#${argName}, :${argName})"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}", { "${attributeType}": "$ctx.args.${argName}.beginsWith" })`)
+                ])
+            ),
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.between)`),
+                compoundExpression([
+                    iff(
+                        raw(`$ctx.args.${argName}.between.size() != 2`),
+                        raw(`$util.error("Argument ${argName}.between expects exactly 2 elements.")`)
+                    ),
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND #${argName} BETWEEN :${argName}0 AND :${argName}1"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}0", { "${attributeType}": "$ctx.args.${argName}.between[0]" })`),
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}1", { "${attributeType}": "$ctx.args.${argName}.between[1]" })`)
+                ])
+            ),
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.eq)`),
+                compoundExpression([
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND #${argName} = :${argName}"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}", { "${attributeType}": "$ctx.args.${argName}.eq" })`)
+                ])
+            ),
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.lt)`),
+                compoundExpression([
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND #${argName} < :${argName}"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}", { "${attributeType}": "$ctx.args.${argName}.lt" })`)
+                ])
+            ),
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.le)`),
+                compoundExpression([
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND #${argName} <= :${argName}"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}", { "${attributeType}": "$ctx.args.${argName}.le" })`)
+                ])
+            ),
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.gt)`),
+                compoundExpression([
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND #${argName} > :${argName}"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}", { "${attributeType}": "$ctx.args.${argName}.gt" })`)
+                ])
+            ),
+            iff(
+                raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.ge)`),
+                compoundExpression([
+                    set(ref('query.expression'), raw(`"$${queryExprReference}.expression AND #${argName} >= :${argName}"`)),
+                    qref(`$${queryExprReference}.expressionNames.put("#${argName}", "${argName}")`),
+                    // TODO: Handle N & B.
+                    qref(`$${queryExprReference}.expressionValues.put(":${argName}", { "${attributeType}": "$ctx.args.${argName}.ge" })`)
+                ])
+            )
+        ]);
     }
 }

--- a/packages/graphql-mapping-template/src/dynamodb.ts
+++ b/packages/graphql-mapping-template/src/dynamodb.ts
@@ -43,7 +43,7 @@ export class DynamoDBMappingTemplate {
      * @param key A list of strings pointing to the key value locations. E.G. ctx.args.x (note no $)
      */
     public static query({ query, filter, scanIndexForward, limit, nextToken, index }: {
-        query: ObjectNode;
+        query: ObjectNode | Expression;
         scanIndexForward: Expression;
         filter: ObjectNode | Expression;
         limit: Expression;

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -19,6 +19,13 @@ export class ModelResourceIDs {
         }
         return `Model${name}FilterInput`
     }
+    static ModelKeyConditionInputTypeName(name: string): string {
+        const nameOverride = DEFAULT_SCALARS[name]
+        if (nameOverride) {
+            return `Model${nameOverride}KeyConditionInput`
+        }
+        return `Model${name}KeyConditionInput`
+    }
     static ModelFilterListInputTypeName(name: string): string {
         const nameOverride = DEFAULT_SCALARS[name]
         if (nameOverride) {

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -9,7 +9,10 @@ import {
 } from 'graphql'
 import { access } from 'fs';
 
-export const STANDARD_SCALARS = {
+type ScalarMap = {
+    [k: string]: 'String' | 'Int' | 'Float' | 'Boolean' | 'ID'
+}
+export const STANDARD_SCALARS: ScalarMap = {
     String: 'String',
     Int: 'Int',
     Float: 'Float',
@@ -17,12 +20,12 @@ export const STANDARD_SCALARS = {
     ID: 'ID'
 };
 
-const OTHER_SCALARS = {
+const OTHER_SCALARS: ScalarMap = {
     BigInt: 'Int',
     Double: 'Float'
 };
 
-export const APPSYNC_DEFINED_SCALARS: { [k: string]: string } = {
+export const APPSYNC_DEFINED_SCALARS: ScalarMap = {
     AWSDate: 'String',
     AWSTime: 'String',
     AWSDateTime: 'String',
@@ -34,7 +37,7 @@ export const APPSYNC_DEFINED_SCALARS: { [k: string]: string } = {
     AWSIPAddress: 'String'
 };
 
-export const DEFAULT_SCALARS: { [k: string]: string } = {
+export const DEFAULT_SCALARS: ScalarMap = {
     ...STANDARD_SCALARS,
     ...OTHER_SCALARS,
     ...APPSYNC_DEFINED_SCALARS
@@ -51,6 +54,26 @@ export const NUMERIC_SCALARS: { [k: string]: boolean } = {
 export const MAP_SCALARS: { [k: string]: boolean } = {
     AWSJSON: true
 };
+
+export function attributeTypeFromScalar(scalar: TypeNode) {
+    const baseType = getBaseType(scalar);
+    const baseScalar = DEFAULT_SCALARS[baseType];
+    if (!baseScalar) {
+        throw new Error(`Expected scalar and got ${baseType}`);
+    }
+    switch (baseScalar) {
+        case 'String':
+        case 'ID':
+            return 'S';
+        case 'Int':
+        case 'Float':
+            return 'N';
+        case 'Boolean':
+            throw new Error(`Boolean values cannot be used as sort keys.`)
+        default:
+            throw new Error(`There is no valid DynamoDB attribute type for scalar ${baseType}`)
+    }
+}
 
 export function isScalar(type: TypeNode) {
     if (type.kind === Kind.NON_NULL_TYPE) {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -57,7 +57,7 @@ beforeAll(async () => {
         id: ID!
         content: String!
         when: String!
-        post: Post @connection(name: "SortedPostComments", keyField: "postId")
+        post: Post @connection(name: "SortedPostComments", keyField: "postId", sortField: "when")
     }
     `
     const transformer = new GraphQLTransform({
@@ -129,149 +129,268 @@ afterAll(async () => {
  */
 
 test('Test queryPost query', async () => {
-    try {
-        const createResponse = await GRAPHQL_CLIENT.query(`mutation {
-            createPost(input: { title: "Test Query" }) {
+    const createResponse = await GRAPHQL_CLIENT.query(`mutation {
+        createPost(input: { title: "Test Query" }) {
+            id
+            title
+        }
+    }`, {})
+    expect(createResponse.data.createPost.id).toBeDefined()
+    expect(createResponse.data.createPost.title).toEqual('Test Query')
+    const createCommentResponse = await GRAPHQL_CLIENT.query(`mutation {
+        createComment(input: { content: "A comment!", postId: "${createResponse.data.createPost.id}" }) {
+            id
+            content
+            post {
                 id
                 title
             }
-        }`, {})
-        expect(createResponse.data.createPost.id).toBeDefined()
-        expect(createResponse.data.createPost.title).toEqual('Test Query')
-        const createCommentResponse = await GRAPHQL_CLIENT.query(`mutation {
-            createComment(input: { content: "A comment!", postId: "${createResponse.data.createPost.id}" }) {
-                id
-                content
-                post {
+        }
+    }`, {})
+    expect(createCommentResponse.data.createComment.id).toBeDefined()
+    expect(createCommentResponse.data.createComment.content).toEqual('A comment!')
+    expect(createCommentResponse.data.createComment.post.id).toEqual(createResponse.data.createPost.id)
+    expect(createCommentResponse.data.createComment.post.title).toEqual(createResponse.data.createPost.title)
+    const queryResponse = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            comments {
+                items {
                     id
-                    title
+                    content
                 }
             }
-        }`, {})
-        expect(createCommentResponse.data.createComment.id).toBeDefined()
-        expect(createCommentResponse.data.createComment.content).toEqual('A comment!')
-        expect(createCommentResponse.data.createComment.post.id).toEqual(createResponse.data.createPost.id)
-        expect(createCommentResponse.data.createComment.post.title).toEqual(createResponse.data.createPost.title)
-        const queryResponse = await GRAPHQL_CLIENT.query(`query {
-            getPost(id: "${createResponse.data.createPost.id}") {
-                id
-                title
-                comments {
-                    items {
-                        id
-                        content
-                    }
-                }
-            }
-        }`, {})
-        expect(queryResponse.data.getPost).toBeDefined()
-        const items = queryResponse.data.getPost.comments.items
-        expect(items.length).toEqual(1)
-        expect(items[0].id).toEqual(createCommentResponse.data.createComment.id)
-    } catch (e) {
-        console.error(e)
-        // fail
-        expect(e).toBeUndefined()
-    }
+        }
+    }`, {})
+    expect(queryResponse.data.getPost).toBeDefined()
+    const items = queryResponse.data.getPost.comments.items
+    expect(items.length).toEqual(1)
+    expect(items[0].id).toEqual(createCommentResponse.data.createComment.id)
 })
 
 const title = "Test Query with Sort Field"
 const comment1 = "a comment and a date! - 1"
 const comment2 = "a comment and a date! - 2"
+const whenpast = "2017-10-01T00:00:00.000Z"
 const when1 = "2018-10-01T00:00:00.000Z"
-const when2 = "2018-10-01T00:00:01.000Z"
+const whenmid = "2018-12-01T00:00:00.000Z"
+const when2 = "2019-10-01T00:00:01.000Z"
+const whenfuture = "2020-10-01T00:00:00.000Z"
 
 test('Test queryPost query with sortField', async () => {
-    try {
-        const createResponse = await GRAPHQL_CLIENT.query(`mutation {
-            createPost(input: { title: "${title}" }) {
+    const createResponse = await GRAPHQL_CLIENT.query(`mutation {
+        createPost(input: { title: "${title}" }) {
+            id
+            title
+        }
+    }`, {})
+    expect(createResponse.data.createPost.id).toBeDefined()
+    expect(createResponse.data.createPost.title).toEqual(title)
+    const createCommentResponse1 = await GRAPHQL_CLIENT.query(`mutation {
+        createSortedComment(input:
+            { content: "${comment1}",
+                when: "${when1}"
+                postId: "${createResponse.data.createPost.id}"
+            }) {
+            id
+            content
+            post {
                 id
                 title
             }
-        }`, {})
-        expect(createResponse.data.createPost.id).toBeDefined()
-        expect(createResponse.data.createPost.title).toEqual(title)
-        const createCommentResponse1 = await GRAPHQL_CLIENT.query(`mutation {
-            createSortedComment(input:
-                { content: "${comment1}",
-                    when: "${when1}"
-                    postId: "${createResponse.data.createPost.id}"
-                }) {
+        }
+    }`, {})
+    expect(createCommentResponse1.data.createSortedComment.id).toBeDefined()
+    expect(createCommentResponse1.data.createSortedComment.content).toEqual(comment1)
+    expect(createCommentResponse1.data.createSortedComment.post.id).toEqual(createResponse.data.createPost.id)
+    expect(createCommentResponse1.data.createSortedComment.post.title).toEqual(createResponse.data.createPost.title)
+
+    // create 2nd comment, 1 second later
+    const createCommentResponse2 = await GRAPHQL_CLIENT.query(`mutation {
+        createSortedComment(input:
+            { content: "${comment2}",
+                when: "${when2}"
+                postId: "${createResponse.data.createPost.id}"
+            }) {
+            id
+            content
+            post {
                 id
-                content
-                post {
+                title
+            }
+        }
+    }`, {})
+    expect(createCommentResponse2.data.createSortedComment.id).toBeDefined()
+    expect(createCommentResponse2.data.createSortedComment.content).toEqual(comment2)
+    expect(createCommentResponse2.data.createSortedComment.post.id).toEqual(createResponse.data.createPost.id)
+    expect(createCommentResponse2.data.createSortedComment.post.title).toEqual(createResponse.data.createPost.title)
+
+    const queryResponse = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments {
+                items {
                     id
-                    title
+                    when
+                    content
                 }
             }
-        }`, {})
-        expect(createCommentResponse1.data.createSortedComment.id).toBeDefined()
-        expect(createCommentResponse1.data.createSortedComment.content).toEqual(comment1)
-        expect(createCommentResponse1.data.createSortedComment.post.id).toEqual(createResponse.data.createPost.id)
-        expect(createCommentResponse1.data.createSortedComment.post.title).toEqual(createResponse.data.createPost.title)
+        }
+    }`, {})
+    expect(queryResponse.data.getPost).toBeDefined()
+    const items = queryResponse.data.getPost.sortedComments.items
+    expect(items.length).toEqual(2)
+    expect(items[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
+    expect(items[1].id).toEqual(createCommentResponse2.data.createSortedComment.id)
 
-        // create 2nd comment, 1 second later
-        const createCommentResponse2 = await GRAPHQL_CLIENT.query(`mutation {
-            createSortedComment(input:
-                { content: "${comment2}",
-                    when: "${when2}"
-                    postId: "${createResponse.data.createPost.id}"
-                }) {
-                id
-                content
-                post {
+    const queryResponseDesc = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(sortDirection: DESC) {
+                items {
                     id
-                    title
+                    when
+                    content
                 }
             }
-        }`, {})
-        expect(createCommentResponse2.data.createSortedComment.id).toBeDefined()
-        expect(createCommentResponse2.data.createSortedComment.content).toEqual(comment2)
-        expect(createCommentResponse2.data.createSortedComment.post.id).toEqual(createResponse.data.createPost.id)
-        expect(createCommentResponse2.data.createSortedComment.post.title).toEqual(createResponse.data.createPost.title)
+        }
+    }`, {})
+    expect(queryResponseDesc.data.getPost).toBeDefined()
+    const itemsDesc = queryResponseDesc.data.getPost.sortedComments.items
+    expect(itemsDesc.length).toEqual(2)
+    expect(itemsDesc[0].id).toEqual(createCommentResponse2.data.createSortedComment.id)
+    expect(itemsDesc[1].id).toEqual(createCommentResponse1.data.createSortedComment.id)
 
-        const queryResponse = await GRAPHQL_CLIENT.query(`query {
-            getPost(id: "${createResponse.data.createPost.id}") {
-                id
-                title
-                sortedComments {
-                    items {
-                        id
-                        when
-                        content
-                    }
+    const queryResponseWithKeyCondition = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { beginsWith: "2018"}) {
+                items {
+                    id
+                    when
+                    content
                 }
             }
-        }`, {})
-        expect(queryResponse.data.getPost).toBeDefined()
-        const items = queryResponse.data.getPost.sortedComments.items
-        expect(items.length).toEqual(2)
-        expect(items[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
-        expect(items[1].id).toEqual(createCommentResponse2.data.createSortedComment.id)
+        }
+    }`, {})
+    expect(queryResponseWithKeyCondition.data.getPost).toBeDefined()
+    const itemsDescWithKeyCondition = queryResponseWithKeyCondition.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyCondition.length).toEqual(1)
+    expect(itemsDescWithKeyCondition[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
 
-        const queryResponseDesc = await GRAPHQL_CLIENT.query(`query {
-            getPost(id: "${createResponse.data.createPost.id}") {
-                id
-                title
-                sortedComments(sortDirection: DESC) {
-                    items {
-                        id
-                        when
-                        content
-                    }
+    const queryResponseWithKeyConditionEq = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { eq: "${when1}"}) {
+                items {
+                    id
+                    when
+                    content
                 }
             }
-        }`, {})
-        expect(queryResponseDesc.data.getPost).toBeDefined()
-        const itemsDesc = queryResponseDesc.data.getPost.sortedComments.items
-        expect(itemsDesc.length).toEqual(2)
-        expect(itemsDesc[0].id).toEqual(createCommentResponse2.data.createSortedComment.id)
-        expect(itemsDesc[1].id).toEqual(createCommentResponse1.data.createSortedComment.id)
-    } catch (e) {
-        console.error(e)
-        // fail
-        expect(e).toBeUndefined()
-    }
+        }
+    }`, {})
+    expect(queryResponseWithKeyConditionEq.data.getPost).toBeDefined()
+    const itemsDescWithKeyConditionEq = queryResponseWithKeyConditionEq.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyConditionEq.length).toEqual(1)
+    expect(itemsDescWithKeyConditionEq[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
+
+    const queryResponseWithKeyConditionGt = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { gt: "${when1}"}) {
+                items {
+                    id
+                    when
+                    content
+                }
+            }
+        }
+    }`, {})
+    expect(queryResponseWithKeyConditionGt.data.getPost).toBeDefined()
+    const itemsDescWithKeyConditionGt = queryResponseWithKeyConditionGt.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyConditionGt.length).toEqual(1)
+    expect(itemsDescWithKeyConditionGt[0].id).toEqual(createCommentResponse2.data.createSortedComment.id)
+
+    const queryResponseWithKeyConditionGe = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { ge: "${when1}"}) {
+                items {
+                    id
+                    when
+                    content
+                }
+            }
+        }
+    }`, {})
+    expect(queryResponseWithKeyConditionGe.data.getPost).toBeDefined()
+    const itemsDescWithKeyConditionGe = queryResponseWithKeyConditionGe.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyConditionGe.length).toEqual(2)
+    expect(itemsDescWithKeyConditionGe[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
+    expect(itemsDescWithKeyConditionGe[1].id).toEqual(createCommentResponse2.data.createSortedComment.id)
+
+    const queryResponseWithKeyConditionLe = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { le: "${when2}"}) {
+                items {
+                    id
+                    when
+                    content
+                }
+            }
+        }
+    }`, {})
+    expect(queryResponseWithKeyConditionLe.data.getPost).toBeDefined()
+    const itemsDescWithKeyConditionLe = queryResponseWithKeyConditionLe.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyConditionLe.length).toEqual(2)
+    expect(itemsDescWithKeyConditionLe[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
+    expect(itemsDescWithKeyConditionLe[1].id).toEqual(createCommentResponse2.data.createSortedComment.id)
+
+    const queryResponseWithKeyConditionLt = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { lt: "${when2}"}) {
+                items {
+                    id
+                    when
+                    content
+                }
+            }
+        }
+    }`, {})
+    expect(queryResponseWithKeyConditionLt.data.getPost).toBeDefined()
+    const itemsDescWithKeyConditionLt = queryResponseWithKeyConditionLt.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyConditionLt.length).toEqual(1)
+    expect(itemsDescWithKeyConditionLt[0].id).toEqual(createCommentResponse1.data.createSortedComment.id)
+
+    const queryResponseWithKeyConditionBetween = await GRAPHQL_CLIENT.query(`query {
+        getPost(id: "${createResponse.data.createPost.id}") {
+            id
+            title
+            sortedComments(when: { between: ["${whenmid}", "${whenfuture}"]}) {
+                items {
+                    id
+                    when
+                    content
+                }
+            }
+        }
+    }`, {})
+    expect(queryResponseWithKeyConditionBetween.data.getPost).toBeDefined()
+    const itemsDescWithKeyConditionBetween = queryResponseWithKeyConditionBetween.data.getPost.sortedComments.items
+    expect(itemsDescWithKeyConditionBetween.length).toEqual(1)
+    expect(itemsDescWithKeyConditionBetween[0].id).toEqual(createCommentResponse2.data.createSortedComment.id)
 })
 
 test('Test create comment without a post and then querying the comment.', async () => {


### PR DESCRIPTION
*Issue #, if available:*

Implements work item one from #1062

Solves #1242

*Description of changes:*

Adds support for key condition input objects on @connection types.

Quoted from the RFC:

There is currently no support for passing sort key conditions to query operations created by the @connection directive. Key conditions offer a different set of operator than filter expressions so we are unable to reuse the `ModelXFilterInput` types that are currently generated. Read more about key conditions in the Amazon DynamoDB docs https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.KeyConditions.html.

Given a schema:

```graphql
type Post @model {
  id: ID!
  name: String!
  comments: [Comment] @connection(name: "PostComments", keyField: "postId", sortField: "statusDate")
}

type Comment @model(queries: null) {
  id: ID!
  post: Post! @connection(name: "PostComments", keyField: "postId", sortField: "statusDate")
  postId: ID!
  statusDate: String!
}
```

This work would generate additional input types and update the generated connection resolver.

```graphql
# The new input types.
input ModelStringKeyConditionInput {
  eq: String
  le: String
  lt: String
  ge: String
  gt: String
  beginsWith: String
  between: [String]
}

input ModelIDKeyConditionInput {
  eq: ID
  le: ID
  lt: ID
  ge: ID
  gt: ID
  beginsWith: ID
  between: [ID]
}

input ModelIntKeyConditionInput {
  eq: Int
  le: Int
  lt: Int
  ge: Int
  gt: Int
  between: [Int]
}

input ModelFloatKeyConditionInput {
  eq: Float
  le: Float
  lt: Float
  ge: Float
  gt: Float
  between: [Float]
}
```

```graphql
# The updated post type
type Post {
  id: ID!
  name: String!

  # new statusDate sort key condition input
  comments(
    statusDate: ModelStringKeyConditionInput, 
    filter: ModelCommentFilterInput, 
    sortDirection: ModelSortDirection, 
    limit: Int, 
     nextToken: String
  ): ModelCommentConnection
}
```

With this in place you can create comments with a "statusDate" such as "PUBLISHED_2019-04-25" and then run a query like shown below to get a post and its comments published in April, 2019.

```
query {
  getPost(id: 1) {
    comments(statusDate: { beginsWith: "PUBLISHED_2019-04" }) {
      items {
        ...
      }
    }
  }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.