### PR TITLE
fix(graphql-elasticsearch-transformer): changed nonKeyword types

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -1,4 +1,6 @@
-import { Transformer, TransformerContext, getDirectiveArguments, gql } from "graphql-transformer-core";
+import {
+    Transformer, TransformerContext, getDirectiveArguments,
+    gql } from "graphql-transformer-core";
 import {
     DirectiveNode,
     ObjectTypeDefinitionNode
@@ -99,10 +101,10 @@ export class SearchableModelTransformer extends Transformer {
 
         //SearchablePostSortableFields
         const queryFields = [];
-        const numberFields: Expression[] = [];
+        const nonKeywordFields: Expression[] = [];
         def.fields.forEach( field => {
             if (nonKeywordTypes.includes(getBaseType(field.type))) {
-                numberFields.push(str(field.name.value));
+                nonKeywordFields.push(str(field.name.value));
             }
         });
 
@@ -111,7 +113,7 @@ export class SearchableModelTransformer extends Transformer {
             this.generateSearchableInputs(ctx, def)
             this.generateSearchableXConnectionType(ctx, def)
 
-            const searchResolver = this.resources.makeSearchResolver(def.name.value, numberFields, searchFieldNameOverride);
+            const searchResolver = this.resources.makeSearchResolver(def.name.value, nonKeywordFields, searchFieldNameOverride);
             ctx.setResource(ResolverResourceIDs.ElasticsearchSearchResolverResourceID(def.name.value), searchResolver)
             ctx.mapResourceToStack(
                 STACK_NAME,

--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -23,7 +23,7 @@ import { ResolverResourceIDs, SearchableResourceIDs, getBaseType } from 'graphql
 import path = require('path');
 
 const STACK_NAME = 'SearchableStack';
-const numberTypes = ["Int", "Float", "Boolean", "AWSTimestamp"];
+const nonKeywordTypes = ["Int", "Float", "Boolean", "AWSTimestamp", "AWSDate", "AWSDateTime"];
 
 interface QueryNameMap {
     search?: string;
@@ -101,7 +101,7 @@ export class SearchableModelTransformer extends Transformer {
         const queryFields = [];
         const numberFields: Expression[] = [];
         def.fields.forEach( field => {
-            if (numberTypes.includes(getBaseType(field.type))) {
+            if (nonKeywordTypes.includes(getBaseType(field.type))) {
                 numberFields.push(str(field.name.value));
             }
         });

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -382,7 +382,7 @@ export class ResourceFactory {
     /**
      * Create the Elasticsearch search resolver.
      */
-    public makeSearchResolver(type: string, numberFields: Expression[], nameOverride?: string, queryTypeName: string = 'Query') {
+    public makeSearchResolver(type: string, nonKeywordFields: Expression[], nameOverride?: string, queryTypeName: string = 'Query') {
         const fieldName = nameOverride ? nameOverride : graphqlName('search' + plurality(toUpper(type)));
         return new AppSync.Resolver({
             ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -392,7 +392,7 @@ export class ResourceFactory {
             RequestMappingTemplate: print(
                 compoundExpression([
                     set(ref('indexPath'), str(`/${type.toLowerCase()}/doc/_search`)),
-                    set(ref('numberFields'), list(numberFields)),
+                    set(ref('nonKeywordFields'), list(nonKeywordFields)),
                     ElasticsearchMappingTemplate.searchItem({
                         path: str('$indexPath'),
                         size: ifElse(
@@ -411,7 +411,7 @@ export class ResourceFactory {
                             ref('context.args.sort'),
                             list([
                                 iff(raw('!$util.isNullOrEmpty($context.args.sort.field) && !$util.isNullOrEmpty($context.args.sort.direction)'),
-                                raw(`{${'#if($numberFields.contains($context.args.sort.field))\
+                                raw(`{${'#if($nonKeywordFields.contains($context.args.sort.field))\
                                     \n"$context.args.sort.field" #else "${context.args.sort.field}.keyword" #end'} : {
                                         "order": "$context.args.sort.direction"
                                     }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
@@ -32,7 +32,7 @@ const customS3Client = new S3Client('us-west-2')
 const awsS3Client = new S3({ region: 'us-west-2' })
 
 const fragments = [
-    `fragment FullPost on Post { id author title ups downs percentageUp isPublished }`
+    `fragment FullPost on Post { id author title ups downs percentageUp isPublished createdAt }`
 ]
 
 const createPosts = async () => {
@@ -95,6 +95,7 @@ beforeAll(async () => {
         version: Int
         relatedPosts: [Post]
         postedAt: String
+        createdAt: AWSDateTime
         comments: [String!]
         ratings: [Int!]
         percentageUp: Float
@@ -212,6 +213,28 @@ test('Test searchPosts with sort field on a string field', async () => {
     expect(thirdQuery.data.searchPosts).toBeDefined()
     const firstItemOfThirdQuery = thirdQuery.data.searchPosts.items[0]
     expect(firstItemOfThirdQuery).toEqual(fourthItemOfFirstQuery)
+})
+
+test('Test searchPosts with sort on date type', async () => {
+    const query  = await runQuery(`query {
+        searchPosts(
+            sort: {
+                field: createdAt
+                direction: desc
+            }) {
+            items {
+                ...FullPost
+            }
+        }
+    }`, 'Test search posts with date type response: ')
+    expect(query).toBeDefined()
+    expect(query.data.searchPosts).toBeDefined()
+    const recentItem = new Date(query.data.searchPosts.items[0].createdAt)
+    const oldestItem = new Date(query.data.searchPosts.items[
+        query.data.searchPosts.items.length - 1
+    ].createdAt)
+    expect(recentItem > oldestItem)
+
 })
 
 test('Test searchPosts query without filter', async () => {


### PR DESCRIPTION
*Issue #, if available:*
re #2080
*Description of changes:*
change the numberTypes to nonKeyword type as there can other data types in es which will not include keywords, such as date (ref AWSDate, AWSDateTime)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.