### PR TITLE
fix(amplify-graphql-types-generator): set AWSTimestamp to number type

### DIFF
--- a/packages/amplify-graphql-types-generator/src/flow/types.js
+++ b/packages/amplify-graphql-types-generator/src/flow/types.js
@@ -27,6 +27,10 @@ const builtInScalarMap = {
   [GraphQLID.name]: 'string',
 }
 
+const appSyncScalars = {
+  AWSTimestamp: 'number',
+};
+
 export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = true) {
   if (type instanceof GraphQLNonNull) {
     return typeNameFromGraphQLType(context, type.ofType, bareTypeName, false)
@@ -36,7 +40,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
   if (type instanceof GraphQLList) {
     typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName)} >`;
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name : 'any');
+    typeName = builtInScalarMap[type.name] || appSyncScalars[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name : 'any');
   } else {
     typeName = bareTypeName || type.name;
   }

--- a/packages/amplify-graphql-types-generator/src/typescript/types.ts
+++ b/packages/amplify-graphql-types-generator/src/typescript/types.ts
@@ -20,6 +20,11 @@ const builtInScalarMap = {
   [GraphQLID.name]: 'string',
 }
 
+const appSyncScalars: any = {
+  AWSTimestamp: 'number',
+}
+
+
 export function typeNameFromGraphQLType(context: LegacyCompilerContext, type: GraphQLType, bareTypeName?: string | null, nullable = true): string {
   if (isNonNullType(type)) {
     return typeNameFromGraphQLType(context, type.ofType, bareTypeName, false)
@@ -29,7 +34,12 @@ export function typeNameFromGraphQLType(context: LegacyCompilerContext, type: Gr
   if (isListType(type)) {
     typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName, true)} >`;
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.options.passthroughCustomScalars ? context.options.customScalarsPrefix + type.name : builtInScalarMap[GraphQLString.name]);
+    typeName =
+      builtInScalarMap[type.name] ||
+      appSyncScalars[type.name] ||
+      (context.options.passthroughCustomScalars
+        ? context.options.customScalarsPrefix + type.name
+        : builtInScalarMap[GraphQLString.name]);
   } else {
     typeName = bareTypeName || type.name;
   }


### PR DESCRIPTION
AWSTimestamp is serialized to number type. Updating codegen to use number type instead of string

fix #1348

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.