### PR TITLE
fix: Fix package.json exists check for functions

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -84,8 +84,12 @@ function runBuildScriptHook(resourceName, projectRoot) {
 }
 
 function scriptExists(projectRoot, scriptName) {
-  const rootPackageJsonContents = require(path.normalize(path.join(projectRoot, 'package.json')));
-  return rootPackageJsonContents.scripts && rootPackageJsonContents.scripts[scriptName];
+  const packageJsonPath = path.normalize(path.join(projectRoot, 'package.json'));
+  if (fs.existsSync(packageJsonPath)) {
+    const rootPackageJsonContents = require(packageJsonPath);
+    return rootPackageJsonContents.scripts && rootPackageJsonContents.scripts[scriptName];
+  }
+  return false;
 }
 
 function installDependencies(resourceDir) {


### PR DESCRIPTION
*Issue #, if available:*

E2E tests with functions and with no package.json in the project dir are failing.

*Description of changes:*

Fix function hooks 'package.json' exists check.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.