### PR TITLE
Fix KeyTransformer E2E tests

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -199,6 +199,9 @@ test('Test listX with three part primary key.', async () => {
     expect(items.data.listItems.items).toHaveLength(1)
     items = await listItem(hashKey, { le: { status: 'IN_TRANSIT', createdAt: '2018-01-01T00:01:01.000Z'}});
     expect(items.data.listItems.items).toHaveLength(1)
+    await deleteItem(hashKey, 'IN_TRANSIT', '2018-01-01T00:01:01.000Z');
+    await deleteItem(hashKey, 'PENDING', '2018-06-01T00:01:01.000Z');
+    await deleteItem(hashKey, 'PENDING', '2018-09-01T00:01:01.000Z');
 })
 
 test('Test query with three part secondary key.', async () => {
@@ -228,6 +231,9 @@ test('Test query with three part secondary key.', async () => {
     items = await itemsByStatus(undefined, { le: '2018-09-01' });
     expect(items.data).toBeNull()
     expect(items.errors.length).toBeGreaterThan(0);
+    await deleteItem('order1', hashKey, '2018-01-01T00:01:01.000Z');
+    await deleteItem('order2', hashKey, '2018-06-01T00:01:01.000Z');
+    await deleteItem('order3', hashKey, '2018-09-01T00:01:01.000Z');
 })
 
 test('Test query with three part secondary key, where sort key is an enum.', async () => {
@@ -258,6 +264,9 @@ test('Test query with three part secondary key, where sort key is an enum.', asy
     items = await itemsByCreatedAt(undefined, { le: sortKey });
     expect(items.data).toBeNull()
     expect(items.errors.length).toBeGreaterThan(0);
+    await deleteItem('order1', sortKey, '2018-01-01T00:01:01.000Z');
+    await deleteItem('order2', sortKey, hashKey);
+    await deleteItem('order3', sortKey, '2018-09-01T00:01:01.000Z');
 })
 
 test('Test update mutation validation with three part secondary key.', async () => {


### PR DESCRIPTION
*Description of changes:*
KeyTransformer E2E tests were leaving some data behind that caused test suite run failure, but individual tests were ok, it is fixed by deleting the conflicting data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.