### PR TITLE
refactor(amplify-util-mock): stop mock config mutation

### DIFF
--- a/packages/amplify-util-mock/src/utils/ddb-utils.ts
+++ b/packages/amplify-util-mock/src/utils/ddb-utils.ts
@@ -13,13 +13,22 @@ export async function ensureDynamoDBTables(dynamodb, config) {
 }
 
 export function configureDDBDataSource(config, ddbConfig) {
-  config.dataSources
-    .filter(d => d.type === 'AMAZON_DYNAMODB')
-    .forEach(d => {
-      d.config.endpoint = ddbConfig.endpoint;
-      d.config.region = ddbConfig.region;
-      d.config.accessKeyId = ddbConfig.accessKeyId;
-      d.config.secretAccessKey = ddbConfig.secretAccessKey;
-    });
-  return config;
+  return {
+    ...config,
+    dataSources: config.dataSources.map(d => {
+      if (d.type !== 'AMAZON_DYNAMODB') {
+        return d;
+      }
+        return {
+          ...d,
+          config: {
+            ...d.config,
+            endpoint: ddbConfig.endpoint,
+            region: ddbConfig.region,
+            accessKeyId: ddbConfig.accessKeyId,
+            secretAccessKey: ddbConfig.secretAccessKey,
+          },
+        };
+    }),
+  };
 }


### PR DESCRIPTION
Stop mutating input config object when configuring data sources. This is addressing the [comment](https://github.com/aws-amplify/amplify-cli/pull/2357#discussion_r326508567)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.