### PR TITLE
fix(amplify-provider-awscloudformation): amplify delete delete the stack

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/update-idp-roles-cfn.json
+++ b/packages/amplify-provider-awscloudformation/lib/update-idp-roles-cfn.json
@@ -33,9 +33,8 @@
                             "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
                             "        Promise.all(promises)",
                             "         .then((res) => {",
-                            "            console.log(\"delete\" + res);",
-                            "            console.log(\"response data\" + JSON.stringify(res));",
-                            "            response.send(event, context, response.SUCCESS, res);",
+                            "            console.log(\"delete response data\" + JSON.stringify(res));",
+                            "            response.send(event, context, response.SUCCESS, {});",
                             "         });",
                             "    }",
                             "    if (event.RequestType == 'Update' || event.RequestType == 'Create') {",
@@ -87,7 +86,7 @@
             },
             "idpId": {
                 "Fn::GetAtt": [
-                    
+
                     "Outputs.IdentityPoolId"
                 ]
             },
@@ -111,7 +110,7 @@
                         },
                         "-idp"
                     ]
-                ]   
+                ]
             },
             "AssumeRolePolicyDocument": {
                 "Version": "2012-10-17",


### PR DESCRIPTION
amplify delete command failed to delete the complete stack due to the invalid lambda response sent
from UpdateRolesWithIDPFunction. Updated the response to send an empty object

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.