### PR TITLE
Allow self-signed certs.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,10 @@ The Amplify CLI supports the commands shown in the following table.
 | amplify codegen add \| generate | Performs generation of strongly typed objects using a GraphQL schema. |
 | amplify env add \| list \| remove \| get \| pull \| import | See the [multienv docs](https://aws-amplify.github.io/docs/cli/multienv). |
 
+### Allow self-signed certs:
+
+To allow self-signed certs, please append --ignore-ssl to your amplify commands. 
+
 ### Category specific commands:
 - [auth (Amazon Cognito)](packages/amplify-category-auth/Readme.md)
 - [storage (Amazon S3 & Amazon DynamoDB)](packages/amplify-category-storage/Readme.md)

--- a/packages/amplify-cli/src/cli.js
+++ b/packages/amplify-cli/src/cli.js
@@ -28,6 +28,8 @@ async function run(argv) {
 
   const context = await cli.run(argv);
 
+  context.ignoreSSL = !(argv.includes('--ignoressl') || argv.includes('--ignore-ssl'));
+
   // send it back (for testing, mostly)
   return context;
 }

--- a/packages/amplify-provider-awscloudformation/lib/initializer.js
+++ b/packages/amplify-provider-awscloudformation/lib/initializer.js
@@ -78,7 +78,10 @@ async function getAwsConfig(context) {
   if (httpProxy) {
     awsConfig = {
       ...awsConfig,
-      httpOptions: { agent: proxyAgent(httpProxy) },
+      httpOptions: {
+        agent: proxyAgent(httpProxy),
+        rejectUnauthorized: context.ignoreSSL,
+      },
     };
   }
 

--- a/packages/amplify-provider-awscloudformation/lib/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/system-config-manager.js
@@ -62,6 +62,7 @@ function setProfile(awsConfig, profileName) {
 async function getProfiledAwsConfig(context, profileName, isRoleSourceProfile) {
   let awsConfig;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+
   const profileConfig = getProfileConfig(profileName);
   if (profileConfig) {
     if (!isRoleSourceProfile && profileConfig.role_arn) {
@@ -86,7 +87,10 @@ async function getProfiledAwsConfig(context, profileName, isRoleSourceProfile) {
   if (httpProxy) {
     awsConfig = {
       ...awsConfig,
-      httpOptions: { agent: proxyAgent(httpProxy) },
+      httpOptions: {
+        agent: proxyAgent(httpProxy),
+        rejectUnauthorized: context.ignoreSSL,
+      },
     };
   }
 

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-pinpoint.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-pinpoint.js
@@ -43,11 +43,13 @@ async function getConfiguredPinpointClient(context, category, action, options = 
   };
 
   if (httpProxy) {
-    aws.config.update({
+    awsConfig = {
+      ...awsConfig,
       httpOptions: {
         agent: proxyAgent(httpProxy),
+        rejectUnauthorized: context.ignoreSSL,
       },
-    });
+    };
   }
 
   return new aws.Pinpoint({ ...cred, ...defaultOptions, ...options });

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws.js
@@ -5,17 +5,20 @@ const configurationManager = require('../../lib/configuration-manager');
 
 aws.configureWithCreds = async (context) => {
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+
   const config = await configurationManager.loadConfiguration(context, aws);
   if (config) {
     aws.config.update(config);
   }
 
   if (httpProxy) {
-    aws.config.update({
+    awsConfig = {
+      ...awsConfig,
       httpOptions: {
         agent: proxyAgent(httpProxy),
+        rejectUnauthorized: context.ignoreSSL,
       },
-    });
+    };
   }
 
   return aws;


### PR DESCRIPTION
Issue #1486 

*Description of changes:*

I added logic to search for the `--ignore-ssl` argument in the CLI tool and then set a variable in the context that'll change the http options.

It sets the rejectUnauthorized flag in httpOptions to false to allow self-signed certs.

The next plan is to add in logic to:

- Specify a location for a cert.
- Add support for profiles so a user doesn't need to use command-line arguments.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This contribution has been made by [Lockheed Martin](https://www.lockheedmartin.com/en-us/index.html)