### PR TITLE
fix(amplify-util-mock): use lambda fn name instead of resource name

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/lambda-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/lambda-resource-processor.ts
@@ -1,0 +1,62 @@
+import { CloudFormationParseContext } from './types';
+import { parseValue } from './field-parser';
+
+export type LambdaFunctionConfig = {
+  name: string;
+  handler: string;
+  basePath?: string;
+  environment?: object;
+};
+
+const CFN_DEFAULT_PARAMS = {
+  'AWS::Region': 'us-east-1-fake',
+  'AWS::AccountId': '12345678910',
+  'AWS::StackId': 'fake-stackId',
+  'AWS::StackName': 'local-testing',
+};
+
+const CFN_DEFAULT_CONDITIONS = {
+  ShouldNotCreateEnvResources: true,
+};
+
+export function lambdaFunctionHandler(
+  resourceName,
+  resource,
+  cfnContext: CloudFormationParseContext
+): LambdaFunctionConfig {
+  const name: string = parseValue(resource.Properties.FunctionName, cfnContext);
+  const handler = parseValue(resource.Properties.Handler, cfnContext);
+  const environment =
+    resource.Properties.Environment && resource.Properties.Environment.Variables
+      ? Object.entries(resource.Properties.Environment.Variables).reduce(
+          (acc, [varName, varValue]) => ({
+            ...acc,
+            [varName]: parseValue(varValue, cfnContext),
+          }),
+          {}
+        )
+      : {};
+  return {
+    name,
+    handler,
+    environment,
+  };
+}
+
+export function processResources(
+  resources: { [key: string]: any },
+  transformResult: any,
+  params = {}
+): LambdaFunctionConfig | undefined {
+  const definition = Object.entries(resources).find(
+    (entry: [string, any]) => entry[1].Type === 'AWS::Lambda::Function'
+  );
+  if (definition) {
+    return lambdaFunctionHandler(definition[0], definition[1], {
+      conditions: CFN_DEFAULT_CONDITIONS,
+      params: { ...CFN_DEFAULT_PARAMS, ...params },
+      exports: {},
+      resources: {},
+    });
+  }
+}

--- a/packages/amplify-util-mock/src/utils/lambda/invoke.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/invoke.ts
@@ -6,7 +6,8 @@ export function invoke(options) {
         try {
             // XXX: Make the path work in both e2e and
             const lambdaFn = fork(path.join(__dirname, '../../../lib/utils/lambda', 'execute.js'), [], {
-                execArgv: []
+                execArgv: [],
+                env: options.environment || {}
             });
             lambdaFn.on('message', msg => {
                 const result = JSON.parse(msg);

--- a/packages/amplify-util-mock/src/utils/lambda/load.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/load.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { LambdaFunctionConfig, processResources } from '../../CFNParser/lambda-resource-processor';
+
+export function getAllLambdaFunctions(context, backendPath: string): LambdaFunctionConfig[] {
+  const lambdas: LambdaFunctionConfig[] = [];
+  const lambdaCategoryPath = path.join(backendPath, 'function');
+  if (fs.existsSync(lambdaCategoryPath) && fs.lstatSync(lambdaCategoryPath).isDirectory) {
+    fs.readdirSync(lambdaCategoryPath)
+      .filter(p => {
+        const lambdaDir = path.join(lambdaCategoryPath, p);
+        return fs.existsSync(lambdaDir) && fs.lstatSync(lambdaDir).isDirectory;
+      })
+      .forEach(resourceName => {
+        const lambdaDir = path.join(lambdaCategoryPath, resourceName);
+        const cfnPath = path.join(lambdaDir, `${resourceName}-cloudformation-template.json`);
+        const cfnParams = path.join(lambdaDir, 'function-parameters.json');
+        try {
+          const lambdaCfn = JSON.parse(fs.readFileSync(cfnPath, 'utf-8'));
+          const lambdaCfnParams = fs.existsSync(cfnParams)
+            ? JSON.parse(fs.readFileSync(cfnParams, 'utf-8'))
+            : {};
+          const lambdaConfig = processResources(
+            lambdaCfn.Resources,
+            {},
+            { ...lambdaCfnParams, env: 'NONE' }
+          );
+          lambdaConfig.basePath = path.join(lambdaDir, 'src');
+          lambdas.push(lambdaConfig);
+        } catch (e) {
+          context.print.error(`Failed to parse Lambda function cloudformation in ${cfnPath}`);
+          context.print.error(`\n${e}`);
+        }
+      });
+  }
+  return lambdas;
+}

--- a/packages/amplify-util-mock/tsconfig.json
+++ b/packages/amplify-util-mock/tsconfig.json
@@ -6,7 +6,7 @@
         "outDir": "lib",
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        // "sourceRoot": "src",
+        "sourceRoot": "src",
         "lib": [
             "es2017",
             "esnext.asynciterable"

--- a/packages/amplify-util-mock/tsconfig.json
+++ b/packages/amplify-util-mock/tsconfig.json
@@ -6,7 +6,7 @@
         "outDir": "lib",
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "sourceRoot": "src",
+        // "sourceRoot": "src",
         "lib": [
             "es2017",
             "esnext.asynciterable"


### PR DESCRIPTION
Mock implementation used lambda function resource name instead of the function name when mocking API. Update the implementation to parse lambda cloudformation to get function name, handler and enviornment variables and use them for mock invocation
    
fix #2280