### PR TITLE
fix(graphql-transformer-core) Adds a missing null check for the current cloud backend.

### DIFF
--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -105,48 +105,51 @@ export async function ensureMissingStackMappings(config: FindMissingStackMapping
     const transformOutput = await _buildProject(buildConfig);
     const copyOfCloudBackend = await readFromPath(currentCloudBackendDirectory);
     const stackMapping = transformOutput.stackMapping;
-    const stackNames = Object.keys(copyOfCloudBackend.build.stacks);
+    if (copyOfCloudBackend && copyOfCloudBackend.build) {
+        const stackNames = copyOfCloudBackend.build.stacks;
 
-    // We walk through each of the stacks that were deployed in the most recent deployment.
-    // If we find a resource that was deployed into a different stack than it should have
-    // we make a note of it and include it in the missing stack mapping.
-    for (const stackFileName of stackNames) {
-        const stackName = stackFileName.slice(0, stackFileName.length - path.extname(stackFileName).length);
-        const lastDeployedStack = JSON.parse(copyOfCloudBackend.build.stacks[stackFileName]);
-        if (lastDeployedStack) {
-            const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);
-            for (const resourceId of resourceIdsInStack) {
-                if (stackMapping[resourceId] && stackName !== stackMapping[resourceId]) {
-                    missingStackMappings[resourceId] = stackName;
+        // We walk through each of the stacks that were deployed in the most recent deployment.
+        // If we find a resource that was deployed into a different stack than it should have
+        // we make a note of it and include it in the missing stack mapping.
+        for (const stackFileName of stackNames) {
+            const stackName = stackFileName.slice(0, stackFileName.length - path.extname(stackFileName).length);
+            const lastDeployedStack = JSON.parse(copyOfCloudBackend.build.stacks[stackFileName]);
+            if (lastDeployedStack) {
+                const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);
+                for (const resourceId of resourceIdsInStack) {
+                    if (stackMapping[resourceId] && stackName !== stackMapping[resourceId]) {
+                        missingStackMappings[resourceId] = stackName;
+                    }
+                }
+                const outputIdsInStack = Object.keys(lastDeployedStack.Outputs);
+                for (const outputId of outputIdsInStack) {
+                    if (stackMapping[outputId] && stackName !== stackMapping[outputId]) {
+                        missingStackMappings[outputId] = stackName;
+                    }
                 }
             }
-            const outputIdsInStack = Object.keys(lastDeployedStack.Outputs);
-            for (const outputId of outputIdsInStack) {
-                if (stackMapping[outputId] && stackName !== stackMapping[outputId]) {
-                    missingStackMappings[outputId] = stackName;
-                }
+        }
+
+        // We then do the same thing with the root stack.
+        const lastDeployedStack = JSON.parse(copyOfCloudBackend.build[config.rootStackFileName]);
+        const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);
+        for (const resourceId of resourceIdsInStack) {
+            if (stackMapping[resourceId] && 'root' !== stackMapping[resourceId]) {
+                missingStackMappings[resourceId] = 'root';
             }
         }
-    }
-    // We then do the same thing with the root stack.
-    const lastDeployedStack = JSON.parse(copyOfCloudBackend.build[config.rootStackFileName]);
-    const resourceIdsInStack = Object.keys(lastDeployedStack.Resources);
-    for (const resourceId of resourceIdsInStack) {
-        if (stackMapping[resourceId] && 'root' !== stackMapping[resourceId]) {
-            missingStackMappings[resourceId] = 'root';
+        const outputIdsInStack = Object.keys(lastDeployedStack.Outputs);
+        for (const outputId of outputIdsInStack) {
+            if (stackMapping[outputId] && 'root' !== stackMapping[outputId]) {
+                missingStackMappings[outputId] = 'root';
+            }
+        };
+        // If there are missing stack mappings, we write them to disk.
+        if (Object.keys(missingStackMappings).length) {
+            let conf = await loadConfig(config.projectDirectory);
+            conf = { ...conf, StackMapping: { ...getOrDefault(conf, 'StackMapping', {}), ...missingStackMappings } };
+            await writeConfig(config.projectDirectory, conf);
         }
-    }
-    const outputIdsInStack = Object.keys(lastDeployedStack.Outputs);
-    for (const outputId of outputIdsInStack) {
-        if (stackMapping[outputId] && 'root' !== stackMapping[outputId]) {
-            missingStackMappings[outputId] = 'root';
-        }
-    };
-    // If there are missing stack mappings, we write them to disk.
-    if (Object.keys(missingStackMappings).length) {
-        let conf = await loadConfig(config.projectDirectory);
-        conf = { ...conf, StackMapping: { ...getOrDefault(conf, 'StackMapping', {}), ...missingStackMappings } };
-        await writeConfig(config.projectDirectory, conf);
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

N/A. This fixes a bug that has not been released.

*Description of changes:*

Adds a missing null check to a new function that compares the current deployment against the last deployment in the current cloud backend.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.