### PR TITLE
fixing npe where add-graphql-datasource fails if user doesn't have an…

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -10,7 +10,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, datasourceMeta
   const amplifyMeta = context.amplify.getProjectMeta();
 
   // Verify that an API exists in the project before proceeding.
-  if (Object.keys(amplifyMeta[category]).length === 0) {
+  if (amplifyMeta == null || amplifyMeta[category] == null || Object.keys(amplifyMeta[category]).length === 0) {
     context.print.error('You must create an AppSync API in your project before adding a graphql datasource. Please use "amplify api add" to create the API.');
     process.exit(0);
   }

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -10,7 +10,8 @@ async function serviceWalkthrough(context, defaultValuesFilename, datasourceMeta
   const amplifyMeta = context.amplify.getProjectMeta();
 
   // Verify that an API exists in the project before proceeding.
-  if (amplifyMeta == null || amplifyMeta[category] == null || Object.keys(amplifyMeta[category]).length === 0) {
+  if (amplifyMeta == null || amplifyMeta[category] == null
+   || Object.keys(amplifyMeta[category]).length === 0) {
     context.print.error('You must create an AppSync API in your project before adding a graphql datasource. Please use "amplify api add" to create the API.');
     process.exit(0);
   }


### PR DESCRIPTION
… API created beforehand

*Issue #, if available:* n/a

*Description of changes:*

fixing npe where add-graphql-datasource fails if user doesn't have an API created beforehand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.