### PR TITLE
fix(amplify-frontend-javascript): fix implicit grant oauth bug

### DIFF
--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -200,6 +200,9 @@ function getCognitoConfig(cognitoResources, projectRegion) {
     redirectSignIn = oAuthMetadata.CallbackURLs.join(',');
     redirectSignOut = oAuthMetadata.LogoutURLs.join(',');
     [responseType] = oAuthMetadata.AllowedOAuthFlows;
+    if (responseType === 'implicit') {
+      responseType = 'token';
+    }
     userPoolFederation = true;
   }
 


### PR DESCRIPTION
*Description of changes:*
Ensure that aws-exports file's `oauth.responseType' value is 'token' when the implicit grant flow is selected.  This ensures that the correct response_type is used in the query string that amplify.js builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.