### PR TITLE
fix(amplify-category-storage): consider env in S3TriggerBucketPolicy

### DIFF
--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -280,6 +280,9 @@
             }
         },
          "S3TriggerBucketPolicy": {
+            "DependsOn": [
+                "S3Bucket"
+            ],
             "Type": "AWS::IAM::Policy",
             "Properties": {
                 "PolicyName": "amplify-lambda-execution-policy",
@@ -306,7 +309,7 @@
                                         [
                                             "arn:aws:s3:::",
                                             {
-                                                "Ref": "bucketName"
+                                                "Ref": "S3Bukect"
                                             },
                                             "/*"
                                         ]

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -309,7 +309,7 @@
                                         [
                                             "arn:aws:s3:::",
                                             {
-                                                "Ref": "S3Bukect"
+                                                "Ref": "S3Bucket"
                                             },
                                             "/*"
                                         ]

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -540,7 +540,7 @@ async function addTrigger(context, resourceName, triggerFunction, options) {
                     [
                       'arn:aws:s3:::',
                       {
-                        Ref: 'bucketName',
+                        Ref: 'S3Bucket',
                       },
                       '/*',
                     ],

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -515,6 +515,9 @@ async function addTrigger(context, resourceName, triggerFunction, options) {
 
     storageCFNFile.Resources.S3TriggerBucketPolicy = {
       Type: 'AWS::IAM::Policy',
+      DependsOn: [
+        "S3Bucket"
+      ],
       Properties: {
         PolicyName: 's3-trigger-lambda-execution-policy',
         Roles: [

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -516,7 +516,7 @@ async function addTrigger(context, resourceName, triggerFunction, options) {
     storageCFNFile.Resources.S3TriggerBucketPolicy = {
       Type: 'AWS::IAM::Policy',
       DependsOn: [
-        "S3Bucket"
+        'S3Bucket',
       ],
       Properties: {
         PolicyName: 's3-trigger-lambda-execution-policy',


### PR DESCRIPTION
*Issue #, if available:*
fix #1852

*Description of changes:*
Change to reference actual S3 bucket name instead of `bucketName` parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.