### PR TITLE
fix duplicate operation being set in mutation vtl response resolvers

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/PerFieldAuthArgument.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/PerFieldAuthArgument.test.ts
@@ -1,0 +1,59 @@
+import GraphQLTransform from 'graphql-transformer-core'
+import { ResourceConstants } from 'graphql-transformer-common'
+import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer'
+import { ModelAuthTransformer } from '../ModelAuthTransformer'
+
+test('Test that subscriptions are only generated if the respective mutation operation exists', () => {
+    const validSchema = `
+    type Salary
+        @model
+        @auth(rules: [
+                {allow: owner},
+                {allow: groups, groups: ["Moderator"]}
+            ])
+    {
+        id: ID!
+        wage: Int
+        owner: String
+        secret: String @auth(rules: [{allow: owner}])
+    }
+    `
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer(),
+            new ModelAuthTransformer({
+                authConfig: {
+                    defaultAuthentication: {
+                        authenticationType: "AMAZON_COGNITO_USER_POOLS"
+                    },
+                    additionalAuthenticationProviders: []
+                }
+            })
+        ]
+    })
+    const out = transformer.transform(validSchema)
+    // expect to generate subscription resolvers for create and update only
+    expect(out).toBeDefined()
+    expect(
+        out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType
+    ).toEqual('AMAZON_COGNITO_USER_POOLS')
+    expect(
+        out.resolvers['Salary.secret.res.vtl']
+    ).toContain('#if( $operation == "Mutation" )')
+    expect(out.resolvers['Salary.secret.res.vtl']).toMatchSnapshot();
+
+    expect(
+        out.resolvers['Mutation.createSalary.res.vtl']
+    ).toContain('#set( $context.result.operation = "Mutation" )')
+    expect(out.resolvers['Mutation.createSalary.res.vtl']).toMatchSnapshot();
+
+    expect(
+        out.resolvers['Mutation.updateSalary.res.vtl']
+    ).toContain('#set( $context.result.operation = "Mutation" )')
+    expect(out.resolvers['Mutation.updateSalary.res.vtl']).toMatchSnapshot();
+
+    expect(
+        out.resolvers['Mutation.deleteSalary.res.vtl']
+    ).toContain('#set( $context.result.operation = "Mutation" )')
+    expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toMatchSnapshot();
+})

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test that subscriptions are only generated if the respective mutation operation exists 1`] = `
+"## [Start] Checking for allowed operations which can return this field **
+#set( $operation = $util.defaultIfNull($context.source.operation, \\"null\\") )
+#if( $operation == \\"Mutation\\" )
+$util.toJson(null)
+#else
+$util.toJson($context.source.secret)
+#end
+## [End] Checking for allowed operations which can return this field **"
+`;
+
+exports[`Test that subscriptions are only generated if the respective mutation operation exists 2`] = `
+"## [Start] Setting the operation **
+#set( $context.result.operation = \\"Mutation\\" )
+## [End] Setting the operation **
+
+$util.toJson($context.result)"
+`;
+
+exports[`Test that subscriptions are only generated if the respective mutation operation exists 3`] = `
+"## [Start] Setting the operation **
+#set( $context.result.operation = \\"Mutation\\" )
+## [End] Setting the operation **
+
+$util.toJson($context.result)"
+`;
+
+exports[`Test that subscriptions are only generated if the respective mutation operation exists 4`] = `
+"## [Start] Setting the operation **
+#set( $context.result.operation = \\"Mutation\\" )
+## [End] Setting the operation **
+
+$util.toJson($context.result)"
+`;

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -938,10 +938,10 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
         ])
     }
 
-    public setOperationExpression(operation: string) {
-        return block('Setting the operation', [
+    public setOperationExpression(operation: string): string {
+        return print(block('Setting the operation', [
             set(ref('context.result.operation'), str(operation))
-        ])
+        ]))
     }
 
     public getAuthModeCheckWrappedExpression(expectedAuthModes: Set<AuthProvider>, expression: Expression): Expression {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- made sure mutationTypeName is set as opposed to the name of the actual operation
- operation is set mutliple times per field - it only needs to be set one with the operationTypeName
- set correct resolver id to delete `protectDeleteForField`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.