### PR TITLE
fix(amplify-category-auth): match cognito token expiration date range

### DIFF
--- a/packages/amplify-category-auth/provider-utils/supported-services.json
+++ b/packages/amplify-category-auth/provider-utils/supported-services.json
@@ -563,8 +563,8 @@
 				],
 				"validation": {
 					"operator": "range",
-					"value": {"min": 1, "max": 365},
-					"onErrorMsg": "Token expiration should be between 1 to 365 days."
+					"value": {"min": 1, "max": 3650},
+					"onErrorMsg": "Token expiration should be between 1 to 3650 days."
 				}
 			},
 			{


### PR DESCRIPTION
Increased the range from 365 to 3650 to match the constraints defined by Cognito

fix #1385

*Issue #, if available:*
#1385

*Description of changes:*
Change Cognito Token Value from 365 to 3650.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.