### PR TITLE
refactor(amplify-codegen): skip types gen early

### DIFF
--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -22,19 +22,20 @@ async function generateTypes(context, forceDownloadSchema) {
     const { projectPath } = context.amplify.getEnvInfo();
 
     projects.forEach(async (cfg) => {
-      const excludes = cfg.excludes.map(pattern => `!${pattern}`);
+      const { generatedFileName } = cfg.amplifyExtension || {};
       const includeFiles = cfg.includes;
+      if (!generatedFileName || (generatedFileName === '') || (includeFiles.length === 0)) {
+        return;
+      }
+
+      const excludes = cfg.excludes.map(pattern => `!${pattern}`);
       const queries = glob.sync([...includeFiles, ...excludes], {
         cwd: projectPath,
         absolute: true,
       });
       const schemaPath = path.join(projectPath, cfg.schema);
-      const { generatedFileName } = cfg.amplifyExtension;
       const target = cfg.amplifyExtension.codeGenTarget;
 
-      if (!generatedFileName || generatedFileName === '') {
-        return;
-      }
       const outputPath = path.join(projectPath, generatedFileName);
       if (forceDownloadSchema || jetpack.exists(schemaPath) !== 'file') {
         await downloadIntrospectionSchemaWithProgress(

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -124,4 +124,18 @@ describe('command - types', () => {
     await generateTypes(MOCK_CONTEXT, false);
     expect(MOCK_CONTEXT.print.info).toHaveBeenCalledWith(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
   });
+
+  it('should not generate types when includePattern is empty', async () => {
+    MOCK_PROJECT.includes = [];
+    await generateTypes(MOCK_CONTEXT, true);
+    expect(generate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('should not generate type when generatedFileName is missing', async () => {
+    MOCK_PROJECT.amplifyExtension.generatedFileName = '';
+    await generateTypes(MOCK_CONTEXT, true);
+    expect(generate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Add checks before running types generator. If the codegen config doesn't require generation of types
bail before doing any other operation

partial fix #1585

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.