### PR TITLE
fix(cli): update inquirer validation function to return msg

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/input-validation.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/input-validation.js
@@ -1,33 +1,31 @@
 function inputValidation(question) {
-  const validator = input => new Promise((resolve, reject) => {
+  const validator = (input) => {
     if (!question.validation) {
       if (question.required) {
-        return input ? resolve(true) : reject(new Error('A response is required for this field'));
+        return input ? true : 'A response is required for this field';
       }
-      resolve(true);
+      return true;
     }
     if (question.validation.operator === 'includes') {
-      return input.includes(question.validation.value) ?
-        resolve(true) : reject(question.validation.onErrorMsg);
+      return input.includes(question.validation.value) ? true : question.validation.onErrorMsg;
     }
     if (question.validation.operator === 'regex') {
       const regex = new RegExp(question.validation.value);
 
-      return regex.test(input) ?
-        resolve(true) : reject(question.validation.onErrorMsg);
+      return regex.test(input) ? true : question.validation.onErrorMsg;
     }
     if (question.validation.operator === 'range') {
-      const isGood = input >= question.validation.value.min &&
-                        input <= question.validation.value.max;
-      return isGood ? resolve(true) : reject(question.validation.onErrorMsg);
+      const isGood =
+        input >= question.validation.value.min && input <= question.validation.value.max;
+      return isGood ? true : question.validation.onErrorMsg;
     }
     if (question.validation.operator === 'noEmptyArray') {
-      return Array.isArray(input) && input.length > 0 ? resolve(true) : reject(question.validation.onErrorMsg); //eslint-disable-line
+      return Array.isArray(input) && input.length > 0 ? true : question.validation.onErrorMsg;
     }
     if (question.required) {
-      return input ? resolve(true) : reject(new Error('A response is required for this field'));
+      return input ? true : 'A response is required for this field';
     }
-  });
+  };
   // RETURN THE FUNCTION SO IT CAN BE SET AS THE QUESTION'S "VALIDATE" VALUE
   return validator;
 }

--- a/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/lib/init-steps/s0-analyzeProject.js
@@ -146,7 +146,10 @@ async function getEnvName(context) {
       type: 'input',
       name: 'envName',
       message: 'Enter a name for the environment',
-      validate: input => new Promise((resolvePromise, reject) => (!isEnvNameValid(input) ? reject(new Error('Environment name should be between 2 and 10 characters (only lowercase alphabets).')) : resolvePromise(true))),
+      validate: input =>
+        (!isEnvNameValid(input)
+          ? 'Environment name should be between 2 and 10 characters (only lowercase alphabets).'
+          : true),
     };
 
     ({ envName } = await inquirer.prompt(envNameQuestion));

--- a/packages/amplify-cli/tests/amplify-helpers/input-validation.test.js
+++ b/packages/amplify-cli/tests/amplify-helpers/input-validation.test.js
@@ -14,17 +14,17 @@ describe('input-validation helper: ', () => {
 
   describe('case: question does not have validation', () => {
     it('...promise should resolve(true) if input is not present and question is not required', async () => {
-      await expect(inputValidation(question)(null)).resolves.toEqual(true);
+      await expect(inputValidation(question)(null)).toEqual(true);
     });
 
     it('...promise should resolve(true) if input is present and question is required', async () => {
       question = { required: true };
-      await expect(inputValidation(question)('val')).resolves.toEqual(true);
+      await expect(inputValidation(question)('val')).toEqual(true);
     });
 
     it('...promise should reject(e) if input is not present but question is required', async () => {
       question = { required: true };
-      await expect(inputValidation(question)(null)).rejects.toThrowError(rejectionString);
+      await expect(inputValidation(question)(null)).toEqual(rejectionString);
     });
   });
 
@@ -38,15 +38,15 @@ describe('input-validation helper: ', () => {
     });
 
     it('...promise should reject if input is empty', async () => {
-      await expect(inputValidation(question)('')).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)('')).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should reject if input does not include value', async () => {
-      await expect(inputValidation(question)('my-other-value')).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)('my-other-value')).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should resolve(true) if input includes value', async () => {
-      await expect(inputValidation(question)('test-value')).resolves.toEqual(true);
+      await expect(inputValidation(question)('test-value')).toEqual(true);
     });
   });
 
@@ -60,15 +60,15 @@ describe('input-validation helper: ', () => {
     });
 
     it('...promise should reject if input is empty', async () => {
-      await expect(inputValidation(question)([])).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)([])).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should reject if input does not include value', async () => {
-      await expect(inputValidation(question)(['other-value'])).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)(['other-value'])).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should resolve(true) if input includes value', async () => {
-      await expect(inputValidation(question)(['test-value', 'other-value'])).resolves.toEqual(true);
+      await expect(inputValidation(question)(['test-value', 'other-value'])).toEqual(true);
     });
   });
 
@@ -82,15 +82,15 @@ describe('input-validation helper: ', () => {
     });
 
     it('...promise should reject if input is empty', async () => {
-      await expect(inputValidation(question)('')).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)('')).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should reject if input fails regex test', async () => {
-      await expect(inputValidation(question)('@@1')).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)('@@1')).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should resolve(true) if input passes regex test', async () => {
-      await expect(inputValidation(question)('hello1')).resolves.toEqual(true);
+      await expect(inputValidation(question)('hello1')).toEqual(true);
     });
   });
 
@@ -104,15 +104,15 @@ describe('input-validation helper: ', () => {
     });
 
     it('...promise should reject if input is empty', async () => {
-      await expect(inputValidation(question)('')).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)('')).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should reject if input fails range test', async () => {
-      await expect(inputValidation(question)(0)).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)(0)).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should resolve(true) if input passes range test', async () => {
-      await expect(inputValidation(question)(5)).resolves.toEqual(true);
+      await expect(inputValidation(question)(5)).toEqual(true);
     });
   });
 
@@ -126,15 +126,15 @@ describe('input-validation helper: ', () => {
     });
 
     it('...promise should reject if input is empty', async () => {
-      await expect(inputValidation(question)()).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)()).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should reject if input is empty', async () => {
-      await expect(inputValidation(question)([])).rejects.toEqual(question.validation.onErrorMsg);
+      await expect(inputValidation(question)([])).toEqual(question.validation.onErrorMsg);
     });
 
     it('...promise should resolve(true) if input is populated array', async () => {
-      await expect(inputValidation(question)([1, 2])).resolves.toEqual(true);
+      await expect(inputValidation(question)([1, 2])).toEqual(true);
     });
   });
 
@@ -147,13 +147,13 @@ describe('input-validation helper: ', () => {
     });
 
     it('...promise should reject(e) if input is not present but question is required', async () => {
-      await expect(inputValidation(question)()).rejects.toThrowError(rejectionString);
+      await expect(inputValidation(question)()).toEqual(rejectionString);
     });
 
     it('...promise should resolve(true) if input equals anything truthy', async () => {
-      await expect(inputValidation(question)('val')).resolves.toEqual(true);
-      await expect(inputValidation(question)(1)).resolves.toEqual(true);
-      await expect(inputValidation(question)(['index'])).resolves.toEqual(true);
+      await expect(inputValidation(question)('val')).toEqual(true);
+      await expect(inputValidation(question)(1)).toEqual(true);
+      await expect(inputValidation(question)(['index'])).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
Inquirer expects the validation function to return string or boolean value and does not throwing an
error from validation function. It cause the program to crash. Updated validation functions to send
string error messages

fix #2164

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.