### PR TITLE
Simple grammar fix in codegen.js

### DIFF
--- a/packages/amplify-codegen/commands/codegen/codegen.js
+++ b/packages/amplify-codegen/commands/codegen/codegen.js
@@ -8,7 +8,7 @@ module.exports = {
   run: async (context) => {
     if (context.parameters.options.help) {
       const header = `amplify ${featureName} [subcommand] [[--nodownload] [--max-depth <number>]]\nDescriptions:
-      Generates GraphQL statements(queries, mutations and subscriptions) and type annotations. \nSub Commands:`;
+      Generates GraphQL statements (queries, mutations and subscriptions) and type annotations. \nSub Commands:`;
 
       const commands = [
         {


### PR DESCRIPTION
*Description of changes:*
`Generates GraphQL statements(queries, mutations and subscriptions) and type annotations. ` -> `Generates GraphQL statements (queries, mutations and subscriptions) and type annotations.`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.