### PR TITLE
fix(amplify-category-analytics): Allow hyphens for pinpoint resources name

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/supported-services.json
+++ b/packages/amplify-category-analytics/provider-utils/supported-services.json
@@ -16,8 +16,8 @@
 				"question": "Provide your pinpoint resource name:",
 				"validation": {
 					"operator": "regex",
-					"value": "^[a-zA-Z0-9]+$",
-					"onErrorMsg": "Resource name should be alphanumeric"
+					"value": "^[a-zA-Z0-9-]+$",
+					"onErrorMsg": "Resource name should be alphanumeric or can contain '-'"
 				},
 				"required": true
 			}

--- a/packages/amplify-e2e-tests/__tests__/analytics.test.ts
+++ b/packages/amplify-e2e-tests/__tests__/analytics.test.ts
@@ -1,0 +1,26 @@
+require('../src/aws-matchers/'); // custom matcher for assertion
+import { initProjectWithProfile } from '../src/init';
+import { addAnalytics, removeAnalytics } from '../src/categories/analytics';
+import { createNewProjectDir, deleteProjectDir } from '../src/utils';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('amplify add analytics', () => {
+  let projRoot: string;
+  beforeEach(() => {
+    projRoot = createNewProjectDir();
+    jest.setTimeout(1000 * 60 * 60); // 1 hour
+  });
+
+  afterEach(async () => {
+    await removeAnalytics(projRoot, {});
+    deleteProjectDir(projRoot);
+  });
+
+  it('add analytics', async () => {
+    await initProjectWithProfile(projRoot, {});
+    const rightName = 'my-app';
+    await addAnalytics(projRoot, { rightName, wrongName: 'my=app' });
+    expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'analytics', rightName))).toBe(true);
+  });
+});

--- a/packages/amplify-e2e-tests/src/categories/analytics.ts
+++ b/packages/amplify-e2e-tests/src/categories/analytics.ts
@@ -1,5 +1,4 @@
 import * as nexpect from 'nexpect';
-import * as path from 'path';
 import { getCLIPath, isCI } from '../utils';
 
 export function addAnalytics(cwd: string, settings: any, verbose: boolean = !isCI()) {

--- a/packages/amplify-e2e-tests/src/categories/analytics.ts
+++ b/packages/amplify-e2e-tests/src/categories/analytics.ts
@@ -1,0 +1,43 @@
+import * as nexpect from 'nexpect';
+import * as path from 'path';
+import { getCLIPath, isCI } from '../utils';
+
+export function addAnalytics(cwd: string, settings: any, verbose: boolean = !isCI()) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['add', 'analytics'], { cwd, stripColors: true, verbose })
+      .wait('Provide your pinpoint resource name:')
+      .sendline('$')
+      .wait("Resource name should be alphanumeric or can contain '-'")
+      .sendline('\r')
+      .send('\b')
+      .sendline(settings.rightName)
+      .wait('Adding analytics would add the Auth category to the project if not already added.')
+      .sendline('n')
+      .wait(`Successfully added resource ${settings.rightName} locally`)
+      .sendEof()
+      .run((err: Error) => {
+        if (!err) resolve();
+        else reject(err);
+      });
+  });
+}
+
+export function removeAnalytics(cwd: string, settings: any, verbose: boolean = !isCI()) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['remove', 'analytics'], { cwd, stripColors: true, verbose })
+      .wait('Choose the resource you would want to remove')
+      .send('j')
+      .sendline('\r')
+      .wait('Are you sure you want to delete the resource?')
+      .send('Y')
+      .sendline('\r')
+      .wait('Successfully removed resource')
+      .sendEof()
+      .run((err: Error) => {
+        if (!err) resolve();
+        else reject(err);
+      });
+  });
+}


### PR DESCRIPTION
*Issue #, if available:*
#1877 
*Description of changes:*
Modified the regex to allow hyphen characters in resource name
Created test to add analytics pinpoint resource and cleanup after

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.