### PR TITLE
fix: #1056, dedup environment file reading

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -312,7 +312,7 @@ async function updateConfigOnEnvInit(context, category, service) {
       });
 
       if (missingParams.length) {
-        throw Error(`auth headless init is missing the following inputParams ${missingParams.join(', ')}`);
+        throw new Error(`auth headless init is missing the following inputParams ${missingParams.join(', ')}`);
       }
     }
     if (resourceParams.hostedUIProviderMeta) {

--- a/packages/amplify-cli/src/cli.js
+++ b/packages/amplify-cli/src/cli.js
@@ -6,6 +6,17 @@ const globalPrefix = require('./lib/global-prefix');
 
 const MIGRATE = 'migrate';
 
+// Gluegun has no hooks for errors happening inside executing the commands,
+// so we need a process level handler, to log the errors like environment
+// not initialized and such errors in a friendly way without technical data
+// like stacktrace which does not add value in this case.
+process.on('uncaughtException', handleError);
+
+function handleError(error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
 async function run(argv) {
   const localNodeModulesDirPath = path.normalize(path.join(__dirname, '../', 'node_modules'));
   const globalNodeModulesDirPath = globalPrefix.getGlobalNodeModuleDirPath();

--- a/packages/amplify-cli/src/commands/env/checkout.js
+++ b/packages/amplify-cli/src/commands/env/checkout.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const sequential = require('promise-sequential');
 const { initializeEnv } = require('../../lib/initialize-env');
 const { getProviderPlugins } = require('../../extensions/amplify-helpers/get-provider-plugins');
-const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
+const { getEnvInfo } = require('../../extensions/amplify-helpers/get-env-info');
 
 module.exports = {
   name: 'checkout',
@@ -20,11 +20,10 @@ module.exports = {
     // Set the current env to the environment name provided
 
     const localEnvFilePath = context.amplify.pathManager.getLocalEnvFilePath();
-    const localEnvInfo = readJsonFile(localEnvFilePath);
+    const localEnvInfo = getEnvInfo();
     localEnvInfo.envName = envName;
     const jsonString = JSON.stringify(localEnvInfo, null, 4);
     fs.writeFileSync(localEnvFilePath, jsonString, 'utf8');
-
 
     // Setup exeinfo
 

--- a/packages/amplify-cli/src/commands/push.js
+++ b/packages/amplify-cli/src/commands/push.js
@@ -1,10 +1,11 @@
 module.exports = {
   name: 'push',
   run: async (context) => {
-    context.amplify.constructExeInfo(context);
     try {
+      context.amplify.constructExeInfo(context);
       await context.amplify.pushResources(context);
     } catch (e) {
+      context.print.error(`An error occured during the push operation: ${e.message}`);
       process.exit(1);
     }
   },

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.js
@@ -7,6 +7,9 @@ function getEnvInfo() {
   let envInfo = {};
   if (fs.existsSync(envFilePath)) {
     envInfo = readJsonFile(envFilePath);
+  } else {
+    // EnvInfo is required by all the callers so we can safely throw here
+    throw new Error('Current environment cannot be determined\nUse \'amplify init\' in the root of your app directory to initialize your project with Amplify');
   }
 
   return envInfo;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-project-details.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-project-details.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const pathManager = require('./path-manager');
+const { getEnvInfo } = require('./get-env-info');
 const { readJsonFile } = require('./read-json-file');
 
 function getProjectDetails() {
@@ -12,11 +13,7 @@ function getProjectDetails() {
     amplifyMeta = readJsonFile(amplifyMetaFilePath);
   }
 
-  let localEnvInfo = {};
-  const envFilePath = pathManager.getLocalEnvFilePath();
-  if (fs.existsSync(envFilePath)) {
-    localEnvInfo = readJsonFile(envFilePath);
-  }
+  const localEnvInfo = getEnvInfo();
 
   let teamProviderInfo = {};
   const teamProviderFilePath = pathManager.getProviderInfoFilePath();

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.js
@@ -4,6 +4,7 @@ const { showResourceTable } = require('./resource-status');
 const { onCategoryOutputsChange } = require('./on-category-outputs-change');
 const { initializeEnv } = require('../../lib/initialize-env');
 const { getProviderPlugins } = require('./get-provider-plugins');
+const { getEnvInfo } = require('./get-env-info');
 const { readJsonFile } = require('./read-json-file');
 
 /*
@@ -24,8 +25,7 @@ async function pushResources(context, category, resourceName, filteredResources)
       if (fs.existsSync(projectConfigFilePath)) {
         context.exeInfo.projectConfig = readJsonFile(projectConfigFilePath);
       }
-      const envFilePath = context.amplify.pathManager.getLocalEnvFilePath();
-      context.exeInfo.localEnvInfo = readJsonFile(envFilePath);
+      context.exeInfo.localEnvInfo = getEnvInfo();
 
       if (context.exeInfo.localEnvInfo.envName !== envName) {
         context.exeInfo.localEnvInfo.envName = envName;

--- a/packages/amplify-cli/src/lib/config-steps/c0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/config-steps/c0-analyzeProject.js
@@ -4,6 +4,7 @@ const inquirer = require('inquirer');
 const { normalizeEditorCode, editorSelection } =
   require('../../extensions/amplify-helpers/editor-selection');
 const { makeId } = require('../../extensions/amplify-helpers/make-id');
+const { getEnvInfo } = require('../../extensions/amplify-helpers/get-env-info');
 const { readJsonFile } = require('../../extensions/amplify-helpers/read-json-file');
 
 async function run(context) {
@@ -11,8 +12,7 @@ async function run(context) {
   if (fs.existsSync(projectConfigFilePath)) {
     context.exeInfo.projectConfig = readJsonFile(projectConfigFilePath);
   }
-  const envFilePath = context.amplify.pathManager.getLocalEnvFilePath();
-  context.exeInfo.localEnvInfo = readJsonFile(envFilePath);
+  context.exeInfo.localEnvInfo = getEnvInfo();
 
   const projectPath = process.cwd();
   Object.assign(context.exeInfo.localEnvInfo, { projectPath });

--- a/packages/amplify-cli/src/lib/config-steps/c9-onSuccess.js
+++ b/packages/amplify-cli/src/lib/config-steps/c9-onSuccess.js
@@ -6,8 +6,8 @@ async function run(context) {
   const { amplify } = context;
 
   let jsonString = JSON.stringify(context.exeInfo.projectConfig, null, 4);
-  const projectCofnigFilePath = amplify.pathManager.getProjectConfigFilePath(projectPath);
-  fs.writeFileSync(projectCofnigFilePath, jsonString, 'utf8');
+  const projectConfigFilePath = amplify.pathManager.getProjectConfigFilePath(projectPath);
+  fs.writeFileSync(projectConfigFilePath, jsonString, 'utf8');
 
   jsonString = JSON.stringify(context.exeInfo.localEnvInfo, null, 4);
   const envFilePath = context.amplify.pathManager.getLocalEnvFilePath();

--- a/packages/amplify-codegen/src/commands/remove.js
+++ b/packages/amplify-codegen/src/commands/remove.js
@@ -8,7 +8,7 @@ async function remove(context) {
   const projects = config.getProjects();
   let projectName;
   if (projects.length === 0) {
-    throw Error('Codegen is not configured');
+    throw new Error('Codegen is not configured');
   }
 
   if (projects.length === 1) {

--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -500,7 +500,7 @@ function loadConfigFromPath(context, profilePath) {
       return config;
     }
   }
-  throw Error(`Invalid config ${profilePath}`);
+  throw new Error(`Invalid config ${profilePath}`);
 }
 
 async function loadConfigurationForEnv(context, env) {

--- a/packages/amplify-util-mock/src/storage/storage.ts
+++ b/packages/amplify-util-mock/src/storage/storage.ts
@@ -18,7 +18,6 @@ export class StorageTest {
     const meta = context.amplify.getProjectDetails().amplifyMeta;
     const existingStorage = meta.storage;
     this.storageRegion = meta.providers.awscloudformation.Region;
-    //console.log("existingStorage",existingStorage);
     if (
       existingStorage === undefined ||
       Object.keys(existingStorage).length === 0


### PR DESCRIPTION
*Issue #, if available:*

#1056

*Description of changes:*

- Add uncaught error handler to CLI for friendlier error messages, due to the lack of GlueGun capability for this
- Throw friendly error message when environment seems to be uninitialized for various commands
- Deduplicate the code when reading the environment file
- Fix some typos

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.