### PR TITLE
[WIP] Add support for new multi-auth AppSync directives

### DIFF
--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -206,7 +206,8 @@ export default class GraphQLTransform {
         const context = new TransformerContext(schema)
         const validDirectiveNameMap = this.transformers.reduce(
             (acc: any, t: Transformer) => ({ ...acc, [t.directive.name.value]: true }),
-            { aws_subscribe: true, aws_auth: true, deprecated: true }
+            { aws_subscribe: true, aws_auth: true, aws_api_key: true, aws_iam: true, 
+                aws_oidc: true, aws_cognito_user_pools: true, deprecated: true }
         )
         let allModelDefinitions = [...context.inputDocument.definitions]
         for (const transformer of this.transformers) {

--- a/packages/graphql-transformer-core/src/TransformFormatter.ts
+++ b/packages/graphql-transformer-core/src/TransformFormatter.ts
@@ -101,7 +101,7 @@ export class TransformFormatter {
         const astSansDirectives = stripDirectives({
             kind: 'Document',
             definitions: Object.keys(ctx.nodeMap).map((k: string) => ctx.getType(k))
-        }, ['aws_subscribe', 'aws_auth'])
+        }, ['aws_subscribe', 'aws_auth', 'aws_api_key', 'aws_iam', 'aws_oidc', 'aws_cognito_user_pools'])
         const SDL = print(astSansDirectives)
         return SDL;
     }

--- a/packages/graphql-transformer-core/src/validation.ts
+++ b/packages/graphql-transformer-core/src/validation.ts
@@ -89,6 +89,10 @@ scalar Double
 const EXTRA_DIRECTIVES_DOCUMENT = parse(`
 directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
 directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
+directive @aws_api_key on FIELD_DEFINITION | OBJECT
+directive @aws_iam on FIELD_DEFINITION | OBJECT
+directive @aws_oidc on FIELD_DEFINITION | OBJECT
+directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT
 
 # Allows transformer libraries to deprecate directive arguments.
 directive @deprecated(reason: String!) on INPUT_FIELD_DEFINITION | ENUM

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.e2e.test.ts
@@ -1,6 +1,6 @@
 import {
     ObjectTypeDefinitionNode, parse, FieldDefinitionNode, DocumentNode,
-    DefinitionNode, Kind, InputObjectTypeDefinitionNode
+    DefinitionNode, Kind, InputObjectTypeDefinitionNode, ListValueNode, ValueNode, StringValueNode
 } from 'graphql'
 import GraphQLTransform from 'graphql-transformer-core'
 import DynamoDBModelTransformer from 'graphql-dynamodb-transformer'
@@ -163,9 +163,10 @@ test('Test custom root query, mutation, and subscriptions.', () => {
     expect(authedField.directives[0].name.value).toEqual('aws_auth')
     expect(authedField.directives[0].arguments.length).toEqual(1)
     expect(authedField.directives[0].arguments[0].name.value).toEqual("cognito_groups")
-    expect(authedField.directives[0].arguments[0].value.values.length).toEqual(2)
-    expect(authedField.directives[0].arguments[0].value.values[0].value).toEqual("Bloggers")
-    expect(authedField.directives[0].arguments[0].value.values[1].value).toEqual("Readers")
+    const arg0 = <ListValueNode>authedField.directives[0].arguments[0].value
+    expect(arg0.values.length).toEqual(2)
+    expect((<StringValueNode>arg0.values[0]).value).toEqual("Bloggers")
+    expect((<StringValueNode>arg0.values[1]).value).toEqual("Readers")
     expect(authedField.directives[1].name.value).toEqual('aws_api_key')
     expect(authedField.directives[2].name.value).toEqual('aws_iam')
     expect(authedField.directives[3].name.value).toEqual('aws_oidc')
@@ -173,9 +174,10 @@ test('Test custom root query, mutation, and subscriptions.', () => {
     expect(authedField.directives[5].name.value).toEqual('aws_cognito_user_pools')
     expect(authedField.directives[5].arguments.length).toEqual(1)
     expect(authedField.directives[5].arguments[0].name.value).toEqual("cognito_groups")
-    expect(authedField.directives[5].arguments[0].value.values.length).toEqual(2)
-    expect(authedField.directives[5].arguments[0].value.values[0].value).toEqual("Bloggers")
-    expect(authedField.directives[5].arguments[0].value.values[1].value).toEqual("Readers")
+    const arg5 = <ListValueNode>authedField.directives[5].arguments[0].value
+    expect(arg5.values.length).toEqual(2)
+    expect((<StringValueNode>arg5.values[0]).value).toEqual("Bloggers")
+    expect((<StringValueNode>arg5.values[1]).value).toEqual("Readers")
     const mutationType = getObjectType(parsed, 'Mutation2');
     expectFields(mutationType, ['createPost', 'updatePost', 'deletePost', 'additionalMutationField'])
     const subscriptionType = getObjectType(parsed, 'Subscription2');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/CustomRoots.e2e.test.ts
@@ -128,6 +128,11 @@ test('Test custom root query, mutation, and subscriptions.', () => {
 
         authedField: String
             @aws_auth(cognito_groups: ["Bloggers", "Readers"])
+            @aws_api_key
+            @aws_iam
+            @aws_oidc
+            @aws_cognito_user_pools
+            @aws_cognito_user_pools(cognito_groups: ["Bloggers", "Readers"])
     }
     type Mutation2 {
         additionalMutationField: String
@@ -154,8 +159,23 @@ test('Test custom root query, mutation, and subscriptions.', () => {
     const queryType = getObjectType(parsed, 'Query2');
     expectFields(queryType, ['getPost', 'listPosts', 'additionalQueryField', 'authedField'])
     const authedField = queryType.fields.find(f => f.name.value === 'authedField')
-    expect(authedField.directives.length).toEqual(1)
+    expect(authedField.directives.length).toEqual(6)
     expect(authedField.directives[0].name.value).toEqual('aws_auth')
+    expect(authedField.directives[0].arguments.length).toEqual(1)
+    expect(authedField.directives[0].arguments[0].name.value).toEqual("cognito_groups")
+    expect(authedField.directives[0].arguments[0].value.values.length).toEqual(2)
+    expect(authedField.directives[0].arguments[0].value.values[0].value).toEqual("Bloggers")
+    expect(authedField.directives[0].arguments[0].value.values[1].value).toEqual("Readers")
+    expect(authedField.directives[1].name.value).toEqual('aws_api_key')
+    expect(authedField.directives[2].name.value).toEqual('aws_iam')
+    expect(authedField.directives[3].name.value).toEqual('aws_oidc')
+    expect(authedField.directives[4].name.value).toEqual('aws_cognito_user_pools')
+    expect(authedField.directives[5].name.value).toEqual('aws_cognito_user_pools')
+    expect(authedField.directives[5].arguments.length).toEqual(1)
+    expect(authedField.directives[5].arguments[0].name.value).toEqual("cognito_groups")
+    expect(authedField.directives[5].arguments[0].value.values.length).toEqual(2)
+    expect(authedField.directives[5].arguments[0].value.values[0].value).toEqual("Bloggers")
+    expect(authedField.directives[5].arguments[0].value.values[1].value).toEqual("Readers")
     const mutationType = getObjectType(parsed, 'Mutation2');
     expectFields(mutationType, ['createPost', 'updatePost', 'deletePost', 'additionalMutationField'])
     const subscriptionType = getObjectType(parsed, 'Subscription2');


### PR DESCRIPTION
*Issue #, if available:*
Enables part of #1485

*Description of changes:*
Enable the usage of new AppSync new authorization directives in the GraphQL schema.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.