### PR TITLE
Storage Triggers Integration Tests + address DA/PM Feedback

### DIFF
--- a/packages/amplify-category-function/provider-utils/awscloudformation/cloudformation-templates/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/cloudformation-templates/lambda-cloudformation-template.json.ejs
@@ -187,6 +187,11 @@
             "Value": {
                 "Ref": "AWS::Region"
             }
+        },
+        "LambdaExecutionRole": {
+            "Value": {
+                "Ref": "LambdaExecutionRole"
+            }
         }
     }
 }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -279,6 +279,45 @@
                 }
             }
         },
+         "S3TriggerBucketPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "amplify-lambda-execution-policy",
+                "Roles": [
+                    {
+                        "Ref": "function<%= props.triggerFunction %>LambdaExecutionRole"
+                    }
+                ],
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:PutObject",
+                                "s3:GetObject",
+                                "s3:ListBucket",
+                                "s3:DeleteObject"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:s3:::",
+                                            {
+                                                "Ref": "bucketName"
+                                            },
+                                            "/*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
 	    <% } %>
 		"S3AuthPublicPolicy": {
 			"DependsOn": [

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -366,7 +366,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
   if (!storageParams ||
     !storageParams.triggerFunctions ||
     storageParams.triggerFunctions.length === 0) {
-    if (await amplify.confirmPrompt.run('Do you want to add a Lambda Trigger for your Table?')) {
+    if (await amplify.confirmPrompt.run('Do you want to add a Lambda Trigger for your Table?', false)) {
       let triggerName;
 
       try {
@@ -713,6 +713,9 @@ async function addTrigger(context, resourceName, triggerList) {
 
     context.amplify.updateamplifyMetaAfterResourceUpdate('function', functionName, 'dependsOn', resourceDependsOn);
     context.print.success(`Successfully updated resource ${functionName} locally`);
+    if (await context.amplify.confirmPrompt.run(`Do you want to edit the local ${functionName} lambda function now?`)) {
+      await context.amplify.openEditor(context, `${projectBackendDirPath}/function/${functionName}/src/index.js`);
+    }
   } else {
     throw new Error(`Function ${functionName} does not exist`);
   }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
@@ -130,6 +130,11 @@
             "Value": {
                 "Ref": "AWS::Region"
             }
+        },
+        "LambdaExecutionRole": {
+            "Value": {
+                "Ref": "LambdaExecutionRole"
+            }
         }
     }
 }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
@@ -130,6 +130,11 @@
             "Value": {
                 "Ref": "AWS::Region"
             }
+        },
+        "LambdaExecutionRole": {
+            "Value": {
+                "Ref": "LambdaExecutionRole"
+            }
         }
     }
 }

