### PR TITLE
fix: #1720 - fix GraphQL name generation for @key

### DIFF
--- a/packages/graphql-key-transformer/package.json
+++ b/packages/graphql-key-transformer/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
+    "case": "^1.6.2",
     "cloudform": "^3.5.0",
     "cloudform-types": "^3.7.0",
     "graphql": "^0.13.2",

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -20,6 +20,7 @@ import {
 } from 'graphql';
 import { AppSync, IAM, Fn, DynamoDB, Refs } from 'cloudform-types'
 import { Projection, GlobalSecondaryIndex, LocalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
+import * as Case from 'case';
 
 interface KeyArguments {
     name?: string;
@@ -160,7 +161,7 @@ export default class FunctionTransformer extends Transformer {
         if (args.fields.length > 2) {
             const compositeKeyFieldNames = args.fields.slice(1);
             const compositeKeyFields = definition.fields.filter(field => Boolean(compositeKeyFieldNames.find(k => k === field.name.value)));
-            const keyName = args.name || 'Primary';
+            const keyName = Case.pascal(args.name || 'Primary');
             const keyConditionInput = makeCompositeKeyConditionInputForKey(definition.name.value, keyName, compositeKeyFields);
             if (!ctx.getType(keyConditionInput.name.value)) {
                 ctx.addInput(keyConditionInput);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5013,6 +5013,11 @@ case-sensitive-paths-webpack-plugin@2.2.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz#3371ef6365ef9c25fa4b81c16ace0e9c7dc58c3e"
   integrity sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g==
 
+case@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.2.tgz#2ea68af6956752cd69c349c8b3e6bc860d1cba95"
+  integrity sha512-ll380ZRoraT7mUK2G92UbH+FJVD5AwdVIAYk9xhV1tauh0carDgYByUD1HhjCWsWgxrfQvCeHvtfj7IYR6TKeg==
+
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"


### PR DESCRIPTION
*Issue #, if available:*

#1720

*Description of changes:*

Make sure that for 2+ part @key names valid GraphQL type names will be generated, with proper pascal casing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.