### PR TITLE
fix(amplify-appsync-simulator): impl missing methods in velocity utils

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -25,7 +25,6 @@
     "@conduitvc/mosca": "^2.8.3",
     "amplify-velocity-template": "0.14.0",
     "cors": "^2.8.5",
-    "dateformat": "^3.0.3",
     "event-to-promise": "^0.8.0",
     "express": "^4.17.1",
     "fs-extra": "^8.1.0",
@@ -40,6 +39,9 @@
     "jwt-decode": "^2.2.0",
     "libphonenumber-js": "^1.7.18",
     "lodash": "^4.17.15",
+    "moment": "^2.24.0",
+    "moment-jdateformatparser": "^1.2.1",
+    "moment-timezone": "0.5.26",
     "portfinder": "^1.0.21",
     "uuid": "^3.3.2"
   },
@@ -56,7 +58,8 @@
     "prettier": "^1.18.2",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "@types/moment-timezone":"0.5.12"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/time.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/time.test.ts
@@ -1,0 +1,101 @@
+import { time as Time } from '../../../velocity/util/time';
+
+describe('Velocity $context.util.time', () => {
+  let dateNowSpy;
+  let time;
+  const FORMAT_CUSTOM_ZONED = 'yyyy-MM-dd HH:mm:ss.SSS Z';
+  const FORMAT_CUSTOM_UNZONED = 'yyyy-MM-dd HH:mm:ss.SSS';
+  const TEST_TIMESTAMP_MILLIS = 1267378472045; // 2010-02-28T17:34:32.045Z
+  const TEST_TIMESTAMP_SECS = 1267378472;
+  const TEST_TIMESTAMP_ZULU = '2010-02-28T17:34:32.045Z';
+  const TEST_TIMESTAMP_PLUS8 = '2010-03-01T01:34:32.045+08:00';
+  const TEST_TIMESTAMP_CUSTOM_UTC = '2010-02-28 17:34:32.045 +0000';
+  const TEST_TIMESTAMP_CUSTOM_PLUS8 = '2010-03-01 01:34:32.045 +0800';
+  const TEST_TIMESTAMP_CUSTOM_UTC_UNZONED = '2010-02-28 17:34:32.045';
+  const TEST_TIMESTAMP_CUSTOM_PLUS8_UNZONED = '2010-03-01 01:34:32.045';
+
+  beforeAll(() => {
+    // freeze time
+    time = Time();
+    dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => TEST_TIMESTAMP_MILLIS);
+  });
+  afterAll(() => {
+    // unfreeze time
+    dateNowSpy.mockRestore();
+  });
+
+  it('nowISO8601', () => {
+    expect(time.nowISO8601()).toEqual(TEST_TIMESTAMP_ZULU);
+  });
+
+  it('nowEpochSeconds', () => {
+    expect(time.nowEpochSeconds()).toEqual(TEST_TIMESTAMP_SECS);
+  });
+
+  it('nowEpochMilliSeconds', () => {
+    expect(time.nowEpochMilliSeconds()).toEqual(TEST_TIMESTAMP_MILLIS);
+  });
+
+  it('parseFormattedToEpochMilliSeconds', () => {
+    expect(
+      time.parseFormattedToEpochMilliSeconds(TEST_TIMESTAMP_CUSTOM_UTC, FORMAT_CUSTOM_ZONED)
+    ).toEqual(TEST_TIMESTAMP_MILLIS);
+    expect(
+      time.parseFormattedToEpochMilliSeconds(TEST_TIMESTAMP_CUSTOM_PLUS8, FORMAT_CUSTOM_ZONED)
+    ).toEqual(TEST_TIMESTAMP_MILLIS);
+    expect(
+      time.parseFormattedToEpochMilliSeconds(TEST_TIMESTAMP_CUSTOM_UTC, FORMAT_CUSTOM_ZONED)
+    ).toEqual(TEST_TIMESTAMP_MILLIS);
+    expect(
+      time.parseFormattedToEpochMilliSeconds(
+        TEST_TIMESTAMP_CUSTOM_PLUS8,
+        FORMAT_CUSTOM_ZONED,
+        'Australia/Perth'
+      )
+    ).toEqual(TEST_TIMESTAMP_MILLIS);
+    expect(
+      time.parseFormattedToEpochMilliSeconds(
+        TEST_TIMESTAMP_CUSTOM_UTC_UNZONED,
+        FORMAT_CUSTOM_UNZONED,
+        'UTC'
+      )
+    ).toEqual(TEST_TIMESTAMP_MILLIS);
+
+    expect(
+      time.parseFormattedToEpochMilliSeconds(
+        TEST_TIMESTAMP_CUSTOM_PLUS8_UNZONED,
+        FORMAT_CUSTOM_UNZONED,
+        'Australia/Perth'
+      )
+    ).toEqual(TEST_TIMESTAMP_MILLIS);
+  });
+
+  it('parseISO8601ToEpochMilliSeconds', () => {
+    expect(time.parseISO8601ToEpochMilliSeconds(TEST_TIMESTAMP_ZULU)).toEqual(
+      TEST_TIMESTAMP_MILLIS
+    );
+    expect(time.parseISO8601ToEpochMilliSeconds(TEST_TIMESTAMP_PLUS8)).toEqual(
+      TEST_TIMESTAMP_MILLIS
+    );
+  });
+  it('epochMilliSecondsToSeconds', () => {
+    expect(time.epochMilliSecondsToSeconds(TEST_TIMESTAMP_MILLIS)).toEqual(TEST_TIMESTAMP_SECS);
+  });
+  it('epochMilliSecondsToISO8601', () => {
+    expect(time.epochMilliSecondsToISO8601(TEST_TIMESTAMP_MILLIS)).toEqual(TEST_TIMESTAMP_ZULU);
+  });
+
+  it('epochMilliSecondsToFormatted', () => {
+    expect(time.epochMilliSecondsToFormatted(TEST_TIMESTAMP_MILLIS, FORMAT_CUSTOM_ZONED)).toEqual(
+      TEST_TIMESTAMP_CUSTOM_UTC
+    );
+
+    expect(
+      time.epochMilliSecondsToFormatted(
+        TEST_TIMESTAMP_MILLIS,
+        FORMAT_CUSTOM_ZONED,
+        'Australia/Perth'
+      )
+    ).toEqual(TEST_TIMESTAMP_CUSTOM_PLUS8);
+  });
+});

