### PR TITLE
Feature/@key

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -215,11 +215,8 @@ async function transformGraphQLSchema(context, options) {
     new ModelAuthTransformer({ authMode }),
     new VersionedModelTransformer(),
     new FunctionTransformer(),
-<<<<<<< HEAD
     new HTTPTransformer(),
-=======
-    new KeyTransformer()
->>>>>>> Adding support for create, update, delete, & get with updated index structures. Still need to update list as well as implement the new query resolver using existing parts. The last change is to handle the partial key update scenario in update operations.
+    new KeyTransformer(),
   ];
 
   if (usedDirectives.includes('searchable')) {

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -212,11 +212,13 @@ async function transformGraphQLSchema(context, options) {
   const transformerList = [
     new DynamoDBModelTransformer(getModelConfig(project)),
     new ModelConnectionTransformer(),
-    new ModelAuthTransformer({ authMode }),
     new VersionedModelTransformer(),
     new FunctionTransformer(),
     new HTTPTransformer(),
     new KeyTransformer(),
+    // TODO: Build dependency mechanism into transformers. Auth runs last
+    // so any resolvers that need to be protected will already be created.
+    new ModelAuthTransformer({ authMode }),
   ];
 
   if (usedDirectives.includes('searchable')) {

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -9,6 +9,7 @@ const SearchableModelTransformer = require('graphql-elasticsearch-transformer').
 const VersionedModelTransformer = require('graphql-versioned-transformer').default;
 const FunctionTransformer = require('graphql-function-transformer').default;
 const HTTPTransformer = require('graphql-http-transformer').default;
+const KeyTransformer = require('graphql-key-transformer').default;
 const providerName = require('./constants').ProviderName;
 const TransformPackage = require('graphql-transformer-core');
 
@@ -214,7 +215,11 @@ async function transformGraphQLSchema(context, options) {
     new ModelAuthTransformer({ authMode }),
     new VersionedModelTransformer(),
     new FunctionTransformer(),
+<<<<<<< HEAD
     new HTTPTransformer(),
+=======
+    new KeyTransformer()
+>>>>>>> Adding support for create, update, delete, & get with updated index structures. Still need to update list as well as implement the new query resolver using existing parts. The last change is to handle the partial key update scenario in update operations.
   ];
 
   if (usedDirectives.includes('searchable')) {

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -23,6 +23,7 @@
     "graphql-dynamodb-transformer": "3.7.0",
     "graphql-elasticsearch-transformer": "3.6.0",
     "graphql-function-transformer": "1.0.2",
+    "graphql-key-transformer": "^1.0.0",
     "graphql-http-transformer": "3.4.6",
     "graphql-transformer-common": "3.7.0",
     "graphql-transformer-core": "3.6.3",

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -189,13 +189,18 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   #set( $keyFields = [\\"id\\"] )
 #end
 #foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
-  #if( $util.isNull($entry.value) )
-    #set( $discard = $expRemove.add(\\"#$entry.key\\") )
-    $util.qr($expNames.put(\\"#$entry.key\\", \\"$entry.key\\"))
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
   #else
-    $util.qr($expSet.put(\\"#$entry.key\\", \\":$entry.key\\"))
-    $util.qr($expNames.put(\\"#$entry.key\\", \\"$entry.key\\"))
-    $util.qr($expValues.put(\\":$entry.key\\", $util.dynamodb.toDynamoDB($entry.value)))
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
   #end
 #end
 #set( $expression = \\"\\" )
@@ -564,13 +569,18 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   #set( $keyFields = [\\"id\\"] )
 #end
 #foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
-  #if( $util.isNull($entry.value) )
-    #set( $discard = $expRemove.add(\\"#$entry.key\\") )
-    $util.qr($expNames.put(\\"#$entry.key\\", \\"$entry.key\\"))
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
   #else
-    $util.qr($expSet.put(\\"#$entry.key\\", \\":$entry.key\\"))
-    $util.qr($expNames.put(\\"#$entry.key\\", \\"$entry.key\\"))
-    $util.qr($expValues.put(\\":$entry.key\\", $util.dynamodb.toDynamoDB($entry.value)))
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
   #end
 #end
 #set( $expression = \\"\\" )

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -33,15 +33,15 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 ## [End] Throw if unauthorized **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.time.nowISO8601()))
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.time.nowISO8601()))
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
-  \\"key\\": {
-      \\"id\\":     $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
-  },
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": {
       \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -132,19 +132,42 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
-  $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
-  $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
 #else
-  #set( $condition = {
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
   },
   \\"expressionValues\\": {}
 } )
+  #end
 #end
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.time.nowISO8601()))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -157,7 +180,15 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $expSet = {} )
 #set( $expAdd = {} )
 #set( $expRemove = [] )
-#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, [\\"id\\"]).entrySet() )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
   #if( $util.isNull($entry.value) )
     #set( $discard = $expRemove.add(\\"#$entry.key\\") )
     $util.qr($expNames.put(\\"#$entry.key\\", \\"$entry.key\\"))
@@ -206,11 +237,11 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"UpdateItem\\",
-  \\"key\\": {
-      \\"id\\": {
-          \\"S\\": \\"$context.args.input.id\\"
-    }
-  },
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": \\"$context.args.input.id\\"
+  }
+} #end,
   \\"update\\": $util.toJson($update),
   \\"condition\\": $util.toJson($condition)
 }"
@@ -295,15 +326,37 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
 
 #if( $authCondition )
   #set( $condition = $authCondition )
-  $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
-  $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
 #else
-  #set( $condition = {
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
   }
 } )
+  #end
 #end
 #if( $versionedCondition )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
@@ -315,9 +368,9 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"DeleteItem\\",
-  \\"key\\": {
-      \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
-  },
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
   \\"condition\\": $util.toJson($condition)
 }"
 `;
@@ -355,15 +408,15 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 ## [End] Throw if unauthorized **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.time.nowISO8601()))
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.time.nowISO8601()))
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
-  \\"key\\": {
-      \\"id\\":     $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
-  },
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": {
       \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -454,19 +507,42 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
-  $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
-  $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
 #else
-  #set( $condition = {
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
   },
   \\"expressionValues\\": {}
 } )
+  #end
 #end
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.time.nowISO8601()))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -479,7 +555,15 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $expSet = {} )
 #set( $expAdd = {} )
 #set( $expRemove = [] )
-#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, [\\"id\\"]).entrySet() )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
   #if( $util.isNull($entry.value) )
     #set( $discard = $expRemove.add(\\"#$entry.key\\") )
     $util.qr($expNames.put(\\"#$entry.key\\", \\"$entry.key\\"))
@@ -528,11 +612,11 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"UpdateItem\\",
-  \\"key\\": {
-      \\"id\\": {
-          \\"S\\": \\"$context.args.input.id\\"
-    }
-  },
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": \\"$context.args.input.id\\"
+  }
+} #end,
   \\"update\\": $util.toJson($update),
   \\"condition\\": $util.toJson($condition)
 }"
@@ -617,15 +701,37 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
 
 #if( $authCondition )
   #set( $condition = $authCondition )
-  $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
-  $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
 #else
-  #set( $condition = {
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
   }
 } )
+  #end
 #end
 #if( $versionedCondition )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
@@ -637,9 +743,9 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"DeleteItem\\",
-  \\"key\\": {
-      \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
-  },
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
   \\"condition\\": $util.toJson($condition)
 }"
 `;

--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -10,14 +10,15 @@ import {
     makeModelConnectionType,
     makeModelConnectionField,
     makeScalarFilterInputs,
-    makeScalarKeyConditionInputs,
     makeModelXFilterInputObject,
     makeModelSortDirectionEnumObject,
 } from 'graphql-dynamodb-transformer'
 import {
     getBaseType, isListType, getDirectiveArgument, blankObject,
     isScalar, STANDARD_SCALARS,
-    toCamelCase, isNonNullType, attributeTypeFromScalar
+    toCamelCase, isNonNullType, attributeTypeFromScalar,
+    makeScalarKeyConditionInputs, makeScalarKeyConditionForType,
+    makeNamedType,
 } from 'graphql-transformer-common'
 import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common'
 import { updateCreateInputWithConnectionField, updateUpdateInputWithConnectionField } from './definitions';
@@ -405,14 +406,9 @@ export class ModelConnectionTransformer extends Transformer {
         // Create sort key condition inputs for valid sort key types
         // We only create the KeyConditionInput if it is being used.
         if (sortKeyInfo) {
-            const sortKeyConditionInputs = makeScalarKeyConditionInputs()
-            for (const keyCondition of sortKeyConditionInputs) {
-                if (
-                    keyCondition.name.value === ModelResourceIDs.ModelKeyConditionInputTypeName(sortKeyInfo.typeName) &&
-                    !this.typeExist(keyCondition.name.value, ctx)
-                ) {
-                    ctx.addInput(keyCondition)
-                }
+            const sortKeyConditionInput = makeScalarKeyConditionForType(makeNamedType(sortKeyInfo.typeName))
+            if (!this.typeExist(sortKeyConditionInput.name.value, ctx)) {
+                ctx.addInput(sortKeyConditionInput);
             }
         }
     }

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -6,14 +6,14 @@ import { ResourceFactory } from './resources'
 import {
     makeCreateInputObject, makeUpdateInputObject, makeDeleteInputObject,
     makeModelXFilterInputObject, makeModelSortDirectionEnumObject, makeModelConnectionType,
-    makeScalarFilterInputs, makeModelScanField, makeSubscriptionField, getNonModelObjectArray,
+    makeScalarFilterInputs, makeSubscriptionField, getNonModelObjectArray,
     makeNonModelInputObject, makeEnumFilterInputObjects
 } from './definitions'
 import {
     blankObject, makeField, makeInputValueDefinition, makeNamedType,
     makeNonNullType
 } from 'graphql-transformer-common'
-import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common'
+import { ResolverResourceIDs, ModelResourceIDs, makeConnectionField } from 'graphql-transformer-common'
 
 interface QueryNameMap {
     get?: string;
@@ -313,7 +313,7 @@ export class DynamoDBModelTransformer extends Transformer {
             const listResolver = this.resources.makeListResolver(def.name.value, listFieldNameOverride, ctx.getQueryTypeName())
             ctx.setResource(ResolverResourceIDs.DynamoDBListResolverResourceID(typeName), listResolver)
 
-            queryFields.push(makeModelScanField(listResolver.Properties.FieldName, def.name.value))
+            queryFields.push(makeConnectionField(listResolver.Properties.FieldName, def.name.value))
         }
         this.generateFilterInputs(ctx, def)
 

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -23,12 +23,6 @@ const INT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notCont
 const FLOAT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between']
 const BOOLEAN_CONDITIONS = ['ne', 'eq']
 
-// Key conditions
-const STRING_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between', 'beginsWith']
-const ID_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between', 'beginsWith']
-const INT_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between']
-const FLOAT_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between']
-
 export function getNonModelObjectArray(
     obj: ObjectTypeDefinitionNode,
     ctx: TransformerContext,
@@ -531,18 +525,6 @@ export function makeSubscriptionField(fieldName: string, returnTypeName: string,
     )
 }
 
-export function makeModelScanField(fieldName: string, returnTypeName: string): FieldDefinitionNode {
-    return makeField(
-        fieldName,
-        [
-            makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
-            makeInputValueDefinition('limit', makeNamedType('Int')),
-            makeInputValueDefinition('nextToken', makeNamedType('String'))
-        ],
-        makeNamedType(ModelResourceIDs.ModelConnectionTypeName(returnTypeName))
-    )
-}
-
 export interface SortKeyFieldInfo {
     // The name of the sort key field.
     fieldName: string;
@@ -575,48 +557,5 @@ export function makeScalarFilterInputs(): InputObjectTypeDefinitionNode[] {
         makeModelScalarFilterInputObject('Int'),
         makeModelScalarFilterInputObject('Float'),
         makeModelScalarFilterInputObject('Boolean')
-    ];
-}
-
-function getScalarKeyConditions(type: string): string[] {
-    switch (type) {
-        case 'String':
-            return STRING_KEY_CONDITIONS
-        case 'ID':
-            return ID_KEY_CONDITIONS
-        case 'Int':
-            return INT_KEY_CONDITIONS
-        case 'Float':
-            return FLOAT_KEY_CONDITIONS
-        default:
-            throw 'Valid types are String, ID, Int, Float, Boolean'
-    }
-}
-export function makeModelStringKeyConditionInputObject(type: string): InputObjectTypeDefinitionNode {
-    const name = ModelResourceIDs.ModelKeyConditionInputTypeName(type)
-    const conditions = getScalarKeyConditions(type)
-    const fields: InputValueDefinitionNode[] = conditions
-        .map((condition: string) => ({
-            kind: Kind.INPUT_VALUE_DEFINITION,
-            name: { kind: "Name" as "Name", value: condition },
-            type: condition === 'between' ? makeListType(makeNamedType(type)) : makeNamedType(type),
-            directives: []
-        }))
-    return {
-        kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
-        name: {
-            kind: 'Name',
-            value: name
-        },
-        fields,
-        directives: []
-    }
-}
-export function makeScalarKeyConditionInputs(): InputObjectTypeDefinitionNode[] {
-    return [
-        makeModelStringKeyConditionInputObject('String'),
-        makeModelStringKeyConditionInputObject('ID'),
-        makeModelStringKeyConditionInputObject('Int'),
-        makeModelStringKeyConditionInputObject('Float')
     ];
 }

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -550,7 +550,7 @@ export class ResourceFactory {
                         ref('context.args.filter'),
                         set(
                             ref(`${requestVariable}.filter`),
-                            ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)')
+                            ref('util.parseJson("$util.transform.toDynamoDBFilterExpression($ctx.args.filter)")')
                         ),
                     ),
                     ifElse(

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -415,7 +415,8 @@ export class ResourceFactory {
                             true
                         ),
                         condition: ref('util.toJson($condition)'),
-                        objectKeyVariable: ResourceConstants.SNIPPETS.ModelObjectKey
+                        objectKeyVariable: ResourceConstants.SNIPPETS.ModelObjectKey,
+                        nameOverrideMap: ResourceConstants.SNIPPETS.DynamoDBNameOverrideMap
                     })
                 ])
             ),

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -3,7 +3,7 @@ import Output from 'cloudform-types/types/output';
 import {
     DynamoDBMappingTemplate, printBlock, str, print,
     ref, obj, set, nul,
-    ifElse, compoundExpression, qref, bool, equals, iff, raw, comment
+    ifElse, compoundExpression, qref, bool, equals, iff, raw, comment, forEach, list
 } from 'graphql-mapping-template'
 import { ResourceConstants, plurality, graphqlName, toUpper, ModelResourceIDs } from 'graphql-transformer-common'
 
