### PR TITLE
fix(amplify-category-function): fixing headless params

### DIFF
--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -415,8 +415,12 @@ function isInHeadlessMode(context) {
 }
 
 function getHeadlessParams(context, service) {
-  const { inputParams } = context.exeInfo;
-  return inputParams.categories.function.find(i => i.resourceName === service) || {};
+  const { inputParams = {} } = context.exeInfo;
+  return (
+    inputParams.categories &&
+    inputParams.categories.function &&
+    Array.isArray(inputParams.categories.function)
+  ) ? inputParams.categories.function.find(i => i.resourceName === service) : {};
 }
 
 

--- a/packages/amplify-category-function/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/index.js
@@ -420,7 +420,8 @@ function getHeadlessParams(context, service) {
     inputParams.categories &&
     inputParams.categories.function &&
     Array.isArray(inputParams.categories.function)
-  ) ? inputParams.categories.function.find(i => i.resourceName === service) : {};
+  ) ? inputParams.categories.function.find(i => i.resourceName === service) || {}
+    : {};
 }
 
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1826 

*Description of changes:*
Fixes issue when headless init does not pass function category or any categories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.