### PR TITLE
fix(amplify-provider-awscloudformation): check creds before setting

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws.js
@@ -4,7 +4,9 @@ const configurationManager = require('../../lib/configuration-manager');
 
 aws.configureWithCreds = async (context) => {
   const config = await configurationManager.loadConfiguration(context, aws);
-  aws.config.update(config);
+  if (config) {
+    aws.config.update(config);
+  }
   return aws;
 };
 


### PR DESCRIPTION
aws.configureWithCreds trys to load aws config and when the configuration is general configuration,
it returns null. Conditionally setting the credentials iff user has project specific config

fix #1424

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.