### PR TITLE
fix(graphql-auth-transformer): add support for ownerfield

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/OwnerAuthTransformer.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/OwnerAuthTransformer.test.ts
@@ -34,3 +34,53 @@ test('Test ModelAuthTransformer validation happy case', () => {
         out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType
     ).toEqual('AMAZON_COGNITO_USER_POOLS')
 });
+
+
+test('Test OwnerField with Subscriptions', () => {
+    const validSchema = `
+        type Post @model
+            @auth(rules: [
+                {allow: owner, ownerField: "postOwner"}
+            ])
+        {
+            id: ID!
+            title: String
+            postOwner: String
+        }`
+    const transformer = new GraphQLTransform({
+        transformers: [
+            new DynamoDBModelTransformer(),
+            new ModelAuthTransformer({
+                authConfig: {
+                    defaultAuthentication: {
+                        authenticationType: "AMAZON_COGNITO_USER_POOLS"
+                    },
+                    additionalAuthenticationProviders: []
+                }})
+        ]
+    })
+    const out = transformer.transform(validSchema)
+    expect(out).toBeDefined()
+
+    // expect 'postOwner' as an argument for subscription operations
+    expect(out.schema).toContain(
+        'onCreatePost(postOwner: String!)'
+    )
+    expect(out.schema).toContain(
+        'onUpdatePost(postOwner: String!)'
+    )
+    expect(out.schema).toContain(
+        'onDeletePost(postOwner: String!)'
+    )
+
+    // expect logic in the resolvers to check for postOwner args as an allowerOwner
+    expect(
+        out.resolvers['Subscription.onCreatePost.res.vtl']
+    ).toContain('#set( $allowedOwners0 = $util.defaultIfNull($ctx.args.postOwner, null) )')
+    expect(
+        out.resolvers['Subscription.onUpdatePost.res.vtl']
+    ).toContain('#set( $allowedOwners0 = $util.defaultIfNull($ctx.args.postOwner, null) )')
+    expect(
+        out.resolvers['Subscription.onDeletePost.res.vtl']
+    ).toContain('#set( $allowedOwners0 = $util.defaultIfNull($ctx.args.postOwner, null) )')
+})


### PR DESCRIPTION
add support for ownerField in auth subscriptions

*Issue #, if available:*
- re #2361

*Description of changes:*

- If there are no static group rules and only owner rules then the owner rules are required int the subscription operation this also applies to owner rules with an ownerField.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.