### PR TITLE
fix(cli): add default value for options in updateAmplifyMeta

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
@@ -70,7 +70,7 @@ function moveBackendResourcesToCurrentCloudBackend(resources) {
   fs.copySync(backendConfigFilePath, backendConfigCloudFilePath, { overwrite: true });
 }
 
-function updateamplifyMetaAfterResourceAdd(category, resourceName, options) {
+function updateamplifyMetaAfterResourceAdd(category, resourceName, options = {}) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
   const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   if (options.dependsOn) {


### PR DESCRIPTION
updateamplifyMetaAfterResourceAdd expected an object to be passed but not all the categories pass
them. Setting default value

fix #1621 
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.