### PR TITLE
Add new available regions for Aurora Serverless

### DIFF
--- a/packages/amplify-category-api/provider-utils/supported-datasources.json
+++ b/packages/amplify-category-api/provider-utils/supported-datasources.json
@@ -34,6 +34,6 @@
 		"serviceWalkthroughFilename": "appSync-rds-walkthrough.js",
 		"cfnFilename": "appSync-rds-cloudformation-template-default.yml.ejs",
 		"provider": "awscloudformation",
-		"availableRegions": ["us-east-1"]
+		"availableRegions": ["us-east-1", "us-east-2", "us-west-2", "ap-northeast-1", "eu-west-1"]
 	}
 }


### PR DESCRIPTION
I bumped into a missing availability region while playing with Aurora Serverless and AppSync.

I was trying the `amplify api add-graphql-datasource` command in the CLI.

According to [this blog](https://aws.amazon.com/blogs/aws/new-data-api-for-amazon-aurora-serverless/), the necessary Data API feature has only recently been added to more regions.

I only had a brief look through the codebase, but I think this is the only change necessary - hope it's a helpful first contribution :) Btw, thanks to the AppSync and Amplify team for the great work!



~
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.