### PR TITLE
chore: fix nexpect references, add missing engines in 2 other CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/config-lerna-scopes": "^8.1.0",
-    "commitizen": "^4.0.3",
+    "commitizen": "^3.1.2",
     "cz-conventional-changelog": "^3.0.2",
     "husky": "^3.0.3"
   },

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -19,7 +19,6 @@
     "aws-amplify": "^1.1.36",
     "dotenv": "6.2.0",
     "jest": "23.1.0",
-    "nexpect": "0.5.0",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^22.4.6",

--- a/packages/amplify-e2e-tests/src/categories/api.ts
+++ b/packages/amplify-e2e-tests/src/categories/api.ts
@@ -1,4 +1,4 @@
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { join } from 'path';
 import { updateSchema } from '../utils';
 import * as fs from 'fs';

--- a/packages/amplify-e2e-tests/src/categories/function.ts
+++ b/packages/amplify-e2e-tests/src/categories/function.ts
@@ -1,5 +1,5 @@
 
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/categories/interactions.ts
+++ b/packages/amplify-e2e-tests/src/categories/interactions.ts
@@ -1,5 +1,4 @@
-
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/categories/predictions.ts
+++ b/packages/amplify-e2e-tests/src/categories/predictions.ts
@@ -1,5 +1,5 @@
 import { isCI } from "../utils";
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { getCLIPath } from '../utils/index';
 
 // add convert resource

--- a/packages/amplify-e2e-tests/src/categories/storage.ts
+++ b/packages/amplify-e2e-tests/src/categories/storage.ts
@@ -1,5 +1,5 @@
 
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/configure/index.ts
+++ b/packages/amplify-e2e-tests/src/configure/index.ts
@@ -1,4 +1,4 @@
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { join } from 'path';
 
 import { getCLIPath, isCI } from '../utils';

