### PR TITLE
fix(amplify-category-notifications): remove env name

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/service-walkthroughs/pinpoint-walkthrough.js
@@ -145,10 +145,11 @@ function checkIfNotificationsCategoryExists(context) {
   if (amplifyMeta.notifications) {
     const categoryResources = amplifyMeta.notifications;
     Object.keys(categoryResources).forEach((resource) => {
-      if (categoryResources[resource].service === serviceName) {
+      if (categoryResources[resource].service === serviceName &&
+        categoryResources[resource].output.Id) {
         pinpointApp = {};
         pinpointApp.appId = categoryResources[resource].output.Id;
-        pinpointApp.appName = categoryResources[resource].output.Name;
+        pinpointApp.appName = resource;
       }
     });
   }

--- a/packages/amplify-category-notifications/index.js
+++ b/packages/amplify-category-notifications/index.js
@@ -13,10 +13,6 @@ async function initEnv(context) {
   await multiEnvManager.initEnv(context);
 }
 
-async function initEnvPush(context) {
-  await multiEnvManager.initEnvPush(context);
-}
-
 async function migrate(context) {
   await multiEnvManager.migrate(context);
 }
@@ -25,7 +21,6 @@ module.exports = {
   console,
   deletePinpointAppForEnv,
   initEnv,
-  initEnvPush,
   migrate,
 };
 

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -17,65 +17,85 @@ function getPinpointApp(context) {
   return pinpointApp;
 }
 
-async function ensurePinpointApp(context) {
-  const { amplifyMeta } = context.exeInfo;
-  let pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.CategoryName]);
-  if (!pinpointApp) {
+async function ensurePinpointApp(context, resourceName) {
+  const { amplifyMeta, localEnvInfo } = context.exeInfo;
+  const scanOptions = {
+    isRegulatingResourceName: true,
+    envName: localEnvInfo.envName,
+  };
+  let pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.CategoryName], scanOptions);
+  if (pinpointApp) {
+    resourceName = scanOptions.regulatedResourceName;
+  } else {
     pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.AnalyticsCategoryName]);
     if (pinpointApp) {
-      if (!pinpointApp.Name) {
-        pinpointApp = await getApp(context, pinpointApp.Id);
-      }
-      amplifyMeta[constants.CategoryName] = {};
-      amplifyMeta[constants.CategoryName][pinpointApp.Name] = {
-        service: constants.PinpointName,
-        output: {
-          Name: pinpointApp.Name,
-          Id: pinpointApp.Id,
-          Region: pinpointApp.Region,
-        },
-      };
+      resourceName = generateResourceName(pinpointApp.Name, localEnvInfo.envName);
+      constructResourceMeta(amplifyMeta, resourceName, pinpointApp);
     } else {
       context.print.info('');
-      pinpointApp = await createPinpointApp(context);
+      resourceName = await createPinpointApp(context, resourceName);
     }
   }
-  context.exeInfo.pinpointApp = pinpointApp;
   context.exeInfo.serviceMeta =
-    context.exeInfo.amplifyMeta[constants.CategoryName][pinpointApp.Name];
+    context.exeInfo.amplifyMeta[constants.CategoryName][resourceName];
+  context.exeInfo.pinpointApp = context.exeInfo.serviceMeta.output;
 }
 
