### PR TITLE
fix(graphql-key-transformer)

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -262,7 +262,6 @@ export default class FunctionTransformer extends Transformer {
     // Update the create, update, and delete input objects to account for any changes to the primary key.
     private updateInputObjects = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         if (this.isPrimaryKey(directive)) {
-            console.log(`Updating input structures for key: ${JSON.stringify(getDirectiveArguments(directive))}`);
             const directiveArgs: KeyArguments = getDirectiveArguments(directive);            
             const createInput = ctx.getType(ModelResourceIDs.ModelCreateInputObjectName(definition.name.value)) as InputObjectTypeDefinitionNode;
             if (createInput) {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -93,26 +93,26 @@ beforeAll(async () => {
     GRAPHQL_CLIENT = new GraphQLClient(endpoint, { 'x-api-key': apiKey })
 });
 
-// afterAll(async () => {
-//     try {
-//         console.log('Deleting stack ' + STACK_NAME)
-//         await cf.deleteStack(STACK_NAME)
-//         // await cf.waitForStack(STACK_NAME)
-//         console.log('Successfully deleted stack ' + STACK_NAME)
-//     } catch (e) {
-//         if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-//             // The stack was deleted. This is good.
-//             expect(true).toEqual(true)
-//             console.log('Successfully deleted stack ' + STACK_NAME)
-//         } else {
-//             console.error(e)
-//             expect(true).toEqual(false)
-//         }
-//     }
-//     try {
-//         await emptyBucket(BUCKET_NAME);
-//     } catch (e) { console.warn(`Error during bucket cleanup: ${e}`)}
-// })
+afterAll(async () => {
+    try {
+        console.log('Deleting stack ' + STACK_NAME)
+        await cf.deleteStack(STACK_NAME)
+        // await cf.waitForStack(STACK_NAME)
+        console.log('Successfully deleted stack ' + STACK_NAME)
+    } catch (e) {
+        if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
+            // The stack was deleted. This is good.
+            expect(true).toEqual(true)
+            console.log('Successfully deleted stack ' + STACK_NAME)
+        } else {
+            console.error(e)
+            expect(true).toEqual(false)
+        }
+    }
+    try {
+        await emptyBucket(BUCKET_NAME);
+    } catch (e) { console.warn(`Error during bucket cleanup: ${e}`)}
+})
 
 /**
  * Test queries below


### PR DESCRIPTION
*Description of changes:*

- Adding back the afterAll hook in KeyTransformer.e2e.tests
- Removing unnecessary console log.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.