### PR TITLE
fix(amplify-appsync-simulator): allow null returns in response template

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -117,7 +117,7 @@ export class VelocityTemplate {
       identity,
       stash: convertToJavaTypes(stash || {}),
       source: convertToJavaTypes(source),
-      result: convertToJavaTypes(result || {}),
+      result: convertToJavaTypes(result),
     };
 
     if (prevResult) {


### PR DESCRIPTION
Simulator converted falsy results to an empty object which prevented returning null for fields in
connection type and caused graphql validation error when query included a non nullable field

fix #2248

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.