### PR TITLE
fix(amplify-codegen): support headless push for newly added api

### DIFF
--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -69,7 +69,7 @@ async function addWalkThrough(context, skip = [], withoutInit,
 
   if (!skip.includes('includePattern')) {
     answers.includePattern =
-    await determineValue(inputParams, yesFlag, 'includePattern', includePathGlob, () => askCodeGenQueryFilePattern([includePathGlob]));
+    await determineValue(inputParams, yesFlag, 'includePattern', [includePathGlob], () => askCodeGenQueryFilePattern([includePathGlob]));
   }
   if (!skip.includes('shouldGenerateDocs')) {
     answers.shouldGenerateDocs =


### PR DESCRIPTION
When a new API is added and if the api is pushed with yes flag (headless mode), then codegen fails
with error proj.inclues || []).map is not a function. Updated codegen to return a array of include
pattern when using headless mode

fix #2365

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.