### PR TITLE
fix: multiauth-e2e typo

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -169,9 +169,9 @@ beforeAll(async () => {
     type PostIAMWithKeys @model
     @auth (
         rules: [
-            // API Key can CRUD
+            # API Key can CRUD
             { allow: public }
-            // IAM can read
+            # IAM can read
             { allow: public, provider iam, operations: [read] }
         ]
     )


### PR DESCRIPTION
*Description of changes:*

Fix a typo in the multi auth test GraphQL schema that caused e2e test failures for the whole suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.