### PR TITLE
fix(graphql-transformer-core) - Fixing stack mapping.

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -225,11 +225,14 @@ async function transformGraphQLSchema(context, options) {
     transformerList.push(new SearchableModelTransformer());
   }
 
-  await TransformPackage.buildAPIProject({
+  const buildConfig = {
     projectDirectory: resourceDir,
     transformers: transformerList,
     rootStackFileName: 'cloudformation-template.json',
-  });
+    currentCloudBackendDirectory: previouslyDeployedBackendDir,
+  };
+  await TransformPackage.ensureMissingStackMappings(buildConfig);
+  await TransformPackage.buildAPIProject(buildConfig);
 
   context.print.success(`\nGraphQL schema compiled successfully.\n\nEdit your schema at ${schemaFilePath} or \
 place .graphql files in a directory at ${schemaDirPath}`);

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -263,7 +263,7 @@ Static group authorization should perform as expected.`
                     ctx.setResource(ResourceConstants.RESOURCES.NoneDataSource, this.resources.noneDataSource())
                 }
                 // We also need to add a stack mapping so that this resolver is added to the model stack.
-                ctx.addToStackMapping(`${typeName}`, resolverResourceId)
+                ctx.mapResourceToStack(typeName, resolverResourceId)
                 resolver = this.resources.blankResolver(typeName, fieldName)
             }
             const authExpression = this.authorizationExpressionOnSingleObject(rules, 'ctx.source')

--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -83,9 +83,9 @@ export class ModelConnectionTransformer extends Transformer {
     ): void => {
         const parentTypeName = parent.name.value;
         const fieldName = field.name.value;
-        ctx.addToStackMapping(
+        ctx.mapResourceToStack(
             CONNECTION_STACK_NAME,
-            `^${ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName)}$`
+            ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName)
         )
         const parentModelDirective = parent.directives.find((dir: DirectiveNode) => dir.name.value === 'model')
         if (!parentModelDirective) {

--- a/packages/graphql-function-transformer/src/FunctionTransformer.ts
+++ b/packages/graphql-function-transformer/src/FunctionTransformer.ts
@@ -31,21 +31,21 @@ export default class FunctionTransformer extends Transformer {
         const iamRoleKey = FunctionResourceIDs.FunctionIAMRoleID(name, region);
         if (!ctx.getResource(iamRoleKey)) {
             ctx.setResource(iamRoleKey, this.role(name, region));
-            ctx.addToStackMapping(FUNCTION_DIRECTIVE_STACK, iamRoleKey);
+            ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, iamRoleKey);
         }
 
         // Add the data source if it does not exist.
         const lambdaDataSourceKey = FunctionResourceIDs.FunctionDataSourceID(name, region);
         if (!ctx.getResource(lambdaDataSourceKey)) {
             ctx.setResource(lambdaDataSourceKey, this.datasource(name, region));
-            ctx.addToStackMapping(FUNCTION_DIRECTIVE_STACK, lambdaDataSourceKey);
+            ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, lambdaDataSourceKey);
         }
 
         // Add function that invokes the lambda function
         const functionConfigurationKey = FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region);
         if (!ctx.getResource(functionConfigurationKey)) {
             ctx.setResource(functionConfigurationKey, this.function(name, region));
-            ctx.addToStackMapping(FUNCTION_DIRECTIVE_STACK, functionConfigurationKey);
+            ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, functionConfigurationKey);
         }
 
         // Add resolver that invokes our function
@@ -55,7 +55,7 @@ export default class FunctionTransformer extends Transformer {
         const resolver = ctx.getResource(resolverKey);
         if (!resolver) {
             ctx.setResource(resolverKey, this.resolver(typeName, fieldName, name, region));
-            ctx.addToStackMapping(FUNCTION_DIRECTIVE_STACK, resolverKey);
+            ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, resolverKey);
         } else if (resolver.Properties.Kind === 'PIPELINE') {
             ctx.setResource(resolverKey, this.appendFunctionToResolver(resolver, FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region)))
         }

--- a/packages/graphql-http-transformer/src/HttpTransformer.ts
+++ b/packages/graphql-http-transformer/src/HttpTransformer.ts
@@ -97,7 +97,7 @@ export class HttpTransformer extends Transformer {
             const dataSourceID = HttpResourceIDs.HttpDataSourceID(baseURL)
             // only create one DataSource per base URL
             if (!ctx.getResource(dataSourceID)) {
-                ctx.addToStackMapping(HTTP_STACK_NAME, `^${dataSourceID}$`)
+                ctx.mapResourceToStack(HTTP_STACK_NAME, dataSourceID)
                 ctx.setResource(
                     dataSourceID,
                     this.resources.makeHttpDataSource(baseURL)
@@ -115,9 +115,9 @@ export class HttpTransformer extends Transformer {
         directive: DirectiveNode,
         ctx: TransformerContext
     ): void => {
-        ctx.addToStackMapping(
+        ctx.mapResourceToStack(
             HTTP_STACK_NAME,
-            `^${ResolverResourceIDs.ResolverResourceID(parent.name.value, field.name.value)}$`
+            ResolverResourceIDs.ResolverResourceID(parent.name.value, field.name.value)
         )
         const url: string = getDirectiveArgument(directive)("url")
         const baseURL: string = url.replace(HttpTransformer.urlRegex, '$1')

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -149,7 +149,7 @@ export default class FunctionTransformer extends Transformer {
                 const queryTypeName = ctx.getQueryTypeName();
                 const queryResolverId = ResolverResourceIDs.ResolverResourceID(queryTypeName, directiveArgs.queryField);
                 const queryResolver = makeQueryResolver(definition, directive, ctx);
-                ctx.addToStackMapping(definition.name.value, `^${queryResolverId}$`);
+                ctx.mapResourceToStack(definition.name.value, queryResolverId);
                 ctx.setResource(queryResolverId, queryResolver);
             }
         }

--- a/packages/graphql-transformer-core/src/DeploymentResources.ts
+++ b/packages/graphql-transformer-core/src/DeploymentResources.ts
@@ -8,19 +8,23 @@ export type ResolverMap = StringMap
 export type PipelineFunctionMap = StringMap
 export interface ResolversFunctionsAndSchema {
     // Resolver templates keyed by their filename.
-    resolvers: ResolverMap
+    resolvers: ResolverMap,
     // Contains mapping templates for pipeline functions.
-    pipelineFunctions: PipelineFunctionMap
+    pipelineFunctions: PipelineFunctionMap,
     // Code for any functions that need to be deployed.
     functions: {
         [path: string]: string
     },
     // The full GraphQL schema.
-    schema: string
+    schema: string,
 }
+export interface StackMapping { [resourceId: string]: string }
 
 /**
  * The full set of resources needed for the deployment.
  */
-export interface DeploymentResources extends ResolversFunctionsAndSchema, NestedStacks {}
+export interface DeploymentResources extends ResolversFunctionsAndSchema, NestedStacks {
+    // The full stack mapping for the deployment.
+    stackMapping: StackMapping
+}
 export default DeploymentResources

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -272,15 +272,13 @@ export default class GraphQLTransform {
         }
         // Format the context into many stacks.
         this.updateContextForStackMappingOverrides(context);
-        const formatter = new TransformFormatter({
-            stackRules: context.getStackMapping()
-        })
+        const formatter = new TransformFormatter();
         return formatter.format(context)
     }
 
     private updateContextForStackMappingOverrides(context: TransformerContext) {
-        for (const regexString of Object.keys(this.stackMappingOverrides)) {
-            context.addToStackMapping(this.stackMappingOverrides[regexString], regexString);
+        for (const resourceId of Object.keys(this.stackMappingOverrides)) {
+            context.mapResourceToStack(this.stackMappingOverrides[resourceId], resourceId);
         }
     }
 

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -172,13 +172,13 @@ export interface GraphQLTransformOptions {
     // Override the formatter's stack mapping. This is useful when handling
     // migrations as all the input/export/ref/getatt changes will be made
     // automatically.
-    stackMapping?: StackMappingOption,
+    stackMapping?: StackMapping,
 }
-export type StackMappingOption = { [regexStr: string]: string };
+export type StackMapping = { [resourceId: string]: string };
 export default class GraphQLTransform {
 
     private transformers: ITransformer[]
-    private stackMappingOverrides: StackMappingOption;
+    private stackMappingOverrides: StackMapping;
 
     // A map from `${directive}.${typename}.${fieldName?}`: true
     // that specifies we have run already run a directive at a given location.

--- a/packages/graphql-transformer-core/src/TransformFormatter.ts
+++ b/packages/graphql-transformer-core/src/TransformFormatter.ts
@@ -13,17 +13,9 @@ import splitStack, { StackRules } from './util/splitStack'
 import { DeploymentResources, ResolversFunctionsAndSchema, ResolverMap } from './DeploymentResources';
 import { ResourceConstants } from "graphql-transformer-common";
 
-interface TransformFormatterOptions {
-    stackRules: StackRules
-}
 export class TransformFormatter {
 
-    private opts: TransformFormatterOptions;
     private schemaResourceUtil = new SchemaResourceUtil()
-
-    constructor(opts: TransformFormatterOptions) {
-        this.opts = opts;
-    }
 
     /**
      * Formats the ctx into a set of deployment resources.
@@ -39,7 +31,7 @@ export class TransformFormatter {
         }
         const nestedStacks = splitStack({
             stack: ctx.template,
-            stackRules: this.opts.stackRules,
+            stackRules: ctx.getStackMapping(),
             defaultParameterValues: {
                 [ResourceConstants.PARAMETERS.AppSyncApiId]: Fn.GetAtt(
                     ResourceConstants.RESOURCES.GraphQLAPILogicalID,

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -75,7 +75,13 @@ export class TransformerContextMetadata {
     }
 }
 
-// export interface StackMapping { [k: RegExp]: string }
+/**
+ * The stack mapping defines a full mapping from resource id
+ * to the stack that it belongs to. When transformers add
+ * resources to the context, they add an entry to the
+ * stack mapping and that resource will be pulled into the related stack
+ * automatically.
+ */
 export type StackMapping = Map<string, string>;
 
 /**
@@ -625,14 +631,13 @@ export default class TransformerContext {
         this.nodeMap[en.name.value] = en
     }
 
-    public putStackMapping(stackName: string, listOfRegex: string[]) {
-        for (const reg of listOfRegex) {
-            this.stackMapping.set(reg.toLowerCase(), stackName);
-        }
-    }
-
-    public addToStackMapping(stackName: string, regex: string) {
-        this.stackMapping.set(regex.toLowerCase(), stackName);
+    /**
+     * Add an item to the stack mapping.
+     * @param stackName The destination stack name.
+     * @param resource The resource id that should be put into the stack.
+     */
+    public mapResourceToStack(stackName: string, resource: string) {
+        this.stackMapping.set(resource, stackName);
     }
 
     public getStackMapping(): StackMapping {

--- a/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
@@ -75,7 +75,6 @@ test('Test getTemplateReferences', () => {
     context.mapResourceToStack('PostModel', 'PostTableOutput');
     context.template = template;
     const deploymentResources = formatter.format(context)
-    console.log(deploymentResources);
     expect(Object.keys(deploymentResources.stacks.PostModel.Resources)).toHaveLength(4)
     expect(Object.keys(deploymentResources.rootStack.Resources)).toHaveLength(3)
     expect(Object.keys(deploymentResources.stacks.PostModel.Outputs)).toHaveLength(1);

--- a/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
@@ -66,15 +66,16 @@ const template: Template = {
 
 
 test('Test getTemplateReferences', () => {
-    const stackRules = new Map<string, string>();
-    stackRules.set('.*PostResolver', 'PostModel');
-    stackRules.set('^PostTable.*', 'PostModel');
-    const formatter = new TransformFormatter({
-        stackRules: stackRules,
-    });
+    const formatter = new TransformFormatter();
     const context = new TransformerContext('type Post @model { id: ID! title: String }')
+    context.mapResourceToStack('PostModel', 'CreatePostResolver');
+    context.mapResourceToStack('PostModel', 'UpdatePostResolver');
+    context.mapResourceToStack('PostModel', 'PostTableDataSource');
+    context.mapResourceToStack('PostModel', 'PostTable');
+    context.mapResourceToStack('PostModel', 'PostTableOutput');
     context.template = template;
     const deploymentResources = formatter.format(context)
+    console.log(deploymentResources);
     expect(Object.keys(deploymentResources.stacks.PostModel.Resources)).toHaveLength(4)
     expect(Object.keys(deploymentResources.rootStack.Resources)).toHaveLength(3)
     expect(Object.keys(deploymentResources.stacks.PostModel.Outputs)).toHaveLength(1);

--- a/packages/graphql-transformer-core/src/index.ts
+++ b/packages/graphql-transformer-core/src/index.ts
@@ -10,6 +10,7 @@ import {
     uploadDeployment as uploadAPIProject,
     migrateAPIProject,
     revertAPIMigration,
+    ensureMissingStackMappings
 } from './util/amplifyUtils'
 import {
     readSchema as readProjectSchema,
@@ -32,5 +33,6 @@ export {
     uploadAPIProject,
     readProjectSchema,
     readProjectConfiguration,
-    revertAPIMigration
+    revertAPIMigration,
+    ensureMissingStackMappings
 }

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -95,7 +95,8 @@ export type FindMissingStackMappingConfig = ProjectOptions & { currentCloudBacke
 /**
  * Provided a build configuration & current-cloud-backend directory, calculate
  * any missing stack mappings that might have been caused by the stack mapping
- * bug in June 2019. This allows APIs that were deployed with the bug to continue
+ * bug in June 2019 (https://github.com/aws-amplify/amplify-cli/issues/1652).
+ * This allows APIs that were deployed with the bug to continue
  * working without changes.
  */
 export async function ensureMissingStackMappings(config: FindMissingStackMappingConfig) {
@@ -111,7 +112,6 @@ export async function ensureMissingStackMappings(config: FindMissingStackMapping
     // we make a note of it and include it in the missing stack mapping.
     for (const stackFileName of stackNames) {
         const stackName = stackFileName.slice(0, stackFileName.length - path.extname(stackFileName).length);
-        // const stack = transformOutput.stacks[stackName];
         const lastDeployedStack = JSON.parse(copyOfCloudBackend.build.stacks[stackFileName]);
         if (lastDeployedStack) {
             const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -1,13 +1,13 @@
 const fs = require('fs-extra');
 import * as path from 'path';
-import { CloudFormation, Fn, Template } from "cloudform-types";
+import { CloudFormation, Fn, Template, Cognito } from "cloudform-types";
 import GraphQLTransform from '..';
 import Transformer from '../Transformer';
 import DeploymentResources from '../DeploymentResources';
-import { StackMappingOption } from '../GraphQLTransform';
+import { StackMapping } from '../GraphQLTransform';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { walkDirPosix, readFromPath, writeToPath, throwIfNotJSONExt, emptyDirectory } from './fileUtils';
-import { writeConfig, TransformConfig, TransformMigrationConfig, loadProject, readSchema } from './transformConfig';
+import { writeConfig, TransformConfig, TransformMigrationConfig, loadProject, readSchema, loadConfig } from './transformConfig';
 
 const CLOUDFORMATION_FILE_NAME = 'cloudformation-template.json';
 const PARAMETERS_FILE_NAME = 'parameters.json';
@@ -17,10 +17,14 @@ export interface ProjectOptions {
     transformers: Transformer[]
     rootStackFileName?: string
 }
-
 export async function buildProject(opts: ProjectOptions) {
+    const builtProject = await _buildProject(opts);
+    await writeDeploymentToDisk(builtProject, path.join(opts.projectDirectory, 'build'), opts.rootStackFileName)
+}
+
+async function _buildProject(opts: ProjectOptions) {
     const userProjectConfig = await loadProject(opts.projectDirectory)
-    const stackMapping = getStackMappingsFromMigrationConfig(userProjectConfig.config.Migration);
+    const stackMapping = getStackMappingFromProjectConfig(userProjectConfig.config);
     const transform = new GraphQLTransform({
         transformers: opts.transformers,
         stackMapping
@@ -30,7 +34,7 @@ export async function buildProject(opts: ProjectOptions) {
         transformOutput = adjustBuildForMigration(transformOutput, userProjectConfig.config.Migration);
     }
     const merged = mergeUserConfigWithTransformOutput(userProjectConfig, transformOutput)
-    await writeDeploymentToDisk(merged, path.join(opts.projectDirectory, 'build'), opts.rootStackFileName)
+    return merged;
 }
 
 /**
@@ -38,12 +42,16 @@ export async function buildProject(opts: ProjectOptions) {
  * This will be passed to the transform constructor to cause resources from a migration
  * to remain in the top level stack.
  */
-function getStackMappingsFromMigrationConfig(migrationConfig?: TransformMigrationConfig): StackMappingOption {
+function getStackMappingFromProjectConfig(config?: TransformConfig): StackMapping {
+    const stackMapping = getOrDefault(config, 'StackMapping', {});
+    const migrationConfig = config.Migration;
     if (migrationConfig && migrationConfig.V1) {
         const resourceIdsToHoist = migrationConfig.V1.Resources || [];
-        return resourceIdsToHoist.reduce((acc: any, k: string) => ({ ...acc, [k]: 'root'}), {});
+        for (const idToHoist of resourceIdsToHoist) {
+            stackMapping[idToHoist] = 'root';
+        }
     }
-    return {};
+    return stackMapping;
 }
 
 /**
@@ -80,6 +88,66 @@ function adjustBuildForMigration(resources: DeploymentResources, migrationConfig
         }
     }
     return resources;
+}
+
+
+export type FindMissingStackMappingConfig = ProjectOptions & { currentCloudBackendDirectory: string }
+/**
+ * Provided a build configuration & current-cloud-backend directory, calculate
+ * any missing stack mappings that might have been caused by the stack mapping
+ * bug in June 2019. This allows APIs that were deployed with the bug to continue
+ * working without changes.
+ */
+export async function ensureMissingStackMappings(config: FindMissingStackMappingConfig) {
+    const missingStackMappings = {};
+    const { currentCloudBackendDirectory, ...buildConfig } = config;
+    const transformOutput = await _buildProject(buildConfig);
+    const copyOfCloudBackend = await readFromPath(currentCloudBackendDirectory);
+    const stackMapping = transformOutput.stackMapping;
+    const stackNames = Object.keys(copyOfCloudBackend.build.stacks);
+
+    // We walk through each of the stacks that were deployed in the most recent deployment.
+    // If we find a resource that was deployed into a different stack than it should have
+    // we make a note of it and include it in the missing stack mapping.
+    for (const stackFileName of stackNames) {
+        const stackName = stackFileName.slice(0, stackFileName.length - path.extname(stackFileName).length);
+        // const stack = transformOutput.stacks[stackName];
+        const lastDeployedStack = JSON.parse(copyOfCloudBackend.build.stacks[stackFileName]);
+        if (lastDeployedStack) {
+            const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);
+            for (const resourceId of resourceIdsInStack) {
+                if (stackMapping[resourceId] && stackName !== stackMapping[resourceId]) {
+                    missingStackMappings[resourceId] = stackName;
+                }
+            }
+            const outputIdsInStack = Object.keys(lastDeployedStack.Outputs);
+            for (const outputId of outputIdsInStack) {
+                if (stackMapping[outputId] && stackName !== stackMapping[outputId]) {
+                    missingStackMappings[outputId] = stackName;
+                }
+            }
+        }
+    }
+    // We then do the same thing with the root stack.
+    const lastDeployedStack = JSON.parse(copyOfCloudBackend.build[config.rootStackFileName]);
+    const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);
+    for (const resourceId of resourceIdsInStack) {
+        if (stackMapping[resourceId] && 'root' !== stackMapping[resourceId]) {
+            missingStackMappings[resourceId] = 'root';
+        }
+    }
+    const outputIdsInStack = Object.keys(lastDeployedStack.Outputs);
+    for (const outputId of outputIdsInStack) {
+        if (stackMapping[outputId] && 'root' !== stackMapping[outputId]) {
+            missingStackMappings[outputId] = 'root';
+        }
+    };
+    // If there are missing stack mappings, we write them to disk.
+    if (Object.keys(missingStackMappings).length) {
+        let conf = await loadConfig(config.projectDirectory);
+        conf = { ...conf, StackMapping: { ...getOrDefault(conf, 'StackMapping', {}), ...missingStackMappings } };
+        await writeConfig(config.projectDirectory, conf);
+    }
 }
 
 /**
@@ -544,4 +612,8 @@ function resolverDirectoryPath(rootPath: string) {
 
 function stacksDirectoryPath(rootPath: string) {
     return path.normalize(rootPath + `/stacks`)
+}
+
+function getOrDefault(o: any, k: string, d: any) {
+    return o[k] || d;
 }

--- a/packages/graphql-transformer-core/src/util/splitStack.ts
+++ b/packages/graphql-transformer-core/src/util/splitStack.ts
@@ -15,7 +15,9 @@ export interface NestedStacks {
     // All the nested stack templates.
     stacks: {
         [name: string]: Template
-    }
+    },
+    // The full stack mapping for the deployment.
+    stackMapping: { [resourceId: string]: string }
 }
 interface NestedStackInfo {
     stackDependencyMap: { [k: string]: string[] }
@@ -338,6 +340,7 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
     const templateJson: any = JSON.parse(JSON.stringify(stack));
     const resourceToStackMap = mapResourcesToStack(templateJson);
     const outputToStackMap = mapOutputsToStack(templateJson);
+    const stackMapping = { ...resourceToStackMap, ...outputToStackMap };
     const stacks = collectTemplates(templateJson, resourceToStackMap, outputToStackMap);
     const stackInfo = replaceReferences(stacks, resourceToStackMap);
     let rootStack = stacks[rootStackName];
@@ -345,6 +348,7 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
     rootStack = updateRootWithNestedStacks(rootStack, stacks, stackInfo);
     return {
         rootStack,
-        stacks
+        stacks,
+        stackMapping
     }
 }

--- a/packages/graphql-transformer-core/src/util/splitStack.ts
+++ b/packages/graphql-transformer-core/src/util/splitStack.ts
@@ -22,9 +22,6 @@ interface NestedStackInfo {
     stackParameterMap: { [k: string]: {[p: string]: any }  }
 }
 
-// export interface StackRules {
-//     [key: string]: RegExp[];
-// }
 export type StackRules = Map<string, string>;
 export interface SplitStackOptions {
     stack: Template,
@@ -50,25 +47,24 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
 
     /**
      * Returns a map where the keys are the Resource/Output ids and the values are
-     * the names of the stack where that Resource/Output belongs.
+     * the names of the stack where that Resource/Output belongs. This fills
+     * any missing values with that of the root stack and thus returns a full-mapping.
      */
     function createMapByStackRules(
         keys: string[]
     ): { [key: string]: string } {
         const stackMap = {};
         for (const key of keys) {
-            stackRules.forEach((stackName, regExStr) => {
-                const regEx = new RegExp(regExStr, 'i');
-                if (regEx.test(key)) {
-                    stackMap[key] = stackName;
-                }
-            });
-            if (!stackMap[key]) {
+            const mappedTo = stackRules.get(key);
+            if (mappedTo) {
+                stackMap[key] = mappedTo;
+            } else {
                 stackMap[key] = rootStackName;
             }
         }
         return stackMap;
     }
+    
     /**
      * Returns a map where the keys are the resource ids and the values are the
      * names of the stack where that resource belongs.
@@ -78,6 +74,7 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
     ): { [key: string]: string } {
         return createMapByStackRules(Object.keys(template.Resources));
     }
+
     /**
      * Returns a map where the keys are the Outputs ids and the values are the
      * names of the stack where that Output belongs.

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -16,6 +16,21 @@ export interface TransformMigrationConfig {
 export interface TransformConfig {
 
     /**
+     * The transform library uses a "StackMapping" to determine which stack
+     * a particular resource belongs to. This "StackMapping" allows individual
+     * transformer implementations to add resources to a single context and
+     * reference resources as if they were all members of the same stack. The
+     * transform formatter takes the single context and the stack mapping
+     * and splits the context into a valid nested stack where any Fn::Ref or Fn::GetAtt
+     * is replaced by a Import/Export or Parameter. Users may provide mapping
+     * overrides to get specific behavior out of the transformer. Users may
+     * override the default stack mapping to customize behavior.
+     */
+    StackMapping?: {
+        [resourceId: string]: string
+    }
+
+    /**
      * For backwards compatibility we store a set of resource logical ids that
      * should be preserved in the top level template to prevent deleting
      * resources that holds data and that were created before the new nested stack config.

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/TestComplexStackMappingsLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/TestComplexStackMappingsLocal.e2e.test.ts
@@ -1,0 +1,170 @@
+import GraphQLTransform, { Transformer, InvalidDirectiveError } from 'graphql-transformer-core'
+import ModelTransformer from 'graphql-dynamodb-transformer';
+import ElasticsearchTransformer from 'graphql-elasticsearch-transformer';
+import ConnectionTransformer from 'graphql-connection-transformer';
+import HttpTransformer from 'graphql-http-transformer';
+import AuthTransformer from 'graphql-auth-transformer';
+import FunctionTransformer from 'graphql-function-transformer';
+import Template from "cloudform-types/types/template";
+import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode,
+    Kind, InputObjectTypeDefinitionNode } from 'graphql';
+import { expectExactKeys, expectNonNullFields, expectNullableFields,
+    expectNonNullInputValues, expectNullableInputValues, expectInputValueToHandle  } from '../testUtil';
+
+
+const userType = `
+type User @model @auth(rules: [{ allow: owner }]) {
+    id: ID!
+    name: String
+    posts: [UserPost] @connection(name: "UserPostsUser")
+    profpic: String @http(url: "https://www.profpic.org/this/is/a/fake/url")
+}`;
+const userPostType = `
+type UserPost @model {
+    id: ID!
+    user: User @connection(name: "UserPostsUser")
+    post: Post @connection(name: "UserPostsPost")
+}
+`;
+const postType = `
+type Post @model @searchable {
+    id: ID!
+    name: String
+    authors: [UserPost] @connection(name: "UserPostsPost")
+    score: Int @function(name: "scorefunc")
+}
+`;
+
+/**
+ * We test this schema with the same set of rules multiple times. This protects against a subtle bug in the stack mapping
+ * that caused the order to impact the stack that a resource got mapped to.
+ */
+test('Test that every resource exists in the correct stack given a complex schema with overlapping names.', () => {
+    const schema = [userType, userPostType, postType].join('\n');
+    transpileAndCheck(schema);
+})
+
+test('Test that every resource exists in the correct stack given a complex schema with overlapping names. Rotation 1.', () => {
+    const schema = [userPostType, postType, userType].join('\n');
+    transpileAndCheck(schema);
+})
+
+test('Test that every resource exists in the correct stack given a complex schema with overlapping names. Rotation 2.', () => {
+    const schema = [postType, userType, userPostType].join('\n');
+    transpileAndCheck(schema);
+})
+
+
+function transpileAndCheck(schema: string) {
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new ModelTransformer(),
+            new HttpTransformer(),
+            new ElasticsearchTransformer(),
+            new ConnectionTransformer(),
+            new FunctionTransformer,
+            new AuthTransformer(),
+        ]
+    });
+
+    const out = transformer.transform(schema);
+
+    // Check root
+    expectExactKeys(
+        out.rootStack.Resources,
+        new Set([
+            'GraphQLAPI', 'GraphQLAPIKey', 'GraphQLSchema', 'User', 'UserPost',
+            'Post', 'ConnectionStack', 'SearchableStack', 'FunctionDirectiveStack',
+            'HttpStack'
+        ])
+    );
+    expectExactKeys(
+        out.rootStack.Outputs, 
+        new Set(['GraphQLAPIIdOutput', 'GraphQLAPIEndpointOutput', 'GraphQLAPIKeyOutput'])
+    );
+
+    // Check User
+    expectExactKeys(
+        out.stacks.User.Resources,
+        new Set([
+            'UserTable', 'UserIAMRole', 'UserDataSource', 'GetUserResolver',
+            'ListUserResolver', 'CreateUserResolver', 'UpdateUserResolver',
+            'DeleteUserResolver'
+        ])
+    );
+    expectExactKeys(
+        out.stacks.User.Outputs,
+        new Set(['GetAttUserTableStreamArn', 'GetAttUserDataSourceName', 'GetAttUserTableName'])
+    );
+
+    // Check UserPost
+    expectExactKeys(
+        out.stacks.UserPost.Resources,
+        new Set([
+            'UserPostTable', 'UserPostIAMRole', 'UserPostDataSource', 'GetUserPostResolver',
+            'ListUserPostResolver', 'CreateUserPostResolver', 'UpdateUserPostResolver',
+            'DeleteUserPostResolver'
+        ])
+    );
+    expectExactKeys(
+        out.stacks.UserPost.Outputs,
+        new Set(['GetAttUserPostTableStreamArn', 'GetAttUserPostDataSourceName', 'GetAttUserPostTableName'])
+    );
+
+    // Check Post
+    expectExactKeys(
+        out.stacks.Post.Resources,
+        new Set([
+            'PostTable', 'PostIAMRole', 'PostDataSource', 'GetPostResolver',
+            'ListPostResolver', 'CreatePostResolver', 'UpdatePostResolver',
+            'DeletePostResolver'
+        ])
+    );
+    expectExactKeys(
+        out.stacks.Post.Outputs,
+        new Set(['GetAttPostTableStreamArn', 'GetAttPostDataSourceName', 'GetAttPostTableName'])
+    );
+
+    // Check SearchableStack
+    expectExactKeys(
+        out.stacks.SearchableStack.Resources,
+        new Set([
+            'ElasticSearchAccessIAMRole', 'ElasticSearchDataSource', 'ElasticSearchDomain', 'ElasticSearchStreamingLambdaIAMRole',
+            'ElasticSearchStreamingLambdaFunction', 'SearchablePostLambdaMapping', 'SearchPostResolver'
+        ])
+    );
+    expectExactKeys(
+        out.stacks.SearchableStack.Outputs,
+        new Set(['ElasticsearchDomainArn', 'ElasticsearchDomainEndpoint'])
+    );
+
+    // Check connections
+    expectExactKeys(
+        out.stacks.ConnectionStack.Resources,
+        new Set(['UserpostsResolver', 'UserPostuserResolver', 'UserPostpostResolver', 'PostauthorsResolver'])
+    );
+    expectExactKeys(
+        out.stacks.ConnectionStack.Outputs,
+        new Set([])
+    );
+
+    // Check function stack
+    expectExactKeys(
+        out.stacks.FunctionDirectiveStack.Resources,
+        new Set(['ScorefuncLambdaDataSourceRole', 'ScorefuncLambdaDataSource', 'InvokeScorefuncLambdaDataSource', 'PostscoreResolver'])
+    );
+    expectExactKeys(
+        out.stacks.ConnectionStack.Outputs,
+        new Set([])
+    );
+
+    // Check http stack
+    expectExactKeys(
+        out.stacks.HttpStack.Resources,
+        new Set(['httpswwwprofpicorgDataSource', 'UserprofpicResolver'])
+    )
+    expectExactKeys(
+        out.stacks.HttpStack.Outputs,
+        new Set([])
+    );
+}

--- a/packages/graphql-transformers-e2e-tests/src/testUtil.ts
+++ b/packages/graphql-transformers-e2e-tests/src/testUtil.ts
@@ -83,3 +83,11 @@ export function expectNullableInputValues(type: InputObjectTypeDefinitionNode, f
         expect(isNonNullType(foundField.type)).toBeFalsy();
     }
 }
+
+export function expectExactKeys(obj: Object, expectedSet: Set<string>) {
+    const resourceSet = new Set(Object.keys(obj));
+    expectedSet.forEach(item => {
+        expect(resourceSet.has(item)).toBeTruthy();
+    })
+    expect(resourceSet.size).toEqual(expectedSet.size);
+}


### PR DESCRIPTION
*Issues*
#1581
#1652 - This behavior pattern is now fixed. If you have previously deployed an API with this issue, the new utility method updates `transform.conf.json` such that any subsequent pushes with the fixed implementation do not try to move existing resources out of their existing stacks.

*Description of changes:*

Fixing an issue with an internal mechanism called the stack mapping. The issue materialized when you tried to create an API with types that share name parts (e.g. Post & UserPost & User). When using names that share parts, the order of the types in the input document could impact which stack a resource got mapped to. This fix removes using regular expressions and replaces the stack map with a full mapping where each resource is explicitly mapped to a stack.

*Testing:*

This change includes new tests that cover all directives that create independent resources and strictly inspect the stack outputs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.