### PR TITLE
fix(graphql-transformer-core): dont incl custom stacks in stack mapping

### DIFF
--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -118,8 +118,12 @@ export async function ensureMissingStackMappings(config: ProjectOptions) {
         const transformOutput = await _buildProject(config);
         const copyOfCloudBackend = await readFromPath(currentCloudBackendDirectory);
         const stackMapping = transformOutput.stackMapping;
+        const customStacks = Object.keys(copyOfCloudBackend.stacks || {});
         if (copyOfCloudBackend && copyOfCloudBackend.build) {
-            const stackNames = Object.keys(copyOfCloudBackend.build.stacks);
+            // leave the custom stack alone. Don't split them into separate stacks
+            const stackNames = Object.keys(copyOfCloudBackend.build.stacks).filter(
+                stack => !customStacks.includes(stack)
+              );
 
             // We walk through each of the stacks that were deployed in the most recent deployment.
             // If we find a resource that was deployed into a different stack than it should have


### PR DESCRIPTION
GraphQL transformer splits resources into multiple stack to get over the cloudformation limit on the
number of resource a stack can have. If a resource gets moved to different stack it would cause
cloudformation to delete and recreate the same  resource. To prevent this transformer tries to put
the resources in the same stack in subsequent deployment. We used to include custom resources in
the stack mapping which should not be the case as these are custom stacks. Updated the code not to
include custom stack in stack mapping computation.

fix #2167

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.