### PR TITLE
fix(cli): support es6 import/export

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -50,7 +50,8 @@
     "ora": "^3.0.0",
     "promise-sequential": "^1.1.1",
     "util": "^0.11.0",
-    "which": "^1.3.1"
+    "which": "^1.3.1",
+    "esm":"^3.2.25"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/packages/amplify-cli/src/cli.js
+++ b/packages/amplify-cli/src/cli.js
@@ -1,3 +1,4 @@
+require = require('esm')(module); // eslint-disable-line no-global-assign
 const fs = require('fs-extra');
 const { build } = require('gluegun');
 const path = require('path');

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -101,9 +101,7 @@ async function getCurrentAWSExports(context) {
   let awsExports = {};
 
   if (fs.existsSync(targetFilePath)) {
-    await context.patching.replace(targetFilePath, 'export default awsmobile;\n', 'module.exports = {awsmobile};\n');
-    awsExports = require(targetFilePath).awsmobile;
-    await context.patching.replace(targetFilePath, 'module.exports = {awsmobile};\n', 'export default awsmobile;\n');
+    awsExports = require(targetFilePath).default;
   }
 
   return awsExports;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4675,6 +4675,11 @@ eslint@^4.19.1, eslint@^4.9.0:
     table "4.0.2"
     text-table "~0.2.0"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espower-location-detector@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/espower-location-detector/-/espower-location-detector-1.0.0.tgz#a17b7ecc59d30e179e2bef73fb4137704cb331b5"


### PR DESCRIPTION
Amplify CLI generates the the export file which uses es6 exports. When the config files are updated,
we try to read the value from aws-export to keep the custom setting in aws-export.js. Adding support
for es6 import/export makes it easier to get read the settings

fixes #1623

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.