### PR TITLE
fix: change default length for api key back to 7 days

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -496,7 +496,7 @@ async function askApiKeyQuestions() {
       type: 'input',
       name: 'apiKeyExpirationDays',
       message: 'After how many days from now the API key should expire (1-365):',
-      default: 180,
+      default: 7,
       validate: validateDays,
     },
   ];

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -297,8 +297,8 @@ export class ModelAuthTransformer extends Transformer {
 
         const apiKeyAuthProvider = authProviders.find(p => p.authenticationType === 'API_KEY');
 
-        // Return the found instance or a default instance with 180 days of API key expiration
-        return apiKeyAuthProvider ? apiKeyAuthProvider.apiKeyConfig : { apiKeyExpirationDays: 180 };
+        // Return the found instance or a default instance with 7 days of API key expiration
+        return apiKeyAuthProvider ? apiKeyAuthProvider.apiKeyConfig : { apiKeyExpirationDays: 7 };
     }
 
     /**

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -38,7 +38,7 @@ export class ResourceFactory {
             }),
             [ResourceConstants.PARAMETERS.APIKeyExpirationEpoch]: new NumberParameter({
                 Description: 'The epoch time in seconds when the API Key should expire.' +
-                    ' Setting this to 0 will default to 180 days from the deployment date.' +
+                    ' Setting this to 0 will default to 7 days from the deployment date.' +
                     ' Setting this to -1 will not create an API Key.',
                 Default: 0,
                 MinValue: -1
@@ -83,7 +83,7 @@ export class ResourceFactory {
     }
 
     public makeAppSyncApiKey(apiKeyConfig: Transformer.ApiKeyConfig) {
-        let expirationDays = 180;
+        let expirationDays = 7;
         if (apiKeyConfig && apiKeyConfig.apiKeyExpirationDays) {
             expirationDays = apiKeyConfig.apiKeyExpirationDays;
         }


### PR DESCRIPTION
*Description of changes:*

fix: change default length for api key back to 7 days


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.