### PR TITLE
enhancement(graphql-dynamodb-transformer) - Adding parameter to configure server side encryption

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -72,6 +72,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
   const parameters = {
     AppSyncApiName: resourceAnswers[inputs[1].key],
     DynamoDBBillingMode: 'PAY_PER_REQUEST',
+    DynamoDBEnableServerSideEncryption: 'false',
   };
 
   // Ask auth/security question

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -45,6 +45,14 @@ export class ResourceFactory {
                     'false'
                 ]
             }),
+            [ResourceConstants.PARAMETERS.DynamoDBEnableServerSideEncryption]: new StringParameter({
+                Description: 'Enable server side encryption powered by KMS.',
+                Default: 'true',
+                AllowedValues: [
+                    'true',
+                    'false'
+                ]
+            })
         }
     }
 
@@ -66,7 +74,9 @@ export class ResourceFactory {
                     Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBBillingMode), 'PAY_PER_REQUEST'),
 
                 [ResourceConstants.CONDITIONS.ShouldUsePointInTimeRecovery]:
-                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery), 'true')
+                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery), 'true'),
+                [ResourceConstants.CONDITIONS.ShouldUseServerSideEncryption]:
+                    Fn.Equals(Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBEnableServerSideEncryption), 'true'),
             }
         }
     }
@@ -186,7 +196,11 @@ export class ResourceFactory {
                 }
             ) as any,
             SSESpecification: {
-                SSEEnabled: true
+                SSEEnabled: Fn.If(
+                    ResourceConstants.CONDITIONS.ShouldUseServerSideEncryption,
+                    true,
+                    false
+                )
             },
             PointInTimeRecoverySpecification: Fn.If(
                 ResourceConstants.CONDITIONS.ShouldUsePointInTimeRecovery,

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -39,6 +39,7 @@ export class ResourceConstants {
         DynamoDBModelTableReadIOPS: 'DynamoDBModelTableReadIOPS',
         DynamoDBModelTableWriteIOPS: 'DynamoDBModelTableWriteIOPS',
         DynamoDBEnablePointInTimeRecovery: 'DynamoDBEnablePointInTimeRecovery',
+        DynamoDBEnableServerSideEncryption: 'DynamoDBEnableServerSideEncryption',
 
         // Elasticsearch
         ElasticsearchDomainName: 'ElasticSearchDomainName',
@@ -63,6 +64,7 @@ export class ResourceConstants {
         // DynamoDB
         ShouldUsePayPerRequestBilling: 'ShouldUsePayPerRequestBilling',
         ShouldUsePointInTimeRecovery: 'ShouldUsePointInTimeRecovery',
+        ShouldUseServerSideEncryption: 'ShouldUseServerSideEncryption',
 
         // Auth
         ShouldCreateAPIKey: 'ShouldCreateAPIKey',


### PR DESCRIPTION
*Issue #, if available:*

#1867 

*Description of changes:*

Adds a new CFN parameter that toggles the value of `SSESpecification.SSEEnabled` property of the `AWS::DynamoDB::Table` resources created by `@model`. New projects are now initialized with DynamoDB's `SSEEnabled` set to **false**. Users who have deployed an API already are able to change their table's encryption settings via the DynamoDB console. There is currently a limitation in the DynamoDB CFN implementation that prevents changing this setting via CFN for now. Users are also free to create a new env and manually set the parameter in parameter.json for the new environment.

*How to use*

Add this to your `parameter.json`:

```json
{
  "DynamoDBEnableServerSideEncryption": false
}
```

> Note: If you have deployed this API previously and SSEEnabled was set to true, then this update will fail. Create a new project or create a new env before setting **DynamoDBEnableServerSideEncryption**.

See docs PR https://github.com/aws-amplify/docs/pull/804.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.