### PR TITLE
fix(amplify-category-function): fixed openEditor

### DIFF
--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -177,17 +177,9 @@ async function updateResource(context, category, service) {
 async function openEditor(context, category, options) {
   const targetDir = context.amplify.pathManager.getBackendDirPath();
   if (await context.amplify.confirmPrompt.run('Do you want to edit the local lambda function now?')) {
-    switch (options.functionTemplate) {
-      case 'helloWorld':
-        await context.amplify.openEditor(context, `${targetDir}/${category}/${options.resourceName}/src/index.js`);
-        break;
-      case 'serverless':
-        await context.amplify.openEditor(context, `${targetDir}/${category}/${options.resourceName}/src/app.js`);
-        break;
-      default:
-        await context.amplify.openEditor(context, `${targetDir}/${category}/${options.resourceName}/src/app.js`);
-        break;
-    }
+    const dirTemplate = `${targetDir}/${category}/${options.resourceName}/src`;
+    const functionPackage = require(`${dirTemplate}/package.json`);
+    await context.amplify.openEditor(context, `${dirTemplate}/${functionPackage.main}`);
   }
 }
 


### PR DESCRIPTION
*Issue Number:* #1663 

*Description of changes:* Changed the openEditor method to read the function's package.json and open the function's entry point automatically.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.