### PR TITLE
fix(graphql-dynamodb-transformer): allow id for non model objects

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -433,6 +433,34 @@ test('Test DynamoDBModelTransformer with mutation input overrides when mutations
   expectFieldsOnInputType(deletePostInput, ['different3']);
 });
 
+test('Test non model objects contain id as a type for fields', () => {
+  const validSchema = `
+    type Post @model {
+      id: ID!
+      comments: [Comment]
+    }
+    type Comment {
+      id: String!
+      text: String!
+    }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const commentInput = getInputType(parsed, 'CommentInput');
+  expectFieldsOnInputType(commentInput, ['id', 'text']);
+  const commentObject = getObjectType(parsed, 'Comment');
+  const commentInputObject = getInputType(parsed, 'CommentInput');
+  const commentObjectIDField = getFieldOnObjectType(commentObject, 'id');
+  const commentInputIDField = getFieldOnInputType(commentInputObject, 'id');
+  verifyMatchingTypes(commentObjectIDField.type, commentInputIDField.type);
+});
+
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
   for (const fieldName of fields) {
     const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName);

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -7,7 +7,6 @@ import {
   TypeNode,
   EnumTypeDefinitionNode,
   ObjectTypeExtensionNode,
-  TypeDefinitionNode,
   NamedTypeNode,
   DirectiveNode,
   InterfaceTypeDefinitionNode,
@@ -95,7 +94,7 @@ export function makeNonModelInputObject(
       return {
         kind: Kind.INPUT_VALUE_DEFINITION,
         name: field.name,
-        type: type,
+        type,
         // TODO: Service does not support new style descriptions so wait.
         // description: field.description,
         directives: [],
@@ -136,7 +135,7 @@ export function makeCreateInputObject(
       return false;
     })
     .map((field: FieldDefinitionNode) => {
-      let type;
+      let type: TypeNode;
       if (field.name.value === 'id') {
         // ids are always optional. when provided the value is used.
         // when not provided the value is not used.
@@ -155,7 +154,7 @@ export function makeCreateInputObject(
       return {
         kind: Kind.INPUT_VALUE_DEFINITION,
         name: field.name,
-        type: type,
+        type,
         // TODO: Service does not support new style descriptions so wait.
         // description: field.description,
         directives: [],
@@ -192,9 +191,8 @@ export function makeUpdateInputObject(
         (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)
       ) {
         return true;
-      } else {
-        return false;
       }
+      return false;
     })
     .map((field: FieldDefinitionNode) => {
       let type;
@@ -209,7 +207,7 @@ export function makeUpdateInputObject(
       return {
         kind: Kind.INPUT_VALUE_DEFINITION,
         name: field.name,
-        type: type,
+        type,
         // TODO: Service does not support new style descriptions so wait.
         // description: field.description,
         directives: [],
@@ -437,7 +435,7 @@ export function makeModelSortDirectionEnumObject(): EnumTypeDefinitionNode {
 
 export function makeModelScalarFilterInputObject(type: string): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelFilterInputTypeName(type);
-  let conditions = getScalarConditions(type);
+  const conditions = getScalarConditions(type);
   const fields: InputValueDefinitionNode[] = conditions.map((condition: string) => ({
     kind: Kind.INPUT_VALUE_DEFINITION,
     name: { kind: 'Name' as 'Name', value: condition },
@@ -487,7 +485,7 @@ function getScalarConditions(type: string): string[] {
     case 'Boolean':
       return BOOLEAN_CONDITIONS;
     default:
-      throw 'Valid types are String, ID, Int, Float, Boolean';
+      throw new Error('Valid types are String, ID, Int, Float, Boolean');
   }
 }
 

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -75,9 +75,6 @@ export function makeNonModelInputObject(
   const fields: InputValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.getType(getBaseType(field.type));
-      if (field.name.value === 'id') {
-        return false;
-      }
       if (
         isScalar(field.type) ||
         nonModelTypes.find(e => e.name.value === getBaseType(field.type)) ||


### PR DESCRIPTION
*Issue #, if available:*
ref #1984

*Description of changes:*
- allow id as a type for non model objects
- lint fixes 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.