### PR TITLE
fix(amplify-codegen): add framework only if javascript

### DIFF
--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -148,7 +148,7 @@ async function add(context, apiId = null) {
       region,
       apiId,
       ...(withoutInit ? { frontend } : {}),
-      ...(withoutInit ? { framework } : {}),
+      ...((withoutInit && frontend === 'javascript') ? { framework } : {}),
     },
   };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Only add framework to project config if in a javascript project

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.