### PR TITLE
fix: ensure that transformer instances are not reused

### DIFF
--- a/packages/graphql-transformer-core/src/index.ts
+++ b/packages/graphql-transformer-core/src/index.ts
@@ -10,7 +10,6 @@ import {
     uploadDeployment as uploadAPIProject,
     migrateAPIProject,
     revertAPIMigration,
-    ensureMissingStackMappings
 } from './util/amplifyUtils'
 import {
     readSchema as readProjectSchema,
@@ -39,5 +38,4 @@ export {
     readTransformerConfiguration,
     writeTransformerConfiguration,
     revertAPIMigration,
-    ensureMissingStackMappings
 }


### PR DESCRIPTION
*Description of changes:*

The API project is built twice because of the StackMapping feature. To make sure that Transformer instances (and their states) are not reused between the independent build phases the transformer instantiation is moved out to a factory function and it is getting invoked within ```buildProject```.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.