### PR TITLE
fix(amplify-appsync-simulator): fix none data source handler

### DIFF
--- a/packages/amplify-appsync-simulator/src/data-loader/none/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/none/index.ts
@@ -1,7 +1,7 @@
 import { AmplifyAppSyncSimulatorDataLoader } from '..';
 
 export class NoneDataLoader implements AmplifyAppSyncSimulatorDataLoader {
-  load(payload): any {
-    return payload;
+  load(request): any {
+    return request.payload || null;
   }
 }


### PR DESCRIPTION
None data source handler use to return the data it got instead of returning the payload part of
data. Updated the handler to adhere to appsync behavior

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.