### PR TITLE
fix: check that function-parameters.json exists before trying to read it

### DIFF
--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -421,10 +421,14 @@ function getHeadlessParams(context, service) {
 
 
 async function updateConfigOnEnvInit(context, category, service) {
-  const srvcMetaData = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)
-    .Lambda;
+  const srvcMetaData = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`).Lambda;
   const providerPlugin = context.amplify.getPluginInstance(context, srvcMetaData.provider);
-  const resourceParams = context.amplify.readJsonFile(`${context.amplify.pathManager.getBackendDirPath()}/function/${service}/function-parameters.json`);
+  const functionParametersPath = `${context.amplify.pathManager.getBackendDirPath()}/function/${service}/function-parameters.json`;
+  let resourceParams = {};
+  const functionParametersExists = await fs.exists(functionParametersPath);
+  if (functionParametersExists) {
+    resourceParams = context.amplify.readJsonFile(functionParametersPath);
+  }
   let envParams = {};
 
   // headless mode


### PR DESCRIPTION
*Issue #, if available:* [1806](https://github.com/aws-amplify/amplify-cli/issues/1806)

*Description of changes:*
Functions in projects created with an older version of the Amplify cli seem not to have a `function-parameters.json` file. We should check if this file exists before trying to read it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.