### PR TITLE
fix(amplify-category-function): enable SAM templates for functions

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -22,7 +22,7 @@ async function run(context) {
     const unauthRoleName = `${stackName}-unauthRole`;
     const params = {
       StackName: stackName,
-      Capabilities: ['CAPABILITY_NAMED_IAM'],
+      Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
       TemplateBody: fs.readFileSync(initTemplateFilePath).toString(),
       Parameters: [
         {

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -245,7 +245,7 @@ function packageResources(context, resources) {
 
         const cfnMeta = context.amplify.readJsonFile(cfnFilePath);
 
-        if (cfnMeta.Resources.LambdaFunction.Type==='AWS::Serverless::Function') {
+        if (cfnMeta.Resources.LambdaFunction.Type === 'AWS::Serverless::Function') {
           cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
             Bucket: s3Bucket,
             Key: s3Key,

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -245,10 +245,17 @@ function packageResources(context, resources) {
 
         const cfnMeta = context.amplify.readJsonFile(cfnFilePath);
 
-        cfnMeta.Resources.LambdaFunction.Properties.Code = {
-          S3Bucket: s3Bucket,
-          S3Key: s3Key,
-        };
+        if (cfnMeta.Resources.LambdaFunction.Type==='AWS::Serverless::Function') {
+          cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
+            Bucket: s3Bucket,
+            Key: s3Key,
+          };
+        } else {
+          cfnMeta.Resources.LambdaFunction.Properties.Code = {
+            S3Bucket: s3Bucket,
+            S3Key: s3Key,
+          };
+        }
 
         const jsonString = JSON.stringify(cfnMeta, null, '\t');
         fs.writeFileSync(cfnFilePath, jsonString, 'utf8');

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -251,7 +251,7 @@ class CloudFormation {
             const cfnParentStackParams = {
               StackName: stackName,
               TemplateURL: templateURL,
-              Capabilities: ['CAPABILITY_NAMED_IAM'],
+              Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
               Parameters: [
                 {
                   ParameterKey: 'DeploymentBucketName',

--- a/packages/graphql-transformers-e2e-tests/src/CloudFormationClient.ts
+++ b/packages/graphql-transformers-e2e-tests/src/CloudFormationClient.ts
@@ -56,7 +56,7 @@ export class CloudFormationClient {
             this.client.createStack,
             {
                 StackName: name,
-                Capabilities: ['CAPABILITY_NAMED_IAM'],
+                Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
                 Parameters: params,
                 TemplateBody: JSON.stringify(template)
             },


### PR DESCRIPTION
*Issue #, if available:*

#1740 - Add CAPABILITY_AUTO_EXPAND to CloudFormation stack create and update calls.

*Description of changes:*

By adding CAPABILITY_AUTO_EXPAND to the capabilities parameters this enables customers to use SAM templates for Lambda functions.

If the resource type is ```AWS::Serverless::Function``` the ```CodeUri``` property will be emitted instead of ```Code```.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.