### PR TITLE
fix(amplify-category-api): Fix #2498

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -139,12 +139,11 @@ async function getSecretStoreArn(context, inputs, clusterResourceId, AWS) {
   if (!selectedSecretArn) {
     if (secrets.size > 0) {
       // Kick off questions flow
-      const selectedSecretName
-         = await promptWalkthroughQuestion(inputs, 2, Array.from(secrets.keys()));
+      const selectedSecretName = await promptWalkthroughQuestion(inputs, 2, Array.from(secrets.keys()));
       selectedSecretArn = secrets.get(selectedSecretName);
     } else {
       context.print.error('No RDS access credentials found in the AWS Secrect Manager.');
-      process.exit(0);      
+      process.exit(0);
     }
   }
 

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -136,13 +136,16 @@ async function getSecretStoreArn(context, inputs, clusterResourceId, AWS) {
     secrets.set(rawSecrets[i].Name, rawSecrets[i].ARN);
   }
 
-  if (!selectedSecretArn && secrets.size > 0) {
-    // Kick off questions flow
-    const selectedSecretName = await promptWalkthroughQuestion(inputs, 2, Array.from(secrets.keys()));
-    selectedSecretArn = secrets.get(selectedSecretName);
-  } else {
-    context.print.error('No RDS access credentials found in the AWS Secrect Manager.');
-    process.exit(0);
+  if (!selectedSecretArn) {
+    if (secrets.size > 0) {
+      // Kick off questions flow
+      const selectedSecretName
+         = await promptWalkthroughQuestion(inputs, 2, Array.from(secrets.keys()));
+      selectedSecretArn = secrets.get(selectedSecretName);
+    } else {
+      context.print.error('No RDS access credentials found in the AWS Secrect Manager.');
+      process.exit(0);      
+    }
   }
 
   return selectedSecretArn;


### PR DESCRIPTION
Fixes 'No RDS access credentials found in the AWS Secret Manager' when Query Editor secret is found

*Issue:* #2498

*Description of changes:* Adds nested `if` to fix exit logic if generated secret was found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.