### PR TITLE
feat(amplify-category-auth):update default password policy

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -48,10 +48,6 @@ const userPoolDefaults = projectName => ({
   defaultPasswordPolicy: booleanOptions.find(b => b.value === false).value,
   passwordPolicyMinLength: 8,
   passwordPolicyCharacters: [
-    'Requires Lowercase',
-    'Requires Uppercase',
-    'Requires Numbers',
-    'Requires Symbols',
   ],
   requiredAttributes: ['email'],
   userpoolClientName: `${projectName}_app_client`,


### PR DESCRIPTION
Updated the default password policy used in Cognito userpool to follow nist password guideline[1]

[1] - https://pages.nist.gov/800-63-3/sp800-63b.html#appA
re #1375

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.