### PR TITLE
style(amplify-codegen): eslint-disable comment style

### DIFF
--- a/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/amplify-graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -485,7 +485,7 @@ subscription ReviewAdded($episode: Episode) {
 `;
 
 exports[`end 2 end tests should generate statements in JS 1`] = `
-"// eslint-disable
+"/* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
 export const hero = \`query Hero($episode: Episode) {

--- a/packages/amplify-graphql-docs-generator/templates/javascript.hbs
+++ b/packages/amplify-graphql-docs-generator/templates/javascript.hbs
@@ -1,4 +1,4 @@
-// eslint-disable
+/* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
 {{> renderToVariable }}


### PR DESCRIPTION
*Description of changes:*
The current handlebar template use `// eslint-disable` at the beginning of the file, [which is invalid](https://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments).

Here is the eslint error I have:
```
1:1  error  Prefer default export  import/prefer-default-export
```

If I manually replace the comment type, then it works.
Because these files are autogenerated and will be erased regularly, this forces me to disable the rule in all my project (I could override the eslint config for these specific files, but using the right comment seems to be a better solution 🙂).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.