### PR TITLE
chore(cli): manual update versions

### DIFF
--- a/packages/amplify-category-analytics/package.json
+++ b/packages/amplify-category-analytics/package.json
@@ -1,10 +1,10 @@
 {
   "name": "amplify-category-analytics",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "amplify-cli analytics plugin",
   "main": "index.js",
   "dependencies": {
-    "amplify-category-auth": "1.7.1",
+    "amplify-category-auth": "^1.7.2",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
     "inquirer": "6.3.1",

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "amplify-cli api plugin",
   "main": "index.js",
   "author": "Amazon Web Services",
@@ -10,9 +10,9 @@
     "lint-fix": "eslint . --fix"
   },
   "dependencies": {
-    "amplify-category-auth": "1.7.1",
-    "amplify-category-function": "1.7.1",
-    "amplify-category-storage": "1.8.1",
+    "amplify-category-auth": "^1.7.2",
+    "amplify-category-function": "^1.7.2",
+    "amplify-category-storage": "^1.8.2",
     "aws-sdk": "^2.391.0",
     "eslint": "^4.9.0",
     "fs-extra": "^7.0.0",

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-auth",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "amplify-cli authentication plugin",
   "main": "index.js",
   "author": "Amazon Web Services",
@@ -13,7 +13,7 @@
     "test-ci": "jest --ci -i"
   },
   "dependencies": {
-    "amplify-category-function": "1.7.1",
+    "amplify-category-function": "^1.7.2",
     "aws-sdk": "^2.475.0",
     "chalk": "^2.4.1",
     "chalk-pipe": "^2.0.0",

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -1,10 +1,10 @@
 {
   "name": "amplify-category-function",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "main": "index.js",
   "description": "amplify-cli function plugin",
   "dependencies": {
-    "amplify-category-storage": "1.8.1",
+    "amplify-category-storage": "^1.8.2",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
     "grunt": "^1.0.3",

--- a/packages/amplify-category-interactions/package.json
+++ b/packages/amplify-category-interactions/package.json
@@ -1,11 +1,11 @@
 {
   "name": "amplify-category-interactions",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "index.js",
   "description": "amplify-cli interactions plugin",
   "dependencies": {
-    "amplify-category-auth": "1.7.1",
-    "amplify-category-function": "1.7.1",
+    "amplify-category-auth": "^1.7.2",
+    "amplify-category-function": "^1.7.2",
     "fs-extra": "^7.0.0",
     "fuzzy": "^0.1.3",
     "inquirer": "6.3.1",

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -1,10 +1,10 @@
 {
   "name": "amplify-category-notifications",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "amplify-cli notifications plugin",
   "main": "index.js",
   "dependencies": {
-    "amplify-category-auth": "1.7.1",
+    "amplify-category-auth": "^1.7.2",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
     "inquirer": "6.3.1",

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -1,10 +1,10 @@
 {
   "name": "amplify-category-storage",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "amplify-cli storage plugin",
   "main": "index.js",
   "dependencies": {
-    "amplify-category-auth": "1.7.1",
+    "amplify-category-auth": "^1.7.2",
     "eslint": "^4.19.1",
     "fs-extra": "^7.0.0",
     "inquirer": "6.3.1",

--- a/packages/amplify-category-xr/package.json
+++ b/packages/amplify-category-xr/package.json
@@ -1,10 +1,10 @@
 {
   "name": "amplify-category-xr",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "main": "index.js",
   "description": "amplify-cli xr plugin",
   "dependencies": {
-    "amplify-category-auth": "1.7.1",
+    "amplify-category-auth": "^1.7.2",
     "chalk": "^2.4.1",
     "fs-extra": "^7.0.0",
     "fuzzy": "^0.1.3",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/cli",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Amplify CLI",
   "bin": {
     "amplify": "bin/amplify"
@@ -20,15 +20,15 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
-    "amplify-category-analytics": "1.5.5",
-    "amplify-category-api": "1.7.8",
-    "amplify-category-auth": "1.7.1",
-    "amplify-category-function": "1.7.1",
+    "amplify-category-analytics": "^1.5.6",
+    "amplify-category-api": "^1.7.9",
+    "amplify-category-auth": "^1.7.2",
+    "amplify-category-function": "^1.7.2",
     "amplify-category-hosting": "1.2.2",
-    "amplify-category-interactions": "1.6.1",
-    "amplify-category-notifications": "1.4.12",
-    "amplify-category-storage": "1.8.1",
-    "amplify-category-xr": "1.6.5",
+    "amplify-category-interactions": "^1.6.2",
+    "amplify-category-notifications": "^1.4.13",
+    "amplify-category-storage": "^1.8.2",
+    "amplify-category-xr": "^1.6.6",
     "amplify-codegen": "1.5.6",
     "amplify-frontend-android": "1.8.2",
     "amplify-frontend-ios": "1.8.2",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-e2e-tests",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Circle CI failed to update the versions after npm publish, manually update the package versions to
clear the deployment path

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.