### PR TITLE
ci: upload test run reports from e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
           name: Run GraphQL end-to-end tests
           command: cd packages/graphql-transformers-e2e-tests/ && yarn e2e --maxWorkers=3
           no_output_timeout: 90m
+      - store_test_results:
+          path: packages/graphql-transformers-e2e-tests/
   mock_e2e_tests:
     <<: *defaults
     steps:
@@ -81,6 +83,8 @@ jobs:
           command: "cd packages/amplify-e2e-tests && yarn run e2e --maxWorkers=3"
           name: "Run Amplify end-to-end tests"
           no_output_timeout: 90m
+      - store_test_results:
+          path: packages/amplify-e2e-tests/
     working_directory: ~/repo
 
   integration_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,8 @@ jobs:
           path: /root/videos
       - store_artifacts:
           path: /root/screenshots
+      - store_test_results:
+          path: packages/amplify-ui-tests/
   integration_test_ios:
     macos:
       xcode: "10.3.0"
@@ -298,6 +300,8 @@ jobs:
             npm run delete ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum
           when: always
       - store_artifacts:
+          path: ../uitest_logs
+      - store_test_results:
           path: ../uitest_logs
   integration_test_android:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ packages/*/package-lock.json
 **/.env
 amplify-integ*/
 packages/amplify-storage-simulator/lib
+packages/*/reports/junit

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -24,7 +24,8 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "jest-junit": "^8.0.0"
   },
   "jest": {
     "transform": {
@@ -35,6 +36,16 @@
     "testPathIgnorePatterns": [
       "/node_modules/",
       "src"
+    ],
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!**/node_modules/**",
+      "!__tests__/**"
+    ],
+    "reporters": [
+      "default",
+      "jest-junit"
     ],
     "moduleFileExtensions": [
       "ts",
@@ -50,5 +61,11 @@
     "esm": "^3.2.25",
     "mime-types": "^2.1.24",
     "ora": "^3.4.0"
+  },
+  "jest-junit": {
+    "outputDirectory": "reports/junit/",
+    "outputName": "js-test-results.xml",
+    "usePathForSuiteName": "true",
+    "addFileAttribute": "true"
   }
 }

--- a/packages/amplify-ui-tests/package.json
+++ b/packages/amplify-ui-tests/package.json
@@ -27,7 +27,7 @@
     "rimraf": "2.6.2",
     "ts-jest": "22.4.6",
     "tslint": "5.10.0",
-    "typescript": "2.8.3",
+    "typescript": "3.5.3",
     "jest-junit": "^8.0.0"
   },
   "jest": {

--- a/packages/amplify-ui-tests/package.json
+++ b/packages/amplify-ui-tests/package.json
@@ -27,7 +27,8 @@
     "rimraf": "2.6.2",
     "ts-jest": "22.4.6",
     "tslint": "5.10.0",
-    "typescript": "2.8.3"
+    "typescript": "2.8.3",
+    "jest-junit": "^8.0.0"
   },
   "jest": {
     "transform": {
@@ -39,6 +40,10 @@
       "/node_modules/",
       "src"
     ],
+    "reporters": [
+      "default",
+      "jest-junit"
+    ],
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -47,6 +52,12 @@
       "json",
       "node"
     ]
+  },
+  "jest-junit": {
+    "outputDirectory": "reports/junit/",
+    "outputName": "js-test-results.xml",
+    "usePathForSuiteName": "true",
+    "addFileAttribute": "true"
   },
   "dependencies": {
     "esm": "^3.2.25"

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -45,12 +45,23 @@
     "node-fetch": "^2.6.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "jest-junit": "^8.0.0"
   },
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!**/node_modules/**",
+      "!src/__tests__/**"
+    ],
+    "reporters": [
+      "default",
+      "jest-junit"
+    ],
     "testURL": "http://localhost",
     "testRegex": "(src/__tests__/.*.test.*)$",
     "testPathIgnorePatterns": [
@@ -64,7 +75,12 @@
       "jsx",
       "json",
       "node"
-    ],
-    "collectCoverage": true
+    ]
+  },
+  "jest-junit": {
+    "outputDirectory": "reports/junit/",
+    "outputName": "js-test-results.xml",
+    "usePathForSuiteName": "true",
+    "addFileAttribute": "true"
   }
 }


### PR DESCRIPTION
Update e2e test configuration to generate test results in JUnit format and updated circle ci config
to upload those results for analysis


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.