### PR TITLE
Adds http headers for @http directive

### DIFF
--- a/packages/graphql-http-transformer/src/HttpTransformer.ts
+++ b/packages/graphql-http-transformer/src/HttpTransformer.ts
@@ -158,7 +158,7 @@ export class HttpTransformer extends Transformer {
 
         let headers : HttpHeader[] = getDirectiveArgument(directive)("headers")
 
-        if (!Array.isArray(headers)) {
+        if (!headers || !Array.isArray(headers)) {
             headers = [];
         }
 

--- a/packages/graphql-http-transformer/src/HttpTransformer.ts
+++ b/packages/graphql-http-transformer/src/HttpTransformer.ts
@@ -213,7 +213,8 @@ export class HttpTransformer extends Transformer {
                         field.name.value,
                         queryBodyArgsArray
                             .filter(a => a.type.kind === Kind.NON_NULL_TYPE)
-                            .map(a => a.name.value)
+                            .map(a => a.name.value),
+                        headers
                     )
                     ctx.setResource(postResourceID, postResolver)
                 }
@@ -228,7 +229,8 @@ export class HttpTransformer extends Transformer {
                         field.name.value,
                         queryBodyArgsArray
                             .filter(a => a.type.kind === Kind.NON_NULL_TYPE)
-                            .map(a => a.name.value)
+                            .map(a => a.name.value),
+                        headers
                     )
                     ctx.setResource(putResourceID, putResolver)
                 }
@@ -236,7 +238,7 @@ export class HttpTransformer extends Transformer {
             case 'DELETE':
                 const deleteResourceID = ResolverResourceIDs.ResolverResourceID(parent.name.value, field.name.value)
                 if (!ctx.getResource(deleteResourceID)) {
-                    const deleteResolver = this.resources.makeDeleteResolver(baseURL, path, parent.name.value, field.name.value)
+                    const deleteResolver = this.resources.makeDeleteResolver(baseURL, path, parent.name.value, field.name.value, headers)
                     ctx.setResource(deleteResourceID, deleteResolver)
                 }
                 break;
@@ -250,7 +252,8 @@ export class HttpTransformer extends Transformer {
                         field.name.value,
                         queryBodyArgsArray
                             .filter(a => a.type.kind === Kind.NON_NULL_TYPE)
-                            .map(a => a.name.value)
+                            .map(a => a.name.value),
+                        headers
                     )
                     ctx.setResource(patchResourceID, patchResolver)
                 }

