### PR TITLE
fix(graphql-elasticsearch-transformer): add layer based on region

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -57,12 +57,16 @@ export class SearchableModelTransformer extends Transformer {
         ctx.mergeResources(template.Resources);
         ctx.mergeParameters(template.Parameters);
         ctx.mergeOutputs(template.Outputs);
+        ctx.mergeMappings(template.Mappings);
         ctx.metadata.set('ElasticsearchPathToStreamingLambda', path.resolve(`${__dirname}/../lib/streaming-lambda.zip`))
         for (const resourceId of Object.keys(template.Resources)) {
             ctx.mapResourceToStack(STACK_NAME, resourceId);
         }
         for (const outputId of Object.keys(template.Outputs)) {
             ctx.mapResourceToStack(STACK_NAME, outputId);
+        }
+        for (const mappingId of Object.keys(template.Mappings)) {
+            ctx.mapResourceToStack(STACK_NAME, mappingId);
         }
     };
 

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -10,14 +10,7 @@ import {
     int, Expression
 } from 'graphql-mapping-template'
 import { toUpper, plurality, graphqlName, ResourceConstants, ModelResourceIDs } from 'graphql-transformer-common'
-
-interface Mappings {
-    [key: string]: {
-        [key: string]: {
-            [key: string]: string | number | string[];
-        };
-    };
-};
+import { MappingParameters } from 'graphql-transformer-core/src/TransformerContext'
 
 export class ResourceFactory {
 
@@ -123,7 +116,7 @@ export class ResourceFactory {
         }).dependsOn(ResourceConstants.RESOURCES.ElasticsearchDomainLogicalID)
     }
 
