### PR TITLE
fix(amplify-provider-awscloudformation): prevent abrupt closing of CLI

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
@@ -18,7 +18,7 @@ function run(context) {
   context.print.info('');
   context.print.info('Sign in to your AWS administrator account:');
   context.print.info(chalk.green(constants.AWSAmazonConsoleUrl));
-  opn(constants.AWSAmazonConsoleUrl, { wait: false });
+  opn(constants.AWSAmazonConsoleUrl, { wait: false }).catch(() => {});
 
   return context.amplify.pressEnterToContinue.run({ message: 'Press Enter to continue' })
     .then(() => {
@@ -45,7 +45,7 @@ function run(context) {
       const deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', answers.userName).replace('{region}', answers.region);
       context.print.info('Complete the user creation using the AWS console');
       context.print.info(chalk.green(deepLinkURL));
-      opn(deepLinkURL, { wait: false });
+      opn(deepLinkURL, { wait: false }).catch(() => {});
       return context.amplify.pressEnterToContinue.run({ message: 'Press Enter to continue' });
     })
     .then(() => {


### PR DESCRIPTION
Amplify CLI tries to open AWS Console links when adding new user. In some windows system, opening
browser fail and cause the CLI to terminate abruptly. Handling failure gracefully

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.