### PR TITLE
Add multi env on @http

### DIFF
--- a/packages/graphql-http-transformer/src/HttpTransformer.ts
+++ b/packages/graphql-http-transformer/src/HttpTransformer.ts
@@ -41,7 +41,7 @@ export class HttpTransformer extends Transformer {
 
     resources: ResourceFactory
 
-    static urlRegex = /(http(s)?:\/\/)|www\.|(\/.*)/g
+    static urlRegex = /(http(s)?:\/\/)|(\/.*)/g
 
     constructor() {
         super(
@@ -92,7 +92,7 @@ export class HttpTransformer extends Transformer {
                 throw new TransformerContractError(`@http directive at location ${value.loc.start} ` +
                     `requires a url parameter that begins with http:// or https://.`)
             }
-            // extract just the base url, without "www" or path information
+            // extract just the base url with protocol
             const baseURL = url.replace(HttpTransformer.urlRegex, '$1')
             const dataSourceID = HttpResourceIDs.HttpDataSourceID(baseURL)
             // only create one DataSource per base URL

--- a/packages/graphql-http-transformer/src/__tests__/HttpTransformer.test.ts
+++ b/packages/graphql-http-transformer/src/__tests__/HttpTransformer.test.ts
@@ -136,3 +136,82 @@ test('Test HttpTransformer with URL and headers params happy case', () => {
     expect(out.resolvers['Comment.complexPut.req.vtl']).toContain('$util.qr($headers.put("X-Header", "X-Header-ValuePut"))');    
 
 });
+
+test('Test HttpTransformer with four basic requests with env on the URI', () => {
+    const validSchema = `
+    type Comment {
+        id: ID!
+        content: String @http(method: POST, url: "http://www.api.com/ping\${env}")
+        content2: String @http(method: PUT, url: "http://www.api.com/ping\${env}")
+        more: String @http(url: "http://api.com/ping/me/2\${env}")
+        evenMore: String @http(method: DELETE, url: "http://www.google.com/query/id\${env}")
+        stillMore: String @http(method: PATCH, url: "https://www.api.com/ping/id\${env}")
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new HttpTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    const schemaDoc = parse(out.schema)
+
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "content")].Properties.RequestMappingTemplate['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "content")].Properties.RequestMappingTemplate['Fn::Sub'][1].env.Ref).toBe('env')
+    
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "content2")].Properties.RequestMappingTemplate['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "content2")].Properties.RequestMappingTemplate['Fn::Sub'][1].env.Ref).toBe('env')
+    
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "more")].Properties.RequestMappingTemplate['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "more")].Properties.RequestMappingTemplate['Fn::Sub'][1].env.Ref).toBe('env')
+    
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "evenMore")].Properties.RequestMappingTemplate['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "evenMore")].Properties.RequestMappingTemplate['Fn::Sub'][1].env.Ref).toBe('env')
+    
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "stillMore")].Properties.RequestMappingTemplate['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID("Comment", "stillMore")].Properties.RequestMappingTemplate['Fn::Sub'][1].env.Ref).toBe('env')
+});
+
+test('Test HttpTransformer with four basic requests with env on the hostname', () => {
+    const validSchema = `
+    type Comment {
+        id: ID!
+        content: String @http(method: POST, url: "http://\${env}www.api.com/ping")
+        content2: String @http(method: PUT, url: "http://\${env}www.api.com/ping")
+        more: String @http(url: "http://\${env}api.com/ping/me/2")
+        evenMore: String @http(method: DELETE, url: "http://\${env}www.google.com/query/id")
+        stillMore: String @http(method: PATCH, url: "https://\${env}www.api.com/ping/id")
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new HttpTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    
+    const schemaDoc = parse(out.schema)
+
+    const contentDatasource = out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content')].Properties.DataSourceName['Fn::GetAtt'][0];
+    expect(out.stacks.HttpStack.Resources[contentDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[contentDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].env.Ref).toBe('env')
+
+    const content2Datasource = out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content2')].Properties.DataSourceName['Fn::GetAtt'][0];
+    expect(out.stacks.HttpStack.Resources[content2Datasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[content2Datasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].env.Ref).toBe('env')
+
+    const moreDatasource = out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'more')].Properties.DataSourceName['Fn::GetAtt'][0];
+    expect(out.stacks.HttpStack.Resources[moreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[moreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].env.Ref).toBe('env')
+
+    const evenMoreDatasource = out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'evenMore')].Properties.DataSourceName['Fn::GetAtt'][0];
+    expect(out.stacks.HttpStack.Resources[evenMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[evenMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].env.Ref).toBe('env')
+
+    const stillMoreDatasource = out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'stillMore')].Properties.DataSourceName['Fn::GetAtt'][0];
+    expect(out.stacks.HttpStack.Resources[stillMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${env}')
+    expect(out.stacks.HttpStack.Resources[stillMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].env.Ref).toBe('env')
+
+});


### PR DESCRIPTION
*Description of changes:*

Adds support to ${env} on the hostname and URI
It is also fixing one regex which was removing 'www' from the URLs

Usage:
```
type Comment {
        id: ID!
        content: String @http(url: "https://${env}.api.com/ping-${env}")
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.