### PR TITLE
feat(graphql-connection-transformer): limit

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -88,10 +88,11 @@ function getFieldType(fields: ReadonlyArray<FieldDefinitionNode>, fieldName: str
  * @param inputFieldNames: The fields passed in to the @connection directive.
  * @param keySchema: The key schema for the index being used.
  */
-function checkFieldsAgainstIndex(parentFields: ReadonlyArray<FieldDefinitionNode>,
-                                 relatedTypeFields: ReadonlyArray<FieldDefinitionNode>,
-                                 inputFieldNames: string[],
-                                 keySchema: KeySchema[]): void {
+function checkFieldsAgainstIndex(
+        parentFields: ReadonlyArray<FieldDefinitionNode>,
+        relatedTypeFields: ReadonlyArray<FieldDefinitionNode>,
+        inputFieldNames: string[],
+        keySchema: KeySchema[]): void {
     const hashAttributeName = keySchema[0].AttributeName;
     const tablePKType = getFieldType(relatedTypeFields, String(hashAttributeName));
     const queryPKType = getFieldType(parentFields, inputFieldNames[0]);
@@ -144,10 +145,11 @@ export class ModelConnectionTransformer extends Transformer {
         super(
             'ModelConnectionTransformer',
             gql`directive @connection(name: String,
-                                      keyField: String,
-                                      sortField: String,
-                                      keyName: String,
-                                      fields: [String!]) on FIELD_DEFINITION`
+                                        keyField: String,
+                                        sortField: String,
+                                        keyName: String,
+                                        limit: Int,
+                                        fields: [String!]) on FIELD_DEFINITION`
         )
         this.resources = new ResourceFactory();
     }
@@ -234,6 +236,7 @@ export class ModelConnectionTransformer extends Transformer {
         const leftConnectionIsNonNull = isNonNullType(field.type)
         const rightConnectionIsList = associatedConnectionField ? isListType(associatedConnectionField.type) : undefined
         const rightConnectionIsNonNull = associatedConnectionField ? isNonNullType(associatedConnectionField.type) : undefined
+        const limit = getDirectiveArgument(directive)("limit")
 
         let connectionAttributeName = getDirectiveArgument(directive)("keyField")
         const associatedSortField = associatedSortFieldName &&
@@ -294,7 +297,8 @@ export class ModelConnectionTransformer extends Transformer {
                 connectionAttributeName,
                 connectionName,
                 // If there is a sort field for this connection query then use
-                sortKeyInfo
+                sortKeyInfo,
+                limit
             )
             ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver)
 
@@ -371,7 +375,8 @@ export class ModelConnectionTransformer extends Transformer {
                 relatedTypeName,
                 connectionAttributeName,
                 connectionName,
-                sortKeyInfo
+                sortKeyInfo,
+                limit
             )
             ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver)
 

--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -528,6 +528,58 @@ test('Test ModelConnectionTransformer does not throw with valid key fields', () 
     expect(() => transformer.transform(validSchema3)).toBeTruthy();
 })
 
+test('Test ModelConnectionTransformer overrides the default limit', () => {
+    const validSchema = `
+    type Post @model {
+        id: ID!
+        title: String!
+        comments: [Comment] @connection(limit: 50)
+    }
+    type Comment @model {
+        id: ID!
+        content: String
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer(),
+            new ModelConnectionTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    expect(out.stacks.ConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy()
+
+    // Post.comments field
+    expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 50) )');
+});
+
+test('Test ModelConnectionTransformer uses the default limit', () => {
+    const validSchema = `
+    type Post @model {
+        id: ID!
+        title: String!
+        comments: [Comment] @connection
+    }
+    type Comment @model {
+        id: ID!
+        content: String
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer(),
+            new ModelConnectionTransformer()
+        ]
+    })
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined()
+    expect(out.stacks.ConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy()
+
+    // Post.comments field
+    expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 10) )');
+});
+
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
     for (const fieldName of fields) {
         const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)

--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -9,7 +9,7 @@ import {
     ifElse, compoundExpression, bool, equals, iff, raw, comment, qref, Expression, block
 } from 'graphql-mapping-template'
 import { ResourceConstants, ModelResourceIDs, DEFAULT_SCALARS, NONE_VALUE, applyKeyConditionExpression,
-         attributeTypeFromScalar, toCamelCase, applyCompositeKeyConditionExpression } from 'graphql-transformer-common'
+        attributeTypeFromScalar, toCamelCase, applyCompositeKeyConditionExpression } from 'graphql-transformer-common'
 import { InvalidDirectiveError } from 'graphql-transformer-core';
 
 
@@ -129,13 +129,15 @@ export class ResourceFactory {
      * @param type
      */
     public makeQueryConnectionResolver(
-        type: string, field: string, relatedType: string,
-        connectionAttribute: string, connectionName: string,
-        sortKeyInfo?: { fieldName: string, attributeType: 'S' | 'B' | 'N' }
+        type: string, field: string, relatedType: string, 
+        connectionAttribute: string, connectionName: string, 
+        sortKeyInfo?: { fieldName: string, attributeType: 'S' | 'B' | 'N' },
+        limit?: number
     ) {
         const defaultPageLimit = 10
+        const pageLimit = limit || defaultPageLimit
         const setup: Expression[] = [
-            set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
+            set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${pageLimit})`)),
             set(ref('query'), obj({
                 'expression': str('#connectionAttribute = :connectionAttribute'),
                 'expressionNames': obj({
@@ -204,11 +206,12 @@ export class ResourceFactory {
      * @param connectionAttributes The names of the underlying attributes containing the fields to query by.
      * @param keySchema Key schema of the index or table being queried.
      */
-    public makeGetItemConnectionWithKeyResolver(type: string,
-                                           field: string,
-                                           relatedType: string,
-                                           connectionAttributes: string[],
-                                           keySchema: KeySchema[]): Resolver {
+    public makeGetItemConnectionWithKeyResolver(
+        type: string,
+        field: string,
+        relatedType: string,
+        connectionAttributes: string[],
+        keySchema: KeySchema[]): Resolver {
 
         const partitionKeyName = keySchema[0].AttributeName as string
 


### PR DESCRIPTION
The @connection directive can optionally accept a limit which overrides
the default limit of 10.

*Issue #, if available:* #1703

*Description of changes:*

The `ModelConnectionTransformer` sets the limit in the vtl file if it was provided in the `@connection` directive, e.g.:

```graphql
type Post @model {
    id: ID!
    title: String!
    comments: [Comment] @connection(limit: 50)
}
type Comment @model {
    id: ID!
    content: String
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.