@@ -317,9 +317,14 @@ export class ResourceFactory {
                     qref('$context.args.input.put("updatedAt", $util.time.nowISO8601())'),
                     qref(`$context.args.input.put("__typename", "${type}")`),
                     DynamoDBMappingTemplate.putItem({
-                        key: obj({
-                            id: raw(`$util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))`)
-                        }),
+                        key: ifElse(
+                            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                            raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+                            obj({
+                                id: raw(`$util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))`)
+                            }),
+                            true
+                        ),
                         attributeValues: ref('util.dynamodb.toMapValuesJson($context.args.input)'),
                         condition: obj({
                             expression: str(`attribute_not_exists(#id)`),
@@ -349,16 +354,43 @@ export class ResourceFactory {
                         raw(`$${ResourceConstants.SNIPPETS.AuthCondition} && $${ResourceConstants.SNIPPETS.AuthCondition}.expression != ""`),
                         compoundExpression([
                             set(ref('condition'), ref(ResourceConstants.SNIPPETS.AuthCondition)),
-                            qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
-                            qref('$condition.expressionNames.put("#id", "id")')
+                            ifElse(
+                                ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`),[
+                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
+                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                ]),
+                                compoundExpression([
+                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
+                                    qref('$condition.expressionNames.put("#id", "id")')
+                                ])
+                            )
                         ]),
-                        set(ref('condition'), obj({
-                            expression: str("attribute_exists(#id)"),
-                            expressionNames: obj({
-                                "#id": str("id")
-                            }),
-                            expressionValues: obj({}),
-                        }))
+                        ifElse(
+                            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                            compoundExpression([
+                                set(ref('condition'), obj({
+                                    expression: str(""),
+                                    expressionNames: obj({}),
+                                    expressionValues: obj({}),
+                                })),
+                                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
+                                    ifElse(
+                                        raw('$velocityCount == 1'),
+                                        qref('$condition.put("expression", "attribute_exists(#$entry.key)")'),
+                                        qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
+                                    ),
+                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                ])
+                            ]),
+                            set(ref('condition'), obj({
+                                expression: str("attribute_exists(#id)"),
+                                expressionNames: obj({
+                                    "#id": str("id")
+                                }),
+                                expressionValues: obj({}),
+                            }))
+                        )
                     ),
                     comment('Automatically set the updatedAt timestamp.'),
                     qref('$context.args.input.put("updatedAt", $util.time.nowISO8601())'),
@@ -374,10 +406,16 @@ export class ResourceFactory {
                         ])
                     ),
                     DynamoDBMappingTemplate.updateItem({
-                        key: obj({
-                            id: obj({ S: str('$context.args.input.id') })
-                        }),
-                        condition: ref('util.toJson($condition)')
+                        key: ifElse(
+                            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                            raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+                            obj({
+                                id: obj({ S: str('$context.args.input.id') })
+                            }),
+                            true
+                        ),
+                        condition: ref('util.toJson($condition)'),
+                        objectKeyVariable: ResourceConstants.SNIPPETS.ModelObjectKey
                     })
                 ])
             ),
@@ -400,9 +438,14 @@ export class ResourceFactory {
             TypeName: queryTypeName,
             RequestMappingTemplate: print(
                 DynamoDBMappingTemplate.getItem({
-                    key: obj({
-                        id: ref('util.dynamodb.toDynamoDBJson($ctx.args.id)')
-                    })
+                    key: ifElse(
+                        ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                        raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+                        obj({
+                            id: ref('util.dynamodb.toDynamoDBJson($ctx.args.id)')
+                        }),
+                        true
+                    )
                 })
             ),
             ResponseMappingTemplate: print(
@@ -527,15 +570,41 @@ export class ResourceFactory {
                         ref(ResourceConstants.SNIPPETS.AuthCondition),
                         compoundExpression([
                             set(ref('condition'), ref(ResourceConstants.SNIPPETS.AuthCondition)),
-                            qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
-                            qref('$condition.expressionNames.put("#id", "id")')
+                            ifElse(
+                                ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`),[
+                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
+                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                ]),
+                                compoundExpression([
+                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
+                                    qref('$condition.expressionNames.put("#id", "id")')
+                                ])
+                            )
                         ]),
-                        set(ref('condition'), obj({
-                            expression: str("attribute_exists(#id)"),
-                            expressionNames: obj({
-                                "#id": str("id")
-                            })
-                        }))
+                        ifElse(
+                            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                            compoundExpression([
+                                set(ref('condition'), obj({
+                                    expression: str(""),
+                                    expressionNames: obj({}),
+                                })),
+                                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
+                                    ifElse(
+                                        raw('$velocityCount == 1'),
+                                        qref('$condition.put("expression", "attribute_exists(#$entry.key)")'),
+                                        qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
+                                    ),
+                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                ])
+                            ]),
+                            set(ref('condition'), obj({
+                                expression: str("attribute_exists(#id)"),
+                                expressionNames: obj({
+                                    "#id": str("id")
+                                })
+                            }))
+                        )
                     ),
                     iff(
                         ref(ResourceConstants.SNIPPETS.VersionedCondition),
@@ -549,9 +618,14 @@ export class ResourceFactory {
                         ])
                     ),
                     DynamoDBMappingTemplate.deleteItem({
-                        key: obj({
-                            id: ref('util.dynamodb.toDynamoDBJson($ctx.args.input.id)')
-                        }),
+                        key: ifElse(
+                            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                            raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+                            obj({
+                                id: ref('util.dynamodb.toDynamoDBJson($ctx.args.input.id)')
+                            }),
+                            true
+                        ),
                         condition: ref('util.toJson($condition)')
                     })
                 ])

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -357,8 +357,8 @@ export class ResourceFactory {
                             ifElse(
                                 ref(ResourceConstants.SNIPPETS.ModelObjectKey),
                                 forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`),[
-                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
-                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
+                                    qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")')
                                 ]),
                                 compoundExpression([
                                     qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
@@ -377,10 +377,10 @@ export class ResourceFactory {
                                 forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
                                     ifElse(
                                         raw('$velocityCount == 1'),
-                                        qref('$condition.put("expression", "attribute_exists(#$entry.key)")'),
-                                        qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
+                                        qref('$condition.put("expression", "attribute_exists(#keyCondition$velocityCount)")'),
+                                        qref('$condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
                                     ),
-                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                    qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")')
                                 ])
                             ]),
                             set(ref('condition'), obj({
@@ -590,8 +590,8 @@ export class ResourceFactory {
                             ifElse(
                                 ref(ResourceConstants.SNIPPETS.ModelObjectKey),
                                 forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`),[
-                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
-                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                    qref('$condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
+                                    qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")')
                                 ]),
                                 compoundExpression([
                                     qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
@@ -609,10 +609,10 @@ export class ResourceFactory {
                                 forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
                                     ifElse(
                                         raw('$velocityCount == 1'),
-                                        qref('$condition.put("expression", "attribute_exists(#$entry.key)")'),
-                                        qref('$condition.put("expression", "$condition.expression AND attribute_exists(#$entry.key)")'),
+                                        qref('$condition.put("expression", "attribute_exists(#keyCondition$velocityCount)")'),
+                                        qref('$condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
                                     ),
-                                    qref('$condition.expressionNames.put("#$entry.key", "$entry.key")')
+                                    qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")')
                                 ])
                             ]),
                             set(ref('condition'), obj({

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -522,7 +522,7 @@ export class ResourceFactory {
     public makeListResolver(type: string, nameOverride?: string, queryTypeName: string = 'Query') {
         const fieldName = nameOverride ? nameOverride : graphqlName('list' + plurality(toUpper(type)))
         const defaultPageLimit = 10
-
+        const requestVariable = 'ListRequest';
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
             DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
@@ -531,19 +531,36 @@ export class ResourceFactory {
             RequestMappingTemplate: print(
                 compoundExpression([
                     set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
-                    DynamoDBMappingTemplate.listItem({
-                        filter: ifElse(
-                            ref('context.args.filter'),
-                            ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'),
-                            nul()
-                        ),
-                        limit: ref('limit'),
-                        nextToken: ifElse(
-                            ref('context.args.nextToken'),
-                            str('$context.args.nextToken'),
-                            nul()
+                    set(
+                        ref(requestVariable),
+                        obj({
+                            version: str('2017-02-28'),
+                            limit: ref('limit')
+                        })
+                    ),
+                    iff(
+                        ref('context.args.nextToken'),
+                        set(
+                            ref(`${requestVariable}.nextToken`),
+                            str('$context.args.nextToken')
                         )
-                    })
+                    ),
+                    iff(
+                        ref('context.args.filter'),
+                        set(
+                            ref(`${requestVariable}.filter`),
+                            ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)')
+                        ),
+                    ),
+                    ifElse(
+                        raw(`!$util.isNull($${ResourceConstants.SNIPPETS.ModelQueryExpression}) && !$util.isNullOrEmpty($${ResourceConstants.SNIPPETS.ModelQueryExpression}.expression)`),
+                        compoundExpression([
+                            qref(`$${requestVariable}.put("operation", "Query")`),
+                            qref(`$${requestVariable}.put("query", $${ResourceConstants.SNIPPETS.ModelQueryExpression})`)
+                        ]),
+                        qref(`$${requestVariable}.put("operation", "Scan")`)
+                    ),
+                    raw(`$util.toJson($${requestVariable})`)
                 ])
             ),
             ResponseMappingTemplate: print(

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -313,8 +313,8 @@ export class ResourceFactory {
             TypeName: mutationTypeName,
             RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
                 compoundExpression([
-                    qref('$context.args.input.put("createdAt", $util.time.nowISO8601())'),
-                    qref('$context.args.input.put("updatedAt", $util.time.nowISO8601())'),
+                    qref('$context.args.input.put("createdAt", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601()))'),
+                    qref('$context.args.input.put("updatedAt", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601()))'),
                     qref(`$context.args.input.put("__typename", "${type}")`),
                     DynamoDBMappingTemplate.putItem({
                         key: ifElse(
@@ -393,7 +393,7 @@ export class ResourceFactory {
                         )
                     ),
                     comment('Automatically set the updatedAt timestamp.'),
-                    qref('$context.args.input.put("updatedAt", $util.time.nowISO8601())'),
+                    qref('$context.args.input.put("updatedAt", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601()))'),
                     qref(`$context.args.input.put("__typename", "${type}")`),
                     comment('Update condition if type is @versioned'),
                     iff(

--- a/packages/graphql-function-transformer/src/__tests__/FunctionTransformer.test.ts
+++ b/packages/graphql-function-transformer/src/__tests__/FunctionTransformer.test.ts
@@ -24,7 +24,7 @@ test('FunctionTransformer should add a datasource, IAM role and a resolver resou
     let datasourceResource = out.stacks.FunctionDirectiveStack.Resources.EchofunctionLambdaDataSource
     expect(datasourceResource).toBeDefined()
     expect(
-        datasourceResource.Properties.LambdaConfig.LambdaFunctionArn['Fn::Sub'][0],
+        datasourceResource.Properties.LambdaConfig.LambdaFunctionArn['Fn::If'][1]['Fn::Sub'][0],
     ).toEqual(expectedLambdaArn)
 
     // IAM role
@@ -40,7 +40,7 @@ test('FunctionTransformer should add a datasource, IAM role and a resolver resou
         iamRoleResource.Properties.Policies[0].PolicyDocument.Statement[0].Action[0]
     ).toEqual('lambda:InvokeFunction')
     expect(
-        iamRoleResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource[0]['Fn::Sub'][0]
+        iamRoleResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource['Fn::If'][1]['Fn::Sub'][0]
     ).toEqual(expectedLambdaArn)
     
     // Resolver
@@ -94,10 +94,10 @@ test('two @function directives for the same field should be valid', () => {
     expect(resolverResource.Properties.TypeName).toEqual("Query")
     expect(resolverResource.Properties.PipelineConfig.Functions.length).toEqual(2)
     const otherFunctionIamResource = out.stacks.FunctionDirectiveStack.Resources.OtherfunctionLambdaDataSourceRole;
-    expect(otherFunctionIamResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource[0]["Fn::Sub"][0]).toEqual('arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:otherfunction');
+    expect(otherFunctionIamResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource['Fn::If'][1]["Fn::Sub"][0]).toEqual('arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:otherfunction');
     const echoFunctionIamResource = out.stacks.FunctionDirectiveStack.Resources.EchofunctionLambdaDataSourceRole;
-    expect(echoFunctionIamResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource[0]["Fn::Sub"][0]).toEqual('arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}');
-    expect(echoFunctionIamResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource[0]["Fn::Sub"][1].env.Ref).toEqual('env');
+    expect(echoFunctionIamResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource['Fn::If'][1]["Fn::Sub"][0]).toEqual('arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}');
+    expect(echoFunctionIamResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource['Fn::If'][1]["Fn::Sub"][1].env.Ref).toEqual('env');
 })
 
 test('@function directive applied to Object should throw SchemaValidationError', () => {

--- a/packages/graphql-key-transformer/package.json
+++ b/packages/graphql-key-transformer/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "graphql-key-transformer",
+  "version": "1.0.0",
+  "description": "Implements the @key directive.",
+  "main": "lib/index.js",
+  "author": "Michael Paris",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "clean": "rm -rf ./lib"
+  },
+  "dependencies": {
+    "cloudform": "^3.5.0",
+    "cloudform-types": "^3.7.0",
+    "graphql": "^0.13.2",
+    "graphql-mapping-template": "^3.0.6",
+    "graphql-transformer-common": "^3.6.1",
+    "graphql-transformer-core": "^3.6.1"
+  },
+  "devDependencies": {
+    "@types/jest": "23.1.1",
+    "jest": "^23.1.0",
+    "ts-jest": "^22.4.6",
+    "tslint-config-airbnb": "^5.11.1"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testURL": "http://localhost",
+    "testRegex": "(src/__tests__/.*.test.*)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  }
+}

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -71,6 +71,7 @@ export default class FunctionTransformer extends Transformer {
      */
     private updateSchema = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         this.updateQueryFields(definition, directive, ctx);
+        this.updateInputObjects(definition, directive, ctx);
     }
 
     /**
@@ -133,7 +134,6 @@ export default class FunctionTransformer extends Transformer {
         this.updateGetField(definition, directive, ctx);
         this.updateListField(definition, directive, ctx);
         this.ensureQueryField(definition, directive, ctx);
-        this.updateInputObjects(definition, directive, ctx);
     }
 
     // If the get field exists, update its arguments with primary key information.

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -168,7 +168,7 @@ export default class FunctionTransformer extends Transformer {
                 const keyField = definition.fields.find(field => field.name.value === keyAttributeName);
                 // The last value passed via fields in @key(field: [...]) get a full KeyConditionInput
                 // while all others simply get an equality check of the same type as their base type.
-                const keyArgument = i === args.fields.length - 1 ?
+                const keyArgument = i === args.fields.length - 1 && args.fields.length !== 1 ?
                     makeInputValueDefinition(keyAttributeName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(keyField.type)))) :
                     makeInputValueDefinition(keyAttributeName, makeNamedType(getBaseType(keyField.type)));
                 listArguments.unshift(keyArgument)
@@ -186,7 +186,7 @@ export default class FunctionTransformer extends Transformer {
                 const keyField = definition.fields.find(field => field.name.value === keyAttributeName);
                 // The last value passed via fields in @key(field: [...]) get a full KeyConditionInput
                 // while all others simply get an equality check of the same type as their base type.
-                const keyArgument = i === args.fields.length - 1 ?
+                const keyArgument = i === args.fields.length - 1 && args.fields.length !== 1 ?
                     makeInputValueDefinition(keyAttributeName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(keyField.type)))) :
                     makeInputValueDefinition(keyAttributeName, makeNonNullType(makeNamedType(getBaseType(keyField.type))));
                 return keyArgument;

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -1,17 +1,22 @@
 import { 
     Transformer, gql, TransformerContext, getDirectiveArguments, TransformerContractError, InvalidDirectiveError
 } from 'graphql-transformer-core';
-import { obj, str, ref, printBlock, compoundExpression, qref, raw, iff } from 'graphql-mapping-template';
-import { ResolverResourceIDs, ResourceConstants, isNonNullType, toCamelCase, attributeTypeFromScalar, ModelResourceIDs } from 'graphql-transformer-common';
-import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode } from 'graphql';
+import { obj, str, ref, printBlock, compoundExpression, newline, raw, qref, set, Expression } from 'graphql-mapping-template';
+import { 
+    ResolverResourceIDs, ResourceConstants, isNonNullType,
+    attributeTypeFromScalar, ModelResourceIDs, makeInputValueDefinition, 
+    makeNonNullType, makeNamedType, getBaseType,
+    makeConnectionField,
+    makeField, makeScalarKeyConditionForType
+} from 'graphql-transformer-common';
+import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode, InputObjectDefinitionNode, TypeNode, Kind } from 'graphql';
 import { AppSync, IAM, Fn, DynamoDB, Refs } from 'cloudform-types'
 import { Projection, GlobalSecondaryIndex, LocalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
-
-const FUNCTION_DIRECTIVE_STACK = 'FunctionDirectiveStack';
 
 interface KeyArguments {
     name?: string;
     fields: string[];
+    queryField?: string;
 }
 
 export default class FunctionTransformer extends Transformer {
@@ -19,24 +24,200 @@ export default class FunctionTransformer extends Transformer {
     constructor() {
         super(
             'KeyTransformer', 
-            gql`directive @key(name: String, fields: [String!]!) on OBJECT`
+            gql`directive @key(name: String, fields: [String!]!, queryField: String) on OBJECT`
         )
     }
 
     /**
      * Augment the table key structures based on the @key.
      */
-    object = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => {
-        this.validate(definition, directive, acc);
+    object = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        this.validate(definition, directive, ctx);
+        this.updateIndexStructures(definition, directive, ctx);
+        this.updateSchema(definition, directive, ctx);
+        this.updateResolvers(definition, directive, ctx);
+        this.addKeyConditionInputs(definition, directive, ctx);
+    };
 
+    /**
+     * Update the existing @model table's index structures. Includes primary key, GSI, and LSIs.
+     * @param definition The object type definition node.
+     * @param directive The @key directive
+     * @param ctx The transformer context
+     */
+    private updateIndexStructures = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         if (this.isPrimaryKey(directive)) {
             // Set the table's primary key using the @key definition.
-            this.replacePrimaryKey(definition, directive, acc);
+            this.replacePrimaryKey(definition, directive, ctx);
         } else {
             // Append a GSI/LSI to the table configuration.
-            this.appendSecondaryIndex(definition, directive, acc);
+            this.appendSecondaryIndex(definition, directive, ctx);
         }
-    };
+    }
+
+    /**
+     * Update the structural components of the schema that are relevant to the new index structures.
+     * 
+     * Updates:
+     * 1. getX with new primary key information.
+     * 2. listX with new primary key information.
+     * 
+     * Creates:
+     * 1. A query field for each secondary index.
+     */
+    private updateSchema = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        this.updateQueryFields(definition, directive, ctx);
+    }
+
+    /**
+     * Update the get, list, create, update, and delete resolvers with updated key information.
+     */
+    private updateResolvers = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        if (this.isPrimaryKey(directive)) {
+            const getResolver = ctx.getResource(ResolverResourceIDs.DynamoDBGetResolverResourceID(definition.name.value));
+            if (getResolver) {
+                getResolver.Properties.RequestMappingTemplate = this.setKeySnippet(directive) + '\n' + getResolver.Properties.RequestMappingTemplate
+            }
+            const listResolver = ctx.getResource(ResolverResourceIDs.DynamoDBListResolverResourceID(definition.name.value));
+            if (listResolver) {}
+            const createResolver = ctx.getResource(ResolverResourceIDs.DynamoDBCreateResolverResourceID(definition.name.value));
+            if (createResolver) {
+                createResolver.Properties.RequestMappingTemplate = this.setKeySnippet(directive, true) + '\n' + createResolver.Properties.RequestMappingTemplate
+            }
+            const updateResolver = ctx.getResource(ResolverResourceIDs.DynamoDBUpdateResolverResourceID(definition.name.value));
+            if (updateResolver) {
+                updateResolver.Properties.RequestMappingTemplate = this.setKeySnippet(directive, true) + '\n' + updateResolver.Properties.RequestMappingTemplate
+            }
+            const deleteResolver = ctx.getResource(ResolverResourceIDs.DynamoDBDeleteResolverResourceID(definition.name.value));
+            if (deleteResolver) {
+                deleteResolver.Properties.RequestMappingTemplate = this.setKeySnippet(directive, true) + '\n' + deleteResolver.Properties.RequestMappingTemplate
+            }
+        }
+    }
+
+    private addKeyConditionInputs = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        const args: KeyArguments = getDirectiveArguments(directive);
+        if (args.fields.length > 1) {
+            const finalSortKeyFieldName = args.fields[args.fields.length-1];
+            const finalSortKeyField = definition.fields.find(f => f.name.value === finalSortKeyFieldName);
+            // All composite keys (length > 2) are casted to strings.
+            const sortKeyConditionInput = args.fields.length > 2 ? 
+                makeScalarKeyConditionForType(makeNamedType('String')) :
+                makeScalarKeyConditionForType(finalSortKeyField.type);
+            if (!ctx.getType(sortKeyConditionInput.name.value)) {
+                ctx.addInput(sortKeyConditionInput);
+            }
+        }
+    }
+
+    /**
+     * Updates query fields to include any arguments required by the key structures.
+     * @param definition The object type definition node.
+     * @param directive The @key directive
+     * @param ctx The transformer context
+     */
+    private updateQueryFields = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        this.updateGetField(definition, directive, ctx);
+        this.updateListField(definition, directive, ctx);
+        this.ensureQueryField(definition, directive, ctx);
+        this.updateInputObjects(definition, directive, ctx);
+    }
+
+    // If the get field exists, update its arguments with primary key information.
+    private updateGetField = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        let query = ctx.getQuery();
+        const getResourceID = ResolverResourceIDs.DynamoDBGetResolverResourceID(definition.name.value);
+        const getResolverResource = ctx.getResource(getResourceID);
+        if (getResolverResource && this.isPrimaryKey(directive)) {
+            // By default takes a single argument named 'id'. Replace it with the updated primary key structure.
+            const getField: FieldDefinitionNode = query.fields.find(field => field.name.value === getResolverResource.Properties.FieldName) as FieldDefinitionNode;
+            const args: KeyArguments = getDirectiveArguments(directive);
+            const getArguments = args.fields.map(keyAttributeName => {
+                const keyField = definition.fields.find(field => field.name.value === keyAttributeName);
+                const keyArgument = makeInputValueDefinition(keyAttributeName, makeNonNullType(makeNamedType(getBaseType(keyField.type))));
+                return keyArgument;
+            })
+            getField.arguments = getArguments;
+        }
+    }
+
+    // If the list field exists, update its arguments with primary key information.
+    private updateListField = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        const listResourceID = ResolverResourceIDs.DynamoDBListResolverResourceID(definition.name.value);
+        const listResolverResource = ctx.getResource(listResourceID);
+        if (listResolverResource && this.isPrimaryKey(directive)) {
+            // By default takes a single argument named 'id'. Replace it with the updated primary key structure.
+            const listField: FieldDefinitionNode = ctx.getQuery().fields.find(field => field.name.value === listResolverResource.Properties.FieldName) as FieldDefinitionNode;
+            const listArguments = listField.arguments;
+            const args: KeyArguments = getDirectiveArguments(directive);
+            for (let i = args.fields.length-1; i >= 0; i--) {
+                const keyAttributeName = args.fields[i];
+                const keyField = definition.fields.find(field => field.name.value === keyAttributeName);
+                // The last value passed via fields in @key(field: [...]) get a full KeyConditionInput
+                // while all others simply get an equality check of the same type as their base type.
+                const keyArgument = i === args.fields.length - 1 ?
+                    makeInputValueDefinition(keyAttributeName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(keyField.type)))) :
+                    makeInputValueDefinition(keyAttributeName, makeNamedType(getBaseType(keyField.type)));
+                listArguments.unshift(keyArgument)
+            }
+            listField.arguments = listArguments;
+        }
+    }
+
+    // If this is a secondary key and a queryField has been provided, create the query field.
+    private ensureQueryField = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        const args: KeyArguments = getDirectiveArguments(directive);
+        if (args.queryField && !this.isPrimaryKey(directive)) {
+            let queryType = ctx.getQuery();
+            const queryArgs = args.fields.map((keyAttributeName, i) => {
+                const keyField = definition.fields.find(field => field.name.value === keyAttributeName);
+                // The last value passed via fields in @key(field: [...]) get a full KeyConditionInput
+                // while all others simply get an equality check of the same type as their base type.
+                const keyArgument = i === args.fields.length - 1 ?
+                    makeInputValueDefinition(keyAttributeName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(keyField.type)))) :
+                    makeInputValueDefinition(keyAttributeName, makeNonNullType(makeNamedType(getBaseType(keyField.type))));
+                return keyArgument;
+            })
+            const queryField = makeConnectionField(args.queryField, definition.name.value, queryArgs);
+            queryType = {
+                ...queryType,
+                fields: [...queryType.fields, queryField]
+            };
+            ctx.putType(queryType);
+        }
+    }
+
+    // Update the create, update, and delete input objects to account for any changes to the primary key.
+    private updateInputObjects = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        if (this.isPrimaryKey(directive)) {
+            const directiveArgs: KeyArguments = getDirectiveArguments(directive);            
+            const createInput = ctx.getType(ModelResourceIDs.ModelCreateInputObjectName(definition.name.value));
+            if (createInput) {
+                ctx.putType(replaceCreateInput(definition, createInput, directiveArgs.fields));
+            }
+            const updateInput = ctx.getType(ModelResourceIDs.ModelUpdateInputObjectName(definition.name.value));
+            if (updateInput) {
+                ctx.putType(replaceUpdateInput(definition, updateInput, directiveArgs.fields));
+            }
+            const deleteInput = ctx.getType(ModelResourceIDs.ModelDeleteInputObjectName(definition.name.value));
+            if (deleteInput) {
+                ctx.putType(replaceDeleteInput(definition, deleteInput, directiveArgs.fields));
+            }
+        }
+    }
+
+    // Return a VTL snippet that sets the key for key for get, update, and delete operations.
+    private setKeySnippet = (directive: DirectiveNode, isMutation: boolean = false) => {
+        const directiveArgs = getDirectiveArguments(directive);
+        const cmds: Expression[] = [set(
+            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+            modelObjectKey(directiveArgs, isMutation)
+        )];
+        if (isMutation) {
+            cmds.push(ensureCompositeKey(directiveArgs));
+        }
+        return printBlock(`Set the primary @key`)(compoundExpression(cmds));
+    }
 
     /**
      * Validates the directive usage is semantically valid.
@@ -44,18 +225,24 @@ export default class FunctionTransformer extends Transformer {
      * 1. There may only be 1 @key without a name (specifying the primary key)
      * 2. There may only be 1 @key with a given name.
      * 3. @key must only reference existing scalar fields that map to DynamoDB S, N, or B.
+     * 4. A primary key must not include a 'queryField'.
+     * @param definition The object type definition node.
      * @param directive The @key directive
      * @param ctx The transformer context
      */
-    validate = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+    private validate = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         const directiveArgs = getDirectiveArguments(directive);
         if (!directiveArgs.name) {
             // 1. Make sure there are no more directives without a name.
             for (const otherDirective of definition.directives.filter(d => d.name.value === 'key')) {
                 const otherArgs = getDirectiveArguments(otherDirective);
                 if (otherDirective !== directive && !otherArgs.name) {
-                    throw new InvalidDirectiveError(`You may only supply one @key without a name on type '${definition.name.value}'.`);
+                    throw new InvalidDirectiveError(`You may only supply one primary @key on type '${definition.name.value}'.`);
                 }
+            }
+            // 4. Make sure that a 'queryField' is not included on a primary @key.
+            if (directiveArgs.queryField) {
+                throw new InvalidDirectiveError(`You cannot pass 'queryField' to the primary @key on type '${definition.name.value}'.`);
             }
         } else {
             // 2. Make sure there are no more directives with the same name.
@@ -76,7 +263,7 @@ export default class FunctionTransformer extends Transformer {
                 throw new InvalidDirectiveError(`You cannot specify a non-existant field '${fieldName}' in @key '${directiveArgs.name}' on type '${definition.name.value}'.`);
             } else {
                 const existingField = fieldMap.get(fieldName);
-                const ddbKeyType = attributeTypeFromScalar(existingField.type);
+                const ddbKeyType = attributeTypeFromType(existingField.type, ctx);
                 if (!isNonNullType(existingField.type)) {
                     throw new InvalidDirectiveError(`The primary @key on type '${definition.name.value}' must reference non-null fields.`);
                 } else if (ddbKeyType !== 'S' && ddbKeyType !== 'N' && ddbKeyType !== 'B') {
@@ -97,11 +284,14 @@ export default class FunctionTransformer extends Transformer {
 
     /**
      * Replace the primary key schema with one defined by a @key.
+     * @param definition The object type definition node.
+     * @param directive The @key directive
+     * @param ctx The transformer context
      */
     replacePrimaryKey = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         const args: KeyArguments = getDirectiveArguments(directive);
         const ks = keySchema(args);
-        const attrDefs = attributeDefinitions(args, definition);
+        const attrDefs = attributeDefinitions(args, definition, ctx);
         const tableLogicalID = ModelResourceIDs.ModelTableResourceID(definition.name.value);
         const tableResource = ctx.getResource(tableLogicalID);
         if (!tableResource) {
@@ -127,11 +317,14 @@ export default class FunctionTransformer extends Transformer {
 
     /**
      * Add a LSI or GSI to the table as defined by a @key.
+     * @param definition The object type definition node.
+     * @param directive The @key directive
+     * @param ctx The transformer context
      */
     appendSecondaryIndex = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         const args: KeyArguments = getDirectiveArguments(directive);
         const ks = keySchema(args);
-        const attrDefs = attributeDefinitions(args, definition);
+        const attrDefs = attributeDefinitions(args, definition, ctx);
         const tableLogicalID = ModelResourceIDs.ModelTableResourceID(definition.name.value);
         const tableResource = ctx.getResource(tableLogicalID);
         const primaryKeyDirective = getPrimaryKey(definition);
@@ -181,9 +374,13 @@ export default class FunctionTransformer extends Transformer {
     }
 }
 
+/**
+ * Return a key schema given @key directive arguments.
+ * @param args The arguments of the @key directive.
+ */
 function keySchema(args: KeyArguments) {
     if (args.fields.length > 1) {
-        const condensedSortKey = toCamelCase(args.fields.slice(1));
+        const condensedSortKey = condenseRangeKey(args.fields.slice(1));
         return [
             { AttributeName: args.fields[0], KeyType: 'HASH' },
             { AttributeName: condensedSortKey, KeyType: 'RANGE' },
@@ -193,28 +390,42 @@ function keySchema(args: KeyArguments) {
     }
 }
 
-function attributeDefinitions(args: KeyArguments, def: ObjectTypeDefinitionNode) {
+function attributeTypeFromType(type: TypeNode, ctx: TransformerContext) {
+    const baseTypeName = getBaseType(type);
+    const ofType = ctx.getType(baseTypeName);
+    if (ofType && ofType.kind === Kind.ENUM_TYPE_DEFINITION) {
+        return 'S';
+    }
+    return attributeTypeFromScalar(type);
+}
+
+/**
+ * Return a list of attribute definitions given a @key directive arguments and an object definition.
+ * @param args The arguments passed to @key.
+ * @param def The object type definition containing the @key.
+ */
+function attributeDefinitions(args: KeyArguments, def: ObjectTypeDefinitionNode, ctx: TransformerContext) {
     const fieldMap = new Map();
     for (const field of def.fields) {
         fieldMap.set(field.name.value, field);
     }
     if (args.fields.length > 2) {
         const hashName = args.fields[0];
-        const condensedSortKey = toCamelCase(args.fields.slice(1));
+        const condensedSortKey = condenseRangeKey(args.fields.slice(1));
         return [
-            { AttributeName: hashName, AttributeType: attributeTypeFromScalar(fieldMap.get(hashName).type) },
+            { AttributeName: hashName, AttributeType: attributeTypeFromType(fieldMap.get(hashName).type, ctx) },
             { AttributeName: condensedSortKey, AttributeType: 'S' },
         ];
     } else if (args.fields.length === 2) {
         const hashName = args.fields[0];
         const sortName = args.fields[1];
         return [
-            { AttributeName: hashName, AttributeType: attributeTypeFromScalar(fieldMap.get(hashName).type) },
-            { AttributeName: sortName, AttributeType: attributeTypeFromScalar(fieldMap.get(sortName).type) },
+            { AttributeName: hashName, AttributeType: attributeTypeFromType(fieldMap.get(hashName).type, ctx) },
+            { AttributeName: sortName, AttributeType: attributeTypeFromType(fieldMap.get(sortName).type, ctx) },
         ];
     } else {
         const fieldName = args.fields[0];
-        return [{ AttributeName: fieldName, AttributeType: attributeTypeFromScalar(fieldMap.get(fieldName).type) }];
+        return [{ AttributeName: fieldName, AttributeType: attributeTypeFromType(fieldMap.get(fieldName).type, ctx) }];
     }
 }
 
@@ -231,4 +442,105 @@ function getPrimaryKey(obj: ObjectTypeDefinitionNode): DirectiveNode | undefined
             return directive;
         }
     }
+}
+
+function primaryIdFields(definition: ObjectTypeDefinitionNode, keyFields: string[]): FieldDefinitionNode[] {
+    return keyFields.map(keyFieldName => {
+        const keyField: FieldDefinitionNode = definition.fields.find(field => field.name.value === keyFieldName);
+        return makeField(keyFieldName, [], makeNonNullType(makeNamedType(getBaseType(keyField.type))));
+    })
+}
+
+// Key fields are non-nullable, non-key fields follow what their @model declaration makes.
+function replaceCreateInput(definition: ObjectTypeDefinitionNode, input: InputObjectDefinitionNode, keyFields: string[]) {
+    return {
+        ...input,
+        fields: input.fields.reduce((acc, f) => {
+            // If the field is a key, make it non-null.
+            if (keyFields.find(k => k === f.name.value)) {
+                return [...acc, makeField(f.name.value, [], makeNonNullType(makeNamedType(getBaseType(f.type))))];
+            } else {
+                // If the field is not a key, use whatever the model type defines.
+                const existingField = definition.fields.find(field => field.name.value === f.name.value);
+                if (existingField && isNonNullType(existingField.type)) {
+                    return [...acc, makeField(f.name.value, [], makeNonNullType(makeNamedType(getBaseType(f.type))))];
+                } else if (existingField) {
+                    return [...acc, makeField(f.name.value, [], makeNamedType(getBaseType(f.type)))];
+                }
+            }
+            return acc;
+        }, [])
+    };
+};
+
+// Key fields are non-nullable, non-key fields are not non-nullable.
+function replaceUpdateInput(definition: ObjectTypeDefinitionNode, input: InputObjectDefinitionNode, keyFields: string[]) {
+    return {
+        ...input,
+        fields: input.fields.map(
+            f => {
+                if (keyFields.find(k => k === f.name.value)) {
+                    return makeField(f.name.value, [], makeNonNullType(makeNamedType(getBaseType(f.type))));
+                } else {
+                    return makeField(f.name.value, [], makeNamedType(getBaseType(f.type)));
+                }
+            }
+        )
+    };
+};
+
+// Key fields are non-nullable, non-key fields are not non-nullable.
+function replaceDeleteInput(definition: ObjectTypeDefinitionNode, input: InputObjectDefinitionNode, keyFields: string[]) {
+    return {
+        ...input,
+        fields: primaryIdFields(definition, keyFields)
+    };
+};
+
+/**
+ * Return a VTL object containing the compressed key information.
+ * @param args The arguments of the @key directive.
+ */
+function modelObjectKey(args: KeyArguments, isMutation: boolean) {
+    const argsPrefix = isMutation ?
+        'ctx.args.input' :
+        'ctx.args';
+    if (args.fields.length > 2) {
+        const rangeKeyFields = args.fields.slice(1);
+        const condensedSortKey = condenseRangeKey(rangeKeyFields);
+        const condensedSortKeyValue = condenseRangeKey(
+            rangeKeyFields.map(keyField => `\${${argsPrefix}.${keyField}}`)
+        );
+        return obj({
+            [args.fields[0]]: ref(`util.dynamodb.toDynamoDB($${argsPrefix}.${args.fields[0]})`),
+            [condensedSortKey]: ref(`util.dynamodb.toDynamoDB("${condensedSortKeyValue}")`)
+        });
+    } else if (args.fields.length === 2) {
+        return obj({
+            [args.fields[0]]: ref(`util.dynamodb.toDynamoDB($${argsPrefix}.${args.fields[0]})`),
+            [args.fields[1]]: ref(`util.dynamodb.toDynamoDB($${argsPrefix}.${args.fields[1]})`)
+        });
+    } else if (args.fields.length === 1) {
+        return obj({
+            [args.fields[0]]: ref(`util.dynamodb.toDynamoDB($${argsPrefix}.${args.fields[0]})`),
+        });
+    }
+    throw new InvalidDirectiveError('@key directives must include at least one field.');
+}
+
+function ensureCompositeKey(args: KeyArguments) {
+    const argsPrefix = 'ctx.args.input';
+    if (args.fields.length > 2) {
+        const rangeKeyFields = args.fields.slice(1);
+        const condensedSortKey = condenseRangeKey(rangeKeyFields);
+        const condensedSortKeyValue = condenseRangeKey(
+            rangeKeyFields.map(keyField => `\${${argsPrefix}.${keyField}}`)
+        );
+        return qref(`$ctx.args.input.put("${condensedSortKey}","${condensedSortKeyValue}")`);
+    }
+    return newline();
+}
+
+function condenseRangeKey(fields: string[]) {
+    return fields.join('#');
 }

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -179,7 +179,7 @@ export default class FunctionTransformer extends Transformer {
             // By default takes a single argument named 'id'. Replace it with the updated primary key structure.
             let query = ctx.getQuery();
             let listField: FieldDefinitionNode = query.fields.find(field => field.name.value === listResolverResource.Properties.FieldName) as FieldDefinitionNode;
-            let listArguments: InputValueDefinitionNode[] = listField.arguments;
+            let listArguments: InputValueDefinitionNode[] = [ ...listField.arguments ];
             const args: KeyArguments = getDirectiveArguments(directive);
             if (args.fields.length > 2) {
                 listArguments = addCompositeSortKey(definition, args, listArguments);

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -118,8 +118,7 @@ export default class FunctionTransformer extends Transformer {
             }
             if (deleteResolver) {
                 deleteResolver.Properties.RequestMappingTemplate = joinSnippets([
-                    this.setKeySnippet(directive, true), 
-                    ensureCompositeKeySnippet(directive),
+                    this.setKeySnippet(directive, true),
                     deleteResolver.Properties.RequestMappingTemplate
                 ]);
             }
@@ -169,13 +168,10 @@ export default class FunctionTransformer extends Transformer {
             if (!ctx.getType(compositeKeyInput.name.value)) {
                 ctx.addInput(compositeKeyInput);
             }
-        } else if (args.fields.length > 1) {
-            const finalSortKeyFieldName = args.fields[args.fields.length-1];
+        } else if (args.fields.length === 2) {
+            const finalSortKeyFieldName = args.fields[1];
             const finalSortKeyField = definition.fields.find(f => f.name.value === finalSortKeyFieldName);
-            // All composite keys (length > 2) are casted to strings.
-            const sortKeyConditionInput = args.fields.length > 2 ? 
-                makeScalarKeyConditionForType(makeNamedType('String')) :
-                makeScalarKeyConditionForType(finalSortKeyField.type);
+            const sortKeyConditionInput = makeScalarKeyConditionForType(finalSortKeyField.type);
             if (!ctx.getType(sortKeyConditionInput.name.value)) {
                 ctx.addInput(sortKeyConditionInput);
             }

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -179,7 +179,7 @@ export default class FunctionTransformer extends Transformer {
             // By default takes a single argument named 'id'. Replace it with the updated primary key structure.
             let query = ctx.getQuery();
             let listField: FieldDefinitionNode = query.fields.find(field => field.name.value === listResolverResource.Properties.FieldName) as FieldDefinitionNode;
-            let listArguments = listField.arguments;
+            let listArguments: InputValueDefinitionNode[] = listField.arguments;
             const args: KeyArguments = getDirectiveArguments(directive);
             if (args.fields.length > 2) {
                 listArguments = addCompositeSortKey(definition, args, listArguments);
@@ -643,19 +643,19 @@ function setQuerySnippet(definition: ObjectTypeDefinitionNode, directive: Direct
     ])
 }
 
-function addHashField(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]) {
+function addHashField(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]): InputValueDefinitionNode[] {
     let hashFieldName = args.fields[0];
     const hashField = definition.fields.find(field => field.name.value === hashFieldName);
     const hashKey = makeInputValueDefinition(hashFieldName, makeNamedType(getBaseType(hashField.type)));
     return [hashKey, ...elems];
 }
-function addSimpleSortKey(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]) {
+function addSimpleSortKey(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]): InputValueDefinitionNode[] {
     let sortKeyName = args.fields[1];
     const sortField = definition.fields.find(field => field.name.value === sortKeyName);
     const hashKey = makeInputValueDefinition(sortKeyName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(sortField.type))));
     return [hashKey, ...elems];
 }
-function addCompositeSortKey(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]) {
+function addCompositeSortKey(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]): InputValueDefinitionNode[] {
     let sortKeyNames = args.fields.slice(1);
     const compositeSortKeyName = toCamelCase(sortKeyNames);
     const hashKey = makeInputValueDefinition(compositeSortKeyName, makeNamedType(ModelResourceIDs.ModelCompositeKeyConditionInputTypeName(definition.name.value, args.name || 'Primary')));

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -1,0 +1,169 @@
+import { 
+    Transformer, gql, TransformerContext, getDirectiveArguments, TransformerContractError, InvalidDirectiveError
+} from 'graphql-transformer-core';
+import { obj, str, ref, printBlock, compoundExpression, qref, raw, iff } from 'graphql-mapping-template';
+import { ResolverResourceIDs, ResourceConstants, isNonNullType, toCamelCase, attributeTypeFromScalar, ModelResourceIDs } from 'graphql-transformer-common';
+import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode } from 'graphql';
+import { AppSync, IAM, Fn, DynamoDB } from 'cloudform-types'
+
+const FUNCTION_DIRECTIVE_STACK = 'FunctionDirectiveStack';
+
+interface KeyArguments {
+    name?: string;
+    fields: string[];
+}
+
+export default class FunctionTransformer extends Transformer {
+
+    constructor() {
+        super(
+            'KeyTransformer', 
+            gql`directive @key(name: String, fields: [String!]!) on OBJECT`
+        )
+    }
+
+    /**
+     * Augment the table key structures based on the @key.
+     */
+    object = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => {
+        this.validate(definition, directive, acc);
+
+        if (this.isPrimaryKey(directive)) {
+            // Set the table's primary key using the @key definition.
+            this.replacePrimaryKey(definition, directive, acc);
+        } else {
+            // Append a GSI/LSI to the table configuration.
+            this.appendSecondaryIndex(definition, directive, acc);
+        }
+    };
+
+    /**
+     * Validates the directive usage is semantically valid.
+     * 
+     * 1. There may only be 1 @key without a name (specifying the primary key)
+     * 2. There may only be 1 @key with a given name.
+     * 3. @key must only reference existing scalar fields that map to DynamoDB S, N, or B.
+     * @param directive The @key directive
+     * @param ctx The transformer context
+     */
+    validate = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        const directiveArgs = getDirectiveArguments(directive);
+        if (!directiveArgs.name) {
+            // 1. Make sure there are no more directives without a name.
+            for (const otherDirective of definition.directives.filter(d => d.name.value === 'key')) {
+                const otherArgs = getDirectiveArguments(otherDirective);
+                if (otherDirective !== directive && !otherArgs.name) {
+                    throw new InvalidDirectiveError(`You may only supply one @key without a name on type '${definition.name.value}'.`);
+                }
+            }
+        } else {
+            // 2. Make sure there are no more directives with the same name.
+            for (const otherDirective of definition.directives.filter(d => d.name.value === 'key')) {
+                const otherArgs = getDirectiveArguments(otherDirective);
+                if (otherDirective !== directive && otherArgs.name === directiveArgs.name) {
+                    throw new InvalidDirectiveError(`You may only supply one @key with the name '${directiveArgs.name}' on type '${definition.name.value}'.`);
+                }
+            }
+        }
+        // 3. Check that fields exists and are valid key types.
+        const fieldMap = new Map();
+        for (const field of definition.fields) {
+            fieldMap.set(field.name.value, field);
+        }
+        for (const fieldName of directiveArgs.fields) {
+            if (!fieldMap.has(fieldName)) {
+                throw new InvalidDirectiveError(`You cannot specify a non-existant field '${fieldName}' in @key '${directiveArgs.name}' on type '${definition.name.value}'.`);
+            } else {
+                const existingField = fieldMap.get(fieldName);
+                const ddbKeyType = attributeTypeFromScalar(existingField.type);
+                if (!isNonNullType(existingField.type)) {
+                    throw new InvalidDirectiveError(`The primary @key on type '${definition.name.value}' must reference non-null fields.`);
+                } else if (ddbKeyType !== 'S' && ddbKeyType !== 'N' && ddbKeyType !== 'B') {
+                    throw new InvalidDirectiveError(`The primary @key on type '${definition.name.value}' cannot reference non-scalar field ${fieldName}.`);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns true if the directive specifies a primary key.
+     * @param directive The directive node.
+     */
+    isPrimaryKey = (directive: DirectiveNode) => {
+        const directiveArgs = getDirectiveArguments(directive);
+        return !Boolean(directiveArgs.name);
+    }
+
+    /**
+     * Replace the primary key schema with one defined by a @key.
+     */
+    replacePrimaryKey = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+        const args: KeyArguments = getDirectiveArguments(directive);
+        const ks = keySchema(args);
+        const attrDefs = attributeDefinitions(args, definition);
+        const tableLogicalID = ModelResourceIDs.ModelTableResourceID(definition.name.value);
+        const tableResource = ctx.getResource(tableLogicalID);
+        if (!tableResource) {
+            throw new InvalidDirectiveError(`The @key directive may only be added to object definitions annotated with @model.`);
+        } else {
+            // First remove any attribute definitions in the current primary key.
+            const existingAttrDefSet = new Set(tableResource.Properties.AttributeDefinitions.map(ad => ad.AttributeName));
+            for (const existingKey of tableResource.Properties.KeySchema) {
+                if (existingAttrDefSet.has(existingKey.AttributeName)) {
+                    tableResource.Properties.AttributeDefinitions = tableResource.Properties.AttributeDefinitions.filter(ad => ad.AttributeName !== existingKey.AttributeName);
+                    existingAttrDefSet.delete(existingKey.AttributeName);
+                }
+            }
+            // Then replace the KeySchema and add any new attribute definitions back.
+            tableResource.Properties.KeySchema = ks;
+            for (const attr of attrDefs) {
+                if (!existingAttrDefSet.has(attr.AttributeName)) {
+                    tableResource.Properties.AttributeDefinitions.push(attr);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add a LSI or GSI to the table as defined by a @key.
+     */
+    appendSecondaryIndex = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+    }
+}
+
+function keySchema(args: KeyArguments) {
+    if (args.fields.length > 1) {
+        const condensedSortKey = toCamelCase(args.fields.slice(1));
+        return [
+            { AttributeName: args.fields[0], KeyType: 'HASH' },
+            { AttributeName: condensedSortKey, KeyType: 'RANGE' },
+        ];
+    } else {
+        return [{ AttributeName: args.fields[0], KeyType: 'HASH' }];
+    }
+}
+
+function attributeDefinitions(args: KeyArguments, def: ObjectTypeDefinitionNode) {
+    const fieldMap = new Map();
+    for (const field of def.fields) {
+        fieldMap.set(field.name.value, field);
+    }
+    if (args.fields.length > 2) {
+        const hashName = args.fields[0];
+        const condensedSortKey = toCamelCase(args.fields.slice(1));
+        return [
+            { AttributeName: hashName, AttributeType: attributeTypeFromScalar(fieldMap.get(hashName).type) },
+            { AttributeName: condensedSortKey, AttributeType: 'S' },
+        ];
+    } else if (args.fields.length === 2) {
+        const hashName = args.fields[0];
+        const sortName = args.fields[1];
+        return [
+            { AttributeName: hashName, AttributeType: attributeTypeFromScalar(fieldMap.get(hashName).type) },
+            { AttributeName: sortName, AttributeType: attributeTypeFromScalar(fieldMap.get(sortName).type) },
+        ];
+    } else {
+        const fieldName = args.fields[0];
+        return [{ AttributeName: fieldName, AttributeType: attributeTypeFromScalar(fieldMap.get(fieldName).type) }];
+    }
+}

--- a/packages/graphql-key-transformer/src/__tests__/KeyTransformer.test.ts
+++ b/packages/graphql-key-transformer/src/__tests__/KeyTransformer.test.ts
@@ -1,0 +1,71 @@
+import GraphQLTransform, { Transformer, InvalidDirectiveError } from 'graphql-transformer-core'
+import KeyTransformer from '../KeyTransformer'
+
+test('KeyTransformer should fail if more than 1 @key is provided without a name.', () => {
+    const validSchema = `
+    type Test @key(fields: ["id"]) @key(fields: ["email"]) {
+        id: ID!
+        email: String
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new KeyTransformer()
+        ]
+    })
+
+    expect(() => transformer.transform(validSchema)).toThrowError(InvalidDirectiveError);
+})
+
+test('KeyTransformer should fail if more than 1 @key is provided with the same name.', () => {
+    const validSchema = `
+    type Test @key(name: "Test", fields: ["id"]) @key(name: "Test", fields: ["email"]) {
+        id: ID!
+        email: String
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new KeyTransformer()
+        ]
+    })
+
+    expect(() => transformer.transform(validSchema)).toThrowError(InvalidDirectiveError);
+})
+
+
+test('KeyTransformer should fail if referencing a field that does not exist.', () => {
+    const validSchema = `
+    type Test @key(fields: ["someWeirdId"]) {
+        id: ID!
+        email: String
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new KeyTransformer()
+        ]
+    })
+
+    expect(() => transformer.transform(validSchema)).toThrowError(InvalidDirectiveError);
+})
+
+test('Test that a primary @key fails if pointing to nullable fields.', () => {
+    const validSchema = `
+    type Test @key(fields: ["email"]) {
+        id: ID!
+        email: String
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new KeyTransformer()
+        ]
+    })
+
+    expect(() => transformer.transform(validSchema)).toThrowError(InvalidDirectiveError);
+})

--- a/packages/graphql-key-transformer/src/index.ts
+++ b/packages/graphql-key-transformer/src/index.ts
@@ -1,0 +1,2 @@
+import KeyTransformer from './KeyTransformer';
+export default KeyTransformer;

--- a/packages/graphql-key-transformer/tsconfig.json
+++ b/packages/graphql-key-transformer/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "sourceMap": true,
+        "outDir": "lib",
+        "lib": [
+            "es2015",
+            "es2016.array.include",
+            "esnext.asynciterable",
+            "dom"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
+}

--- a/packages/graphql-key-transformer/tslint.json
+++ b/packages/graphql-key-transformer/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "tslint-config-airbnb",
+    "rules": {
+        "semicolon": true
+    }
+}

--- a/packages/graphql-mapping-template/src/dynamodb.ts
+++ b/packages/graphql-mapping-template/src/dynamodb.ts
@@ -66,17 +66,23 @@ export class DynamoDBMappingTemplate {
      * Create a list item resolver template.
      * @param key A list of strings pointing to the key value locations. E.G. ctx.args.x (note no $)
      */
-    public static listItem({ filter, limit, nextToken }: {
+    public static listItem({ filter, limit, nextToken, scanIndexForward, query, index }: {
         filter: ObjectNode | Expression,
         limit: Expression,
-        nextToken?: Expression
+        nextToken?: Expression,
+        scanIndexForward?: Expression;
+        query?: ObjectNode | Expression,
+        index?: StringNode,
     }): ObjectNode {
         return obj({
             version: str('2017-02-28'),
             operation: str('Scan'),
             filter,
             limit,
-            nextToken
+            nextToken,
+            query,
+            index,
+            scanIndexForward,
         })
     }
 

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -1,4 +1,4 @@
-import { graphqlName, toUpper } from './util'
+import { graphqlName, toUpper, toCamelCase, simplifyName } from './util'
 import { DEFAULT_SCALARS } from './definition'
 
 export class ModelResourceIDs {
@@ -28,6 +28,21 @@ export class ModelResourceIDs {
             return `Model${nameOverride}KeyConditionInput`
         }
         return `Model${name}KeyConditionInput`
+    }
+    static ModelCompositeKeyArgumentName(keyFieldNames: string[]) {
+        return toCamelCase(keyFieldNames.map(n => graphqlName(n)));
+    }
+    static ModelCompositeKeySeparator() {
+        return '#';
+    }
+    static ModelCompositeAttributeName(keyFieldNames: string[]) {
+        return keyFieldNames.join(ModelResourceIDs.ModelCompositeKeySeparator());
+    }
+    static ModelCompositeKeyConditionInputTypeName(modelName: string, keyName: string): string {
+        return `Model${modelName}${keyName}CompositeKeyConditionInput`
+    }
+    static ModelCompositeKeyInputTypeName(modelName: string, keyName: string): string {
+        return `Model${modelName}${keyName}CompositeKeyInput`
     }
     static ModelFilterListInputTypeName(name: string): string {
         const nameOverride = DEFAULT_SCALARS[name]

--- a/packages/graphql-transformer-common/src/ResolverResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ResolverResourceIDs.ts
@@ -1,4 +1,4 @@
-import { graphqlName } from "./util";
+import { graphqlName, toUpper } from "./util";
 
 export class ResolverResourceIDs {
     static DynamoDBCreateResolverResourceID(typeName: string): string {
@@ -9,9 +9,6 @@ export class ResolverResourceIDs {
     }
     static DynamoDBDeleteResolverResourceID(typeName: string): string {
         return `Delete${typeName}Resolver`
-    }
-    static DynamoDBQueryResolverResourceID(typeName: string): string {
-        return `Query${typeName}Resolver`
     }
     static DynamoDBGetResolverResourceID(typeName: string): string {
         return `Get${typeName}Resolver`

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -92,6 +92,8 @@ export class ResourceConstants {
         AuthCondition: "authCondition",
         VersionedCondition: "versionedCondition",
         ModelObjectKey: "modelObjectKey",
+        ModelQueryExpression: "modelQueryExpression",
+        ModelQueryIndex: "modelQueryIndex",
         IsDynamicGroupAuthorizedVariable: "isDynamicGroupAuthorized",
         IsLocalDynamicGroupAuthorizedVariable: "isLocalDynamicGroupAuthorized",
         IsStaticGroupAuthorizedVariable: "isStaticGroupAuthorized",

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -92,6 +92,7 @@ export class ResourceConstants {
         AuthCondition: "authCondition",
         VersionedCondition: "versionedCondition",
         ModelObjectKey: "modelObjectKey",
+        DynamoDBNameOverrideMap: "dynamodbNameOverrideMap",
         ModelQueryExpression: "modelQueryExpression",
         ModelQueryIndex: "modelQueryIndex",
         IsDynamicGroupAuthorizedVariable: "isDynamicGroupAuthorized",

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -91,6 +91,7 @@ export class ResourceConstants {
     public static readonly SNIPPETS = {
         AuthCondition: "authCondition",
         VersionedCondition: "versionedCondition",
+        ModelObjectKey: "modelObjectKey",
         IsDynamicGroupAuthorizedVariable: "isDynamicGroupAuthorized",
         IsLocalDynamicGroupAuthorizedVariable: "isLocalDynamicGroupAuthorized",
         IsStaticGroupAuthorizedVariable: "isStaticGroupAuthorized",

--- a/packages/graphql-transformer-common/src/connectionUtils.ts
+++ b/packages/graphql-transformer-common/src/connectionUtils.ts
@@ -1,0 +1,15 @@
+import { makeField, makeInputValueDefinition, makeNamedType } from './definition';
+import { ModelResourceIDs } from './ModelResourceIDs';
+import { FieldDefinitionNode, InputValueDefinitionNode } from 'graphql';
+export function makeConnectionField(fieldName: string, returnTypeName: string, args: InputValueDefinitionNode[] = []): FieldDefinitionNode {
+    return makeField(
+        fieldName,
+        [
+            ...args,
+            makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
+            makeInputValueDefinition('limit', makeNamedType('Int')),
+            makeInputValueDefinition('nextToken', makeNamedType('String'))
+        ],
+        makeNamedType(ModelResourceIDs.ModelConnectionTypeName(returnTypeName))
+    )
+}

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -5,7 +5,8 @@ import {
     valueFromASTUntyped, ArgumentNode, DirectiveNode, EnumTypeDefinitionNode,
     ValueNode,
     ListValueNode,
-    ObjectValueNode
+    ObjectValueNode,
+    InputObjectTypeDefinitionNode
 } from 'graphql'
 import { access } from 'fs';
 
@@ -201,6 +202,18 @@ export function extensionWithFields(object: ObjectTypeExtensionNode, fields: Fie
     return {
         ...object,
         fields: [...object.fields, ...fields]
+    }
+}
+
+export function makeInputObjectDefinition(name: string, inputs: InputValueDefinitionNode[]): InputObjectTypeDefinitionNode {
+    return {
+        kind: 'InputObjectTypeDefinition',
+        name: {
+            kind: 'Name',
+            value: name
+        },
+        fields: inputs,
+        directives: []
     }
 }
 

--- a/packages/graphql-transformer-common/src/dynamodbUtils.ts
+++ b/packages/graphql-transformer-common/src/dynamodbUtils.ts
@@ -1,6 +1,7 @@
 import { InputObjectTypeDefinitionNode, InputValueDefinitionNode, Kind, TypeNode } from 'graphql';
 import { makeListType, makeNamedType, getBaseType } from './definition';
 import { ModelResourceIDs } from './ModelResourceIDs';
+import { compoundExpression, block, iff, raw, set, ref, qref, obj, str, printBlock, list, forEach, Expression, newline, ReferenceNode } from 'graphql-mapping-template';
 
 // Key conditions
 const STRING_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between', 'beginsWith']
@@ -57,5 +58,222 @@ export function makeScalarKeyConditionForType(type: TypeNode): InputObjectTypeDe
         if (key.name.value === inputName) {
             return key;
         }
+    }
+}
+
+/**
+* Key conditions materialize as instances of ModelXKeyConditionInput passed via $ctx.args.
+* If the arguments with the given sortKey name exists, create a DynamoDB expression that
+* implements its logic. Possible operators: eq, le, lt, ge, gt, beginsWith, and between.
+* @param argName The name of the argument containing the sort key condition object.
+* @param attributeType The type of the DynamoDB attribute in the table.
+* @param queryExprReference The name of the variable containing the query expression in the template.
+*/
+export function  applyKeyConditionExpression(argName: string, attributeType: 'S' | 'N' | 'B' = 'S', queryExprReference: string = 'query', sortKeyName?: string, prefixVariableName?: string) {
+    const prefixValue = (value: string): string => prefixVariableName ? `$${prefixVariableName}#${value}` : value;
+    const _sortKeyName = sortKeyName ? sortKeyName : argName;
+    return block("Applying Key Condition", [
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.beginsWith)`),
+           compoundExpression([
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND begins_with(#sortKey, :sortKey)"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.beginsWith`)}" })`)
+           ])
+       ),
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.between)`),
+           compoundExpression([
+               iff(
+                   raw(`$ctx.args.${argName}.between.size() != 2`),
+                   raw(`$util.error("Argument ${argName}.between expects exactly 2 elements.")`)
+               ),
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND #sortKey BETWEEN :sortKey0 AND :sortKey1"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey0", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.between[0]`)}" })`),
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey1", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.between[1]`)}" })`)
+           ])
+       ),
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.eq)`),
+           compoundExpression([
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND #sortKey = :sortKey"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.eq`)}" })`)
+           ])
+       ),
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.lt)`),
+           compoundExpression([
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND #sortKey < :sortKey"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.lt`)}" })`)
+           ])
+       ),
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.le)`),
+           compoundExpression([
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND #sortKey <= :sortKey"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.le`)}" })`)
+           ])
+       ),
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.gt)`),
+           compoundExpression([
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND #sortKey > :sortKey"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.gt`)}" })`)
+           ])
+       ),
+       iff(
+           raw(`!$util.isNull($ctx.args.${argName}) && !$util.isNull($ctx.args.${argName}.ge)`),
+           compoundExpression([
+               set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND #sortKey >= :sortKey"`)),
+               qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${_sortKeyName}")`),
+               // TODO: Handle N & B.
+               qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "${attributeType}": "${prefixValue(`$ctx.args.${argName}.ge`)}" })`)
+           ])
+       )
+   ]);
+}
+
+
+/**
+* Key conditions materialize as instances of ModelXKeyConditionInput passed via $ctx.args.
+* If the arguments with the given sortKey name exists, create a DynamoDB expression that
+* implements its logic. Possible operators: eq, le, lt, ge, gt, beginsWith, and between.
+* @param argName The name of the argument containing the sort key condition object.
+* @param attributeType The type of the DynamoDB attribute in the table.
+* @param queryExprReference The name of the variable containing the query expression in the template.
+* @param compositeKeyName When handling a managed composite key from @key the name of the arg and underlying fields are different.
+* @param compositeKeyValue When handling a managed composite key from @key the value of the composite key is made up of multiple parts known by the caller.
+*/
+export function  applyKeyExpressionForCompositeKey(keys: string[], attributeTypes: ('S' | 'N' | 'B')[] = ['S'], queryExprReference: string = 'query') {
+    if (keys.length > 2) {
+        // In the case of > 2, we condense the composite key, validate inputs at runtime, and wire up the HASH/RANGE expressions.
+        // In the case of === 2, we validate inputs at runtime and wire up the HASH/RANGE expressions.
+        const hashKeyName = keys[0];
+        const hashKeyAttributeType = attributeTypes[0];
+        const sortKeys = keys.slice(1);
+        const sortKeyTypes = attributeTypes.slice(1);
+        return compoundExpression([
+            validateKeyArguments(keys),
+            setupHashKeyExpression(hashKeyName, hashKeyAttributeType, queryExprReference),
+            applyCompositeSortKey(sortKeys, sortKeyTypes, queryExprReference)
+        ]);
+    } else if (keys.length === 2) {
+        // In the case of === 2, we validate inputs at runtime and wire up the HASH/RANGE expressions.
+        const hashKeyName = keys[0];
+        const hashKeyAttributeType = attributeTypes[0];
+        const sortKeyName = keys[1];
+        const sortKeyAttributeType = attributeTypes[1];
+        return compoundExpression([
+            validateKeyArguments(keys),
+            setupHashKeyExpression(hashKeyName, hashKeyAttributeType, queryExprReference),
+            applyKeyConditionExpression(sortKeyName, sortKeyAttributeType, queryExprReference)
+        ]);
+    } else if (keys.length === 1) {
+        const hashKeyName = keys[0];
+        const hashKeyAttributeType = attributeTypes[0];
+        return setupHashKeyExpression(hashKeyName, hashKeyAttributeType, queryExprReference);
+    }
+}
+
+function setupHashKeyExpression(hashKeyName: string, hashKeyAttributeType: string, queryExprReference: string) {
+    return iff(
+        raw(`!$util.isNull($ctx.args.${hashKeyName})`),
+        compoundExpression([
+            set(ref(`${queryExprReference}.expression`), str(`#${hashKeyName} = :${hashKeyName}`)),
+            set(ref(`${queryExprReference}.expressionNames`), obj({ [`#${hashKeyName}`]: str(hashKeyName) })),
+            set(ref(`${queryExprReference}.expressionValues`), obj({ [`:${hashKeyName}`]: obj({ [hashKeyAttributeType]: str(`$ctx.args.${hashKeyName}`) }) })),
+        ])
+    )
+}
+
+/**
+ * Applies a composite sort key to the query expression.
+ */
+function applyCompositeSortKey(sortKeys: string[], sortKeyTypes: ('S'|'N'|'B')[], queryExprReference: string) {
+    if (sortKeys.length === 0) {
+        return newline();
+    }
+    // const sortKeyValue = sortKeys.map(key => `$ctx.args.${key}`).join('#')
+    const sortKeyValueVariableName = 'sortKeyValue';
+    const exprs: Expression[] = [
+        set(ref(sortKeyValueVariableName), str(''))
+    ];
+    const sortKeyAttributeName = sortKeys.join('#');
+    for (let index = 0; index < sortKeys.length; index++) {
+        const key = sortKeys[index];
+        const keyType = sortKeyTypes[index];
+        if (index === sortKeys.length - 1) {
+            // If this is the last element in the sort key list then handle the full KeyCondition.
+            exprs.push(applyKeyConditionExpression(key, keyType, queryExprReference, sortKeyAttributeName, sortKeyValueVariableName));
+            // Handle the case where the last element (that contains the DynamoDB operation information) is left undefined.
+            // listX and queryX where the first n-1 values are provided should always be handled with a begins_with.
+            exprs.push(
+                iff(
+                    raw(`$util.isNull($ctx.args.${key}) && $sortKeyValue.length() > 0`),
+                    compoundExpression([
+                        set(ref(`${queryExprReference}.expression`), raw(`"$${queryExprReference}.expression AND begins_with(#sortKey, :sortKey)"`)),
+                        qref(`$${queryExprReference}.expressionNames.put("#sortKey", "${sortKeyAttributeName}")`),
+                        // TODO: Handle N & B.
+                        qref(`$${queryExprReference}.expressionValues.put(":sortKey", { "S": "$${sortKeyValueVariableName}" })`)
+                    ])
+                )
+            );
+        } else if (index === 0) {
+            // If this is the first element then initialize the key value.
+            exprs.push(
+                iff(
+                    raw(`!$util.isNull($ctx.args.${key})`),
+                    set(ref('sortKeyValue'), str(`\${ctx.args.${key}}`))
+                )
+            )
+        } else {
+            // If this is an element in the middle of the list, concat the element.
+            exprs.push(
+                iff(
+                    raw(`!$util.isNull($ctx.args.${key})`),
+                    set(ref('sortKeyValue'), str(`\${sortKeyValue}#\${ctx.args.${key}}`))
+                )
+            )
+        }
+    }
+    return compoundExpression(exprs);
+}
+
+/**
+ * When providing keys, you must provide them from left to right.
+ * E.G. when providing @key(fields: ["k1", "k2", "k3"]) then you may
+ * query by ["k1"] or ["k1", "k2"] or ["k1", "k2", "k3"] BUT you may not
+ * query by ["k1", "k3"] as it is impossible to create a key condition without
+ * the "k2" value. This snippet fails a query/list operation when invalid
+ * argument sets are provided.
+ * @param keys 
+ */
+function validateKeyArguments(keys: string[]) {
+    const exprs: Expression[] = [];
+    if (keys.length > 1) {
+        for (let index = keys.length - 1; index > 0; index--) {
+            const rightKey = keys[index];
+            const previousKey = keys[index - 1];
+            exprs.push(
+                iff(
+                    raw(`!$util.isNull($ctx.args.${rightKey}) && $util.isNull($ctx.args.${previousKey})`),
+                    raw(`$util.error("When providing argument '${rightKey}' you must also provide arguments ${keys.slice(0, index).join(', ')}", "InvalidArgumentsError")`)
+                )
+            )
+        }
+        return block('Validate key arguments.', exprs);
+    } else {
+        return newline();
     }
 }

