### PR TITLE
fix: provider configLevel general

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -514,6 +514,8 @@ async function loadConfigurationForEnv(context, env) {
       awsConfig = loadConfigFromPath(context, config.awsConfigFilePath);
     }
     return awsConfig;
+  } else {
+    return {};
   }
 }
 

--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -514,9 +514,9 @@ async function loadConfigurationForEnv(context, env) {
       awsConfig = loadConfigFromPath(context, config.awsConfigFilePath);
     }
     return awsConfig;
-  } else {
-    return {};
   }
+
+  return {};
 }
 
 async function resetCache(context) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/1455

*Description of changes:*
Adding an empty config object to be returned on config level being set to general vs project

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.