### PR TITLE
Fix filter args not converted as json for resolvers generated by key …

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -693,7 +693,7 @@ function makeQueryResolver(definition: ObjectTypeDefinitionNode, directive: Dire
                     ref('context.args.filter'),
                     set(
                         ref(`${requestVariable}.filter`),
-                        ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)')
+                        ref('util.parseJson("$util.transform.toDynamoDBFilterExpression($ctx.args.filter)")')
                     ),
                     true
                 ),


### PR DESCRIPTION
Fix filter args not converted as json for resolvers generated by key transformers

*Issue #, if available:*
Queries generated by new @key directive returns invalid *filter* args resolver errors. #1554 

*Description of changes:*
use `$util.parseJson` to parse filter expression.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.