### PR TITLE
fix(amplify-util-mock): handle unsupported data source gracefully

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -86,7 +86,7 @@ export function graphQLDataSource(
     `Data source of type ${typeName} is not supported by local mocking. A NONE data source will be used.`
   );
   return {
-    name: resource.Properties.Name,
+    name: resourceName,
     type: 'NONE',
   };
 }


### PR DESCRIPTION
API Mock server did not handle unsupported data source such as elastic search well. Updated the code
to handle it gracefully and use NONE as the data source when not supported

fix #1997

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.