### PR TITLE
fix(amplify-category-storage): pass context to DDB migration helper

### DIFF
--- a/packages/amplify-category-storage/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/index.js
@@ -41,7 +41,7 @@ function migrateResource(context, projectPath, service, resourceName) {
     return;
   }
 
-  return migrate(context, projectPath, resourceName);
+  return migrate(projectPath, resourceName);
 }
 
 

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/index.js
@@ -41,7 +41,7 @@ function migrateResource(context, projectPath, service, resourceName) {
     return;
   }
 
-  return migrate(projectPath, resourceName);
+  return migrate(context, projectPath, resourceName);
 }
 
 

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -389,7 +389,7 @@ function copyCfnTemplate(context, categoryName, resourceName, options) {
   return context.amplify.copyBatch(context, copyJobs, options);
 }
 
-function migrate(projectPath, resourceName) {
+function migrate(context, projectPath, resourceName) {
   const resourceDirPath = path.join(projectPath, 'amplify', 'backend', category, resourceName);
   const cfnFilePath = path.join(resourceDirPath, `${resourceName}-cloudformation-template.json`);
 


### PR DESCRIPTION
The arity of migrate method on DDB and S3 were not the same and caused issues when migrating DynamoDB resources. This fixes the arity by passing context as the first argument of migrate method DynamoDB category

*Issue #, if available:*
fix #1384 

*Description of changes:*
See commit message above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.