### PR TITLE
fix(amplify-category-interactions): call updateMetaAfterAdd only once

### DIFF
--- a/packages/amplify-category-interactions/commands/interactions/add.js
+++ b/packages/amplify-category-interactions/commands/interactions/add.js
@@ -21,13 +21,8 @@ module.exports = {
           context.print.error('Provider not configured for this category');
           return;
         }
-        return providerController.addResource(context, category, result.service);
+        return providerController.addResource(context, category, result.service, options);
       })
-      .then(resourceName => amplify.updateamplifyMetaAfterResourceAdd(
-        category,
-        resourceName,
-        options,
-      ))
       .then(() => context.print.success('Successfully added resource'))
       .catch((err) => {
         context.print.info(err.stack);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
@@ -80,12 +80,13 @@ function updateamplifyMetaAfterResourceAdd(category, resourceName, options = {})
   if (!amplifyMeta[category]) {
     amplifyMeta[category] = {};
   }
-  if (!amplifyMeta[category][resourceName]) {
-    amplifyMeta[category][resourceName] = {};
-    amplifyMeta[category][resourceName] = options;
-    const jsonString = JSON.stringify(amplifyMeta, null, '\t');
-    fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
+  if (amplifyMeta[category][resourceName]) {
+    throw new Error(`${resourceName} is present in amplify-meta.json`);
   }
+  amplifyMeta[category][resourceName] = {};
+  amplifyMeta[category][resourceName] = options;
+  const jsonString = JSON.stringify(amplifyMeta, null, '\t');
+  fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
 
   updateBackendConfigAfterResourceAdd(category, resourceName, options);
 }

--- a/packages/amplify-e2e-tests/__tests__/interactions.test.ts
+++ b/packages/amplify-e2e-tests/__tests__/interactions.test.ts
@@ -1,0 +1,32 @@
+require('../src/aws-matchers/'); // custom matcher for assertion
+import { initProjectWithProfile, deleteProject, amplifyPushAuth } from '../src/init';
+import { addSampleInteraction } from '../src/categories/interactions';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getBot } from '../src/utils';
+
+describe('amplify add interactions', () => {
+  let projRoot: string;
+  beforeEach(() => {
+    projRoot = createNewProjectDir();
+    jest.setTimeout(1000 * 60 * 60); // 1 hour
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('init a project and add  simple interaction', async () => {
+    await initProjectWithProfile(projRoot, {});
+    await addSampleInteraction(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    const meta = getProjectMeta(projRoot);
+    const { FunctionArn: functionArn, BotName: botName, Region: region } = Object.keys(
+      meta.interactions
+    ).map(key => meta.interactions[key])[0].output;
+    expect(functionArn).toBeDefined();
+    expect(botName).toBeDefined();
+    expect(region).toBeDefined();
+    const bot = await getBot(botName, region);
+    expect(bot.name).toEqual(botName);
+  });
+});

--- a/packages/amplify-e2e-tests/src/categories/interactions.ts
+++ b/packages/amplify-e2e-tests/src/categories/interactions.ts
@@ -1,0 +1,40 @@
+
+import * as nexpect from 'nexpect';
+import { join } from 'path';
+import * as fs from 'fs';
+
+import { getCLIPath, isCI, getEnvVars } from '../utils';
+const defaultSettings = {
+  projectName: 'CLI Interaction test',
+};
+
+
+export function addSampleInteraction(
+  cwd: string,
+  settings: any,
+  verbose: boolean = !isCI()
+) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['add', 'interactions'], { cwd, stripColors: true, verbose })
+      .wait('Provide a friendly resource name that will be used to label this category')
+      .sendline('\r')
+      .wait('Would you like to start with a sample chatbot')
+      .sendline('\r')
+      .wait('Choose a sample chatbot:')
+      .sendline('\r')
+      .wait('Please indicate if your use of this bot is subject to the Children\'s')
+      .sendline('y')
+      .sendEof()
+      // tslint:disable-next-line
+      .run(function(err: Error) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      })
+  })
+}
+
+

--- a/packages/amplify-e2e-tests/src/utils/index.ts
+++ b/packages/amplify-e2e-tests/src/utils/index.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from 'fs';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
 export { default  as getProjectMeta } from './projectMeta';
-export { getUserPool, getUserPoolClients } from './sdk-calls'
+export { getUserPool, getUserPoolClients, getBot } from './sdk-calls'
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
@@ -1,17 +1,18 @@
 import * as AWS from 'aws-sdk';
 
-
 const getUserPool = async (userpoolId, region) => {
   AWS.config.update({ region });
   const CognitoIdentityServiceProvider = AWS.CognitoIdentityServiceProvider;
   let res;
   try {
-    res = await new CognitoIdentityServiceProvider().describeUserPool({UserPoolId: userpoolId}).promise();
+    res = await new CognitoIdentityServiceProvider()
+      .describeUserPool({ UserPoolId: userpoolId })
+      .promise();
   } catch (e) {
     console.log(e);
   }
   return res;
-}
+};
 
 const getUserPoolClients = async (userpoolId, region) => {
   AWS.config.update({ region });
@@ -19,18 +20,25 @@ const getUserPoolClients = async (userpoolId, region) => {
   const provider = new CognitoIdentityServiceProvider();
   let res = [];
   try {
-    let clients = await provider.listUserPoolClients({UserPoolId: userpoolId}).promise();
+    let clients = await provider.listUserPoolClients({ UserPoolId: userpoolId }).promise();
     for (let i = 0; i < clients.UserPoolClients.length; i++) {
-      let clientData = await provider.describeUserPoolClient({
-        UserPoolId: userpoolId,
-        ClientId: clients.UserPoolClients[i].ClientId
-      }).promise();
+      let clientData = await provider
+        .describeUserPoolClient({
+          UserPoolId: userpoolId,
+          ClientId: clients.UserPoolClients[i].ClientId
+        })
+        .promise();
       res.push(clientData);
     }
   } catch (e) {
     console.log(e);
   }
   return res;
-}
+};
 
-export { getUserPool, getUserPoolClients }
+const getBot = async (botName: string, region: string) => {
+  const service = new AWS.LexModelBuildingService({ region });
+  return await service.getBot({ name: botName, versionOrAlias: '$LATEST' }).promise();
+};
+
+export { getUserPool, getUserPoolClients, getBot };


### PR DESCRIPTION
When adding interaction category, updateMateAfterAdd got called multiple times and if a resource
already exists with the name, no data is added to amplify-meta. Update interaction category to call
the method only once. Update the updateMetaAfterAdd to throw error when called multiple times for
the same resource. Also added integration test to ensure interaction add works

fix #1621

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.