### PR TITLE
fix: generate iam policies for auth role for public rules as well

### DIFF
--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -1837,7 +1837,7 @@ found '${rule.provider}' assigned.`);
         }
 
         for (const rule of rules) {
-            if (rule.allow === 'private' && rule.provider === 'iam') {
+            if ((rule.allow === 'private' || rule.allow === 'public') && rule.provider === 'iam') {
                 this.generateIAMPolicyforAuthRole = true;
                 return;
             }
@@ -1909,6 +1909,7 @@ found '${rule.provider}' assigned.`);
 
         if (iamPublicRules.length > 0) {
             this.unauthPolicyResources.add(`${typeName}/null`);
+            this.authPolicyResources.add(`${typeName}/null`);
         }
         if (iamPrivateRules.length > 0) {
             this.authPolicyResources.add(`${typeName}/null`);
@@ -1921,6 +1922,7 @@ found '${rule.provider}' assigned.`);
 
         if (iamPublicRules.length > 0) {
             this.unauthPolicyResources.add(`${typeName}/${fieldName}`);
+            this.authPolicyResources.add(`${typeName}/${fieldName}`);
         }
         if (iamPrivateRules.length > 0) {
             this.authPolicyResources.add(`${typeName}/${fieldName}`);


### PR DESCRIPTION
*Description of changes:*

With this change if there is an ```@auth``` rule like this:

```graphql
    @auth(rules: [
        { allow: public, provider: iam }
    ])
```

The CLI will generate IAM policies for the authRole as well, not just the unauthRole.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.