### PR TITLE
fix(amplify-codegen): auto detect S3Object in swift codegen

### DIFF
--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -48,6 +48,7 @@ async function generateTypes(context, forceDownloadSchema) {
       codeGenSpinner.start();
       generate(queries, schemaPath, path.join(projectPath, generatedFileName), '', target, '', {
         addTypename: true,
+        complexObjectSupport: 'auto',
       });
       codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${path.relative(path.resolve('.'), outputPath)}`);
     });

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -83,7 +83,7 @@ describe('command - types', () => {
       '',
       MOCK_TARGET,
       '',
-      { addTypename: true },
+      { addTypename: true, complexObjectSupport: 'auto' },
     );
   });
 


### PR DESCRIPTION
Codegen has capabilites to detect if an S3 object is used in AppSync looking at the schema and
document. This feature was added to types generator but was not switched on in codege. Updated the
code to turn the autodetection on

fix #1468

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.