--- a/packages/amplify-e2e-tests/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-tests/src/init/amplifyPush.ts
@@ -1,4 +1,4 @@
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { getCLIPath, isCI } from '../utils';
 
 function amplifyPush(

--- a/packages/amplify-e2e-tests/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-tests/src/init/deleteProject.ts
@@ -1,5 +1,5 @@
 import * as AWS from 'aws-sdk';
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 
 import { getCLIPath, isCI } from '../utils';
 import { getProjectMeta } from '../utils';

--- a/packages/amplify-e2e-tests/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-tests/src/init/initProjectHelper.ts
@@ -1,4 +1,4 @@
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { join } from 'path';
 
 import { getCLIPath, isCI } from '../utils';

--- a/packages/amplify-e2e-tests/src/utils/nexpect-modified/lib/nexpect.js
+++ b/packages/amplify-e2e-tests/src/utils/nexpect-modified/lib/nexpect.js
@@ -333,8 +333,13 @@ function testExpectation(data, expectation) {
 }
 
 function createUnexpectedEndError(message, remainingQueue) {
-  var desc = remainingQueue.map(function(it) { return it.description; });
-  var msg = message + '\n' + desc.join('\n');
+  var desc = [];
+
+  if (isCI() === false) {
+    var desc = remainingQueue.map(function(it) { return it.description; });
+    var msg = message + '\n' + desc.join('\n');
+  }
+
   return new AssertionError({
     message: msg,
     expected: [],
@@ -392,6 +397,10 @@ function nspawn (command, params, options) {
   };
 
   return chain(context);
+}
+
+function isCI() {
+  return process.env.CI ? true : false;
 }
 
 //

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -4,6 +4,9 @@
   "main": "lib/index.js",
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=8.12.0"
+  },
   "bin": {
     "amplify-graphql-docs-generator": "./bin/cli"
   },

--- a/packages/amplify-graphql-types-generator/package.json
+++ b/packages/amplify-graphql-types-generator/package.json
@@ -3,6 +3,9 @@
   "version": "1.4.0",
   "description": "Generate API code or type annotations based on a GraphQL schema and statements",
   "main": "./lib/index.js",
+  "engines": {
+    "node": ">=8.12.0"
+  },
   "bin": "./lib/cli.js",
   "scripts": {
     "clean": "rm -rf lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,6 +4870,11 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cachedir@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.1.0.tgz#b448c32b44cd9c0cd6ce4c419fa5b3c112c02191"
+  integrity sha512-xGBpPqoBvn3unBW7oxgb8aJn42K0m9m1/wyjmazah10Fq7bROGG3kRAE6OIyr3U3PIJUqGuebhCEdMk9OKJG0A==
+
 cachedir@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.2.0.tgz#19afa4305e05d79e417566882e0c8f960f62ff0e"
@@ -5586,6 +5591,27 @@ commist@^1.0.0:
   dependencies:
     leven "^2.1.0"
     minimist "^1.1.0"
+
+commitizen@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/commitizen/-/commitizen-3.1.2.tgz#29ddd8b39396923e9058a0e4840cbeef144290be"
+  integrity sha512-eD0uTUsogu8ksFjFFYq75LLfXeLXsCIa27TPfOqvBI+tCx1Pp5QfKqC9oC+qTpSz3nTn9/+7TL5mE/wurB22JQ==
+  dependencies:
+    cachedir "2.1.0"
+    cz-conventional-changelog "2.1.0"
+    dedent "0.7.0"
+    detect-indent "^5.0.0"
+    find-node-modules "2.0.0"
+    find-root "1.1.0"
+    fs-extra "^7.0.0"
+    glob "7.1.3"
+    inquirer "6.2.0"
+    is-utf8 "^0.2.1"
+    lodash "4.17.14"
+    minimist "1.2.0"
+    shelljs "0.7.6"
+    strip-bom "3.0.0"
+    strip-json-comments "2.0.1"
 
 commitizen@^4.0.3:
   version "4.0.3"
@@ -6423,6 +6449,17 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+
+cz-conventional-changelog@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz#2f4bc7390e3244e4df293e6ba351e4c740a7c764"
+  integrity sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=
+  dependencies:
+    conventional-commit-types "^2.0.0"
+    lodash.map "^4.5.1"
+    longest "^1.0.1"
+    right-pad "^1.0.1"
+    word-wrap "^1.0.3"
 
 cz-conventional-changelog@3.0.1:
   version "3.0.1"
@@ -7974,7 +8011,7 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
-external-editor@^3.0.3:
+external-editor@^3.0.0, external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
   integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
@@ -10279,6 +10316,25 @@ inquirer-autocomplete-prompt@^1.0.1:
     chalk "^2.0.0"
     figures "^2.0.0"
     run-async "^2.3.0"
+
+inquirer@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  integrity sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
 
 inquirer@6.3.1:
   version "6.3.1"
@@ -13395,6 +13451,11 @@ long@1.1.2:
   resolved "https://registry.yarnpkg.com/long/-/long-1.1.2.tgz#eaef5951ca7551d96926b82da242db9d6b28fb53"
   integrity sha1-6u9ZUcp1UdlpJrgtokLbnWso+1M=
 
+longest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
+
 longest@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-2.0.1.tgz#781e183296aa94f6d4d916dc335d0d17aefa23f8"
@@ -14297,11 +14358,6 @@ netstats@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/netstats/-/netstats-0.0.6.tgz#57072d42a6c420a931d1db9c4ca3379717305069"
   integrity sha512-j5sdwaoLX/0x74+8bFdnoVEo3RUQexm5Lw615MVrgx7/FSQx88dZj+t5whwrDSrlsiHMYhKpn52p/6oMYHTZ2A==
-
-nexpect@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/nexpect/-/nexpect-0.5.0.tgz#f185cf4d3acb5ce38ad7740f5dfa4004559946e0"
-  integrity sha1-8YXPTTrLXOOK13QPXfpABFWZRuA=
 
 next-tick@^1.0.0:
   version "1.0.0"
@@ -18153,7 +18209,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^6.4.0:
+rxjs@^6.1.0, rxjs@^6.4.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
   integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==


### PR DESCRIPTION
*Description of changes:*

- Chore to move to our modified version of ```nextpect```
- Move back to node 8.x compatible commitizen
- Add engines requirement to docs and types generator tool

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.