--- a/packages/amplify-e2e-tests/__tests__/storage.test.ts
+++ b/packages/amplify-e2e-tests/__tests__/storage.test.ts
@@ -1,0 +1,85 @@
+require('../src/aws-matchers/'); // custom matcher for assertion
+import { initProjectWithProfile, deleteProject, amplifyPushAuth } from '../src/init';
+import { addAuthWithDefault } from '../src/categories/auth';
+import { addSimpleDDB, addDDBWithTrigger, updateDDBWithTrigger, addS3WithTrigger } from '../src/categories/storage';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getDDBTable, checkIfBucketExists } from '../src/utils';
+
+
+describe('amplify add/update storage(S3)', () => {
+  let projRoot: string;
+  beforeEach(() => {
+    projRoot = createNewProjectDir();
+    jest.setTimeout(1000 * 60 * 60); // 1 hour
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('init a project and add S3 bucket with trigger', async () => {
+    await initProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot, {});
+    await addS3WithTrigger(projRoot, {});
+    await amplifyPushAuth(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    const { BucketName: bucketName, Region: region } = Object.keys(
+      meta.storage
+    ).map(key => meta.storage[key])[0].output;
+
+    expect(bucketName).toBeDefined();
+    expect(region).toBeDefined();
+    
+    const bucketExists = await checkIfBucketExists(bucketName,region);
+    expect(bucketExists).toMatchObject({});
+
+  });
+});
+
+describe('amplify add/update storage(DDB)', () => {
+  let projRoot: string;
+  beforeEach(() => {
+    projRoot = createNewProjectDir();
+    jest.setTimeout(1000 * 60 * 60); // 1 hour
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('init a project and add/update ddb table with & without trigger', async () => {
+    await initProjectWithProfile(projRoot, {});
+    await addSimpleDDB(projRoot, {});
+    await addDDBWithTrigger(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    await updateDDBWithTrigger(projRoot, {});
+    await amplifyPushAuth(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    const { Name: table1Name, Arn: table1Arn, Region: table1Region, StreamArn: table1StreamArn } = Object.keys(
+      meta.storage
+    ).map(key => meta.storage[key])[0].output;
+
+    expect(table1Name).toBeDefined();
+    expect(table1Arn).toBeDefined();
+    expect(table1Region).toBeDefined();
+    expect(table1StreamArn).toBeDefined()
+    const table1Configs = await getDDBTable(table1Name, table1Region);
+
+    expect(table1Configs.Table.TableArn).toEqual(table1Arn);
+
+    const { Name: table2Name, Arn: table2Arn, Region: table2Region, StreamArn: table2StreamArn } = Object.keys(
+      meta.storage
+    ).map(key => meta.storage[key])[1].output;
+
+    expect(table2Name).toBeDefined();
+    expect(table2Arn).toBeDefined();
+    expect(table2Region).toBeDefined();
+    expect(table2StreamArn).toBeDefined()
+    const table2Configs = await getDDBTable(table2Name, table2Region);
+    expect(table2Configs.Table.TableArn).toEqual(table2Arn);
+
+  });
+});

--- a/packages/amplify-e2e-tests/src/categories/auth.ts
+++ b/packages/amplify-e2e-tests/src/categories/auth.ts
@@ -17,11 +17,11 @@ export function addAuthWithDefault(
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'auth'], { cwd, stripColors: true, verbose })
-      .wait('Do you want to use the default authentication and security configuration?')
+      .wait('Do you want to use the default authentication')
       .sendline('\r')
-      .wait('How do you want users to be able to sign in when using your Cognito User Pool?')
+      .wait('How do you want users to be able to sign in')
       .sendline('\r')
-      .wait('What attributes are required for signing up?')
+      .wait('Do you want to configure advanced settings?')
       .sendline('\r')
       .sendEof()
       // tslint:disable-next-line

--- a/packages/amplify-e2e-tests/src/categories/storage.ts
+++ b/packages/amplify-e2e-tests/src/categories/storage.ts
@@ -1,0 +1,195 @@
+
+import * as nexpect from 'nexpect';
+import { join } from 'path';
+import * as fs from 'fs';
+
+import { getCLIPath, isCI, getEnvVars } from '../utils';
+const defaultSettings = {
+  projectName: 'CLI Storage test',
+};
+
+
+export function addSimpleDDB(
+  cwd: string,
+  settings: any,
+  verbose: boolean = !isCI()
+) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
+      .wait('Please select from one of the below mentioned services')
+      // j = down arrow
+      .sendline('j')
+      .sendline('\r')
+      .wait('Please provide a friendly name for your resource')
+      .sendline('\r')
+      .wait('Please provide table name')
+      .sendline('\r')
+      .wait('What would you like to name this column')
+      .sendline('id')
+      .sendline('\r')
+      .wait('Please choose the data type')
+      .sendline('\r')
+      .wait('Would you like to add another column')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Please choose partition key for the table')
+      .sendline('\r')
+      .wait('Do you want to add a sort key to your table')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Do you want to add global secondary indexes to your table')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Do you want to add a Lambda Trigger for your Table')
+      .sendline('n')
+      .sendline('\r')
+      .sendEof()
+      // tslint:disable-next-line
+      .run(function(err: Error) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      })
+  })
+}
+
+export function addDDBWithTrigger(
+  cwd: string,
+  settings: any,
+  verbose: boolean = !isCI()
+) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
+      .wait('Please select from one of the below mentioned services')
+      // j = down arrow
+      .sendline('j')
+      .sendline('\r')
+      .wait('Please provide a friendly name for your resource')
+      .sendline('\r')
+      .wait('Please provide table name')
+      .sendline('\r')
+      .wait('What would you like to name this column')
+      .sendline('id')
+      .sendline('\r')
+      .wait('Please choose the data type')
+      .sendline('\r')
+      .wait('Would you like to add another column')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Please choose partition key for the table')
+      .sendline('\r')
+      .wait('Do you want to add a sort key to your table')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Do you want to add global secondary indexes to your table')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Do you want to add a Lambda Trigger for your Table')
+      .sendline('y')
+      .sendline('\r')
+      .wait('Select from the following options')
+      // j = down arrow
+      .sendline('j')
+      .sendline('\r')
+      .wait('Do you want to edit the local')
+      .sendline('n')
+      .sendline('\r')
+      .sendEof()
+      // tslint:disable-next-line
+      .run(function(err: Error) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      })
+  })
+}
+
+export function updateDDBWithTrigger(
+  cwd: string,
+  settings: any,
+  verbose: boolean = !isCI()
+) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['update', 'storage'], { cwd, stripColors: true, verbose })
+       .wait('Please select from one of the below mentioned services')
+      // j = down arrow
+      .sendline('j')
+      .sendline('\r')
+      .wait('Specify the resource that you would want to update')
+      .sendline('\r')
+      .wait('Would you like to add another column')
+      .sendline('n')
+      .sendline('\r')
+      .wait('Do you want to add global secondary indexes to your table')
+      .sendline('n')
+      .sendline('\r')
+       .wait('Do you want to add a Lambda Trigger for your Table')
+      .sendline('y')
+      .sendline('\r')
+      .wait('Select from the following options')
+      // j = down arrow
+      .sendline('j')
+      .sendline('\r')
+      .wait('Do you want to edit the local')
+      .sendline('n')
+      .sendline('\r')
+      .sendEof()
+      // tslint:disable-next-line
+      .run(function(err: Error) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      })
+  })
+}
+
+
+export function addS3WithTrigger(
+  cwd: string,
+  settings: any,
+  verbose: boolean = !isCI()
+) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
+      .wait('Please select from one of the below mentioned services')
+      .sendline('\r')
+      .wait('Please provide a friendly name')
+      .sendline('\r')
+      .wait('Please provide bucket name')
+      .sendline('\r')
+      .wait('Who should have access')
+      .sendline('\r')
+      .wait('What kind of access do you want')
+      .sendline('\r')
+      .wait('Do you want to add a Lambda Trigger for your S3 Bucket')
+      .sendline('y')
+      .sendline('\r')
+      .wait('Select from the following options')
+      // j = down arrow
+      .sendline('j')
+      .sendline('\r')
+      .wait('Do you want to edit the local')
+      .sendline('n')
+      .sendline('\r')
+      .sendEof()
+      // tslint:disable-next-line
+      .run(function(err: Error) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      })
+  })
+}
+

