### PR TITLE
fix(amplify-codegen): support multi os team workflow in codegen

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -24,7 +24,8 @@
     "graphql-config": "^2.1.0",
     "inquirer": "^6.5.1",
     "ora": "^3.4.0",
-    "underscore": "^1.9.1"
+    "underscore": "^1.9.1",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/packages/amplify-codegen/tests/codegen-config/AmplifyCodegenConfig.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/AmplifyCodegenConfig.test.js
@@ -1,0 +1,39 @@
+const AmplifyCodeGenConfig = require('../../src/codegen-config/AmplifyCodeGenConfig');
+
+describe('AmplifyCodeGenConfig', () => {
+  describe('normalizePath', () => {
+    let winPathConfig;
+
+    beforeEach(() => {
+      winPathConfig = {
+        schemaPath: 'foo\\schema.graphql',
+        includes: ['foo\\**\\*.grpahql'],
+        excludes: ['bar\\**\\*.grpahql'],
+        extensions: {
+          amplify: {
+            generatedFileName: 'src\\api.ts',
+            docsFilePath: 'src\\graphql\\',
+          },
+        },
+      };
+    });
+    it('should convert windows style path to unix style path', () => {
+      const normalizedConfig = AmplifyCodeGenConfig.normalizePath(winPathConfig);
+      expect(normalizedConfig.schemaPath).toEqual('foo/schema.graphql');
+      expect(normalizedConfig.includes).toEqual(['foo/**/*.grpahql']);
+      expect(normalizedConfig.excludes).toEqual(['bar/**/*.grpahql']);
+      expect(normalizedConfig.extensions.amplify.generatedFileName).toEqual('src/api.ts');
+      expect(normalizedConfig.extensions.amplify.docsFilePath).toEqual('src/graphql/');
+    });
+
+    it('should handle config where generatedFileName is missing', () => {
+      delete winPathConfig.extensions.amplify.generatedFileName;
+      const normalizedConfig = AmplifyCodeGenConfig.normalizePath(winPathConfig);
+      expect(normalizedConfig.schemaPath).toEqual('foo/schema.graphql');
+      expect(normalizedConfig.includes).toEqual(['foo/**/*.grpahql']);
+      expect(normalizedConfig.excludes).toEqual(['bar/**/*.grpahql']);
+      expect(normalizedConfig.extensions.amplify.generatedFileName).toBeUndefined();
+      expect(normalizedConfig.extensions.amplify.docsFilePath).toEqual('src/graphql/');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -20299,6 +20299,11 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
+upath@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
 update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"


### PR DESCRIPTION
Codegen generates grpaql configuration file which contains paths for schema and documents. These
paths used to be platform specific path which caused issues when the same projects were used in
different Operating Systems. Updated codegen to normalize path to posix style path as it is
supported by all the platforms

fix #2147 and #2002

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.