### PR TITLE
fix(amplify-cli): remove console coloring from env get and list commands when --json is specified

### DIFF
--- a/packages/amplify-cli/src/commands/env.js
+++ b/packages/amplify-cli/src/commands/env.js
@@ -23,8 +23,8 @@ module.exports = {
         description: 'Displays a list of all the environments in your Amplify project',
       },
       {
-        name: 'get --name <env-name>',
-        description: 'Displays the details of the environment specified in the command ',
+        name: 'get --name <env-name> [--json]',
+        description: 'Displays the details of the environment specified in the command',
       },
       {
         name: 'import --name <env-name> --config <provider-configs> [--awsInfo <aws-configs>]',

--- a/packages/amplify-cli/src/commands/env/get.js
+++ b/packages/amplify-cli/src/commands/env/get.js
@@ -13,9 +13,9 @@ module.exports = {
 
     if (context.parameters.options.json) {
       if (allEnvs[envName]) {
-        context.print.info(JSON.stringify(allEnvs[envName], null, 4));
+        context.print.fancy(JSON.stringify(allEnvs[envName], null, 4));
       } else {
-        context.print.error('No environment found with the corresponding name provided');
+        context.print.fancy(JSON.stringify({ error: `No environment found with name: '${envName}'` }, null, 4));
       }
       return;
     }

--- a/packages/amplify-cli/src/commands/env/list.js
+++ b/packages/amplify-cli/src/commands/env/list.js
@@ -8,7 +8,7 @@ module.exports = {
     if (context.parameters.options.details) {
       const allEnvs = context.amplify.getEnvDetails();
       if (context.parameters.options.json) {
-        context.print.info(JSON.stringify(allEnvs, null, 4));
+        context.print.fancy(JSON.stringify(allEnvs, null, 4));
         return;
       }
       Object.keys(allEnvs).forEach((env) => {
@@ -36,7 +36,7 @@ module.exports = {
     } else {
       const allEnvs = context.amplify.getAllEnvs();
       if (context.parameters.options.json) {
-        context.print.info(JSON.stringify({ envs: allEnvs }, null, 4));
+        context.print.fancy(JSON.stringify({ envs: allEnvs }, null, 4));
         return;
       }
       const { table } = context.print;


### PR DESCRIPTION
*Issue #, if available:*

Issue: #1616 

*Description of changes:*

- Use `print.fancy` for console output when `--json` is specified
- For `env get` when a non-existent environment name is specified, output a JSON object to make it processable by `jq` and other tools.

Example output:
```
{
    "error": "No environment found with name: 'myenv'"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.