### PR TITLE
fix(amplify-provider-awscloudformation): filter by template extensions

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -231,7 +231,8 @@ function packageResources(context, resources) {
 
         const files = fs.readdirSync(resourceDir);
         // Fetch all the Cloudformation templates for the resource (can be json or yml)
-        const cfnFiles = files.filter(file => file.indexOf('template') !== -1);
+        const cfnFiles = files.filter(file =>
+          (file.indexOf('template') !== -1) && /\.(json|yaml|yml)$/.test(file));
 
         if (cfnFiles.length !== 1) {
           context.print.error('Only one CloudFormation template is allowed in the resource directory');


### PR DESCRIPTION
*Issue #1586

Filter files in dir in respect to file extension


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.