### PR TITLE
fix(graphql-transformer-core): fix migration errors

### DIFF
--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -118,7 +118,7 @@ export async function ensureMissingStackMappings(config: ProjectOptions) {
         const transformOutput = await _buildProject(config);
         const copyOfCloudBackend = await readFromPath(currentCloudBackendDirectory);
         const stackMapping = transformOutput.stackMapping;
-        if (copyOfCloudBackend && copyOfCloudBackend.build) {
+        if (copyOfCloudBackend && copyOfCloudBackend.build && copyOfCloudBackend.build.stacks) {
             // leave the custom stack alone. Don't split them into separate stacks
             const customStacks = Object.keys(copyOfCloudBackend.stacks || {});
             const stackNames = Object.keys(copyOfCloudBackend.build.stacks).filter(

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -41,14 +41,17 @@ export async function check(currentCloudBackendDir: string, buildDirectory: stri
         const diffs = getDiffs(current, next);
         // Loop through the diffs and call each DiffRule.
         // We loop once so each rule does not need to loop.
-        for (const diff of diffs) {
-            for (const rule of diffRules) {
-                rule(diff, current, next);
+        if (diffs) {
+            for (const diff of diffs) {
+                for (const rule of diffRules) {
+                    rule(diff, current, next);
+                }
+            }
+            for (const projectRule of projectRules) {
+                projectRule(diffs, current, next);
             }
         }
-        for (const projectRule of projectRules) {
-            projectRule(diffs, current, next);
-        }
+
     }
 }
 


### PR DESCRIPTION
Updated stack sanity check and stack mapping code to work with older version of project when
migrating project

partial fix to #2196

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.