### PR TITLE
fix(amplify-category-api): safeguard prompt with empty options

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -46,13 +46,14 @@ async function serviceWalkthrough(context, defaultValuesFilename, datasourceMeta
   });
 
   // RDS Cluster Question
-  const { selectedClusterArn, clusterResourceId } = await selectCluster(inputs, AWS);
+  const { selectedClusterArn, clusterResourceId } = await selectCluster(context, inputs, AWS);
 
   // Secret Store Question
-  const selectedSecretArn = await getSecretStoreArn(inputs, clusterResourceId, AWS);
+  const selectedSecretArn = await getSecretStoreArn(context, inputs, clusterResourceId, AWS);
 
   // Database Name Question
-  const selectedDatabase = await selectDatabase(inputs, selectedClusterArn, selectedSecretArn, AWS);
+  const selectedDatabase =
+    await selectDatabase(context, inputs, selectedClusterArn, selectedSecretArn, AWS);
 
   return {
     region: selectedRegion,
@@ -67,7 +68,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, datasourceMeta
  *
  * @param {*} inputs
  */
-async function selectCluster(inputs, AWS) {
+async function selectCluster(context, inputs, AWS) {
   const RDS = new AWS.RDS();
 
   const describeDBClustersResult = await RDS.describeDBClusters().promise();
@@ -80,13 +81,18 @@ async function selectCluster(inputs, AWS) {
     }
   }
 
-  const clusterIdentifier = await promptWalkthroughQuestion(inputs, 1, Array.from(clusters.keys()));
-  const selectedCluster = clusters.get(clusterIdentifier);
+  if (clusters.size > 0) {
+    const clusterIdentifier =
+      await promptWalkthroughQuestion(inputs, 1, Array.from(clusters.keys()));
+    const selectedCluster = clusters.get(clusterIdentifier);
 
-  return {
-    selectedClusterArn: selectedCluster.DBClusterArn,
-    clusterResourceId: selectedCluster.DbClusterResourceId,
-  };
+    return {
+      selectedClusterArn: selectedCluster.DBClusterArn,
+      clusterResourceId: selectedCluster.DbClusterResourceId,
+    };
+  }
+  context.print.error('No properly configured Aurora Serverless clusters found.');
+  process.exit(0);
 }
 
 /**
@@ -94,7 +100,7 @@ async function selectCluster(inputs, AWS) {
  * @param {*} inputs
  * @param {*} clusterResourceId
  */
-async function getSecretStoreArn(inputs, clusterResourceId, AWS) {
+async function getSecretStoreArn(context, inputs, clusterResourceId, AWS) {
   const SecretsManager = new AWS.SecretsManager();
   const NextToken = 'NextToken';
   let rawSecrets = [];
@@ -103,6 +109,7 @@ async function getSecretStoreArn(inputs, clusterResourceId, AWS) {
   };
 
   const listSecretsResult = await SecretsManager.listSecrets(params).promise();
+
   rawSecrets = listSecretsResult.SecretList;
   let token = listSecretsResult.NextToken;
   while (token) {
@@ -128,11 +135,14 @@ async function getSecretStoreArn(inputs, clusterResourceId, AWS) {
     secrets.set(rawSecrets[i].Name, rawSecrets[i].ARN);
   }
 
-  if (!selectedSecretArn) {
+  if (!selectedSecretArn && secrets.size > 0) {
     // Kick off questions flow
     const selectedSecretName
      = await promptWalkthroughQuestion(inputs, 2, Array.from(secrets.keys()));
     selectedSecretArn = secrets.get(selectedSecretName);
+  } else {
+    context.print.error('No RDS access credentials found in the AWS Secrect Manager.');
+    process.exit(0);
   }
 
   return selectedSecretArn;
@@ -144,7 +154,7 @@ async function getSecretStoreArn(inputs, clusterResourceId, AWS) {
  * @param {*} clusterArn
  * @param {*} secretArn
  */
-async function selectDatabase(inputs, clusterArn, secretArn, AWS) {
+async function selectDatabase(context, inputs, clusterArn, secretArn, AWS) {
   // Database Name Question
   const DataApi = new AWS.RDSDataService();
   const params = new DataApiParams();
@@ -170,7 +180,12 @@ async function selectDatabase(inputs, clusterArn, secretArn, AWS) {
 
   spinner.succeed('Fetched Aurora Serverless cluster.');
 
-  return await promptWalkthroughQuestion(inputs, 3, databaseList);
+  if (databaseList.length > 0) {
+    return await promptWalkthroughQuestion(inputs, 3, databaseList);
+  }
+
+  context.print.error('No properly configured databases found.');
+  process.exit(0);
 }
 
 /**


### PR DESCRIPTION
when the CLI prompt the user to select from some options, it uses the inquirer library, and if the
options are empty, inquirer throws error, which leads the CLI to exit without proper messages given
to the user. This PR safeguard against such situation for the RDS selection, and it will print out
proper error message before the CLI exits.

fix #2423

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.