### PR TITLE
fix(amplify-provider-awscloudformation): generate consistent S3 keys

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -38,7 +38,12 @@ async function buildResource(context, resource) {
     !resource.distZipFilename ||
     isPackageOutdated(resourceDir, resource.lastPackageTimeStamp)
   ) {
-    const { hash: folderHash } = await hashElement(resourceDir);
+    // generating hash, ignoring node_modules as this can take long time to hash
+    // the content inside node_modules change only when content of package-lock.json changes
+    const { hash: folderHash } = await hashElement(resourceDir, {
+      folders: { exclude: ['node_modules'] },
+    });
+
     zipFilename = `${resourceName}-${folderHash}-build.zip`;
 
     if (!fs.existsSync(distDir)) {

--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -56,8 +56,7 @@ async function buildResource(context, resource) {
     return new Promise((resolve, reject) => {
       output.on('close', () => {
         context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename);
-        removeOutdatedPackage(zipFilePath).then(() =>
-          resolve({ zipFilePath, zipFilename }));
+        resolve({ zipFilePath, zipFilename });
       });
       output.on('error', () => {
         reject(new Error('Failed to zip code.'));
@@ -95,20 +94,6 @@ function getSourceFiles(dir, ignoredDir) {
   }, []);
 }
 
-function removeOutdatedPackage(currentBuildFile) {
-  try {
-    const distDir = path.dirname(currentBuildFile);
-    const deletePromises = fs
-      .readdirSync(distDir)
-      .map(p => path.join(distDir, p))
-      .filter(p => currentBuildFile !== p)
-      .map(p => fs.remove(p));
-    return Promise.all(deletePromises);
-  } catch (e) {
-    // nothing to do here
-    console.log(`Failed to clean up outdated packages ${e.message}`);
-  }
-}
 
 module.exports = {
   run,


### PR DESCRIPTION
Amplify CLI used to use date to ensure that the functions S3 key was changing every time it got
pushed to the cloud. This caused multi env with multi branch workflow to have git merge conflict as
these keys kept changing based on the time when the function gets pushed. Updated the code to use the
folder hash of function so the key is consistent if the content has not changed

fix #1666


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.