### PR TITLE
test: fixing the graphql_e2e_tests AppSyncApiName missing error

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
@@ -149,10 +149,9 @@ type PostAuthor
     try {
         console.log('Creating Stack ' + STACK_NAME)
         const finishedStack = await deploy(
-            customS3Client, cf, STACK_NAME, out, {}, LOCAL_FS_BUILD_DIR, BUCKET_NAME, S3_ROOT_DIR_KEY,
+            customS3Client, cf, STACK_NAME, out, { CreateAPIKey: '1' }, LOCAL_FS_BUILD_DIR, BUCKET_NAME, S3_ROOT_DIR_KEY,
             BUILD_TIMESTAMP
         )
-
         // Arbitrary wait to make sure everything is ready.
         await cf.wait(5, () => Promise.resolve())
         console.log('Successfully created stack ' + STACK_NAME)

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
@@ -127,7 +127,14 @@ type PostAuthor
         transformers: [
             new DynamoDBModelTransformer(),
             new KeyTransformer(),
-            new ModelConnectionTransformer()
+            new ModelConnectionTransformer(),
+            new ModelAuthTransformer({
+                authConfig: {
+                    defaultAuthentication: {
+                        authenticationType: "API_KEY"
+                    },
+                    additionalAuthenticationProviders: []
+                }})
         ]
     })
     const out = transformer.transform(validSchema);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.