-    public getLayerMapping(): Mappings {
+    public getLayerMapping(): MappingParameters {
         return {
             "LayerResourceMapping":{
                 "ap-northeast-1": {

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -10,7 +10,79 @@ import {
     int, Expression
 } from 'graphql-mapping-template'
 import { toUpper, plurality, graphqlName, ResourceConstants, ModelResourceIDs } from 'graphql-transformer-common'
+import { Ref } from 'cloudform-types/types/functions';
 
+const Layer_mapping = 
+
+{"LayerResourceMapping":{
+        "ap-northeast-1": {
+            "layerRegion": "arn:aws:lambda:ap-northeast-1:249908578461:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "us-east-1": {
+            "layerRegion": "arn:aws:lambda:us-east-1:668099181075:layer:AWSLambda-Python-AWS-SDK:1"
+        }, 
+        "ap-southeast-1": {
+            "layerRegion": "arn:aws:lambda:ap-southeast-1:468957933125:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "eu-west-1": {
+            "layerRegion": "arn:aws:lambda:eu-west-1:399891621064:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "us-west-1": {
+            "layerRegion": "arn:aws:lambda:us-west-1:325793726646:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "ap-east-1": {
+            "layerRegion": "arn:aws:lambda:ap-east-1:118857876118:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "ap-northeast-2": {
+            "layerRegion": "arn:aws:lambda:ap-northeast-2:296580773974:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "ap-northeast-3": {
+            "layerRegion": "arn:aws:lambda:ap-northeast-3:961244031340:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "ap-south-1": {
+            "layerRegion": "arn:aws:lambda:ap-south-1:631267018583:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "ap-southeast-2": {
+            "layerRegion": "arn:aws:lambda:ap-southeast-2:817496625479:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "ca-central-1": {
+            "layerRegion": "arn:aws:lambda:ca-central-1:778625758767:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "eu-central-1": {
+            "layerRegion": "arn:aws:lambda:eu-central-1:292169987271:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "eu-north-1": {
+            "layerRegion": "arn:aws:lambda:eu-north-1:642425348156:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "eu-west-2": {
+            "layerRegion": "arn:aws:lambda:eu-west-2:142628438157:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "eu-west-3": {
+            "layerRegion": "arn:aws:lambda:eu-west-3:959311844005:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "sa-east-1": {
+            "layerRegion": "arn:aws:lambda:sa-east-1:640010853179:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "us-east-2": {
+            "layerRegion": "arn:aws:lambda:us-east-2:259788987135:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "us-west-2": {
+            "layerRegion": "arn:aws:lambda:us-west-2:420165488524:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "cn-north-1": {
+            "layerRegion": "arn:aws-cn:lambda:cn-north-1:683298794825:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "cn-northwest-1": {
+            "layerRegion": "arn:aws-cn:lambda:cn-northwest-1:382066503313:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "us-gov-west-1": {
+            "layerRegion": "arn:aws-us-gov:lambda:us-gov-west-1:556739011827:layer:AWSLambda-Python-AWS-SDK:1"
+        },
+        "us-gov-east-1": {
+            "layerRegion": "arn:aws-us-gov:lambda:us-gov-east-1:138526772879:layer:AWSLambda-Python-AWS-SDK:1"
+        }
+    }
+}
 export class ResourceFactory {
 
     public makeParams() {
@@ -83,6 +155,7 @@ export class ResourceFactory {
                 [ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaIAMRoleLogicalID]: this.makeStreamingLambdaIAMRole(),
                 [ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaFunctionLogicalID]: this.makeDynamoDBStreamingFunction()
             },
+            Mappings: Layer_mapping,
             Outputs: {
                 [ResourceConstants.OUTPUTS.ElasticsearchDomainArn]: this.makeDomainArnOutput(),
                 [ResourceConstants.OUTPUTS.ElasticsearchDomainEndpoint]: this.makeDomainEndpointOutput()
@@ -138,6 +211,7 @@ export class ResourceFactory {
             Handler: Fn.Ref(ResourceConstants.PARAMETERS.ElasticsearchStreamingLambdaHandlerName),
             Role: Fn.GetAtt(ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaIAMRoleLogicalID, 'Arn'),
             Runtime: Fn.Ref(ResourceConstants.PARAMETERS.ElasticsearchStreamingLambdaRuntime),
+            Layers: [Fn.FindInMap('LayerResourceMapping', Fn.Ref("AWS::Region"), "layerRegion")],
             Environment: {
                 Variables: {
                     ES_ENDPOINT: Fn.Join('', [

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -10,79 +10,15 @@ import {
     int, Expression
 } from 'graphql-mapping-template'
 import { toUpper, plurality, graphqlName, ResourceConstants, ModelResourceIDs } from 'graphql-transformer-common'
-import { Ref } from 'cloudform-types/types/functions';
 
-const Layer_mapping = 
+interface Mappings {
+    [key: string]: {
+        [key: string]: {
+            [key: string]: string | number | string[];
+        };
+    };
+};
 
-{"LayerResourceMapping":{
-        "ap-northeast-1": {
-            "layerRegion": "arn:aws:lambda:ap-northeast-1:249908578461:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "us-east-1": {
-            "layerRegion": "arn:aws:lambda:us-east-1:668099181075:layer:AWSLambda-Python-AWS-SDK:1"
-        }, 
-        "ap-southeast-1": {
-            "layerRegion": "arn:aws:lambda:ap-southeast-1:468957933125:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "eu-west-1": {
-            "layerRegion": "arn:aws:lambda:eu-west-1:399891621064:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "us-west-1": {
-            "layerRegion": "arn:aws:lambda:us-west-1:325793726646:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "ap-east-1": {
-            "layerRegion": "arn:aws:lambda:ap-east-1:118857876118:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "ap-northeast-2": {
-            "layerRegion": "arn:aws:lambda:ap-northeast-2:296580773974:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "ap-northeast-3": {
-            "layerRegion": "arn:aws:lambda:ap-northeast-3:961244031340:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "ap-south-1": {
-            "layerRegion": "arn:aws:lambda:ap-south-1:631267018583:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "ap-southeast-2": {
-            "layerRegion": "arn:aws:lambda:ap-southeast-2:817496625479:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "ca-central-1": {
-            "layerRegion": "arn:aws:lambda:ca-central-1:778625758767:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "eu-central-1": {
-            "layerRegion": "arn:aws:lambda:eu-central-1:292169987271:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "eu-north-1": {
-            "layerRegion": "arn:aws:lambda:eu-north-1:642425348156:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "eu-west-2": {
-            "layerRegion": "arn:aws:lambda:eu-west-2:142628438157:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "eu-west-3": {
-            "layerRegion": "arn:aws:lambda:eu-west-3:959311844005:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "sa-east-1": {
-            "layerRegion": "arn:aws:lambda:sa-east-1:640010853179:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "us-east-2": {
-            "layerRegion": "arn:aws:lambda:us-east-2:259788987135:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "us-west-2": {
-            "layerRegion": "arn:aws:lambda:us-west-2:420165488524:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "cn-north-1": {
-            "layerRegion": "arn:aws-cn:lambda:cn-north-1:683298794825:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "cn-northwest-1": {
-            "layerRegion": "arn:aws-cn:lambda:cn-northwest-1:382066503313:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "us-gov-west-1": {
-            "layerRegion": "arn:aws-us-gov:lambda:us-gov-west-1:556739011827:layer:AWSLambda-Python-AWS-SDK:1"
-        },
-        "us-gov-east-1": {
-            "layerRegion": "arn:aws-us-gov:lambda:us-gov-east-1:138526772879:layer:AWSLambda-Python-AWS-SDK:1"
-        }
-    }
-}
 export class ResourceFactory {
 
     public makeParams() {
@@ -155,7 +91,7 @@ export class ResourceFactory {
                 [ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaIAMRoleLogicalID]: this.makeStreamingLambdaIAMRole(),
                 [ResourceConstants.RESOURCES.ElasticsearchStreamingLambdaFunctionLogicalID]: this.makeDynamoDBStreamingFunction()
             },
-            Mappings: Layer_mapping,
+            Mappings: this.getLayerMapping(),
             Outputs: {
                 [ResourceConstants.OUTPUTS.ElasticsearchDomainArn]: this.makeDomainArnOutput(),
                 [ResourceConstants.OUTPUTS.ElasticsearchDomainEndpoint]: this.makeDomainEndpointOutput()
@@ -185,6 +121,79 @@ export class ResourceFactory {
                     ])
             }
         }).dependsOn(ResourceConstants.RESOURCES.ElasticsearchDomainLogicalID)
+    }
+
+    public getLayerMapping(): Mappings {
+        return {
+            "LayerResourceMapping":{
+                "ap-northeast-1": {
+                    "layerRegion": "arn:aws:lambda:ap-northeast-1:249908578461:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "us-east-1": {
+                    "layerRegion": "arn:aws:lambda:us-east-1:668099181075:layer:AWSLambda-Python-AWS-SDK:1"
+                }, 
+                "ap-southeast-1": {
+                    "layerRegion": "arn:aws:lambda:ap-southeast-1:468957933125:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "eu-west-1": {
+                    "layerRegion": "arn:aws:lambda:eu-west-1:399891621064:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "us-west-1": {
+                    "layerRegion": "arn:aws:lambda:us-west-1:325793726646:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "ap-east-1": {
+                    "layerRegion": "arn:aws:lambda:ap-east-1:118857876118:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "ap-northeast-2": {
+                    "layerRegion": "arn:aws:lambda:ap-northeast-2:296580773974:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "ap-northeast-3": {
+                    "layerRegion": "arn:aws:lambda:ap-northeast-3:961244031340:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "ap-south-1": {
+                    "layerRegion": "arn:aws:lambda:ap-south-1:631267018583:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "ap-southeast-2": {
+                    "layerRegion": "arn:aws:lambda:ap-southeast-2:817496625479:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "ca-central-1": {
+                    "layerRegion": "arn:aws:lambda:ca-central-1:778625758767:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "eu-central-1": {
+                    "layerRegion": "arn:aws:lambda:eu-central-1:292169987271:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "eu-north-1": {
+                    "layerRegion": "arn:aws:lambda:eu-north-1:642425348156:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "eu-west-2": {
+                    "layerRegion": "arn:aws:lambda:eu-west-2:142628438157:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "eu-west-3": {
+                    "layerRegion": "arn:aws:lambda:eu-west-3:959311844005:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "sa-east-1": {
+                    "layerRegion": "arn:aws:lambda:sa-east-1:640010853179:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "us-east-2": {
+                    "layerRegion": "arn:aws:lambda:us-east-2:259788987135:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "us-west-2": {
+                    "layerRegion": "arn:aws:lambda:us-west-2:420165488524:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "cn-north-1": {
+                    "layerRegion": "arn:aws-cn:lambda:cn-north-1:683298794825:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "cn-northwest-1": {
+                    "layerRegion": "arn:aws-cn:lambda:cn-northwest-1:382066503313:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "us-gov-west-1": {
+                    "layerRegion": "arn:aws-us-gov:lambda:us-gov-west-1:556739011827:layer:AWSLambda-Python-AWS-SDK:1"
+                },
+                "us-gov-east-1": {
+                    "layerRegion": "arn:aws-us-gov:lambda:us-gov-east-1:138526772879:layer:AWSLambda-Python-AWS-SDK:1"
+                }
+            }
+        }
     }
 
     /**

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -28,7 +28,7 @@ import {
 } from 'graphql/language/ast';
 import { _Kind } from 'graphql/language/kinds';
 
-interface MappingParameters {
+export interface MappingParameters {
     [key: string]: {
         [key: string]: {
             [key: string]: string | number | string[];

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -28,6 +28,14 @@ import {
 } from 'graphql/language/ast';
 import { _Kind } from 'graphql/language/kinds';
 
+interface MappingParameters {
+    [key: string]: {
+        [key: string]: {
+            [key: string]: string | number | string[];
+        };
+    };
+}
+
 export function blankObject(name: string): ObjectTypeDefinitionNode {
     return {
         kind: 'ObjectTypeDefinition',
@@ -249,6 +257,15 @@ export default class TransformerContext {
             }
         }
         this.template.Outputs = { ...this.template.Outputs, ...outputs }
+    }
+
+    public mergeMappings(mapping: MappingParameters ) {
+        for (const mappingName of Object.keys(mapping)) {
+            if (this.template.Mappings[mappingName]) {
+                throw new Error(`Conflicting CloudFormation mapping name: ${mappingName}`)
+            }
+        }
+        this.template.Mappings = {...this.template.Mappings, ...mapping }
     }
 
     /**

--- a/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
@@ -61,8 +61,17 @@ const template: Template = {
             Description: "PostTable Arn.",
             Value: Fn.GetAtt("PostTable", 'Arn')
         }
+    },
+    Mappings: {
+        "LayerResourceMapping":{
+            "us-east-1": {
+                "layerRegion": "arn:aws:lambda:us-east-1:668099181075:layer:AWSLambda-Python-AWS-SDK:1"
+            },
+        }
     }
 }
+    
+
 
 
 test('Test getTemplateReferences', () => {

--- a/packages/graphql-transformer-core/src/util/blankTemplate.ts
+++ b/packages/graphql-transformer-core/src/util/blankTemplate.ts
@@ -8,6 +8,7 @@ export default function blankTemplate(def: Template = {}): Template {
         Parameters: {},
         Resources: {},
         Outputs: {},
+        Mappings: {},
         ...def
     }
 }

--- a/packages/graphql-transformer-core/src/util/splitStack.ts
+++ b/packages/graphql-transformer-core/src/util/splitStack.ts
@@ -77,6 +77,12 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
         return createMapByStackRules(Object.keys(template.Resources));
     }
 
+    function mapMappingToStack(
+        template: Template,
+    ): { [key: string]: string } {
+        return createMapByStackRules(Object.keys(template.Mappings));
+    }
+
     /**
      * Returns a map where the keys are the Outputs ids and the values are the
      * names of the stack where that Output belongs.
@@ -90,7 +96,7 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
     /**
      * Uses the stackRules to split resources out into the different stacks.
      */
-    function collectTemplates(template: Template, resourceToStackMap: { [k: string]: string }, outputToStackMap: { [k: string]: string }) {
+    function collectTemplates(template: Template, resourceToStackMap: { [k: string]: string }, outputToStackMap: { [k: string]: string }, mappingsToStackMap: { [k: string]: string }) {
         const resourceIds = Object.keys(resourceToStackMap);
         const templateMap = {}
         for (const resourceId of resourceIds) {
@@ -124,6 +130,15 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
             const output = template.Outputs[outputId];
             templateMap[stackName].Outputs[outputId] = output;
         }
+
+        const mappingIds = Object.keys(mappingToStackMap);
+        for (const mappingId of mappingIds) {
+            const stackName = mappingsToStackMap[mappingId];
+            const mappings = template.Mappings[mappingId];
+            templateMap[stackName].Mappings[mappingId] = mappings;
+        }
+
+        
         // The root stack exposes all parameters at the top level.
         templateMap[rootStackName].Parameters = template.Parameters;
         templateMap[rootStackName].Conditions = template.Conditions;
@@ -354,8 +369,9 @@ export default function splitStack(opts: SplitStackOptions): NestedStacks {
     const templateJson: any = JSON.parse(JSON.stringify(stack));
     const resourceToStackMap = mapResourcesToStack(templateJson);
     const outputToStackMap = mapOutputsToStack(templateJson);
-    const stackMapping = { ...resourceToStackMap, ...outputToStackMap };
-    const stacks = collectTemplates(templateJson, resourceToStackMap, outputToStackMap);
+    const mappingToStackMap = mapMappingToStack(templateJson);
+    const stackMapping = { ...resourceToStackMap, ...outputToStackMap, ...mappingToStackMap };
+    const stacks = collectTemplates(templateJson, resourceToStackMap, outputToStackMap, stackMapping);
     const stackInfo = replaceReferences(stacks, resourceToStackMap);
     let rootStack = stacks[rootStackName];
     delete(stacks[rootStackName]);


### PR DESCRIPTION
Using a map to determine the correct arn layer from the region of the user

fix #2386

*Issue #, if available:*
#2386

*Description of changes:*
Add a layer that contains the previous version of the SDK to the lambda resource based on the region of the user

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.