--- a/packages/graphql-transformer-common/src/dynamodbUtils.ts
+++ b/packages/graphql-transformer-common/src/dynamodbUtils.ts
@@ -1,0 +1,61 @@
+import { InputObjectTypeDefinitionNode, InputValueDefinitionNode, Kind, TypeNode } from 'graphql';
+import { makeListType, makeNamedType, getBaseType } from './definition';
+import { ModelResourceIDs } from './ModelResourceIDs';
+
+// Key conditions
+const STRING_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between', 'beginsWith']
+const ID_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between', 'beginsWith']
+const INT_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between']
+const FLOAT_KEY_CONDITIONS = ['eq', 'le', 'lt', 'ge', 'gt', 'between']
+
+function getScalarKeyConditions(type: string): string[] {
+    switch (type) {
+        case 'String':
+            return STRING_KEY_CONDITIONS
+        case 'ID':
+            return ID_KEY_CONDITIONS
+        case 'Int':
+            return INT_KEY_CONDITIONS
+        case 'Float':
+            return FLOAT_KEY_CONDITIONS
+        default:
+            throw 'Valid types are String, ID, Int, Float, Boolean'
+    }
+}
+export function makeModelStringKeyConditionInputObject(type: string): InputObjectTypeDefinitionNode {
+    const name = ModelResourceIDs.ModelKeyConditionInputTypeName(type)
+    const conditions = getScalarKeyConditions(type)
+    const fields: InputValueDefinitionNode[] = conditions
+        .map((condition: string) => ({
+            kind: Kind.INPUT_VALUE_DEFINITION,
+            name: { kind: "Name" as "Name", value: condition },
+            type: condition === 'between' ? makeListType(makeNamedType(type)) : makeNamedType(type),
+            directives: []
+        }))
+    return {
+        kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+        name: {
+            kind: 'Name',
+            value: name
+        },
+        fields,
+        directives: []
+    }
+}
+
+const STRING_KEY_CONDITION = makeModelStringKeyConditionInputObject('String');
+const ID_KEY_CONDITION = makeModelStringKeyConditionInputObject('ID');
+const INT_KEY_CONDITION = makeModelStringKeyConditionInputObject('Int');
+const FLOAT_KEY_CONDITION = makeModelStringKeyConditionInputObject('Float');
+const SCALAR_KEY_CONDITIONS = [STRING_KEY_CONDITION, ID_KEY_CONDITION, INT_KEY_CONDITION, FLOAT_KEY_CONDITION];
+export function makeScalarKeyConditionInputs(): InputObjectTypeDefinitionNode[] {
+    return SCALAR_KEY_CONDITIONS;
+}
+export function makeScalarKeyConditionForType(type: TypeNode): InputObjectTypeDefinitionNode {
+    const inputName = ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(type));
+    for (const key of SCALAR_KEY_CONDITIONS) {
+        if (key.name.value === inputName) {
+            return key;
+        }
+    }
+}