--- a/packages/amplify-e2e-tests/src/utils/index.ts
+++ b/packages/amplify-e2e-tests/src/utils/index.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from 'fs';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
 export { default  as getProjectMeta } from './projectMeta';
-export { getUserPool, getUserPoolClients, getBot } from './sdk-calls'
+export { getDDBTable, checkIfBucketExists, getUserPool, getUserPoolClients, getBot } from './sdk-calls'
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
@@ -1,5 +1,16 @@
 import * as AWS from 'aws-sdk';
 
+
+const getDDBTable = async (tableName: string, region: string) => {
+  const service = new AWS.DynamoDB({ region });
+  return await service.describeTable({ TableName: tableName }).promise();
+};
+
+const checkIfBucketExists = async (bucketName: string, region: string) => {
+  const service = new AWS.S3({ region });
+  return await service.headBucket({ Bucket: bucketName }).promise();
+};
+
 const getUserPool = async (userpoolId, region) => {
   AWS.config.update({ region });
   const CognitoIdentityServiceProvider = AWS.CognitoIdentityServiceProvider;
@@ -41,4 +52,4 @@ const getBot = async (botName: string, region: string) => {
   return await service.getBot({ name: botName, versionOrAlias: '$LATEST' }).promise();
 };
 
-export { getUserPool, getUserPoolClients, getBot };
+export { getDDBTable, checkIfBucketExists, getUserPool, getUserPoolClients, getBot };


### PR DESCRIPTION

New features based on feedback:
* Auto-add S3 bucket access permissions on adding a trigger to S3
* Option to edit lambda trigger when adding a new trigger for S3 or Dynamo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.