### PR TITLE
fix: #2360 - meta json was written as object

### DIFF
--- a/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
+++ b/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
@@ -30,7 +30,7 @@ module.exports = async (context, apiDetails) => {
 
 
   const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-  fs.write(amplifyMetaFilePath, JSON.stringify(amplifyMeta, null, 2));
+  fs.write(amplifyMetaFilePath, JSON.stringify(amplifyMeta, null, 4));
 
   const currentAmplifyMetaFilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
   const currentAmplifyMeta = JSON.parse(fs.read(currentAmplifyMetaFilePath));
@@ -38,7 +38,7 @@ module.exports = async (context, apiDetails) => {
     currentAmplifyMeta.api = {};
   }
   currentAmplifyMeta.api[apiDetails.name] = appsyncMetadata;
-  fs.write(currentAmplifyMetaFilePath, JSON.stringify(currentAmplifyMeta, null, 2));
+  fs.write(currentAmplifyMetaFilePath, JSON.stringify(currentAmplifyMeta, null, 4));
 
   await context.amplify.onCategoryOutputsChange(context);
   context.print.success(`Successfully added API ${apiDetails.name} to your Amplify project`);

--- a/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
+++ b/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
@@ -30,7 +30,7 @@ module.exports = async (context, apiDetails) => {
 
 
   const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-  fs.write(amplifyMetaFilePath, amplifyMeta);
+  fs.write(amplifyMetaFilePath, JSON.stringify(amplifyMeta, null, 2));
 
   const currentAmplifyMetaFilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
   const currentAmplifyMeta = JSON.parse(fs.read(currentAmplifyMetaFilePath));
@@ -38,7 +38,7 @@ module.exports = async (context, apiDetails) => {
     currentAmplifyMeta.api = {};
   }
   currentAmplifyMeta.api[apiDetails.name] = appsyncMetadata;
-  fs.write(currentAmplifyMetaFilePath, currentAmplifyMeta);
+  fs.write(currentAmplifyMetaFilePath, JSON.stringify(currentAmplifyMeta, null, 2));
 
   await context.amplify.onCategoryOutputsChange(context);
   context.print.success(`Successfully added API ${apiDetails.name} to your Amplify project`);


### PR DESCRIPTION
*Issue #, if available:*

Fixes #2360 

*Description of changes:*

meta.json was writing out the JS object instead of the JSON version of the object upon codegen add api operation.

This happened because context.filesystem.write is different with the new plugin system.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.