### PR TITLE
 fix(amplify-codegen): prevent schema location change on push

### DIFF
--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -12,20 +12,19 @@ async function postPushCallback(context, graphQLConfig) {
   if (!graphQLConfig) {
     return;
   }
-  const config = loadConfig(context);
-  const newAPIs = getAppSyncAPIDetails(context);
 
-  const api = newAPIs[0];
-  const schemaLocation = getSchemaDownloadLocation(context, graphQLConfig.gqlConfig.projectName);
-  const schema = await downloadIntrospectionSchema(context, api.id, schemaLocation);
+  if (!graphQLConfig.gqlConfig.schema) {
+    const config = loadConfig(context);
+    const schemaLocation = getSchemaDownloadLocation(context);
 
-  const newProject = graphQLConfig.gqlConfig;
-  newProject.schema = schema;
+    const newProject = graphQLConfig.gqlConfig;
+    newProject.schema = schemaLocation;
+    config.addProject(newProject);
+    config.save();
+  }
+  const apis = getAppSyncAPIDetails(context);
 
-  config.addProject(newProject);
-
-  config.save();
-
+  await downloadIntrospectionSchema(context, apis[0].id, graphQLConfig.gqlConfig.schema);
   if (graphQLConfig.shouldGenerateDocs) {
     generateStatements(context);
   }


### PR DESCRIPTION
Codegen use to reset the location of downloaded introspection shcema to the default location when a
push was done. Updated code to prevent chaning of schema location

Fix #1818