### PR TITLE
feat(amplify-provider-awscloudformation): update fn build file name

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -44,7 +44,9 @@ async function buildResource(context, resource) {
       folders: { exclude: ['node_modules'] },
     });
 
-    zipFilename = `${resourceName}-${folderHash}-build.zip`;
+    zipFilename = `${resourceName}-${Buffer.from(folderHash)
+      .toString('hex')
+      .substr(0, 20)}-build.zip`;
 
     if (!fs.existsSync(distDir)) {
       fs.mkdirSync(distDir);
@@ -93,7 +95,6 @@ function getSourceFiles(dir, ignoredDir) {
     return acc.concat(getSourceFiles(path.join(dir, f)));
   }, []);
 }
-
 
 module.exports = {
   run,


### PR DESCRIPTION
Functions need files to uopload the file to s3 to support deployment. Recently the name of the build file was changed from timestamp to hash, which can include / character. Updated the file name to use hex value so there are no / in the name

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.