### PR TITLE
fix(graphql-key-transformer): Fix type resolve for 2 field @key when second field is an Enum

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -1,22 +1,22 @@
-import { 
+import {
     Transformer, gql, TransformerContext, getDirectiveArguments, TransformerContractError, InvalidDirectiveError
 } from 'graphql-transformer-core';
-import { 
+import {
     obj, str, ref, printBlock, compoundExpression, newline, raw, qref, set, Expression, print,
     ifElse, iff, block, bool, forEach, list
 } from 'graphql-mapping-template';
-import { 
+import {
     ResolverResourceIDs, ResourceConstants, isNonNullType,
     attributeTypeFromScalar, ModelResourceIDs, makeInputValueDefinition,
-    wrapNonNull, withNamedNodeNamed, 
+    wrapNonNull, withNamedNodeNamed,
     makeNonNullType, makeNamedType, getBaseType,
     makeConnectionField,
     makeScalarKeyConditionForType, applyKeyExpressionForCompositeKey,
     makeCompositeKeyConditionInputForKey, makeCompositeKeyInputForKey, toCamelCase, graphqlName
 } from 'graphql-transformer-common';
-import { 
-    ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode, 
-    InputObjectTypeDefinitionNode, TypeNode, Kind, InputValueDefinitionNode
+import {
+    ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode,
+    InputObjectTypeDefinitionNode, TypeNode, Kind, InputValueDefinitionNode, EnumTypeDefinitionNode
 } from 'graphql';
 import { AppSync, IAM, Fn, DynamoDB, Refs } from 'cloudform-types'
 import { Projection, GlobalSecondaryIndex, LocalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
@@ -31,7 +31,7 @@ export default class FunctionTransformer extends Transformer {
 
     constructor() {
         super(
-            'KeyTransformer', 
+            'KeyTransformer',
             gql`directive @key(name: String, fields: [String!]!, queryField: String) on OBJECT`
         )
     }
@@ -65,11 +65,11 @@ export default class FunctionTransformer extends Transformer {
 
     /**
      * Update the structural components of the schema that are relevant to the new index structures.
-     * 
+     *
      * Updates:
      * 1. getX with new primary key information.
      * 2. listX with new primary key information.
-     * 
+     *
      * Creates:
      * 1. A query field for each secondary index.
      */
@@ -93,7 +93,7 @@ export default class FunctionTransformer extends Transformer {
             // and ensure any composite sort keys for the primary index.
             if (getResolver) {
                 getResolver.Properties.RequestMappingTemplate = joinSnippets([
-                    this.setKeySnippet(directive), 
+                    this.setKeySnippet(directive),
                     getResolver.Properties.RequestMappingTemplate
                 ]);
             }
@@ -112,7 +112,7 @@ export default class FunctionTransformer extends Transformer {
             }
             if (updateResolver) {
                 updateResolver.Properties.RequestMappingTemplate = joinSnippets([
-                    this.setKeySnippet(directive, true), 
+                    this.setKeySnippet(directive, true),
                     ensureCompositeKeySnippet(directive),
                     updateResolver.Properties.RequestMappingTemplate
                 ]);
@@ -152,7 +152,7 @@ export default class FunctionTransformer extends Transformer {
                 ctx.addToStackMapping(definition.name.value, `^${queryResolverId}$`);
                 ctx.setResource(queryResolverId, queryResolver);
             }
-        } 
+        }
     }
 
     private addKeyConditionInputs = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
@@ -172,7 +172,17 @@ export default class FunctionTransformer extends Transformer {
         } else if (args.fields.length === 2) {
             const finalSortKeyFieldName = args.fields[1];
             const finalSortKeyField = definition.fields.find(f => f.name.value === finalSortKeyFieldName);
-            const sortKeyConditionInput = makeScalarKeyConditionForType(finalSortKeyField.type);
+            const typeResolver = (baseType: string) => {
+                const resolvedEnumType = ctx.getType(baseType) as EnumTypeDefinitionNode;
+                return resolvedEnumType ? 'String' : undefined;
+            };
+            const sortKeyConditionInput = makeScalarKeyConditionForType(finalSortKeyField.type, typeResolver);
+
+            if (!sortKeyConditionInput) {
+                const checkedKeyName = args.name ? args.name : "<unnamed>";
+                throw new InvalidDirectiveError(`Cannot resolve type for field '${finalSortKeyFieldName}' in @key '${checkedKeyName}' on type '${definition.name.value}'.`);
+            }
+
             if (!ctx.getType(sortKeyConditionInput.name.value)) {
                 ctx.addInput(sortKeyConditionInput);
             }
@@ -225,7 +235,7 @@ export default class FunctionTransformer extends Transformer {
                 listArguments = addCompositeSortKey(definition, args, listArguments);
                 listArguments = addHashField(definition, args, listArguments);
             } else if (args.fields.length === 2) {
-                listArguments = addSimpleSortKey(definition, args, listArguments);
+                listArguments = addSimpleSortKey(ctx, definition, args, listArguments);
                 listArguments = addHashField(definition, args, listArguments);
             } else {
                 listArguments = addHashField(definition, args, listArguments);
@@ -240,13 +250,13 @@ export default class FunctionTransformer extends Transformer {
     private ensureQueryField = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         const args: KeyArguments = getDirectiveArguments(directive);
         if (args.queryField && !this.isPrimaryKey(directive)) {
-            let queryType = ctx.getQuery();            
+            let queryType = ctx.getQuery();
             let queryArguments = [];
             if (args.fields.length > 2) {
                 queryArguments = addCompositeSortKey(definition, args, queryArguments);
                 queryArguments = addHashField(definition, args, queryArguments);
             } else if (args.fields.length === 2) {
-                queryArguments = addSimpleSortKey(definition, args, queryArguments);
+                queryArguments = addSimpleSortKey(ctx, definition, args, queryArguments);
                 queryArguments = addHashField(definition, args, queryArguments);
             } else {
                 queryArguments = addHashField(definition, args, queryArguments);
@@ -263,7 +273,7 @@ export default class FunctionTransformer extends Transformer {
     // Update the create, update, and delete input objects to account for any changes to the primary key.
     private updateInputObjects = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
         if (this.isPrimaryKey(directive)) {
-            const directiveArgs: KeyArguments = getDirectiveArguments(directive);            
+            const directiveArgs: KeyArguments = getDirectiveArguments(directive);
             const createInput = ctx.getType(ModelResourceIDs.ModelCreateInputObjectName(definition.name.value)) as InputObjectTypeDefinitionNode;
             if (createInput) {
                 ctx.putType(replaceCreateInput(definition, createInput, directiveArgs.fields));
@@ -320,7 +330,7 @@ export default class FunctionTransformer extends Transformer {
 
     /**
      * Validates the directive usage is semantically valid.
-     * 
+     *
      * 1. There may only be 1 @key without a name (specifying the primary key)
      * 2. There may only be 1 @key with a given name.
      * 3. @key must only reference existing scalar fields that map to DynamoDB S, N, or B.
@@ -359,7 +369,8 @@ export default class FunctionTransformer extends Transformer {
         }
         for (const fieldName of directiveArgs.fields) {
             if (!fieldMap.has(fieldName)) {
-                throw new InvalidDirectiveError(`You cannot specify a non-existant field '${fieldName}' in @key '${directiveArgs.name}' on type '${definition.name.value}'.`);
+                const checkedKeyName = directiveArgs.name ? directiveArgs.name : "<unnamed>";
+                throw new InvalidDirectiveError(`You cannot specify a non-existant field '${fieldName}' in @key '${checkedKeyName}' on type '${definition.name.value}'.`);
             } else {
                 const existingField = fieldMap.get(fieldName);
                 const ddbKeyType = attributeTypeFromType(existingField.type, ctx);
@@ -718,10 +729,13 @@ function addHashField(definition: ObjectTypeDefinitionNode, args: KeyArguments, 
     const hashKey = makeInputValueDefinition(hashFieldName, makeNamedType(getBaseType(hashField.type)));
     return [hashKey, ...elems];
 }
-function addSimpleSortKey(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]): InputValueDefinitionNode[] {
+function addSimpleSortKey(ctx: TransformerContext, definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]): InputValueDefinitionNode[] {
     let sortKeyName = args.fields[1];
     const sortField = definition.fields.find(field => field.name.value === sortKeyName);
-    const hashKey = makeInputValueDefinition(sortKeyName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(getBaseType(sortField.type))));
+    const baseType = getBaseType(sortField.type);
+    const resolvedTypeIfEnum = ctx.getType(baseType) as EnumTypeDefinitionNode ? 'String' : undefined;
+    const resolvedType = resolvedTypeIfEnum ? resolvedTypeIfEnum : baseType;
+    const hashKey = makeInputValueDefinition(sortKeyName, makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(resolvedType)));
     return [hashKey, ...elems];
 }
 function addCompositeSortKey(definition: ObjectTypeDefinitionNode, args: KeyArguments, elems: InputValueDefinitionNode[]): InputValueDefinitionNode[] {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -247,8 +247,8 @@ test('Test query with three part secondary key, where sort key is an enum.', asy
     expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
     items = await itemsByCreatedAt(hashKey, { between: [sortKey, sortKey] });
     expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
-    items = await itemsByCreatedAt(hashKey, { gt: '2018-08-01' });
-    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { gt: sortKey });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(0)
     items = await itemsByCreatedAt(hashKey, { ge: sortKey });
     expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
     items = await itemsByCreatedAt(hashKey, { lt: sortKey });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -47,6 +47,7 @@ beforeAll(async () => {
     type Item @model
         @key(fields: ["orderId", "status", "createdAt"])
         @key(name: "ByStatus", fields: ["status", "createdAt"], queryField: "itemsByStatus")
+        @key(name: "ByCreatedAt", fields: ["createdAt", "status"], queryField: "itemsByCreatedAt")
     {
         orderId: ID!
         status: Status!
@@ -225,6 +226,36 @@ test('Test query with three part secondary key.', async () => {
     items = await itemsByStatus(hashKey, { le: '2018-06-01' });
     expect(items.data.itemsByStatus.items).toHaveLength(1)
     items = await itemsByStatus(undefined, { le: '2018-09-01' });
+    expect(items.data).toBeNull()
+    expect(items.errors.length).toBeGreaterThan(0);
+})
+
+test('Test query with three part secondary key, where sort key is an enum.', async () => {
+    const hashKey = '2018-06-01T00:01:01.000Z';
+    const sortKey = 'UNKNOWN';
+    await createItem('order1', sortKey, 'list1', '2018-01-01T00:01:01.000Z');
+    await createItem('order2', sortKey, 'list2', hashKey);
+    await createItem('order3', sortKey, 'item3', '2018-09-01T00:01:01.000Z');
+    let items = await itemsByCreatedAt(undefined);
+    expect(items.data).toBeNull();
+    expect(items.errors.length).toBeGreaterThan(0);
+    items = await itemsByCreatedAt(hashKey);
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { beginsWith: sortKey });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { eq: sortKey });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { between: [sortKey, sortKey] });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { gt: '2018-08-01' });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { ge: sortKey });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(hashKey, { lt: sortKey });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(0)
+    items = await itemsByCreatedAt(hashKey, { le: sortKey });
+    expect(items.data.itemsByCreatedAt.items).toHaveLength(1)
+    items = await itemsByCreatedAt(undefined, { le: sortKey });
     expect(items.data).toBeNull()
     expect(items.errors.length).toBeGreaterThan(0);
 })
@@ -480,6 +511,22 @@ async function itemsByStatus(status: string, createdAt?: StringKeyConditionInput
             nextToken
         }
     }`, { status, createdAt, limit, nextToken });
+    console.log(JSON.stringify(result, null, 4));
+    return result;
+}
+
+async function itemsByCreatedAt(createdAt: string, status?: StringKeyConditionInput, limit?: number, nextToken?: string) {
+    const result = await GRAPHQL_CLIENT.query(`query ListByCreatedAt($createdAt: AWSDateTime!, $status: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
+        itemsByCreatedAt(createdAt: $createdAt, status: $status, limit: $limit, nextToken: $nextToken) {
+            items {
+                orderId
+                status
+                createdAt
+                name
+            }
+            nextToken
+        }
+    }`, { createdAt, status, limit, nextToken });
     console.log(JSON.stringify(result, null, 4));
     return result;
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixing #1572 

*Description of changes:*

- Add capability to resolve a given type from context when the base type is non-scalar, which is true for enums. If a type could not be resolved with this fix a customer friendly error message is shown.
- Enhance the error message for keys with no name, when a non-existant field is specified in `@key` directive. Instead of `undefined` the error message show `<unnamed>` for `@key` name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.