### PR TITLE
test(graphql-transformers-e2e-tests): key transformer fixes

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -292,7 +292,8 @@ test('Test update mutation validation with three part secondary key.', async () 
     expect(updateResponseMissingFirstSortKey.errors).toHaveLength(1);
     const updateResponseMissingAllSortKeys = await updateShippingUpdate({ id: item.id, orderId: 'order1', name: 'testing'});
     expect(updateResponseMissingAllSortKeys.data.updateShippingUpdate.name).toEqual('testing')
-    const updateResponseMissingNoKeys = await updateShippingUpdate({ id: item.id, orderId: 'order1', itemId: 'item1', status: 'PENDING', name: 'testing2' });
+    const updateResponseMissingNoKeys = await updateShippingUpdate(
+        { id: item.id, orderId: 'order1', itemId: 'item1', status: 'PENDING', name: 'testing2' });
     expect(updateResponseMissingNoKeys.data.updateShippingUpdate.name).toEqual('testing2')
 })
 
@@ -332,7 +333,7 @@ test('Test @key directive with sortDirection on GSI', async () => {
     const newShippingUpdates = await listGSIShippingUpdate('order1', { beginsWith: { itemId: 'product' } }, 'DESC');
     const oldShippingUpdates = await listGSIShippingUpdate('order1', { beginsWith: { itemId: 'product' } }, 'ASC');
     expect(oldShippingUpdates.data.shippingUpdates.items[0].status).toEqual('PENDING');
-    expect(oldShippingUpdates.data.shippingUpdates.items[0].name).toEqual('order1Name1');
+    expect(oldShippingUpdates.data.shippingUpdates.items[0].name).toEqual('testing2');
     expect(newShippingUpdates.data.shippingUpdates.items[0].status).toEqual('DELIVERED');
     expect(newShippingUpdates.data.shippingUpdates.items[0].name).toEqual('order1Name4');
 })
