### PR TITLE
fix(1342): Fixes a bug related to pushing on CI/CD platforms.

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -37,7 +37,7 @@ async function run(context, category, resourceName) {
       handleMigration: opts =>
         updateStackForAPIMigration(context, 'api', resourceName, opts),
     }))
-    .then(() => uploadAppSyncFiles(context, resources))
+    .then(() => uploadAppSyncFiles(context, resources, allResources))
     .then(() => prePushGraphQLCodegen(context, resourcesToBeCreated, resourcesToBeUpdated))
     .then(() => updateS3Templates(context, allResources, projectDetails.amplifyMeta))
     .then(() => {
@@ -111,7 +111,7 @@ async function updateStackForAPIMigration(context, category, resourceName, optio
   resources = allResources.filter(resource => resource.service === 'AppSync');
 
   return packageResources(context, resources)
-    .then(() => uploadAppSyncFiles(context, resources, {
+    .then(() => uploadAppSyncFiles(context, resources, allResources, {
       useDeprecatedParameters: isReverting, defaultParams: { APIKeyExpirationEpoch: -1 },
     }))
     .then(() => updateS3Templates(context, resources, projectDetails.amplifyMeta))

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -21,10 +21,11 @@ function getProjectBucket(context) {
  * contents of the build/ directory to S3.
  * @param {*} context
  * @param {*} resourcesToUpdate
- * @param {*} defaultParams
+ * @param {*} allResources
+ * @param {*} options
  */
 async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, options = {}) {
-  const apiResources = resourcesToUpdate.filter(resource => resource.service === 'AppSync');
+  const allApiResourceToUpdate = resourcesToUpdate.filter(resource => resource.service === 'AppSync');
   const allApiResources = allResources.filter(resource => resource.service === 'AppSync');
   const { defaultParams, useDeprecatedParameters } = options;
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
@@ -84,10 +85,9 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
     fs.writeFileSync(parametersOutputFilePath, jsonString, 'utf8');
   };
 
-  // new Date().getTime().toString();
   // There can only be one appsync resource
-  if (apiResources.length > 0) {
-    const resource = apiResources[0];
+  if (allApiResourceToUpdate.length > 0) {
+    const resource = allApiResourceToUpdate[0];
     const { category, resourceName } = resource;
     const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
     const resourceBuildDir = path.normalize(path.join(resourceDir, 'build'));
@@ -115,7 +115,7 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
   } else if (allApiResources.length > 0) {
     // We need to update the parameters file even when we are not deploying the API
     // category to fix a bug around deployments on CI/CD platforms. Basically if a
-    // build has not run on this machine before and we are updating a non-api cateogry,
+    // build has not run on this machine before and we are updating a non-api category,
     // the params will not have the S3DeploymentRootKey parameter and will fail.
     // This block uses the consistent hash to fill params so the push
     // succeeds when the api category has not been built on this machine.

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -20,28 +20,29 @@ function getProjectBucket(context) {
  * Updates build/parameters.json with new timestamps and then uploads the
  * contents of the build/ directory to S3.
  * @param {*} context
- * @param {*} resources
+ * @param {*} resourcesToUpdate
  * @param {*} defaultParams
  */
-async function uploadAppSyncFiles(context, resources, options = {}) {
-  resources = resources.filter(resource => resource.service === 'AppSync');
+async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, options = {}) {
+  const apiResources = resourcesToUpdate.filter(resource => resource.service === 'AppSync');
+  const allApiResources = allResources.filter(resource => resource.service === 'AppSync');
   const { defaultParams, useDeprecatedParameters } = options;
-  // new Date().getTime().toString();
-  // There can only be one appsync resource
-  if (resources.length > 0) {
-    const resource = resources[0];
-    const { category, resourceName } = resource;
-    const backEndDir = context.amplify.pathManager.getBackendDirPath();
-    const resourceBuildDir = path.normalize(path.join(backEndDir, category, resourceName, 'build'));
-    const projectBucket = getProjectBucket(context);
+  const backEndDir = context.amplify.pathManager.getBackendDirPath();
+  const projectBucket = getProjectBucket(context);
+
+  const getDeploymentRootKey = async (resourceDir) => {
     let deploymentSubKey;
     if (useDeprecatedParameters) {
       deploymentSubKey = new Date().getTime();
     } else {
-      deploymentSubKey = await hashDirectory(resourceBuildDir);
+      deploymentSubKey = await hashDirectory(resourceDir);
     }
     const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${deploymentSubKey}`;
+    return deploymentRootKey;
+  };
 
+  const writeUpdatedParametersJson = (resource, rootKey) => {
+    const { category, resourceName } = resource;
     // Read parameters.json, add timestamps, and write to build/parameters.json
     const parametersFilePath = path.join(backEndDir, category, resourceName, PARAM_FILE_NAME);
     const currentParameters = defaultParams || {};
@@ -57,7 +58,7 @@ async function uploadAppSyncFiles(context, resources, options = {}) {
     if (!useDeprecatedParameters) {
       Object.assign(currentParameters, {
         S3DeploymentBucket: projectBucket,
-        S3DeploymentRootKey: deploymentRootKey,
+        S3DeploymentRootKey: rootKey,
       });
     }
 
@@ -81,6 +82,18 @@ async function uploadAppSyncFiles(context, resources, options = {}) {
     const jsonString = JSON.stringify(currentParameters, null, 4);
     const parametersOutputFilePath = path.join(backEndDir, category, resourceName, 'build', PARAM_FILE_NAME);
     fs.writeFileSync(parametersOutputFilePath, jsonString, 'utf8');
+  };
+
+  // new Date().getTime().toString();
+  // There can only be one appsync resource
+  if (apiResources.length > 0) {
+    const resource = apiResources[0];
+    const { category, resourceName } = resource;
+    const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
+    const resourceBuildDir = path.normalize(path.join(resourceDir, 'build'));
+
+    const deploymentRootKey = await getDeploymentRootKey(resourceDir);
+    writeUpdatedParametersJson(resource, deploymentRootKey);
 
     // Upload build/* to S3.
     const s3Client = await new S3(context);
@@ -99,13 +112,31 @@ async function uploadAppSyncFiles(context, resources, options = {}) {
         });
       },
     });
+  } else if (allApiResources.length > 0) {
+    // We need to update the parameters file even when we are not deploying the API
+    // category to fix a bug around deployments on CI/CD platforms. Basically if a
+    // build has not run on this machine before and we are updating a non-api cateogry,
+    // the params will not have the S3DeploymentRootKey parameter and will fail.
+    // This block uses the consistent hash to fill params so the push
+    // succeeds when the api category has not been built on this machine.
+    const resource = allApiResources[0];
+    const { category, resourceName } = resource;
+    const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
+    const deploymentRootKey = await getDeploymentRootKey(resourceDir);
+    writeUpdatedParametersJson(resource, deploymentRootKey);
   }
 }
 
-// Hash a directory into a unique value.
+/**
+ * Hashes the project directory into a single value. The same project configuration
+ * should return the same hash.
+ */
 async function hashDirectory(directory) {
   const options = {
     encoding: 'hex',
+    folders: {
+      exclude: ['build'],
+    },
   };
 
   return hashElement(directory, options).then(result => (result.hash));


### PR DESCRIPTION

Fixes a bug related to pushing on CI/CD platforms. This change causes every push invocation to
update the S3DeploymentRootKey using a fixed hash function. This is in response to #1342. After
updating to this new version of the CLI, you will need to run `amplify push` one time with changes
to the api category and then every subsequent CI/CD push should succeed regardless of if you are
updating the api category or not.

re #1342

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.