### PR TITLE
fix: the KeyTransformer class name was incorrect

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -27,7 +27,7 @@ interface KeyArguments {
     queryField?: string;
 }
 
-export default class FunctionTransformer extends Transformer {
+export default class KeyTransformer extends Transformer {
 
     constructor() {
         super(


### PR DESCRIPTION
*Description of changes:*

KeyTransformer class name was FunctionTransformer, it was working because it is a default export, but would have failed otherwise.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.