@@ -547,7 +548,8 @@ interface ItemCompositeKeyInput {
     createdAt?: string
 }
 async function listItem(orderId?: string, statusCreatedAt?: ItemCompositeKeyConditionInput, limit?: number, nextToken?: string) {
-    const result = await GRAPHQL_CLIENT.query(`query ListItems($orderId: ID, $statusCreatedAt: ModelItemPrimaryCompositeKeyConditionInput, $limit: Int, $nextToken: String) {
+    const result = await GRAPHQL_CLIENT.query(`query ListItems(
+        $orderId: ID, $statusCreatedAt: ModelItemPrimaryCompositeKeyConditionInput, $limit: Int, $nextToken: String) {
         listItems(orderId: $orderId, statusCreatedAt: $statusCreatedAt, limit: $limit, nextToken: $nextToken) {
             items {
                 orderId
@@ -563,7 +565,8 @@ async function listItem(orderId?: string, statusCreatedAt?: ItemCompositeKeyCond
 }
 
 async function itemsByStatus(status: string, createdAt?: StringKeyConditionInput, limit?: number, nextToken?: string) {
-    const result = await GRAPHQL_CLIENT.query(`query ListByStatus($status: Status!, $createdAt: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
+    const result = await GRAPHQL_CLIENT.query(`query ListByStatus(
+        $status: Status!, $createdAt: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
         itemsByStatus(status: $status, createdAt: $createdAt, limit: $limit, nextToken: $nextToken) {
             items {
                 orderId
@@ -579,7 +582,8 @@ async function itemsByStatus(status: string, createdAt?: StringKeyConditionInput
 }
 
 async function itemsByCreatedAt(createdAt: string, status?: StringKeyConditionInput, limit?: number, nextToken?: string) {
-    const result = await GRAPHQL_CLIENT.query(`query ListByCreatedAt($createdAt: AWSDateTime!, $status: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
+    const result = await GRAPHQL_CLIENT.query(`query ListByCreatedAt(
+        $createdAt: AWSDateTime!, $status: ModelStringKeyConditionInput, $limit: Int, $nextToken: String) {
         itemsByCreatedAt(createdAt: $createdAt, status: $status, limit: $limit, nextToken: $nextToken) {
             items {
                 orderId

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -111,8 +111,8 @@ test('Test that a primary @key with 3 fields changes the hash and sort keys.', (
     expectArguments(getTestField, ['email', 'kind', 'date']);
 
     const listTestField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
-    expect(listTestField.arguments).toHaveLength(5);
-    expectArguments(listTestField, ['email', 'kindDate', 'filter', 'nextToken', 'limit']);
+    expect(listTestField.arguments).toHaveLength(6);
+    expectArguments(listTestField, ['email', 'kindDate', 'filter', 'nextToken', 'limit', 'sortDirection']);
 })
 
 test('Test that a secondary @key with 3 fields changes the hash and sort keys and adds a query fields correctly.', () => {
@@ -141,7 +141,7 @@ test('Test that a secondary @key with 3 fields changes the hash and sort keys an
     expect(hashKey.AttributeName).toEqual('id');
     expect(hashKeyAttr.AttributeType).toEqual('S');
     // composite keys will always be strings.
-    
+
     const gsi = tableResource.Properties.GlobalSecondaryIndexes.find(o => o.IndexName === 'GSI')
     const gsiHashKey = gsi.KeySchema.find(o => o.KeyType === 'HASH');
     const gsiHashKeyAttr = tableResource.Properties.AttributeDefinitions.find(o => o.AttributeName === 'email');
@@ -159,8 +159,8 @@ test('Test that a secondary @key with 3 fields changes the hash and sort keys an
     expectArguments(getTestField, ['id']);
 
     const queryField = queryType.fields.find(f => f.name && f.name.value === 'listByEmailKindDate') as FieldDefinitionNode;
-    expect(queryField.arguments).toHaveLength(5);
-    expectArguments(queryField, ['email', 'kindDate', 'filter', 'nextToken', 'limit']);
+    expect(queryField.arguments).toHaveLength(6);
+    expectArguments(queryField, ['email', 'kindDate', 'filter', 'nextToken', 'limit', 'sortDirection']);
 
     const listTestField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
     expect(listTestField.arguments).toHaveLength(3);
@@ -203,13 +203,14 @@ test('Test that a secondary @key with a single field adds a GSI.', () => {
     expect(listTestsField.arguments).toHaveLength(3);
     expectArguments(listTestsField, ['filter', 'nextToken', 'limit']);
     const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmail') as FieldDefinitionNode;
-    expect(queryIndexField.arguments).toHaveLength(4);
-    expectArguments(queryIndexField, ['email', 'filter', 'nextToken', 'limit']);
+    expect(queryIndexField.arguments).toHaveLength(5);
+    expectArguments(queryIndexField, ['email', 'filter', 'nextToken', 'limit', 'sortDirection']);
 })
 
 test('Test that a secondary @key with a multiple field adds an GSI.', () => {
     const validSchema = `
-    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "CategoryGSI", fields: ["category", "createdAt"], queryField: "testsByCategory") {
+    type Test @model @key(fields: ["email", "createdAt"])
+    @key(name: "CategoryGSI", fields: ["category", "createdAt"], queryField: "testsByCategory") {
         email: String!
         createdAt: String!
         category: String!
@@ -251,13 +252,13 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
     const schema = parse(out.schema);
     const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
     const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByCategory') as FieldDefinitionNode;
-    expect(queryIndexField.arguments).toHaveLength(5);
-    expectArguments(queryIndexField, ['category', 'createdAt', 'filter', 'nextToken', 'limit']);
+    expect(queryIndexField.arguments).toHaveLength(6);
+    expectArguments(queryIndexField, ['category', 'createdAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
 
     // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
     const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
-    expect(listTestsField.arguments).toHaveLength(5);
-    expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit']);
+    expect(listTestsField.arguments).toHaveLength(6);
+    expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
 
     // Check the create, update, delete inputs.
     const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTestInput') as ObjectTypeDefinitionNode;
@@ -276,7 +277,9 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
 
 test('Test that a secondary @key with a multiple field adds an LSI.', () => {
     const validSchema = `
-    type Test @model @key(fields: ["email", "createdAt"]) @key(name: "GSI_Email_UpdatedAt", fields: ["email", "updatedAt"], queryField: "testsByEmailByUpdatedAt") {
+    type Test 
+        @model @key(fields: ["email", "createdAt"]) 
+        @key(name: "GSI_Email_UpdatedAt", fields: ["email", "updatedAt"], queryField: "testsByEmailByUpdatedAt") {
         email: String!
         createdAt: String!
         updatedAt: String!
@@ -317,13 +320,13 @@ test('Test that a secondary @key with a multiple field adds an LSI.', () => {
     const schema = parse(out.schema);
     const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
     const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmailByUpdatedAt') as FieldDefinitionNode;
-    expect(queryIndexField.arguments).toHaveLength(5);
-    expectArguments(queryIndexField, ['email', 'updatedAt', 'filter', 'nextToken', 'limit']);
+    expect(queryIndexField.arguments).toHaveLength(6);
+    expectArguments(queryIndexField, ['email', 'updatedAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
 
     // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
     const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
-    expect(listTestsField.arguments).toHaveLength(5);
-    expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit']);
+    expect(listTestsField.arguments).toHaveLength(6);
+    expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
 })
 
 test('Test that a primary @key with complex fields will update the input objects.', () => {


### PR DESCRIPTION
made sure that all the e2e tests for key account for the sortDirection change

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.