### PR TITLE
fix(graphql-auth-transformer): fixed bug with per field auth on create

### DIFF
--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -605,7 +605,7 @@ Either make the field optional, set auth on the object and not the field, or dis
                     fieldIsList
                 )
 
-                const throwIfUnauthorizedExpression = this.resources.throwIfUnauthorized()
+                const throwIfUnauthorizedExpression = this.resources.throwIfUnauthorized(field)
 
                 // Populate a list of configured authentication providers based on the rules
                 const authModesToCheck = new Set<AuthProvider>();

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -795,11 +795,12 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
         ])
     }
 
-    public throwIfUnauthorized(): Expression {
+    public throwIfUnauthorized(field?: FieldDefinitionNode): Expression {
+        const staticGroupAuthorizedVariable = this.getStaticAuthorizationVariable(field);
         const ifUnauthThrow = iff(
             not(parens(
                 or([
-                    equals(ref(ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable), raw('true')),
+                    equals(ref(staticGroupAuthorizedVariable), raw('true')),
                     equals(ref(ResourceConstants.SNIPPETS.IsDynamicGroupAuthorizedVariable), raw('true')),
                     equals(ref(ResourceConstants.SNIPPETS.IsOwnerAuthorizedVariable), raw('true'))
                 ])

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -172,7 +172,7 @@ beforeAll(async () => {
             # API Key can CRUD
             { allow: public }
             # IAM can read
-            { allow: public, provider iam, operations: [read] }
+            { allow: public, provider: iam, operations: [read] }
         ]
     )
     @key (name: "byDate", fields: ["type", "date"], queryField: "getPostIAMWithKeysByDate")


### PR DESCRIPTION
fixed bug with per field auth not using same variable 'field_isStaticAuthorizedVariable'

re pr #2316

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.