### PR TITLE
fix: handle missing authConfig gracefully

### DIFF
--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -270,7 +270,9 @@ function getAppSyncConfig(appsyncResources, projectRegion) {
     result.AppSync.Default.DangerouslyConnectToHTTPEndpointForTesting = true;
   }
 
-  const additionalAuths = appsyncResource.output.authConfig.additionalAuthenticationProviders || [];
+  const additionalAuths =
+    (appsyncResource.output && appsyncResource.output.authConfig && appsyncResource.output.authConfig.additionalAuthenticationProviders) ||
+    [];
   additionalAuths.forEach(auth => {
     const apiName = `${appsyncResource.resourceName}_${auth.authenticationType}`;
     const config = {

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -266,7 +266,9 @@ function getAppSyncConfig(appsyncResources, projectRegion) {
     result.AppSync.Default.DangerouslyConnectToHTTPEndpointForTesting = true;
   }
 
-  const additionalAuths = appsyncResource.output.authConfig.additionalAuthenticationProviders || [];
+  const additionalAuths =
+    (appsyncResource.output && appsyncResource.output.authConfig && appsyncResource.output.authConfig.additionalAuthenticationProviders) ||
+    [];
   additionalAuths.forEach(auth => {
     const apiName = `${appsyncResource.resourceName}_${auth.authenticationType}`;
     const config = {


### PR DESCRIPTION
If an GraphQL API is provisioned using older version CLI its possible that the cloudformation output
might have authConfig missing. The frontend config creator for andorid and iOS did not handle
missing authConfig. Updated to code to handle missing authConfig

fix #2480

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.