### PR TITLE
fix(amplify-appsync-simulator): add support for AppSync template version

### DIFF
--- a/packages/amplify-appsync-simulator/src/data-loader/lambda/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/lambda/index.ts
@@ -9,6 +9,7 @@ export class LambdaDataLoader implements AmplifyAppSyncSimulatorDataLoader {
     } catch (e) {
       console.log('Lambda Data source failed with the following error');
       console.log(e);
+      throw e;
     }
   }
 }

--- a/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
@@ -33,7 +33,7 @@ export class AppSyncPipelineResolver {
     let stash = {};
     let templateErrors;
 
-    // Pipe line request mapping template
+    // Pipeline request mapping template
     ({ result, stash, errors: templateErrors } = requestMappingTemplate.render(
       { source, arguments: args, stash },
       context,
@@ -41,7 +41,7 @@ export class AppSyncPipelineResolver {
     ));
     context.appsyncErrors = [...context.appsyncErrors, ...templateErrors];
 
-    // Pipe line functions
+    // Pipeline functions
     await this.config.functions
       .reduce((chain, fn) => {
         const fnResolver = this.simulatorContext.getFunction(fn);

--- a/packages/amplify-appsync-simulator/src/server/operations.ts
+++ b/packages/amplify-appsync-simulator/src/server/operations.ts
@@ -123,12 +123,9 @@ export class OperationServer {
             variables,
             operationName
           );
-          if (Object.keys(context.appsyncErrors).length) {
-            results.errors = JSON.stringify(context.appsyncErrors);
-          }
-          // Make extensions available at the root level
-          if (results.errors) {
-            results.errors = exposeGraphQLErrors(results.errors);
+          const errors = [...(results.errors || []), ...context.appsyncErrors];
+          if (errors.length) {
+            results.errors = exposeGraphQLErrors(errors);
           }
           return response.send({ data: null, ...results });
 

--- a/packages/amplify-appsync-simulator/src/server/operations.ts
+++ b/packages/amplify-appsync-simulator/src/server/operations.ts
@@ -124,7 +124,7 @@ export class OperationServer {
             operationName
           );
           const errors = [...(results.errors || []), ...context.appsyncErrors];
-          if (errors.length) {
+          if (errors.length > 0) {
             results.errors = exposeGraphQLErrors(errors);
           }
           return response.send({ data: null, ...results });

--- a/packages/amplify-appsync-simulator/src/utils/expose-graphql-errors.ts
+++ b/packages/amplify-appsync-simulator/src/utils/expose-graphql-errors.ts
@@ -1,7 +1,7 @@
 /**
  * GraphQL Allows to show custom errors properties in errors using a property called extensions.
  * AppSync doesn't use extensions in error instead it puts the error at the objects root level.
- * For instance, UnAuthorized has errotType field with value Unauthorized.
+ * For instance, UnAuthorized has errorType field with value Unauthorized.
  *
  * This utility method takes all the properties exposed through extensions and exposes them at root
  * level of the Error object
@@ -14,7 +14,7 @@ export function exposeGraphQLErrors(errors = []) {
       const additionalProps = Object.entries(e.extensions).reduce((sum, [k, v]) => {
         return { ...sum, [k]: { value: v, enumerable: true } };
       }, {});
-      Object.defineProperties(e, additionalProps);
+      return Object.defineProperties({}, additionalProps);
     }
     return e;
   });

--- a/packages/amplify-appsync-simulator/src/velocity/util/errors.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/errors.ts
@@ -1,24 +1,47 @@
+import { GraphQLResolveInfo } from 'graphql';
+
 export class TemplateSentError extends Error {
-  constructor(gqlMessage, errorType, data, errorInfo) {
-    super(gqlMessage);
-    Object.assign(this, { gqlMessage, errorType, data, errorInfo });
+  extensions: any;
+  constructor(message, errorType, data, errorInfo, info: GraphQLResolveInfo) {
+    super(message);
+    const fieldName = info.fieldName;
+    let path = info.path;
+    const pathArray = []
+    do {
+      pathArray.splice(0, 0, path.key);
+      path = path.prev
+    } while(path);
+
+    const fieldNode = info.fieldNodes.find(f => f.name.value === fieldName);
+    const filedLocation = fieldNode && fieldNode.loc.startToken || null;
+    Object.assign(this, { message, errorType, data, errorInfo });
+    this.extensions = {
+      message: message,
+      errorType,
+      data,
+      errorInfo,
+      path: pathArray,
+      locations: [
+        filedLocation ? {
+          line: filedLocation.line,
+          column: filedLocation.column,
+          sourceName: fieldNode.loc.source.name,
+        } : [],
+      ],
+    };
   }
 }
 
 export class Unauthorized extends TemplateSentError {
   extensions: any;
   errorType: string;
-  constructor(gqlMessage) {
-    super(gqlMessage, 'Unauthorized', {}, {});
-    this.extensions = {
-      errorType: 'Unauthorized',
-    };
-    this.errorType = 'Unauthorized';
+  constructor(gqlMessage, info) {
+    super(gqlMessage, 'Unauthorized', {}, {}, info);
   }
 }
 export class ValidateError extends Error {
-  constructor(gqlMessage, type, data) {
-    super(gqlMessage);
-    Object.assign(this, { gqlMessage, type, data });
+  constructor(message, type, data) {
+    super(message);
+    Object.assign(this, { message, type, data });
   }
 }

--- a/packages/amplify-appsync-simulator/src/velocity/util/errors.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/errors.ts
@@ -2,7 +2,7 @@ import { GraphQLResolveInfo } from 'graphql';
 
 export class TemplateSentError extends Error {
   extensions: any;
-  constructor(message, errorType, data, errorInfo, info: GraphQLResolveInfo) {
+  constructor(public message:string, public errorType:string , public data: any, public errorInfo: any, info: GraphQLResolveInfo) {
     super(message);
     const fieldName = info.fieldName;
     let path = info.path;
@@ -14,7 +14,6 @@ export class TemplateSentError extends Error {
 
     const fieldNode = info.fieldNodes.find(f => f.name.value === fieldName);
     const filedLocation = fieldNode && fieldNode.loc.startToken || null;
-    Object.assign(this, { message, errorType, data, errorInfo });
     this.extensions = {
       message: message,
       errorType,
@@ -33,15 +32,12 @@ export class TemplateSentError extends Error {
 }
 
 export class Unauthorized extends TemplateSentError {
-  extensions: any;
-  errorType: string;
   constructor(gqlMessage, info) {
     super(gqlMessage, 'Unauthorized', {}, {}, info);
   }
 }
 export class ValidateError extends Error {
-  constructor(message, type, data) {
+  constructor(public message: string, public type: string, public data: any) {
     super(message);
-    Object.assign(this, { message, type, data });
   }
 }

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -34,17 +34,17 @@ export const generalUtils = {
     return autoId();
   },
   unauthorized() {
-    const err = new Unauthorized('Unauthorized');
+    const err = new Unauthorized('Unauthorized', this.info);
     this.errors.push(err);
     throw err;
   },
   error(message, type = null, data = null, errorInfo = null) {
-    const err = new TemplateSentError(message, type, data, errorInfo);
+    const err = new TemplateSentError(message, type, data, errorInfo, this.info);
     this.errors.push(err);
     throw err;
   },
   appendError(message, type = null, data = null, errorInfo = null) {
-    this.errors.push(new TemplateSentError(message, type, data, errorInfo));
+    this.errors.push(new TemplateSentError(message, type, data, errorInfo, this.info));
     return '';
   },
   getErrors() {

--- a/packages/amplify-appsync-simulator/src/velocity/util/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/index.ts
@@ -5,8 +5,9 @@ import { listUtils } from './list-utils';
 import { mapUtils } from './map-utils';
 import { transformUtils } from './transform';
 import { time } from './time';
+import { GraphQLResolveInfo } from 'graphql';
 
-export function create(errors = [], now: Date = new Date()) {
+export function create(errors = [], now: Date = new Date(), info: GraphQLResolveInfo) {
   return {
     ...generalUtils,
     dynamodb: dynamodbUtils,
@@ -15,6 +16,7 @@ export function create(errors = [], now: Date = new Date()) {
     transform: transformUtils,
     now,
     errors,
+    info,
     time: time(now),
   };
 }


### PR DESCRIPTION
Mock server did have support for Resolver versions. Updated mock implementation to support template
version and surface errors raised using $util.appendError

fix #2134 #2211 and #2299

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.