--- a/packages/amplify-appsync-simulator/src/velocity/util/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/index.ts
@@ -17,6 +17,6 @@ export function create(errors = [], now: Date = new Date(), info: GraphQLResolve
     now,
     errors,
     info,
-    time: time(now),
+    time: time(),
   };
 }

--- a/packages/amplify-appsync-simulator/src/velocity/util/time.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/time.ts
@@ -9,7 +9,7 @@ declare module 'moment' {
   }
 }
 
-function parseTimeStamp(dateTime: string, format?: string, timezone?: string): moment.Moment {
+const parseTimestamp = (dateTime: string, format?: string, timezone?: string): moment.Moment => {
   if (!dateTime || !format) {
     return null;
   }
@@ -52,11 +52,11 @@ export const time = () => ({
     format: string,
     timezone?: string
   ): number | null {
-    const timestamp = parseTimeStamp(dateTime, format, timezone);
+    const timestamp = parseTimestamp(dateTime, format, timezone);
     return timestamp ? timestamp.valueOf() : null;
   },
   parseISO8601ToEpochMilliSeconds(dateTime): number | null {
-    const timestamp = parseTimeStamp(dateTime, 'YYYY-MM-DDTHH:mm:ss.SZ');
+    const timestamp = parseTimestamp(dateTime, 'YYYY-MM-DDTHH:mm:ss.SZ');
     return timestamp ? timestamp.valueOf() : null;
   },
   epochMilliSecondsToSeconds(milliseconds: number): number | null {

--- a/packages/amplify-appsync-simulator/src/velocity/util/time.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/time.ts
@@ -1,32 +1,89 @@
-import * as dateformat from 'dateformat';
+import * as moment from 'moment';
+import 'moment-timezone';
+import 'moment-jdateformatparser';
 
-export const time = now => ({
-  nowISO8601() {
-    return now.toISOString();
+declare module 'moment' {
+  export interface Moment {
+    toMomentFormatString: (format: string) => string;
+    formatWithJDF: (format: string) => string;
+  }
+}
+
+function parseTimeStamp(dateTime: string, format?: string, timezone?: string): moment.Moment {
+  if (!dateTime || !format) {
+    return null;
+  }
+  try {
+    const momentFormatString = moment().toMomentFormatString(format);
+
+    return timezone
+      ? moment.tz(dateTime, momentFormatString, timezone)
+      : moment(dateTime, momentFormatString);
+  } catch (e) {
+    return null;
+  }
+}
+
+export const time = () => ({
+  nowISO8601(t): string {
+    return moment().toISOString();
   },
-  nowEpochSeconds() {
-    return parseInt((now.valueOf() / 1000).toString(), 10);
+  nowEpochSeconds(): number {
+    return moment().unix();
   },
-  nowEpochMilliSeconds() {
-    return now.valueOf();
+  nowEpochMilliSeconds(): number {
+    return moment().valueOf();
   },
-  nowFormatted(format, timezone = null) {
-    if (timezone) throw new Error('no support for setting timezone!');
-    return dateformat(now, format);
+  nowFormatted(format: string, timezone: string = null): string | null {
+    try {
+      if (timezone) {
+        return moment()
+          .tz(timezone)
+          .formatWithJDF(format);
+      }
+
+      return moment().formatWithJDF(format);
+    } catch (e) {
+      return null;
+    }
   },
-  parseFormattedToEpochMilliSeconds() {
-    throw new Error('not implemented');
+  parseFormattedToEpochMilliSeconds(
+    dateTime: string,
+    format: string,
+    timezone?: string
+  ): number | null {
+    const timestamp = parseTimeStamp(dateTime, format, timezone);
+    return timestamp ? timestamp.valueOf() : null;
   },
-  parseISO8601ToEpochMilliSeconds() {
-    throw new Error('not implemented');
+  parseISO8601ToEpochMilliSeconds(dateTime): number | null {
+    const timestamp = parseTimeStamp(dateTime, 'YYYY-MM-DDTHH:mm:ss.SZ');
+    return timestamp ? timestamp.valueOf() : null;
   },
-  epochMilliSecondsToSeconds() {
-    throw new Error('not implemented');
+  epochMilliSecondsToSeconds(milliseconds: number): number | null {
+    try {
+      return Math.floor(milliseconds / 1000);
+    } catch (e) {
+      return null;
+    }
   },
-  epochMilliSecondsToISO8601() {
-    throw new Error('not implemented');
+  epochMilliSecondsToISO8601(dateTime: number): string | null {
+    try {
+      return moment(dateTime).toISOString();
+    } catch (e) {
+      return null;
+    }
   },
-  epochMilliSecondsToFormatted() {
-    throw new Error('not implemented');
+  epochMilliSecondsToFormatted(
+    timestamp: number,
+    format: string,
+    timezone: string = 'UTC'
+  ): string | null {
+    try {
+      return moment(timestamp)
+        .tz(timezone)
+        .formatWithJDF(format);
+    } catch (e) {
+      return null;
+    }
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,6 +2730,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/moment-timezone@0.5.12":
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/@types/moment-timezone/-/moment-timezone-0.5.12.tgz#0fb680c03db194fe8ff4551eaeb1eec8d3d80e9f"
+  integrity sha512-hnHH2+Efg2vExr/dSz+IX860nSiyk9Sk4pJF2EmS11lRpMcNXeB4KBW5xcgw2QPsb9amTXdsVNEe5IoJXiT0uw==
+  dependencies:
+    moment ">=2.14.0"
+
 "@types/mosca@^2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@types/mosca/-/mosca-2.8.1.tgz#b24c7e082d2799d84e710c5f813a0d83dd70a4c9"
@@ -6618,7 +6625,7 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-dateformat@^3.0.0, dateformat@^3.0.3:
+dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
@@ -13843,7 +13850,19 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.24.0:
+moment-jdateformatparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/moment-jdateformatparser/-/moment-jdateformatparser-1.2.1.tgz#336c41ef7a6db8021d7ca086385a35fb8a648456"
+  integrity sha512-lpUeQtMaxmpK+pPPHGWMnqzgsB/nunbAGPg72mzvRNbxxeQ2uBurdq9EJmvJtOiYB6k/4T9kuvQFbb+8Tirn4A==
+
+moment-timezone@0.5.26:
+  version "0.5.26"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.26.tgz#c0267ca09ae84631aa3dc33f65bedbe6e8e0d772"
+  integrity sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@>=2.14.0, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
Implemented missing time releated method in velocity template utils. Updated the method to support
Java Date format string

fix #2300

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.