### PR TITLE
Fix for invalid JSON in pipeline resolver

### DIFF
--- a/packages/graphql-function-transformer/src/FunctionTransformer.ts
+++ b/packages/graphql-function-transformer/src/FunctionTransformer.ts
@@ -132,8 +132,6 @@ export default class FunctionTransformer extends Transformer {
                 version: str('2018-05-29'),
                 operation: str('Invoke'),
                 payload: obj({
-                    typeName: str('$ctx.stash.get("typeName")'),
-                    fieldName: str('$ctx.stash.get("fieldName")'),
                     arguments: ref('util.toJson($ctx.arguments)'),
                     identity: ref('util.toJson($ctx.identity)'),
                     source: ref('util.toJson($ctx.source)'),


### PR DESCRIPTION
The JSON generated for the pipeline resolver is invalid and results in an error when sending any requests.  The two fields removed appear to be DynamoDB specific, so I removed them since we are resolving to a Lambda function.

*Description of changes:*
The current resulting pipeline resolver is:
```
{
  "version": "2018-05-29",
  "operation": "Invoke",
  "payload": {
      "typeName": "$ctx.stash.get("typeName")",
      "fieldName": "$ctx.stash.get("fieldName")",
      "arguments": $util.toJson($ctx.arguments),
      "identity": $util.toJson($ctx.identity),
      "source": $util.toJson($ctx.source),
      "request": $util.toJson($ctx.request),
      "prev": $util.toJson($ctx.prev)
  }
}
```

The new pipeline resolver is:
```
{
  "version": "2018-05-29",
  "operation": "Invoke",
  "payload": {
      "arguments": $util.toJson($ctx.arguments),
      "identity": $util.toJson($ctx.identity),
      "source": $util.toJson($ctx.source),
      "request": $util.toJson($ctx.request),
      "prev": $util.toJson($ctx.prev)
  }
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.