### PR TITLE
Fixing bug related to DynamoDB Stream Arn Outputs introduced in commi…

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -165,12 +165,7 @@ export class ResourceFactory {
         return new Lambda.EventSourceMapping({
             BatchSize: 1,
             Enabled: true,
-            EventSourceArn: Fn.ImportValue(
-                Fn.Join(
-                    ':',
-                    [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), "GetAtt", ModelResourceIDs.ModelTableResourceID(typeName), "StreamArn"]
-                )
-            ),
+            EventSourceArn: Fn.GetAtt(ModelResourceIDs.ModelTableResourceID(typeName), 'StreamArn'),
             FunctionName: Fn.GetAtt(ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaFunctionLogicalID, 'Arn'),
             StartingPosition: 'LATEST'
         }).dependsOn([


### PR DESCRIPTION
Fixing a bug introduced by this commit: https://github.com/aws-amplify/amplify-cli/commit/df1712b00427792bcce34adf7027698afd8e6841#diff-22e2a5351fb3f897025bc1e45811acb5R168

*Issue #, if available:*

N/A

*Description of changes:*

The mentioned commit removed a mechanic that allowed the amplify project to compute dependencies between nested stacks. This change brings back that ability.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.