### PR TITLE
fix: regression for e2e tests because of nexpect reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ packages/*/node_modules
 packages/*/package-lock.json
 packages/amplify-storage-simulator/lib
 **/.env
+amplify-integ*/

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -14,11 +14,11 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/jest": "23.1.6",
-    "@types/nexpect": "0.4.30",
     "@types/node": "^8.10.51",
     "aws-amplify": "^1.1.36",
     "dotenv": "6.2.0",
     "jest": "23.1.0",
+    "nexpect": "file:./src/utils/nexpect-modified",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^22.4.6",

--- a/packages/amplify-e2e-tests/src/categories/api.ts
+++ b/packages/amplify-e2e-tests/src/categories/api.ts
@@ -1,4 +1,4 @@
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 import { updateSchema } from '../utils';
 import * as fs from 'fs';

--- a/packages/amplify-e2e-tests/src/categories/auth.ts
+++ b/packages/amplify-e2e-tests/src/categories/auth.ts
@@ -1,5 +1,5 @@
 
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/categories/function.ts
+++ b/packages/amplify-e2e-tests/src/categories/function.ts
@@ -1,5 +1,5 @@
 
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/categories/interactions.ts
+++ b/packages/amplify-e2e-tests/src/categories/interactions.ts
@@ -1,4 +1,4 @@
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/categories/predictions.ts
+++ b/packages/amplify-e2e-tests/src/categories/predictions.ts
@@ -1,5 +1,5 @@
 import { isCI } from "../utils";
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { getCLIPath } from '../utils/index';
 
 // add convert resource

--- a/packages/amplify-e2e-tests/src/categories/storage.ts
+++ b/packages/amplify-e2e-tests/src/categories/storage.ts
@@ -1,5 +1,5 @@
 
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 import * as fs from 'fs';
 

--- a/packages/amplify-e2e-tests/src/configure/index.ts
+++ b/packages/amplify-e2e-tests/src/configure/index.ts
@@ -1,4 +1,4 @@
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 
 import { getCLIPath, isCI } from '../utils';

--- a/packages/amplify-e2e-tests/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-tests/src/init/amplifyPush.ts
@@ -1,4 +1,4 @@
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { getCLIPath, isCI } from '../utils';
 
 function amplifyPush(

--- a/packages/amplify-e2e-tests/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-tests/src/init/deleteProject.ts
@@ -1,5 +1,5 @@
 import * as AWS from 'aws-sdk';
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 
 import { getCLIPath, isCI } from '../utils';
 import { getProjectMeta } from '../utils';

--- a/packages/amplify-e2e-tests/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-tests/src/init/initProjectHelper.ts
@@ -1,4 +1,4 @@
-import * as nexpect from '../utils/nexpect-modified';
+import * as nexpect from 'nexpect';
 import { join } from 'path';
 
 import { getCLIPath, isCI } from '../utils';

--- a/packages/amplify-e2e-tests/src/utils/nexpect-modified/index.d.ts
+++ b/packages/amplify-e2e-tests/src/utils/nexpect-modified/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for nexpect 0.4.2
+// Project: https://github.com/nodejitsu/nexpect
+// Definitions by: vvakame <https://github.com/vvakame>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+
+import child_process = require("child_process");
+
+declare function spawn(command: string[], options?: ISpawnOptions): IChain;
+
+declare function spawn(command: string, params?: any[], options?: ISpawnOptions): IChain;
+
+declare function spawn(command: string, options?: ISpawnOptions): IChain;
+
+interface IChain {
+    expect(expectation: string): IChain;
+    expect(expectation: RegExp): IChain;
+    wait(expectation: string): IChain;
+    wait(expectation: RegExp): IChain;
+    send(line: string): IChain;
+    sendline(line: string): IChain;
+    sendEof(): IChain;
+    run(callback: (err: Error, output: string[], exit: string | number) => void): child_process.ChildProcess;
+}
+
+interface ISpawnOptions {
+    cwd?: string;
+    env?: any;
+    ignoreCase?: any;
+    stripColors?: any;
+    stream?: any;
+    verbose?: any;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,7 +962,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
 
-
 "@babel/runtime@7.5.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -2631,20 +2630,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/nexpect@0.4.30":
-  version "0.4.30"
-  resolved "https://registry.yarnpkg.com/@types/nexpect/-/nexpect-0.4.30.tgz#08919064509d78b2b75e7150b07d718597bff9ab"
-  integrity sha512-7JEP3RT7lMjhPSFhHBkBpikReNCBdU8TaYCLLeH8Y74/Prm1hScLZIhvIFo6CBZV7fEiAw35E+cKQVOvbBZvUw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node-fetch@1.6.7":
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-1.6.7.tgz#521078e8f0c69a158e5022005aca92d2620f6d57"
   integrity sha1-UhB46PDGmhWOUCIAWsqS0mIPbVc=
   dependencies:
     "@types/node" "*"
-
 
 "@types/node@*", "@types/node@^12.0.2":
   version "12.7.2"
@@ -4222,7 +4213,6 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
-
 babel-preset-react-app@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-9.0.1.tgz#16a2cf84363045b530b6a03460527a5c6eac42ba"
@@ -4661,7 +4651,6 @@ browserify-zlib@^0.2.0:
   integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   dependencies:
     pako "~1.0.5"
-
 
 browserslist@4.6.6, browserslist@^4.0.0, browserslist@^4.1.1, browserslist@^4.6.0, browserslist@^4.6.3, browserslist@^4.6.4, browserslist@^4.6.6:
   version "4.6.6"
@@ -7480,7 +7469,6 @@ eslint-plugin-jsx-a11y@6.2.3:
     emoji-regex "^7.0.2"
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
-
 
 eslint-plugin-react-hooks@^1.6.1:
   version "1.7.0"
@@ -10409,7 +10397,6 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
-
 
 inquirer@^6.2.0, inquirer@^6.4.1, inquirer@^6.5.1:
   version "6.5.1"
@@ -14371,14 +14358,8 @@ netmask@^1.0.6:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
   integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
 
-nexpect@0.5.0:
+"nexpect@file:./packages/amplify-e2e-tests/src/utils/nexpect-modified":
   version "0.5.0"
-  resolved "https://registry.yarnpkg.com/nexpect/-/nexpect-0.5.0.tgz#f185cf4d3acb5ce38ad7740f5dfa4004559946e0"
-  integrity sha1-8YXPTTrLXOOK13QPXfpABFWZRuA=
-netstats@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/netstats/-/netstats-0.0.6.tgz#57072d42a6c420a931d1db9c4ca3379717305069"
-  integrity sha512-j5sdwaoLX/0x74+8bFdnoVEo3RUQexm5Lw615MVrgx7/FSQx88dZj+t5whwrDSrlsiHMYhKpn52p/6oMYHTZ2A==
 
 next-tick@^1.0.0:
   version "1.0.0"
@@ -15273,7 +15254,6 @@ open@^6.3.0, open@^6.4.0:
   dependencies:
     is-wsl "^1.1.0"
 
-
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -15998,7 +15978,6 @@ pkg-up@2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
-
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -18155,13 +18134,6 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@2.6.3, rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@~2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
@@ -20063,6 +20035,7 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
*Description of changes:*

- Due to a recent change for nexpect related references e2e were broken, this PR fixes it by properly referencing and removing dependency on ```@types/nexpect``` as well.
- amplify-integ*/ added to .gitignore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.