### PR TITLE
fix(amplify-category-auth): checks for google idp federation on native

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -1084,7 +1084,7 @@ Resources:
             - cognito-idp.${region}.amazonaws.com/${client}
             - { region: !Ref "AWS::Region",  client: !Ref UserPool}
       <% } -%>
-      <%if (props.authProviders && Object.keys(props.authProviders).length > 0 && props.authProviders !== '{}') { %>
+      <%if (props.authProviders && Object.keys(props.authProviders).length > 0 && props.authProviders !== '{}' && !(Object.keys(props.authProviders).length === 1 && props.audiences)) { %>
       SupportedLoginProviders: 
         <%if (props.authProviders.indexOf('graph.facebook.com') !== -1) { %>
         graph.facebook.com: !Ref facebookAppId

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -1084,7 +1084,7 @@ Resources:
             - cognito-idp.${region}.amazonaws.com/${client}
             - { region: !Ref "AWS::Region",  client: !Ref UserPool}
       <% } -%>
-      <%if (props.authProviders && Object.keys(props.authProviders).length > 0 && props.authProviders !== '{}' && !(Object.keys(props.authProviders).length === 1 && props.audiences)) { %>
+      <%if (props.authProviders && Object.keys(props.authProviders).length > 0 && props.authProviders !== '{}' && !(Object.keys(props.authProviders).length === 1 && props.authProviders[0] === 'accounts.google.com' && props.audiences)) { %>
       SupportedLoginProviders: 
         <%if (props.authProviders.indexOf('graph.facebook.com') !== -1) { %>
         graph.facebook.com: !Ref facebookAppId


### PR DESCRIPTION
*Issue #, if available:*
fix #2284 

*Description of changes:*
Adds a check in auth yml for supported login providers; this block should NOT display if
authproviders length is 1 and there are audiences, as this scenario indicates that google is the
only selected provider for a native project, and in this case the open id lambda will perform all
configuration


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.