### PR TITLE
fix: #2033 - Make sure key field order is preserved

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -159,7 +159,17 @@ export default class FunctionTransformer extends Transformer {
         const args: KeyArguments = getDirectiveArguments(directive);
         if (args.fields.length > 2) {
             const compositeKeyFieldNames = args.fields.slice(1);
-            const compositeKeyFields = definition.fields.filter(field => Boolean(compositeKeyFieldNames.find(k => k === field.name.value)));
+            // To make sure we get the intended behavior and type conversion we have to keep the order of the fields
+            // as it is in the key field list
+            const compositeKeyFields = [];
+            for (const compositeKeyFieldName of compositeKeyFieldNames) {
+                const field = definition.fields.find(field => field.name.value === compositeKeyFieldName);
+                if (!field) {
+                    throw new InvalidDirectiveError(`Can't find field: ${compositeKeyFieldName} in ${definition.name.value}, but it was specified in the @key definition.`);
+                } else {
+                    compositeKeyFields.push (field);
+                }
+            }
             const keyName = args.name || 'Primary';
             const keyConditionInput = makeCompositeKeyConditionInputForKey(definition.name.value, keyName, compositeKeyFields);
             if (!ctx.getType(keyConditionInput.name.value)) {

--- a/packages/graphql-key-transformer/src/__tests__/KeyTransformer.test.ts
+++ b/packages/graphql-key-transformer/src/__tests__/KeyTransformer.test.ts
@@ -85,3 +85,20 @@ test('Test that model with an LSI but no primary sort key will fail.', () => {
     })
     expect(() => transformer.transform(validSchema)).toThrowError(InvalidDirectiveError);
 })
+
+test('KeyTransformer should fail if a non-existing type field is defined as key field.', () => {
+    const validSchema = `
+    type Test @key(name: "Test", fields: ["one"]) {
+        id: ID!
+        email: String
+    }
+    `
+
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new KeyTransformer()
+        ]
+    })
+
+    expect(() => transformer.transform(validSchema)).toThrowError(InvalidDirectiveError);
+})


### PR DESCRIPTION
*Issue #, if available:*

#2033

*Description of changes:*

To make composite sort keys working as expected we've to preserve the order of fields in the generated input types for composite key filtering, this ensures that proper casting to string will happen during graphql transform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.