-async function createPinpointApp(context) {
+// rerouce name is consistent cross environments
+function generateResourceName(pinpointAppName, envName) {
+  return pinpointAppName.replace(getEnvTagPattern(envName), '');
+}
+
+function generatePinpoinAppName(resourceName, envName) {
+  return resourceName + getEnvTagPattern(envName);
+}
+
+function getEnvTagPattern(envName) {
+  return envName === 'NONE' ? '' : `-${envName}`;
+}
+
+async function createPinpointApp(context, resourceName) {
   const { projectConfig, amplifyMeta, localEnvInfo } = context.exeInfo;
-  let pinpointProjectName = localEnvInfo.envName === 'NONE' ?
-    (projectConfig.projectName + context.amplify.makeId(5)) :
-    `${projectConfig.projectName + context.amplify.makeId(5)}-${localEnvInfo.envName}`;
 
   context.print.info('An Amazon Pinpoint project will be created for notifications.');
-
-  if (!context.exeInfo.inputParams || !context.exeInfo.inputParams.yes) {
-    const answer = await inquirer.prompt({
-      name: 'projectName',
-      type: 'input',
-      message: 'Pinpoint project name',
-      default: pinpointProjectName,
-      validate: (name) => {
-        let result = false;
-        let message = '';
-        if (name && name.length > 0) {
-          result = true;
-        } else {
-          message = 'Project name can not be empty.';
-        }
-        return result || message;
-      },
-    });
-    pinpointProjectName = answer.projectName;
+  if (!resourceName) {
+    resourceName = projectConfig.projectName + context.amplify.makeId(5);
+    if (!context.exeInfo.inputParams || !context.exeInfo.inputParams.yes) {
+      const answer = await inquirer.prompt({
+        name: 'resourceNameInput',
+        type: 'input',
+        message: 'Provide your pinpoint resource name: ',
+        default: resourceName,
+        validate: (name) => {
+          let result = false;
+          let message = '';
+          if (name && name.length > 0) {
+            result = true;
+          } else {
+            message = 'Your pinpoint resource name can not be empty.';
+          }
+          return result || message;
+        },
+      });
+      resourceName = answer.resourceNameInput;
+    }
   }
 
-  const pinpointApp = await createApp(context, pinpointProjectName);
-  amplifyMeta[constants.CategoryName] = {};
-  amplifyMeta[constants.CategoryName][pinpointApp.Name] = {
+  const pinpointAppName = generatePinpoinAppName(resourceName, localEnvInfo.envName);
+  const pinpointApp = await createApp(context, pinpointAppName);
+  constructResourceMeta(amplifyMeta, resourceName, pinpointApp);
+  context.exeInfo.pinpointApp = pinpointApp; // needed for authHelper.ensureAuth(context);
+
+  context.print.info('');
+  await authHelper.ensureAuth(context);
+  context.print.info('');
+
+  return resourceName;
+}
+
+function constructResourceMeta(amplifyMeta, resourceName, pinpointApp) {
+  amplifyMeta[constants.CategoryName] = amplifyMeta[constants.CategoryName] || {};
+  amplifyMeta[constants.CategoryName][resourceName] = {
     service: constants.PinpointName,
     output: {
       Name: pinpointApp.Name,
@@ -84,13 +104,6 @@ async function createPinpointApp(context) {
     },
     lastPushTimeStamp: new Date(),
   };
-
-  context.exeInfo.pinpointApp = pinpointApp;
-  context.print.info('');
-  await authHelper.ensureAuth(context);
-  context.print.info('');
-
-  return pinpointApp;
 }
 
 async function deletePinpointApp(context) {
@@ -106,30 +119,33 @@ async function deletePinpointApp(context) {
   }
 }
 
-function scanCategoryMetaForPinpoint(categoryMeta) {
+function scanCategoryMetaForPinpoint(categoryMeta, options) {
   let result;
   if (categoryMeta) {
-    const services = Object.keys(categoryMeta);
-    for (let i = 0; i < services.length; i++) {
-      const serviceMeta = categoryMeta[services[i]];
+    let resourceName;
+    const resources = Object.keys(categoryMeta);
+    for (let i = 0; i < resources.length; i++) {
+      resourceName = resources[i];
+      const serviceMeta = categoryMeta[resourceName];
       if (serviceMeta.service === constants.PinpointName &&
         serviceMeta.output &&
         serviceMeta.output.Id) {
         result = {
           Id: serviceMeta.output.Id,
         };
-        if (serviceMeta.output.Name) {
-          result.Name = serviceMeta.output.Name;
-        } else if (serviceMeta.output.appName) {
-          result.Name = serviceMeta.output.appName;
-        }
-        if (serviceMeta.output.Region) {
-          result.Region = serviceMeta.output.Region;
+        result.Name = serviceMeta.output.Name || serviceMeta.output.appName;
+        result.Region = serviceMeta.output.Region;
+        if (options && options.isRegulatingResourceName) {
+          const regulatedResourceName = generateResourceName(result.Name, options.envName);
+          categoryMeta[regulatedResourceName] = serviceMeta;
+          delete categoryMeta[resourceName];
+          options.regulatedResourceName = regulatedResourceName;
         }
         break;
       }
     }
   }
+
   return result;
 }
 
@@ -164,26 +180,6 @@ async function createApp(context, pinpointAppName) {
         reject(err);
       } else {
         spinner.succeed(`Successfully created Pinpoint project: ${data.ApplicationResponse.Name}`);
-        data.ApplicationResponse.Region = pinpointClient.config.region;
-        resolve(data.ApplicationResponse);
-      }
-    });
-  });
-}
-
-async function getApp(context, pinpointAppId) {
-  const params = {
-    ApplicationId: pinpointAppId,
-  };
-  spinner.start('Retrieving Pinpoint app information.');
-  const pinpointClient = await getPinpointClient(context, 'get');
-  return new Promise((resolve, reject) => {
-    pinpointClient.getApp(params, (err, data) => {
-      if (err) {
-        spinner.fail('Pinpoint project retrieval error');
-        reject(err);
-      } else {
-        spinner.succeed(`Successfully retrieved Pinpoint project: ${data.ApplicationResponse.Name}`);
         data.ApplicationResponse.Region = pinpointClient.config.region;
         resolve(data.ApplicationResponse);
       }

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -135,12 +135,16 @@ function scanCategoryMetaForPinpoint(categoryMeta, options) {
         };
         result.Name = serviceMeta.output.Name || serviceMeta.output.appName;
         result.Region = serviceMeta.output.Region;
+
         if (options && options.isRegulatingResourceName) {
           const regulatedResourceName = generateResourceName(result.Name, options.envName);
-          categoryMeta[regulatedResourceName] = serviceMeta;
-          delete categoryMeta[resourceName];
           options.regulatedResourceName = regulatedResourceName;
+          if (resourceName !== regulatedResourceName) {
+            categoryMeta[regulatedResourceName] = serviceMeta;
+            delete categoryMeta[resourceName];
+          }
         }
+
         break;
       }
     }


### PR DESCRIPTION
remove env name from the resource name in the notification category
in both the amplify-meta.json file and the backend-config.json file

projects configured by the previous versions will be automatically handled without customers' efforts. 

fix #1372

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.