--- a/packages/graphql-transformer-common/src/index.ts
+++ b/packages/graphql-transformer-common/src/index.ts
@@ -7,3 +7,5 @@ export * from './SearchableResourceIDs'
 export * from './nodeUtils'
 export * from './HttpResourceIDs'
 export * from './FunctionResourceIDs'
+export * from './connectionUtils';
+export * from './dynamodbUtils';

--- a/packages/graphql-transformer-core/src/errors.ts
+++ b/packages/graphql-transformer-core/src/errors.ts
@@ -4,6 +4,7 @@ export class InvalidTransformerError extends Error {
 
     constructor(message: string) {
         super(message);
+        Object.setPrototypeOf(this, InvalidTransformerError.prototype);
         this.name = "InvalidTransformerError";
         if ((Error as any).captureStackTrace) {
             (Error as any).captureStackTrace(this, InvalidTransformerError)
@@ -15,6 +16,7 @@ export class SchemaValidationError extends Error {
 
     constructor(errors: GraphQLError[]) {
         super(`Schema Errors:\n\n${errors.join('\n')}`);
+        Object.setPrototypeOf(this, SchemaValidationError.prototype);
         this.name = "SchemaValidationError";
         if ((Error as any).captureStackTrace) {
             (Error as any).captureStackTrace(this, SchemaValidationError)
@@ -34,6 +36,7 @@ export class TransformerContractError extends Error {
 
     constructor(message: string) {
         super(message);
+        Object.setPrototypeOf(this, TransformerContractError.prototype);
         this.name = "TransformerContractError";
         if ((Error as any).captureStackTrace) {
             (Error as any).captureStackTrace(this, TransformerContractError)
@@ -44,6 +47,7 @@ export class TransformerContractError extends Error {
 export class InvalidDirectiveError extends Error {
     constructor(message: string) {
         super(message);
+        Object.setPrototypeOf(this, InvalidDirectiveError.prototype);
         this.name = "InvalidDirectiveError";
         if ((Error as any).captureStackTrace) {
             (Error as any).captureStackTrace(this, InvalidDirectiveError)
@@ -54,6 +58,7 @@ export class InvalidDirectiveError extends Error {
 export class UnknownDirectiveError extends Error {
     constructor(message: string) {
         super(message);
+        Object.setPrototypeOf(this, UnknownDirectiveError.prototype);
         this.name = "UnknownDirectiveError";
         if ((Error as any).captureStackTrace) {
             (Error as any).captureStackTrace(this, UnknownDirectiveError)

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -39,6 +39,7 @@
     "graphql-elasticsearch-transformer": "3.6.0",
     "graphql-function-transformer": "1.0.2",
     "graphql-versioned-transformer": "3.4.6",
+    "graphql-key-transformer": "1.0.0",
     "jest": "^23.1.0",
     "node-fetch": "^2.2.0",
     "ts-jest": "^22.4.6",

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -30,11 +30,11 @@ test('Test that a primary @key with a single field changes the hash key.', () =>
     expect(
         tableResource.Properties.AttributeDefinitions[0].AttributeType,
     ).toEqual('S');
-    const schema = parse(out.schema);
-    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
-    expect(getTestField.arguments).toHaveLength(1);
-    expectArguments(getTestField, ['email'])
+    // const schema = parse(out.schema);
+    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    // const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    // expect(getTestField.arguments).toHaveLength(1);
+    // expectArguments(getTestField, ['email'])
 })
 
 test('Test that a primary @key with 2 fields changes the hash and sort key.', () => {
@@ -65,11 +65,11 @@ test('Test that a primary @key with 2 fields changes the hash and sort key.', ()
     expect(hashKeyAttr.AttributeType).toEqual('S');
     expect(rangeKeyAttr.AttributeType).toEqual('N');
 
-    const schema = parse(out.schema);
-    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
-    expect(getTestField.arguments).toHaveLength(2);
-    expectArguments(getTestField, ['email', 'kind'])
+    // const schema = parse(out.schema);
+    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    // const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    // expect(getTestField.arguments).toHaveLength(2);
+    // expectArguments(getTestField, ['email', 'kind'])
 })
 
 test('Test that a primary @key with 3 fields changes the hash and sort keys.', () => {
@@ -102,9 +102,148 @@ test('Test that a primary @key with 3 fields changes the hash and sort keys.', (
     // composite keys will always be strings.
     expect(rangeKeyAttr.AttributeType).toEqual('S');
 
-    const schema = parse(out.schema);
-    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
-    expect(getTestField.arguments).toHaveLength(3);
-    expectArguments(getTestField, ['email', 'kind', 'date'])
+    // const schema = parse(out.schema);
+    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    // const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    // expect(getTestField.arguments).toHaveLength(3);
+    // expectArguments(getTestField, ['email', 'kind', 'date'])
+})
+
+test('Test that a secondary @key with a single field adds a GSI.', () => {
+    const validSchema = `
+    type Test @model @key(name: "testsByEmail", fields: ["email"]) {
+        id: ID!
+        email: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName,
+    ).toEqual('email');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
+    ).toEqual('S');
+    // const schema = parse(out.schema);
+    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    // const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmail') as FieldDefinitionNode;
+    // expect(queryIndexField.arguments).toHaveLength(1);
+    // expectArguments(queryIndexField, ['email'])
+})
+
+test('Test that a secondary @key with a multiple field adds an GSI.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "testsByCategory", fields: ["category", "createdAt"]) {
+        email: String!
+        createdAt: String!
+        category: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName,
+    ).toEqual('category');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].AttributeName,
+    ).toEqual('createdAt');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].KeyType,
+    ).toEqual('RANGE');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'category').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType,
+    ).toEqual('S');
+    // const schema = parse(out.schema);
+    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    // const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByCategory') as FieldDefinitionNode;
+    // expect(queryIndexField.arguments).toHaveLength(1);
+    // expectArguments(queryIndexField, ['category', 'createdAt']);
+
+    // // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
+    // const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+    // expect(listTestsField.arguments).toHaveLength(1);
+    // expectArguments(listTestsField, ['email', 'createdAt']);
+})
+
+
+test('Test that a secondary @key with a multiple field adds an LSI.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "testsByEmailByUpdatedAt", fields: ["email", "updatedAt"]) {
+        email: String!
+        createdAt: String!
+        updatedAt: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[0].AttributeName,
+    ).toEqual('email');
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[1].AttributeName,
+    ).toEqual('updatedAt');
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[1].KeyType,
+    ).toEqual('RANGE');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'updatedAt').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType,
+    ).toEqual('S');
+    // const schema = parse(out.schema);
+    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    // const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmailByUpdatedAt') as FieldDefinitionNode;
+    // expect(queryIndexField.arguments).toHaveLength(1);
+    // expectArguments(queryIndexField, ['email', 'updatedAt']);
+
+    // // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
+    // const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+    // expect(listTestsField.arguments).toHaveLength(1);
+    // expectArguments(listTestsField, ['email', 'createdAt']);
 })

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -1,249 +1,272 @@
-import GraphQLTransform, { Transformer, InvalidDirectiveError } from 'graphql-transformer-core'
-import ModelTransformer from 'graphql-dynamodb-transformer';
-import KeyTransformer from 'graphql-key-transformer';
-import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
-import { expectArguments } from '../testUtil';
+import { ResourceConstants } from 'graphql-transformer-common'
+import GraphQLTransform from 'graphql-transformer-core'
+import ModelTransformer from 'graphql-dynamodb-transformer'
+import KeyTransformer from 'graphql-key-transformer'
+import { CloudFormationClient } from '../CloudFormationClient'
+import { Output } from 'aws-sdk/clients/cloudformation'
+import { GraphQLClient } from '../GraphQLClient'
+import * as moment from 'moment';
+import emptyBucket from '../emptyBucket';
+import { deploy } from '../deployNestedStacks'
+import { S3Client } from '../S3Client';
+import * as S3 from 'aws-sdk/clients/s3'
 
-test('Test that a primary @key with a single field changes the hash key.', () => {
-    const validSchema = `
-    type Test @model @key(fields: ["email"]) {
-        email: String!
+jest.setTimeout(2000000);
+
+const cf = new CloudFormationClient('us-west-2')
+const customS3Client = new S3Client('us-west-2')
+const awsS3Client = new S3({ region: 'us-west-2' })
+
+const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss')
+const STACK_NAME = `KeyTransformerTests-${BUILD_TIMESTAMP}`
+const BUCKET_NAME = `appsync-key-transformer-test-bucket-${BUILD_TIMESTAMP}`
+const LOCAL_FS_BUILD_DIR = '/tmp/key_transformer_tests/'
+const S3_ROOT_DIR_KEY = 'deployments'
+
+let GRAPHQL_CLIENT = undefined;
+
+function outputValueSelector(key: string) {
+    return (outputs: Output[]) => {
+        const output = outputs.find((o: Output) => o.OutputKey === key)
+        return output ? output.OutputValue : null
     }
-    `
+}
 
-    const transformer = new GraphQLTransform({
-        transformers: [
-            new ModelTransformer(),
-            new KeyTransformer()
-        ]
-    });
-
-    const out = transformer.transform(validSchema);
-    let tableResource = out.stacks.Test.Resources.TestTable;
-    expect(tableResource).toBeDefined()
-    expect(
-        tableResource.Properties.KeySchema[0].AttributeName,
-    ).toEqual('email');
-    expect(
-        tableResource.Properties.KeySchema[0].KeyType,
-    ).toEqual('HASH');
-    expect(
-        tableResource.Properties.AttributeDefinitions[0].AttributeType,
-    ).toEqual('S');
-    // const schema = parse(out.schema);
-    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    // const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
-    // expect(getTestField.arguments).toHaveLength(1);
-    // expectArguments(getTestField, ['email'])
-})
-
-test('Test that a primary @key with 2 fields changes the hash and sort key.', () => {
+beforeAll(async () => {
     const validSchema = `
-    type Test @model @key(fields: ["email", "kind"]) {
-        email: String!
-        kind: Int!
-    }
-    `
-
-    const transformer = new GraphQLTransform({
-        transformers: [
-            new ModelTransformer(),
-            new KeyTransformer()
-        ]
-    });
-
-    const out = transformer.transform(validSchema);
-    let tableResource = out.stacks.Test.Resources.TestTable;
-    expect(tableResource).toBeDefined()
-    const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');
-    const hashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
-    const rangeKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'RANGE');
-    const rangeKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'kind');
-    expect(tableResource.Properties.AttributeDefinitions).toHaveLength(2);
-    expect(hashKey.AttributeName).toEqual('email');
-    expect(rangeKey.AttributeName).toEqual('kind');
-    expect(hashKeyAttr.AttributeType).toEqual('S');
-    expect(rangeKeyAttr.AttributeType).toEqual('N');
-
-    // const schema = parse(out.schema);
-    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    // const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
-    // expect(getTestField.arguments).toHaveLength(2);
-    // expectArguments(getTestField, ['email', 'kind'])
-})
-
-test('Test that a primary @key with 3 fields changes the hash and sort keys.', () => {
-    const validSchema = `
-    type Test @model @key(fields: ["email", "kind", "date"]) {
-        email: String!
-        kind: Int!
-        date: AWSDateTime!
-    }
-    `
-
-    const transformer = new GraphQLTransform({
-        transformers: [
-            new ModelTransformer(),
-            new KeyTransformer()
-        ]
-    });
-
-    const out = transformer.transform(validSchema);
-    let tableResource = out.stacks.Test.Resources.TestTable;
-    expect(tableResource).toBeDefined()
-    const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');
-    const hashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
-    const rangeKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'RANGE');
-    const rangeKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'kindDate');
-    expect(tableResource.Properties.AttributeDefinitions).toHaveLength(2);
-    expect(hashKey.AttributeName).toEqual('email');
-    expect(rangeKey.AttributeName).toEqual('kindDate');
-    expect(hashKeyAttr.AttributeType).toEqual('S');
-    // composite keys will always be strings.
-    expect(rangeKeyAttr.AttributeType).toEqual('S');
-
-    // const schema = parse(out.schema);
-    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    // const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
-    // expect(getTestField.arguments).toHaveLength(3);
-    // expectArguments(getTestField, ['email', 'kind', 'date'])
-})
-
-test('Test that a secondary @key with a single field adds a GSI.', () => {
-    const validSchema = `
-    type Test @model @key(name: "testsByEmail", fields: ["email"]) {
-        id: ID!
-        email: String!
-    }
-    `
-
-    const transformer = new GraphQLTransform({
-        transformers: [
-            new ModelTransformer(),
-            new KeyTransformer()
-        ]
-    });
-
-    const out = transformer.transform(validSchema);
-    let tableResource = out.stacks.Test.Resources.TestTable;
-    expect(tableResource).toBeDefined()
-    expect(
-        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName,
-    ).toEqual('email');
-    expect(
-        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType,
-    ).toEqual('HASH');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
-    ).toEqual('S');
-    // const schema = parse(out.schema);
-    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    // const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmail') as FieldDefinitionNode;
-    // expect(queryIndexField.arguments).toHaveLength(1);
-    // expectArguments(queryIndexField, ['email'])
-})
-
-test('Test that a secondary @key with a multiple field adds an GSI.', () => {
-    const validSchema = `
-    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "testsByCategory", fields: ["category", "createdAt"]) {
-        email: String!
+    type Order @model @key(fields: ["customerEmail", "createdAt"]) {
+        customerEmail: String!
         createdAt: String!
-        category: String!
+        orderId: ID!
     }
-    `
-
-    const transformer = new GraphQLTransform({
-        transformers: [
-            new ModelTransformer(),
-            new KeyTransformer()
-        ]
-    });
-
-    const out = transformer.transform(validSchema);
-    let tableResource = out.stacks.Test.Resources.TestTable;
-    expect(tableResource).toBeDefined()
-    expect(
-        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName,
-    ).toEqual('category');
-    expect(
-        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType,
-    ).toEqual('HASH');
-    expect(
-        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].AttributeName,
-    ).toEqual('createdAt');
-    expect(
-        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].KeyType,
-    ).toEqual('RANGE');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
-    ).toEqual('S');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'category').AttributeType,
-    ).toEqual('S');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType,
-    ).toEqual('S');
-    // const schema = parse(out.schema);
-    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    // const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByCategory') as FieldDefinitionNode;
-    // expect(queryIndexField.arguments).toHaveLength(1);
-    // expectArguments(queryIndexField, ['category', 'createdAt']);
-
-    // // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
-    // const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
-    // expect(listTestsField.arguments).toHaveLength(1);
-    // expectArguments(listTestsField, ['email', 'createdAt']);
-})
-
-
-test('Test that a secondary @key with a multiple field adds an LSI.', () => {
-    const validSchema = `
-    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "testsByEmailByUpdatedAt", fields: ["email", "updatedAt"]) {
+    type Customer @model @key(fields: ["email"]) {
         email: String!
-        createdAt: String!
-        updatedAt: String!
+        username: String
+    }
+    type Item @model @key(fields: ["orderId", "status", "createdAt"]) {
+        orderId: ID!
+        status: Status!
+        createdAt: AWSDateTime!
+        name: String!
+    }
+    enum Status {
+        DELIVERED IN_TRANSIT PENDING
     }
     `
-
+    try {
+        await awsS3Client.createBucket({Bucket: BUCKET_NAME}).promise()
+    } catch (e) { console.warn(`Could not create bucket: ${e}`) }
     const transformer = new GraphQLTransform({
         transformers: [
             new ModelTransformer(),
             new KeyTransformer()
         ]
-    });
-
+    })
     const out = transformer.transform(validSchema);
-    let tableResource = out.stacks.Test.Resources.TestTable;
-    expect(tableResource).toBeDefined()
-    expect(
-        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[0].AttributeName,
-    ).toEqual('email');
-    expect(
-        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[0].KeyType,
-    ).toEqual('HASH');
-    expect(
-        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[1].AttributeName,
-    ).toEqual('updatedAt');
-    expect(
-        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[1].KeyType,
-    ).toEqual('RANGE');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
-    ).toEqual('S');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'updatedAt').AttributeType,
-    ).toEqual('S');
-    expect(
-        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType,
-    ).toEqual('S');
-    // const schema = parse(out.schema);
-    // const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
-    // const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmailByUpdatedAt') as FieldDefinitionNode;
-    // expect(queryIndexField.arguments).toHaveLength(1);
-    // expectArguments(queryIndexField, ['email', 'updatedAt']);
+    const finishedStack = await deploy(
+        customS3Client, cf, STACK_NAME, out, { env: 'dev' }, LOCAL_FS_BUILD_DIR, BUCKET_NAME, S3_ROOT_DIR_KEY,
+        BUILD_TIMESTAMP
+    )
+    // Arbitrary wait to make sure everything is ready.
+    await cf.wait(5, () => Promise.resolve())
+    console.log('Successfully created stack ' + STACK_NAME)
+    console.log(finishedStack)
+    expect(finishedStack).toBeDefined()
+    const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput)
+    const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput)
+    const endpoint = getApiEndpoint(finishedStack.Outputs)
+    const apiKey = getApiKey(finishedStack.Outputs)
+    expect(apiKey).toBeDefined()
+    expect(endpoint).toBeDefined()
+    GRAPHQL_CLIENT = new GraphQLClient(endpoint, { 'x-api-key': apiKey })
+});
 
-    // // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
-    // const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
-    // expect(listTestsField.arguments).toHaveLength(1);
-    // expectArguments(listTestsField, ['email', 'createdAt']);
+afterAll(async () => {
+    try {
+        console.log('Deleting stack ' + STACK_NAME)
+        await cf.deleteStack(STACK_NAME)
+        await cf.waitForStack(STACK_NAME)
+        console.log('Successfully deleted stack ' + STACK_NAME)
+    } catch (e) {
+        if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
+            // The stack was deleted. This is good.
+            expect(true).toEqual(true)
+            console.log('Successfully deleted stack ' + STACK_NAME)
+        } else {
+            console.error(e)
+            expect(true).toEqual(false)
+        }
+    }
+    try {
+        await emptyBucket(BUCKET_NAME);
+    } catch (e) { console.warn(`Error during bucket cleanup: ${e}`)}
 })
+
+/**
+ * Test queries below
+ */
+test('Test getX with a two part primary key.', async () => {
+    const order1 = await createOrder('test@gmail.com', '1');
+    const getOrder1 = await getOrder('test@gmail.com', order1.data.createOrder.createdAt)
+    expect(getOrder1.data.getOrder.orderId).toEqual('1');
+})
+
+test('Test updateX with a two part primary key.', async () => {
+    const order2 = await createOrder('test3@gmail.com', '2');
+    let getOrder2 = await getOrder('test3@gmail.com', order2.data.createOrder.createdAt)
+    expect(getOrder2.data.getOrder.orderId).toEqual('2');
+    const updateOrder2 = await updateOrder('test3@gmail.com', order2.data.createOrder.createdAt, '3')
+    expect(updateOrder2.data.updateOrder.orderId).toEqual('3');
+    getOrder2 = await getOrder('test3@gmail.com', order2.data.createOrder.createdAt)
+    expect(getOrder2.data.getOrder.orderId).toEqual('3');
+})
+
+test('Test deleteX with a two part primary key.', async () => {
+    const order2 = await createOrder('test2@gmail.com', '2');
+    let getOrder2 = await getOrder('test2@gmail.com', order2.data.createOrder.createdAt)
+    expect(getOrder2.data.getOrder.orderId).toEqual('2');
+    const delOrder2 = await deleteOrder('test2@gmail.com', order2.data.createOrder.createdAt)
+    expect(delOrder2.data.deleteOrder.orderId).toEqual('2');
+    getOrder2 = await getOrder('test2@gmail.com', order2.data.createOrder.createdAt)
+    expect(getOrder2.data.getOrder).toBeNull();
+})
+
+test('Test getX with a three part primary key', async () => {
+    const item1 = await createItem('1', 'PENDING', 'item1');
+    const getItem1 = await getItem('1', 'PENDING', item1.data.createItem.createdAt);
+    expect(getItem1.data.createItem.orderId).toEqual('1');
+    expect(getItem1.data.createItem.status).toEqual('PENDING');
+})
+
+test('Test updateX with a three part primary key.', async () => {
+    const item2 = await createItem('2', 'PENDING', 'item2');
+    let getItem2 = await getItem('2', 'PENDING', item2.data.createItem.createdAt)
+    expect(getItem2.data.getItem.orderId).toEqual('2');
+    const updateItem2 = await updateItem('2', 'PENDING', item2.data.createItem.createdAt, 'item2.1')
+    expect(updateItem2.data.updateItem.name).toEqual('item2.1');
+    getItem2 = await getItem('2', 'PENDING', item2.data.createItem.createdAt)
+    expect(getItem2.data.getItem.name).toEqual('item2.1');
+})
+
+test('Test deleteX with a three part primary key.', async () => {
+    const item3 = await createItem('3', 'IN_TRANSIT', 'item3');
+    let getItem3 = await getItem('3', 'IN_TRANSIT', item3.data.createItem.createdAt)
+    expect(getItem3.data.getItem.name).toEqual('item3');
+    const delItem3 = await deleteItem('3', 'IN_TRANSIT', item3.data.createItem.createdAt)
+    expect(delItem3.data.deleteItem.name).toEqual('item3');
+    getItem3 = await getItem('3', 'IN_TRANSIT', item3.data.createItem.createdAt);
+    expect(getItem3.data.getItem).toBeNull();
+})
+
+async function createOrder(customerEmail: string, orderId: string) {
+    const result = await GRAPHQL_CLIENT.query(`mutation CreateOrder($input: CreateOrderInput!) {
+        createOrder(input: $input) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, {
+        input: { customerEmail, orderId, createdAt: new Date().toISOString() }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function updateOrder(customerEmail: string, createdAt: string, orderId: string) {
+    const result = await GRAPHQL_CLIENT.query(`mutation UpdateOrder($input: UpdateOrderInput!) {
+        updateOrder(input: $input) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, {
+        input: { customerEmail, orderId, createdAt }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function deleteOrder(customerEmail: string, createdAt: string) {
+    const result = await GRAPHQL_CLIENT.query(`mutation DeleteOrder($input: DeleteOrderInput!) {
+        deleteOrder(input: $input) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, {
+        input: { customerEmail, createdAt }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function getOrder(customerEmail: string, createdAt: string) {
+    const result = await GRAPHQL_CLIENT.query(`query GetOrder($customerEmail: String!, $createdAt: String!) {
+        getOrder(customerEmail: $customerEmail, createdAt: $createdAt) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, { customerEmail, createdAt });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function createItem(orderId: string, status: string, name: string) {
+    const result = await GRAPHQL_CLIENT.query(`mutation CreateItem($input: CreateItemInput!) {
+        createItem(input: $input) {
+            orderId
+            status
+            createdAt
+            name
+        }
+    }`, {
+        input: { status, orderId, name, createdAt: new Date().toISOString() }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function updateItem(orderId: string, status: string, createdAt: string, name: string) {
+    const result = await GRAPHQL_CLIENT.query(`mutation UpdateItem($input: UpdateItemInput!) {
+        updateItem(input: $input) {
+            orderId
+            status
+            createdAt
+            name
+        }
+    }`, {
+        input: { status, orderId, createdAt, name }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function deleteItem(orderId: string, status: string, createdAt: string) {
+    const result = await GRAPHQL_CLIENT.query(`mutation DeleteItem($input: DeleteItemInput!) {
+        deleteItem(input: $input) {
+            orderId
+            status
+            createdAt
+            name
+        }
+    }`, {
+        input: { orderId, status, createdAt }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function getItem(orderId: string, status: string, createdAt: string) {
+    const result = await GRAPHQL_CLIENT.query(`query GetItem($orderId: ID!, status: Status!, $createdAt: String!) {
+        getItem(orderId: $orderId, status: $status, createdAt: $createdAt) {
+            orderId
+            status
+            createdAt
+            name
+        }
+    }`, { orderId, status, createdAt });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -1,0 +1,110 @@
+import GraphQLTransform, { Transformer, InvalidDirectiveError } from 'graphql-transformer-core'
+import ModelTransformer from 'graphql-dynamodb-transformer';
+import KeyTransformer from 'graphql-key-transformer';
+import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import { expectArguments } from '../testUtil';
+
+test('Test that a primary @key with a single field changes the hash key.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email"]) {
+        email: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.KeySchema[0].AttributeName,
+    ).toEqual('email');
+    expect(
+        tableResource.Properties.KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.AttributeDefinitions[0].AttributeType,
+    ).toEqual('S');
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    expect(getTestField.arguments).toHaveLength(1);
+    expectArguments(getTestField, ['email'])
+})
+
+test('Test that a primary @key with 2 fields changes the hash and sort key.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "kind"]) {
+        email: String!
+        kind: Int!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');
+    const hashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
+    const rangeKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'RANGE');
+    const rangeKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'kind');
+    expect(tableResource.Properties.AttributeDefinitions).toHaveLength(2);
+    expect(hashKey.AttributeName).toEqual('email');
+    expect(rangeKey.AttributeName).toEqual('kind');
+    expect(hashKeyAttr.AttributeType).toEqual('S');
+    expect(rangeKeyAttr.AttributeType).toEqual('N');
+
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    expect(getTestField.arguments).toHaveLength(2);
+    expectArguments(getTestField, ['email', 'kind'])
+})
+
+test('Test that a primary @key with 3 fields changes the hash and sort keys.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "kind", "date"]) {
+        email: String!
+        kind: Int!
+        date: AWSDateTime!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');
+    const hashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
+    const rangeKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'RANGE');
+    const rangeKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'kindDate');
+    expect(tableResource.Properties.AttributeDefinitions).toHaveLength(2);
+    expect(hashKey.AttributeName).toEqual('email');
+    expect(rangeKey.AttributeName).toEqual('kindDate');
+    expect(hashKeyAttr.AttributeType).toEqual('S');
+    // composite keys will always be strings.
+    expect(rangeKeyAttr.AttributeType).toEqual('S');
+
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    expect(getTestField.arguments).toHaveLength(3);
+    expectArguments(getTestField, ['email', 'kind', 'date'])
+})

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -84,26 +84,26 @@ beforeAll(async () => {
     GRAPHQL_CLIENT = new GraphQLClient(endpoint, { 'x-api-key': apiKey })
 });
 
-// afterAll(async () => {
-//     try {
-//         console.log('Deleting stack ' + STACK_NAME)
-//         await cf.deleteStack(STACK_NAME)
-//         await cf.waitForStack(STACK_NAME)
-//         console.log('Successfully deleted stack ' + STACK_NAME)
-//     } catch (e) {
-//         if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-//             // The stack was deleted. This is good.
-//             expect(true).toEqual(true)
-//             console.log('Successfully deleted stack ' + STACK_NAME)
-//         } else {
-//             console.error(e)
-//             expect(true).toEqual(false)
-//         }
-//     }
-//     try {
-//         await emptyBucket(BUCKET_NAME);
-//     } catch (e) { console.warn(`Error during bucket cleanup: ${e}`)}
-// })
+afterAll(async () => {
+    try {
+        console.log('Deleting stack ' + STACK_NAME)
+        await cf.deleteStack(STACK_NAME)
+        await cf.waitForStack(STACK_NAME)
+        console.log('Successfully deleted stack ' + STACK_NAME)
+    } catch (e) {
+        if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
+            // The stack was deleted. This is good.
+            expect(true).toEqual(true)
+            console.log('Successfully deleted stack ' + STACK_NAME)
+        } else {
+            console.error(e)
+            expect(true).toEqual(false)
+        }
+    }
+    try {
+        await emptyBucket(BUCKET_NAME);
+    } catch (e) { console.warn(`Error during bucket cleanup: ${e}`)}
+})
 
 /**
  * Test queries below

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -1,0 +1,273 @@
+import GraphQLTransform, { Transformer, InvalidDirectiveError } from 'graphql-transformer-core'
+import ModelTransformer from 'graphql-dynamodb-transformer';
+import KeyTransformer from 'graphql-key-transformer';
+import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import { expectArguments, expectFields, expectNonNullFields, expectNullableFields } from '../testUtil';
+
+test('Test that a primary @key with a single field changes the hash key.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email"]) {
+        email: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.KeySchema[0].AttributeName,
+    ).toEqual('email');
+    expect(
+        tableResource.Properties.KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.AttributeDefinitions[0].AttributeType,
+    ).toEqual('S');
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    expect(getTestField.arguments).toHaveLength(1);
+    expectArguments(getTestField, ['email'])
+})
+
+test('Test that a primary @key with 2 fields changes the hash and sort key.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "kind"]) {
+        email: String!
+        kind: Int!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');
+    const hashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
+    const rangeKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'RANGE');
+    const rangeKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'kind');
+    expect(tableResource.Properties.AttributeDefinitions).toHaveLength(2);
+    expect(hashKey.AttributeName).toEqual('email');
+    expect(rangeKey.AttributeName).toEqual('kind');
+    expect(hashKeyAttr.AttributeType).toEqual('S');
+    expect(rangeKeyAttr.AttributeType).toEqual('N');
+
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    expect(getTestField.arguments).toHaveLength(2);
+    expectArguments(getTestField, ['email', 'kind'])
+})
+
+test('Test that a primary @key with 3 fields changes the hash and sort keys.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "kind", "date"]) {
+        email: String!
+        kind: Int!
+        date: AWSDateTime!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');
+    const hashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
+    const rangeKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'RANGE');
+    const rangeKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'kind#date');
+    expect(tableResource.Properties.AttributeDefinitions).toHaveLength(2);
+    expect(hashKey.AttributeName).toEqual('email');
+    expect(rangeKey.AttributeName).toEqual('kind#date');
+    expect(hashKeyAttr.AttributeType).toEqual('S');
+    // composite keys will always be strings.
+    expect(rangeKeyAttr.AttributeType).toEqual('S');
+
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getTestField = queryType.fields.find(f => f.name && f.name.value === 'getTest') as FieldDefinitionNode;
+    expect(getTestField.arguments).toHaveLength(3);
+    expectArguments(getTestField, ['email', 'kind', 'date']);
+
+    const listTestField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+    expect(listTestField.arguments).toHaveLength(6);
+    expectArguments(listTestField, ['email', 'kind', 'date', 'filter', 'nextToken', 'limit']);
+})
+
+test('Test that a secondary @key with a single field adds a GSI.', () => {
+    const validSchema = `
+    type Test @model @key(name: "GSI_Email", fields: ["email"], queryField: "testsByEmail") {
+        id: ID!
+        email: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName,
+    ).toEqual('email');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
+    ).toEqual('S');
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const getField = queryType.fields.find(f => f.name.value === 'getTest');
+    expect(getField.arguments).toHaveLength(1);
+    expectArguments(getField, ['id'])
+    const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+    expect(listTestsField.arguments).toHaveLength(3);
+    expectArguments(listTestsField, ['filter', 'nextToken', 'limit']);
+    const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmail') as FieldDefinitionNode;
+    expect(queryIndexField.arguments).toHaveLength(4);
+    expectArguments(queryIndexField, ['email', 'filter', 'nextToken', 'limit']);
+})
+
+test('Test that a secondary @key with a multiple field adds an GSI.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "CategoryGSI", fields: ["category", "createdAt"], queryField: "testsByCategory") {
+        email: String!
+        createdAt: String!
+        category: String!
+        description: String
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName,
+    ).toEqual('category');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].AttributeName,
+    ).toEqual('createdAt');
+    expect(
+        tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].KeyType,
+    ).toEqual('RANGE');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'category').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType,
+    ).toEqual('S');
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByCategory') as FieldDefinitionNode;
+    expect(queryIndexField.arguments).toHaveLength(5);
+    expectArguments(queryIndexField, ['category', 'createdAt', 'filter', 'nextToken', 'limit']);
+
+    // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
+    const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+    expect(listTestsField.arguments).toHaveLength(5);
+    expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit']);
+
+    // Check the create, update, delete inputs.
+    const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTestInput') as ObjectTypeDefinitionNode;
+    expectNonNullFields(createInput, ['email', 'createdAt', 'category']);
+    expectNullableFields(createInput, ['description']);
+    expect(createInput.fields).toHaveLength(4);
+    const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
+    expectNonNullFields(updateInput, ['email', 'createdAt']);
+    expectNullableFields(updateInput, ['category', 'description']);
+    expect(updateInput.fields).toHaveLength(4);
+    const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
+    expectNonNullFields(deleteInput, ['email', 'createdAt']);
+    expect(deleteInput.fields).toHaveLength(2);
+})
+
+
+test('Test that a secondary @key with a multiple field adds an LSI.', () => {
+    const validSchema = `
+    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "GSI_Email_UpdatedAt", fields: ["email", "updatedAt"], queryField: "testsByEmailByUpdatedAt") {
+        email: String!
+        createdAt: String!
+        updatedAt: String!
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new KeyTransformer()
+        ]
+    });
+
+    const out = transformer.transform(validSchema);
+    let tableResource = out.stacks.Test.Resources.TestTable;
+    expect(tableResource).toBeDefined()
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[0].AttributeName,
+    ).toEqual('email');
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[0].KeyType,
+    ).toEqual('HASH');
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[1].AttributeName,
+    ).toEqual('updatedAt');
+    expect(
+        tableResource.Properties.LocalSecondaryIndexes[0].KeySchema[1].KeyType,
+    ).toEqual('RANGE');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'updatedAt').AttributeType,
+    ).toEqual('S');
+    expect(
+        tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType,
+    ).toEqual('S');
+    const schema = parse(out.schema);
+    const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+    const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmailByUpdatedAt') as FieldDefinitionNode;
+    expect(queryIndexField.arguments).toHaveLength(5);
+    expectArguments(queryIndexField, ['email', 'updatedAt', 'filter', 'nextToken', 'limit']);
+
+    // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
+    const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+    expect(listTestsField.arguments).toHaveLength(5);
+    expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit']);
+})

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
@@ -1,0 +1,356 @@
+import Amplify, { Auth } from 'aws-amplify';
+import { ResourceConstants } from 'graphql-transformer-common'
+import GraphQLTransform from 'graphql-transformer-core'
+import DynamoDBModelTransformer from 'graphql-dynamodb-transformer'
+import ModelAuthTransformer from 'graphql-auth-transformer'
+import KeyTransformer from 'graphql-key-transformer'
+import * as fs from 'fs'
+import { CloudFormationClient } from '../CloudFormationClient'
+import { Output } from 'aws-sdk/clients/cloudformation'
+import * as CognitoClient from 'aws-sdk/clients/cognitoidentityserviceprovider'
+import * as S3 from 'aws-sdk/clients/s3'
+import { GraphQLClient } from '../GraphQLClient'
+import { S3Client } from '../S3Client';
+import * as path from 'path'
+import { deploy } from '../deployNestedStacks'
+import * as moment from 'moment';
+import emptyBucket from '../emptyBucket';
+import {
+    createUserPool, createUserPoolClient, deleteUserPool,
+    signupAndAuthenticateUser, createGroup, addUserToGroup,
+    configureAmplify
+ } from '../cognitoUtils';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require("node-fetch");
+
+jest.setTimeout(2000000);
+
+const cf = new CloudFormationClient('us-west-2')
+
+const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss')
+const STACK_NAME = `KeyWithAuth-${BUILD_TIMESTAMP}`
+const BUCKET_NAME = `appsync-key-with-auth-test-bucket-${BUILD_TIMESTAMP}`
+const LOCAL_FS_BUILD_DIR = '/tmp/key_auth_transform_tests/'
+const S3_ROOT_DIR_KEY = 'deployments'
+
+let GRAPHQL_ENDPOINT = undefined;
+
+/**
+ * Client 1 is logged in and is a member of the Admin group.
+ */
+let GRAPHQL_CLIENT_1 = undefined;
+
+/**
+ * Client 1 is logged in and is a member of the Admin group via an access token.
+ */
+let GRAPHQL_CLIENT_1_ACCESS = undefined;
+
+/**
+ * Client 2 is logged in and is a member of the Devs group.
+ */
+let GRAPHQL_CLIENT_2 = undefined;
+
+/**
+ * Client 3 is logged in and has no group memberships.
+ */
+let GRAPHQL_CLIENT_3 = undefined;
+
+let USER_POOL_ID = undefined;
+
+const USERNAME1 = 'user1@test.com'
+const USERNAME2 = 'user2@test.com'
+const USERNAME3 = 'user3@test.com'
+const TMP_PASSWORD = 'Password123!'
+const REAL_PASSWORD = 'Password1234!'
+
+const ADMIN_GROUP_NAME = 'Admin';
+const DEVS_GROUP_NAME = 'Devs';
+const PARTICIPANT_GROUP_NAME = 'Participant';
+const WATCHER_GROUP_NAME = 'Watcher';
+
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' })
+const customS3Client = new S3Client('us-west-2')
+const awsS3Client = new S3({ region: 'us-west-2' })
+
+function outputValueSelector(key: string) {
+    return (outputs: Output[]) => {
+        const output = outputs.find((o: Output) => o.OutputKey === key)
+        return output ? output.OutputValue : null
+    }
+}
+
+function deleteDirectory(directory: string) {
+    const files = fs.readdirSync(directory)
+    for (const file of files) {
+        const contentPath = path.join(directory, file)
+        if (fs.lstatSync(contentPath).isDirectory()) {
+            deleteDirectory(contentPath)
+            fs.rmdirSync(contentPath)
+        } else {
+            fs.unlinkSync(contentPath)
+        }
+    }
+}
+
+beforeAll(async () => {
+    // Create a stack for the post model with auth enabled.
+    const validSchema = `
+    type Order
+        @model
+        @key(fields: ["customerEmail", "orderId"])
+        @key(name: "GSI", fields: ["orderId"], queryField: "ordersByOrderId")
+        @auth(rules: [{ allow: owner, ownerField: "customerEmail" }, { allow: groups, groups: ["Admin"] }])
+    {
+        customerEmail: String!
+        createdAt: String
+        orderId: String!
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer(),
+            new KeyTransformer(),
+            new ModelAuthTransformer({ authMode: 'AMAZON_COGNITO_USER_POOLS' })
+        ]
+    })
+    try {
+        await awsS3Client.createBucket({Bucket: BUCKET_NAME}).promise()
+    } catch (e) {
+        console.error(`Failed to create bucket: ${e}`)
+    }
+    const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+    USER_POOL_ID = userPoolResponse.UserPool.Id;
+    const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+    const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+    try {
+        // Clean the bucket
+        const out = transformer.transform(validSchema)
+        const finishedStack = await deploy(
+            customS3Client, cf, STACK_NAME, out, { AuthCognitoUserPoolId: USER_POOL_ID }, LOCAL_FS_BUILD_DIR, BUCKET_NAME, S3_ROOT_DIR_KEY,
+            BUILD_TIMESTAMP
+        )
+        expect(finishedStack).toBeDefined()
+        const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput)
+        const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput)
+        GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs)
+        console.log(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
+
+        const apiKey = getApiKey(finishedStack.Outputs)
+        console.log(`API KEY: ${apiKey}`);
+        expect(apiKey).not.toBeTruthy()
+
+        // Verify we have all the details
+        expect(GRAPHQL_ENDPOINT).toBeTruthy()
+        expect(USER_POOL_ID).toBeTruthy()
+        expect(userPoolClientId).toBeTruthy()
+
+        // Configure Amplify, create users, and sign in.
+        configureAmplify(USER_POOL_ID, userPoolClientId)
+
+        const authRes: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD)
+        const authRes2: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD)
+        const authRes3: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD, REAL_PASSWORD)
+
+        await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME)
+        await createGroup(USER_POOL_ID, PARTICIPANT_GROUP_NAME)
+        await createGroup(USER_POOL_ID, WATCHER_GROUP_NAME)
+        await createGroup(USER_POOL_ID, DEVS_GROUP_NAME)
+        await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID)
+        await addUserToGroup(PARTICIPANT_GROUP_NAME, USERNAME1, USER_POOL_ID)
+        await addUserToGroup(WATCHER_GROUP_NAME, USERNAME1, USER_POOL_ID)
+        await addUserToGroup(DEVS_GROUP_NAME, USERNAME2, USER_POOL_ID)
+        const authResAfterGroup: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD)
+
+        const idToken = authResAfterGroup.getIdToken().getJwtToken()
+        GRAPHQL_CLIENT_1 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken })
+
+        const accessToken = authResAfterGroup.getAccessToken().getJwtToken()
+        GRAPHQL_CLIENT_1_ACCESS = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: accessToken })
+
+        const authRes2AfterGroup: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD)
+        const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken()
+        GRAPHQL_CLIENT_2 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken2 })
+
+        const idToken3 = authRes3.getIdToken().getJwtToken()
+        GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 })
+
+        // Wait for any propagation to avoid random
+        // "The security token included in the request is invalid" errors
+        await new Promise((res) => setTimeout(() => res(), 5000))
+    } catch (e) {
+        console.error(e)
+        expect(true).toEqual(false)
+    }
+});
+
+
+afterAll(async () => {
+    try {
+        console.log('Deleting stack ' + STACK_NAME)
+        await cf.deleteStack(STACK_NAME)
+        await deleteUserPool(cognitoClient, USER_POOL_ID)
+        await cf.waitForStack(STACK_NAME)
+        console.log('Successfully deleted stack ' + STACK_NAME)
+    } catch (e) {
+        if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
+            // The stack was deleted. This is good.
+            expect(true).toEqual(true)
+            console.log('Successfully deleted stack ' + STACK_NAME)
+        } else {
+            console.error(e)
+            expect(true).toEqual(false)
+        }
+    }
+    try {
+        await emptyBucket(BUCKET_NAME);
+    } catch (e) {
+        console.error(`Failed to empty S3 bucket: ${e}`)
+    }
+})
+
+/**
+ * Test queries below
+ */
+test('Test createOrder mutation as admin', async () => {
+    const response = await createOrder(GRAPHQL_CLIENT_1, USERNAME2, "order1");
+    expect(response.data.createOrder.customerEmail).toBeDefined()
+    expect(response.data.createOrder.orderId).toEqual('order1')
+    expect(response.data.createOrder.createdAt).toBeDefined()
+})
+
+test('Test createOrder mutation as owner', async () => {
+    const response = await createOrder(GRAPHQL_CLIENT_2, USERNAME2, "order2");
+    expect(response.data.createOrder.customerEmail).toBeDefined()
+    expect(response.data.createOrder.orderId).toEqual('order2')
+    expect(response.data.createOrder.createdAt).toBeDefined()
+})
+
+test('Test createOrder mutation as owner', async () => {
+    const response = await createOrder(GRAPHQL_CLIENT_3, USERNAME2, "order3");
+    expect(response.data.createOrder).toBeNull();
+    expect(response.errors).toHaveLength(1);
+})
+
+test('Test list orders as owner', async () => {
+    await createOrder(GRAPHQL_CLIENT_3, USERNAME3, "owned1")
+    await createOrder(GRAPHQL_CLIENT_3, USERNAME3, "owned2")
+    const listResponse = await listOrders(GRAPHQL_CLIENT_3, USERNAME3, { beginsWith: "owned" })
+    expect(listResponse.data.listOrders.items).toHaveLength(2);
+})
+
+test('Test list orders as non owner', async () => {
+    await createOrder(GRAPHQL_CLIENT_3, USERNAME3, "unowned1")
+    await createOrder(GRAPHQL_CLIENT_3, USERNAME3, "unowned2")
+    const listResponse = await listOrders(GRAPHQL_CLIENT_2, USERNAME3, { beginsWith: "unowned" })
+    expect(listResponse.data.listOrders.items).toHaveLength(0);
+})
+
+test('Test get orders as owner', async () => {
+    await createOrder(GRAPHQL_CLIENT_2, USERNAME2, "myobj")
+    const getResponse = await getOrder(GRAPHQL_CLIENT_2, USERNAME2, "myobj")
+    expect(getResponse.data.getOrder.orderId).toEqual("myobj");
+})
+
+test('Test get orders as non-owner', async () => {
+    await createOrder(GRAPHQL_CLIENT_2, USERNAME2, "notmyobj")
+    const getResponse = await getOrder(GRAPHQL_CLIENT_3, USERNAME2, "notmyobj")
+    expect(getResponse.data.getOrder).toBeNull();
+    expect(getResponse.errors).toHaveLength(1);
+})
+
+test('Test query orders as owner', async () => {
+    await createOrder(GRAPHQL_CLIENT_3, USERNAME3, "ownedby3a")
+    const listResponse = await ordersByOrderId(GRAPHQL_CLIENT_3, "ownedby3a")
+    expect(listResponse.data.ordersByOrderId.items).toHaveLength(1);
+})
+
+test('Test query orders as non owner', async () => {
+    await createOrder(GRAPHQL_CLIENT_3, USERNAME3, "notownedby2a")
+    const listResponse = await ordersByOrderId(GRAPHQL_CLIENT_2, "notownedby2a")
+    expect(listResponse.data.ordersByOrderId.items).toHaveLength(0);
+})
+
+async function createOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
+    const result = await client.query(`mutation CreateOrder($input: CreateOrderInput!) {
+        createOrder(input: $input) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, {
+        input: { customerEmail, orderId }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function updateOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
+    const result = await client.query(`mutation UpdateOrder($input: UpdateOrderInput!) {
+        updateOrder(input: $input) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, {
+        input: { customerEmail, orderId }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function deleteOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
+    const result = await client.query(`mutation DeleteOrder($input: DeleteOrderInput!) {
+        deleteOrder(input: $input) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, {
+        input: { customerEmail, orderId }
+    });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function getOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
+    const result = await client.query(`query GetOrder($customerEmail: String!, $orderId: String!) {
+        getOrder(customerEmail: $customerEmail, orderId: $orderId) {
+            customerEmail
+            orderId
+            createdAt
+        }
+    }`, { customerEmail, orderId });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function listOrders(client: GraphQLClient, customerEmail: string, orderId: { beginsWith: string }) {
+    const result = await client.query(`query ListOrder($customerEmail: String, $orderId: ModelStringKeyConditionInput) {
+        listOrders(customerEmail: $customerEmail, orderId: $orderId) {
+            items {
+                customerEmail
+                orderId
+                createdAt
+            }
+            nextToken
+        }
+    }`, { customerEmail, orderId });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function ordersByOrderId(client: GraphQLClient, orderId: string) {
+    const result = await client.query(`query OrdersByOrderId($orderId: String!) {
+        ordersByOrderId(orderId: $orderId) {
+            items {
+                customerEmail
+                orderId
+                createdAt
+            }
+            nextToken
+        }
+    }`, { orderId });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}

--- a/packages/graphql-transformers-e2e-tests/src/testUtil.ts
+++ b/packages/graphql-transformers-e2e-tests/src/testUtil.ts
@@ -1,0 +1,39 @@
+import { 
+    ObjectTypeDefinitionNode, FieldDefinitionNode, DocumentNode,
+    InputObjectTypeDefinitionNode, Kind, InputValueDefinitionNode,
+    DefinitionNode
+} from 'graphql';
+
+export function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        expect(foundField).toBeDefined()
+    }
+}
+
+export function expectArguments(field: FieldDefinitionNode, args: string[]) {
+    for (const argName of args) {
+        const foundArg = field.arguments.find((a: InputValueDefinitionNode) => a.name.value === argName)
+        expect(foundArg).toBeDefined()
+    }
+}
+
+export function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        expect(
+            type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        ).toBeUndefined()
+    }
+}
+
+export function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+    return doc.definitions.find(
+        (def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type
+    ) as ObjectTypeDefinitionNode | undefined
+}
+
+export function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+    return doc.definitions.find(
+        (def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type
+    ) as InputObjectTypeDefinitionNode | undefined
+}

--- a/packages/graphql-transformers-e2e-tests/src/testUtil.ts
+++ b/packages/graphql-transformers-e2e-tests/src/testUtil.ts
@@ -3,11 +3,28 @@ import {
     InputObjectTypeDefinitionNode, Kind, InputValueDefinitionNode,
     DefinitionNode
 } from 'graphql';
+import { isNonNullType } from 'graphql-transformer-common';
 
 export function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
     for (const fieldName of fields) {
         const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
         expect(foundField).toBeDefined()
+    }
+}
+
+export function expectNonNullFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        expect(foundField).toBeDefined()
+        expect(isNonNullType(foundField.type)).toBeTruthy();
+    }
+}
+
+export function expectNullableFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+    for (const fieldName of fields) {
+        const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
+        expect(foundField).toBeDefined()
+        expect(isNonNullType(foundField.type)).toBeFalsy();
     }
 }
 

--- a/testing-custom-indexes.md
+++ b/testing-custom-indexes.md
@@ -1,0 +1,147 @@
+# Testing Custom Indexes
+
+The `@key` directive makes it simple to configure complex key structures in DynamoDB.
+The first thing to do when starting to build an application on top of DynamoDB is to think about access patterns.
+
+DynamoDB is a distributed hash table that can execute efficient range queries on extremely large data sets but to do so comes with a few restrictions. DynamoDB query operations use at most two attributes to efficiently query data. Even more restrictive is that the first argument (the partition key) must use strict equality and the second attribute may use gt, ge, lt, le, eq, beginsWith, and between (there is no 'ne'). DynamoDB provides features and design best-practices to help get around these restrictions. A few features/patterns are:
+
+1. Secondary Indexes - Create new data structures to store information in a different way to enable new access patterns. Incurs extra cost.
+1. Composite Keys - Store two logical fields in a single field such that more than two logical fields can be used in a range query.
+2. Index overloading - Store more than 1 logical entity in a single index. Different logical entities may contains entirely different types of data. Allows a single index to power more than 1 access pattern.
+
+The `@key` directive, in addition to allowing you to define custom primary index structures, helps with parts 1 and 2 above. The `@key` directive does not automatically overload indexes although this may be a possibility going forward. 
+
+For example, let's say we are building some kind of e-commerce application and need to facilitate these access patterns.
+
+1. Get orders by customer by date.
+2. Get customers by email.
+3. Get items by order by status by date.
+4. Get items by status by date.
+
+We can use the `@key` directive to quickly create an API & data model for this application.
+
+1. Clone this repository and checkout the `feature/@key` branch.
+
+```bash
+git clone https://github.com/mikeparisstuff/amplify-cli.git
+cd amplify-cli
+git checkout feature/@key
+```
+
+2. Run `amplify setup-dev` from the repo's root directory.
+
+3. Create a new directory somewhere else and init the amplify project.
+
+```bash
+mkdir testing-key
+cd testing-key
+amplify init
+# ...
+amplify add api
+# ...
+# Say you don't have a schema, use the guided schema creation, 
+# and open the simplest model in your editor. Replace the schema with the one below.
+```
+
+```graphql
+# A @key without a 'name' specifies the primary key. You may only provide 1 per @model type.
+# The @key creates a primary key where the HASHKEY = "customerEmail" and the SORTKEY = "createdAt".
+type Order @model @key(fields: ["customerEmail", "createdAt"]) {
+    customerEmail: String!
+    createdAt: String!
+    orderId: ID!
+}
+# A @key with one field creates a primary key with a HASHKEY = "email"
+type Customer @model @key(fields: ["email"]) {
+    email: String!
+    username: String
+}
+# The primary @key with 3 fields does something a little special.
+# The first field "orderId" will be the HASH KEY as expected BUT the SORT KEY will be
+# a new composite key named 'status#createdAt' that is made of the "status" and "createdAt" fields.
+# The AppSync resolvers will automatically stitch together the new composite key so the client does not need to worry about that detail.
+# The @key with name = "ByStatus" specifies a secondary index where the HASH KEY = "status" (an enum) and the SORT KEY = "createdAt".
+# The second @key directive also specifies that a top level query field named "itemsByStatus" should be created to query this index in AppSync.
+type Item @model
+    @key(fields: ["orderId", "status", "createdAt"])
+    @key(name: "ByStatus", fields: ["status", "createdAt"], queryField: "itemsByStatus")
+{
+    orderId: ID!
+    status: Status!
+    createdAt: AWSDateTime!
+    name: String!
+}
+enum Status {
+    DELIVERED IN_TRANSIT PENDING UNKNOWN
+}
+```
+
+4. You can test the schema above with these queries/mutations:
+
+```graphql
+mutation CreateItem($input: CreateItemInput!) {
+    createItem(input: $input) {
+        orderId
+        status
+        createdAt
+        name
+    }
+}
+
+mutation UpdateItem($input: UpdateItemInput!) {
+    updateItem(input: $input) {
+        orderId
+        status
+        createdAt
+        name
+    }
+}
+
+mutation DeleteItem($input: DeleteItemInput!) {
+    deleteItem(input: $input) {
+        orderId
+        status
+        createdAt
+        name
+    }
+}
+
+# GetItem takes 3 arguments because the primary @key specifies 3 fields.
+query GetItem($orderId: ID!, status: Status!, $createdAt: String!) {
+    getItem(orderId: $orderId, status: $status, createdAt: $createdAt) {
+        orderId
+        status
+        createdAt
+        name
+    }
+}
+
+# ListItem takes additional arguments because the primary @key specifies 3 fields.
+# Note: There is one thing that is likely going to change around the structure of `$createdAt: ModelStringKeyConditionInput`.
+query ListItems($orderId: ID, $status: Status, $createdAt: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
+    listItems(orderId: $orderId, status: $status, createdAt: $createdAt, limit: $limit, nextToken: $nextToken) {
+        items {
+            orderId
+            status
+            createdAt
+            name
+        }
+        nextToken
+    }
+}
+
+# We may use our new top level query field to query secondary @keys.
+query ListByStatus($status: Status!, $createdAt: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
+    itemsByStatus(status: $status, createdAt: $createdAt, limit: $limit, nextToken: $nextToken) {
+        items {
+            orderId
+            status
+            createdAt
+            name
+        }
+        nextToken
+    }
+}
+```
+
+5. Provide feedback in the issues tab.

--- a/testing-custom-indexes.md
+++ b/testing-custom-indexes.md
@@ -9,14 +9,30 @@ DynamoDB is a distributed hash table that can execute efficient range queries on
 1. Composite Keys - Store two logical fields in a single field such that more than two logical fields can be used in a range query.
 2. Index overloading - Store more than 1 logical entity in a single index. Different logical entities may contains entirely different types of data. Allows a single index to power more than 1 access patterns for one or more logical entities.
 
-The `@key` directive, in addition to allowing you to define custom primary index structures, helps with parts 1 and 2 above. The `@key` directive does not automatically overload indexes although this may be a possibility going forward. 
+The `@key` directive, in addition to allowing you to define custom primary index structures, helps with parts 1 and 2 above. The `@key` directive does not automatically overload indexes although this may be a possibility going forward. This is the definition of `@key`:
+
+```graphql
+# @param name - When provided specifies the name of the secondary index. There may be one @key without a 'name' per @model type.
+# @param fields (required) - Specifies the logical fields that should be included in the index's key structure.
+# @param queryField - When provided specifies the name of the top level query field that should be created to query the secondary index.
+#                     Primary @keys are not allowed to have a queryField because the listX query is already being updated to work with the primary key.
+directive @key(name: String, fields: [String!]!, queryField: String) on OBJECT
+```
 
 For example, let's say we are building some kind of e-commerce application and need to facilitate these access patterns.
 
-1. Get orders by customer by date.
+1. Get orders by customer by createdAt.
 2. Get customers by email.
-3. Get items by order by status by date.
-4. Get items by status by date.
+3. Get items by order by status by createdAt.
+4. Get items by status by createdAt.
+
+When thinking about your access patterns, it is useful to lay them out using the same "by X by Y" structure I have here. 
+Once you have them laid out like this you can translate them directily into a `@key` by including the "X" and "Y" values as `fields`.
+For example to **Get orders by customer by date**, I would create a `@key`:
+
+```graphql
+@key(fields: ["customerEmail", "createdAt"])
+```
 
 We can use the `@key` directive to quickly create an API & data model for this application.
 

--- a/testing-custom-indexes.md
+++ b/testing-custom-indexes.md
@@ -7,7 +7,7 @@ DynamoDB is a distributed hash table that can execute efficient range queries on
 
 1. Secondary Indexes - Create new data structures to store information in a different way to enable new access patterns. Incurs extra cost.
 1. Composite Keys - Store two logical fields in a single field such that more than two logical fields can be used in a range query.
-2. Index overloading - Store more than 1 logical entity in a single index. Different logical entities may contains entirely different types of data. Allows a single index to power more than 1 access pattern.
+2. Index overloading - Store more than 1 logical entity in a single index. Different logical entities may contains entirely different types of data. Allows a single index to power more than 1 access patterns for one or more logical entities.
 
 The `@key` directive, in addition to allowing you to define custom primary index structures, helps with parts 1 and 2 above. The `@key` directive does not automatically overload indexes although this may be a possibility going forward. 
 

--- a/testing-custom-indexes.md
+++ b/testing-custom-indexes.md
@@ -44,7 +44,7 @@ cd amplify-cli
 git checkout feature/@key
 ```
 
-2. Run `amplify setup-dev` from the repo's root directory.
+2. Run `npm run setup-dev` from the repo's root directory.
 
 3. Create a new directory somewhere else and init the amplify project.
 


### PR DESCRIPTION
*Issue #, if available:*

#1062

*Description of changes:*

Still a work in progress. This is the initial work for custom indexes. I have a few more things to finish so please do not merge this yet. These features require substantial changes so I want to start the PR process earlier rather than later.

Complete:
- Implement @key and handle updating DynamoDB table primary and secondary index structures.
- Advanced @key validation.
- Update auto-generated get, create, update, and delete operations for custom primary keys.
- Update GraphQL schema to work with custom primary keys.
- Auto-generate composite keys when indexing on 3 or more attributes for get, create, update, delete.
- Tests for schema structural changes
- Tests for get, create, update, delete operation with composite and simple keys.
- Update list operation to work with custom primary keys.
- Tests for list operations
- Implement query resolver when instructed for secondary indexes.
- Tests for query operations
- Rework composite key condition input shape to be more logically consistent.
- Write docs.
- Handle unique partial composite key update in update operations using one of two strategies. 1. Pre-fetch key and allow partial updates. 2. Force update mutation to include all parts of composite key if any are included.

Work remaining:
- ?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.