### PR TITLE
fix(amplify-codegen): await statement generation before generating types

### DIFF
--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -26,9 +26,9 @@ async function postPushCallback(context, graphQLConfig) {
 
   await downloadIntrospectionSchema(context, apis[0].id, graphQLConfig.gqlConfig.schema);
   if (graphQLConfig.shouldGenerateDocs) {
-    generateStatements(context);
+    await generateStatements(context);
   }
-  generateTypes(context);
+  await generateTypes(context);
 }
 
 module.exports = postPushCallback;

--- a/packages/amplify-codegen/tests/callbacks/postPushCallback.test.js
+++ b/packages/amplify-codegen/tests/callbacks/postPushCallback.test.js
@@ -4,7 +4,8 @@ const {
   getAppSyncAPIDetails,
   getSchemaDownloadLocation,
 } = require('../../src/utils');
-
+const generateStatements = require('../../src/commands/statements');
+const generateTypes = require('../../src/commands/types');
 const postPushCallback = require('../../src/callbacks/postPushCallback');
 
 const MOCK_CONTEXT = {
@@ -15,6 +16,8 @@ const MOCK_CONTEXT = {
 
 jest.mock('../../src/codegen-config');
 jest.mock('../../src/utils');
+jest.mock('../../src/commands/statements');
+jest.mock('../../src/commands/types');
 
 const MOCK_PROJECT_NAME = 'MOCK_PROJECT';
 const MOCK_API_ID = 'MOCK_API_ID';
@@ -67,6 +70,8 @@ describe('Callback - Post Push update AppSync API', () => {
       },
       schema: MOCK_SCHEMA_DOWNLOAD_LOCATION,
     });
+    expect(generateTypes).toHaveBeenCalledTimes(1);
+    expect(generateStatements).toHaveBeenCalledTimes(1);
   });
 
   it('should not update schema location when updating existing API', async () => {
@@ -77,7 +82,7 @@ describe('Callback - Post Push update AppSync API', () => {
         schema: PREV_DOWNLOAD_LOCATION,
       },
     });
-    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(loadConfig).not.toHaveBeenCalledWith();
     expect(getAppSyncAPIDetails).toHaveBeenCalledWith(MOCK_CONTEXT);
     expect(getSchemaDownloadLocation).not.toHaveBeenCalled();
     expect(downloadIntrospectionSchema).toHaveBeenCalledWith(
@@ -95,5 +100,7 @@ describe('Callback - Post Push update AppSync API', () => {
     expect(getSchemaDownloadLocation).not.toHaveBeenCalled();
     expect(downloadIntrospectionSchema).not.toHaveBeenCalled();
     expect(LOAD_CONFIG_METHODS.addProject).not.toHaveBeenCalled();
+    expect(generateTypes).not.toBeCalled();
+    expect(generateStatements).not.toBeCalled();
   });
 });


### PR DESCRIPTION
Amplify CLI generate types based on the statemnt that got generated when pushing the API. The
statement generation method is an async method. Updated the code to await statement generation
before kicking off types generation

fix #2129

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.