--- a/packages/graphql-http-transformer/src/HttpTransformer.ts
+++ b/packages/graphql-http-transformer/src/HttpTransformer.ts
@@ -158,6 +158,10 @@ export class HttpTransformer extends Transformer {
 
         let headers : HttpHeader[] = getDirectiveArgument(directive)("headers")
 
+        if (!Array.isArray(headers)) {
+            headers = [];
+        }
+
         if (queryBodyArgsArray.length > 0) {
             // for GET requests, leave the nullability of the query parameters unchanged -
             // but for PUT, POST and PATCH, unwrap any non-nulls

--- a/packages/graphql-http-transformer/src/HttpTransformer.ts
+++ b/packages/graphql-http-transformer/src/HttpTransformer.ts
@@ -20,9 +20,15 @@ const HTTP_STACK_NAME = 'HttpStack'
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
+export interface HttpHeader {
+    key: String,
+    value: String
+}
+
 interface HttpDirectiveArgs {
     method?: HttpMethod,
     url: String,
+    headers: HttpHeader[]
 }
 
 /**
@@ -43,7 +49,8 @@ export class HttpTransformer extends Transformer {
             `
             directive @http(
                 method: HttpMethod = GET,
-                url: String!
+                url: String!,
+                headers: [HttpHeader] = []
             ) on FIELD_DEFINITION
             enum HttpMethod {
                 GET
@@ -51,6 +58,10 @@ export class HttpTransformer extends Transformer {
                 PUT
                 DELETE
                 PATCH
+            }
+            input HttpHeader {
+                key: String,
+                value: String
             }
             `
         )
@@ -145,6 +156,8 @@ export class HttpTransformer extends Transformer {
             method = 'GET'
         }
 
+        let headers : HttpHeader[] = getDirectiveArgument(directive)("headers")
+
         if (queryBodyArgsArray.length > 0) {
             // for GET requests, leave the nullability of the query parameters unchanged -
             // but for PUT, POST and PATCH, unwrap any non-nulls
@@ -185,6 +198,7 @@ export class HttpTransformer extends Transformer {
                         path,
                         parent.name.value,
                         field.name.value,
+                        headers
                     )
                     ctx.setResource(getResourceID, getResolver)
                 }

--- a/packages/graphql-http-transformer/src/resources.ts
+++ b/packages/graphql-http-transformer/src/resources.ts
@@ -10,7 +10,7 @@ import {
 import { InputValueDefinitionNode } from 'graphql'
 import { ResourceConstants, ModelResourceIDs, HttpResourceIDs, makeNonNullType } from 'graphql-transformer-common'
 import { InvalidDirectiveError } from 'graphql-transformer-core';
-
+import { HttpHeader } from './HttpTransformer';
 export class ResourceFactory {
 
     public makeParams() {
@@ -66,7 +66,10 @@ export class ResourceFactory {
      * is not 200
      * @param type
      */
-    public makeGetResolver(baseURL: string, path: string, type: string, field: string) {
+    public makeGetResolver(baseURL: string, path: string, type: string, field: string, headers: HttpHeader[]) {
+
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(HttpResourceIDs.HttpDataSourceID(baseURL), 'Name'),
@@ -76,6 +79,8 @@ export class ResourceFactory {
                 compoundExpression([
                     set(ref('headers'), ref('utils.http.copyHeaders($ctx.request.headers)')),
                     qref('$headers.put("accept-encoding", "application/json")'),
+                    qref('$headers.put("accept-encoding", "application/jsohtrsliuhltirn")'),
+                    ...parsedHeaders,
                     HttpMappingTemplate.getRequest({
                         resourcePath: path,
                         params: obj({

--- a/packages/graphql-http-transformer/src/resources.ts
+++ b/packages/graphql-http-transformer/src/resources.ts
@@ -67,7 +67,7 @@ export class ResourceFactory {
      * @param type
      */
     public makeGetResolver(baseURL: string, path: string, type: string, field: string, headers: HttpHeader[]) {
-        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}")`))
 
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -118,7 +118,7 @@ export class ResourceFactory {
         nonNullArgs: string[],
         headers: HttpHeader[]
     ) {
-        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}")`))
 
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -172,7 +172,7 @@ export class ResourceFactory {
         nonNullArgs: string[],
         headers: HttpHeader[]
     ) {
-        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}")`))
 
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -215,7 +215,7 @@ export class ResourceFactory {
      * @param type
      */
     public makeDeleteResolver(baseURL: string, path: string, type: string, field: string, headers: HttpHeader[]) {
-        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}")`))
 
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -264,7 +264,7 @@ export class ResourceFactory {
         nonNullArgs: string[],
         headers: HttpHeader[]
     ) {
-        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}")`))
 
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),

--- a/packages/graphql-http-transformer/src/resources.ts
+++ b/packages/graphql-http-transformer/src/resources.ts
@@ -67,7 +67,6 @@ export class ResourceFactory {
      * @param type
      */
     public makeGetResolver(baseURL: string, path: string, type: string, field: string, headers: HttpHeader[]) {
-
         const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
 
         return new AppSync.Resolver({
@@ -116,8 +115,11 @@ export class ResourceFactory {
         path: string,
         type: string,
         field: string,
-        nonNullArgs: string[]
+        nonNullArgs: string[],
+        headers: HttpHeader[]
     ) {
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(HttpResourceIDs.HttpDataSourceID(baseURL), 'Name'),
@@ -129,6 +131,7 @@ export class ResourceFactory {
                     set(ref('headers'), ref('utils.http.copyHeaders($ctx.request.headers)')),
                     qref('$headers.put("Content-Type", "application/json")'),
                     qref('$headers.put("accept-encoding", "application/json")'),
+                    ...parsedHeaders,
                     HttpMappingTemplate.postRequest({
                         resourcePath: path,
                         params: obj({
@@ -166,8 +169,11 @@ export class ResourceFactory {
         path: string,
         type: string,
         field: string,
-        nonNullArgs: string[]
+        nonNullArgs: string[],
+        headers: HttpHeader[]
     ) {
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(HttpResourceIDs.HttpDataSourceID(baseURL), 'Name'),
@@ -179,6 +185,7 @@ export class ResourceFactory {
                     set(ref('headers'), ref('utils.http.copyHeaders($ctx.request.headers)')),
                     qref('$headers.put("Content-Type", "application/json")'),
                     qref('$headers.put("accept-encoding", "application/json")'),
+                    ...parsedHeaders,
                     HttpMappingTemplate.putRequest({
                         resourcePath: path,
                         params: obj({
@@ -207,7 +214,9 @@ export class ResourceFactory {
      * Create a resolver that makes a DELETE request.
      * @param type
      */
-    public makeDeleteResolver(baseURL: string, path: string, type: string, field: string) {
+    public makeDeleteResolver(baseURL: string, path: string, type: string, field: string, headers: HttpHeader[]) {
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(HttpResourceIDs.HttpDataSourceID(baseURL), 'Name'),
@@ -217,6 +226,7 @@ export class ResourceFactory {
                 compoundExpression([
                     set(ref('headers'), ref('utils.http.copyHeaders($ctx.request.headers)')),
                     qref('$headers.put("accept-encoding", "application/json")'),
+                    ...parsedHeaders,
                     HttpMappingTemplate.deleteRequest({
                         resourcePath: path,
                         params: obj({
@@ -251,8 +261,11 @@ export class ResourceFactory {
         path: string,
         type: string,
         field: string,
-        nonNullArgs: string[]
+        nonNullArgs: string[],
+        headers: HttpHeader[]
     ) {
+        const parsedHeaders = headers.map(header => qref(`$headers.put("${header.key}", "${header.value}}")`))
+
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(HttpResourceIDs.HttpDataSourceID(baseURL), 'Name'),
@@ -264,6 +277,7 @@ export class ResourceFactory {
                     set(ref('headers'), ref('utils.http.copyHeaders($ctx.request.headers)')),
                     qref('$headers.put("Content-Type", "application/json")'),
                     qref('$headers.put("accept-encoding", "application/json")'),
+                    ...parsedHeaders,
                     HttpMappingTemplate.patchRequest({
                         resourcePath: path,
                         params: obj({

--- a/packages/graphql-http-transformer/src/resources.ts
+++ b/packages/graphql-http-transformer/src/resources.ts
@@ -78,7 +78,6 @@ export class ResourceFactory {
                 compoundExpression([
                     set(ref('headers'), ref('utils.http.copyHeaders($ctx.request.headers)')),
                     qref('$headers.put("accept-encoding", "application/json")'),
-                    qref('$headers.put("accept-encoding", "application/jsohtrsliuhltirn")'),
                     ...parsedHeaders,
                     HttpMappingTemplate.getRequest({
                         resourcePath: path,


### PR DESCRIPTION
*Description of changes:*

Adds support for http headers for the @http directive.

Usage:

```
type Comment {
        id: ID!
        content: String @http(
            url: "https://www.api.com/ping", 
            headers: [
                {
                    key: "X-Header", 
                    value: "X-Header-Value"
                }
            ]
        )
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.