### PR TITLE
fix(amplify-provider-awscloudformation): apigw unauth access

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/cloudformation-templates/apigw-cloudformation-template-default.json.ejs
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/cloudformation-templates/apigw-cloudformation-template-default.json.ejs
@@ -188,6 +188,37 @@
                             "<%= props.paths[i].name %>/*"
                           ]
                         ]
+                      },
+                                            {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:aws:execute-api:",
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                              "Ref": "AWS::AccountId"
+                            },
+                            ":",
+                            {
+                              "Ref": "<%= props.apiName %>"
+                            },
+                            "/",
+                            {
+                              "Fn::If": [
+                                "ShouldNotCreateEnvResources",
+                                "Prod",
+                                {
+                                  "Ref": "env"
+                                }
+                              ]
+                            },
+                              "<%= props.paths[i].privacy.unauth[x] %>",
+                            "<%= props.paths[i].name %>"
+                          ]
+                        ]
                       }
                     <% if (x !== props.paths[i].privacy.unauth.length - 1) { %>
                       ,


### PR DESCRIPTION
*Issue #, if available:*
#1905
*Description of changes:*
Create parity between `auth` and `unauth` policies when updating APIGW. 

`auth` policy currently allows resource invocation for `route_name` on:
`/{route_name}`
`/{route_name}/*`

`unauth` policy currently only allows resource invocation for `route_name` on:
`/{route_name}/*`

`unauth` policy will henceforth allow resource invocation for `route_name` on:
`/{route_name}`
`/{route_name}/*`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.