### PR TITLE
Adding support for "Retain" deletion policy on DynamoDB tables created by @model.

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -210,7 +210,7 @@ async function transformGraphQLSchema(context, options) {
 
   const authMode = parameters.AuthCognitoUserPoolId ? 'AMAZON_COGNITO_USER_POOLS' : 'API_KEY';
   const transformerList = [
-    new DynamoDBModelTransformer(getModelConfig(project)),
+    new DynamoDBModelTransformer(getTransformerOptions(project, 'model')),
     new ModelConnectionTransformer(),
     new VersionedModelTransformer(),
     new FunctionTransformer(),
@@ -242,11 +242,14 @@ place .graphql files in a directory at ${schemaDirPath}`);
   fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
 }
 
-function getModelConfig(project) {
-  if (project && project.config && project.config.Model && project.config.Model.BillingMode) {
-    return {
-      BillingMode: project.config.Model.BillingMode,
-    };
+function getTransformerOptions(project, transformerName) {
+  if (
+    project &&
+    project.config &&
+    project.config.TransformerOptions &&
+    project.config.TransformerOptions[transformerName]
+  ) {
+    return project.config.TransformerOptions[transformerName];
   }
   return undefined;
 }

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -1,4 +1,4 @@
-import { DynamoDB, AppSync, IAM, Template, Fn, StringParameter, NumberParameter, Refs, IntrinsicFunction } from 'cloudform-types'
+import { DynamoDB, AppSync, IAM, Template, Fn, StringParameter, NumberParameter, Refs, IntrinsicFunction, DeletionPolicy } from 'cloudform-types'
 import Output from 'cloudform-types/types/output';
 import {
     DynamoDBMappingTemplate, printBlock, str, print,
@@ -148,7 +148,7 @@ export class ResourceFactory {
     /**
      * Create a DynamoDB table for a specific type.
      */
-    public makeModelTable(typeName: string, hashKey: string = 'id', rangeKey?: string) {
+    public makeModelTable(typeName: string, hashKey: string = 'id', rangeKey?: string, deletionPolicy: DeletionPolicy = DeletionPolicy.Delete) {
         const keySchema = hashKey && rangeKey ? [
             {
                 AttributeName: hashKey,
@@ -195,7 +195,7 @@ export class ResourceFactory {
                 },
                 Refs.NoValue
             ) as any,
-        })
+        }).deletionPolicy(deletionPolicy)
     }
 
     private dynamoDBTableName(typeName: string): IntrinsicFunction {

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -45,13 +45,6 @@ export class ResourceFactory {
                 Description: 'The number of instances to launch into the Elasticsearch domain.',
                 Default: 1
             }),
-            [ResourceConstants.PARAMETERS.ElasticsearchDomainName]: new StringParameter({
-                Description: 'The name of the Elasticsearch domain.',
-                Default: 'appsync-elasticsearch-domain',
-                AllowedPattern: '^[a-z][a-z0-9-]*$',
-                MinLength: 1,
-                MaxLength: 28
-            }),
             [ResourceConstants.PARAMETERS.ElasticsearchInstanceType]: new StringParameter({
                 Description: 'The type of instance to launch into the Elasticsearch domain.',
                 Default: 't2.small.elasticsearch',

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -41,7 +41,6 @@ export class ResourceConstants {
         DynamoDBEnablePointInTimeRecovery: 'DynamoDBEnablePointInTimeRecovery',
 
         // Elasticsearch
-        ElasticsearchDomainName: 'ElasticSearchDomainName',
         ElasticsearchAccessIAMRoleName: 'ElasticSearchAccessIAMRoleName',
         ElasticsearchDebugStreamingLambda: 'ElasticSearchDebugStreamingLambda',
         ElasticsearchStreamingIAMRoleName: 'ElasticSearchStreamingIAMRoleName',

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -28,7 +28,18 @@ export interface TransformConfig {
      */
     StackMapping?: {
         [resourceId: string]: string
-    }
+    },
+
+    /**
+     * Provide build time options to GraphQL Transformer constructor functions.
+     * Certain options cannot be configured via CloudFormation parameters and
+     * need to be set at build time. E.G. DeletionPolicies cannot depend on parameters.
+     */
+    TransformerOptions?: {
+        [transformer: string]: {
+            [option: string]: any
+        }
+    },
 
     /**
      * For backwards compatibility we store a set of resource logical ids that


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This change adds support for users to set the deletion policy of their DynamoDB tables to "Retain". This will prevent any accidental deletion of DynamoDB tables when making changes to an API or removing an Amplify environment.

The user may set the deletion policy by providing the following configuration in the `transform.conf.json` file. We could not use `parameters.json` because the CFN "DeletionPolicy" cannot accept a "Fn.Ref". There is a corresponding PR in the docs repo.

```
{
    "TransformerOptions": {
        "model": {
            "EnableDeletionProtection": true
        }
    }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.