### PR TITLE
ci: don't fail pipeline on failure of JS tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2
 machine:
-    environment:
-      PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+  environment:
+    PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 
 defaults: &defaults
   working_directory: ~/repo
   docker:
-      - image: circleci/node:10.16
+    - image: circleci/node:10.16
 
 jobs:
   build:
@@ -38,8 +38,8 @@ jobs:
           name: Install Java
           command: sudo apt-get install default-jdk
       - run:
-         name: lint
-         command: yarn lint
+          name: lint
+          command: yarn lint
       - run:
           name: Run tests
           command: yarn test-ci
@@ -74,7 +74,7 @@ jobs:
           command: cd packages/amplify-util-mock/ && yarn e2e
           no_output_timeout: 90m
           environment:
-            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+            JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
       - store_test_results:
           path: packages/amplify-util-mock/
 
@@ -84,109 +84,109 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: "amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum \"yarn.lock\" }}"
+          key: 'amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}'
       - run:
-          command: "cd packages/amplify-e2e-tests && yarn run e2e --maxWorkers=3"
-          name: "Run Amplify end-to-end tests"
+          command: 'cd packages/amplify-e2e-tests && yarn run e2e --maxWorkers=3'
+          name: 'Run Amplify end-to-end tests'
           no_output_timeout: 90m
       - store_test_results:
           path: packages/amplify-e2e-tests/
     working_directory: ~/repo
 
   integration_test:
-      working_directory: ~/repo
-      docker:
-        - image: cypress/base:10
-          environment:
-            TERM: dumb
-      steps:
-        - checkout
-        - run: apt-get install -y sudo
-        - run: sudo apt-get update
-        - run: sudo apt-get install -y tcl
-        - run: sudo apt-get install -y expect
-        - run: sudo apt-get install -y zip
-        - run: sudo apt-get install -y lsof
-        - run: sudo apt-get install -y python
-        - run: sudo apt-get install -y python-pip libpython-dev
-        - run: sudo apt-get install -y jq
-        - run: pip install awscli
-        - run: cd .circleci/ && chmod +x aws.sh
-        - run: expect .circleci/aws_configure.exp
-        - run: yarn setup-dev
-        - run: amplify-dev
-        - run:
-            name: "Clone auth test package"
-            command: |
-              cd ..
-              git clone $AUTH_CLONE_URL
-              cd aws-amplify-cypress-auth
-              yarn
-        - run: cd .circleci/ && chmod +x auth.sh
-        - run: cd .circleci/ && chmod +x amplify_init.sh
-        - run: cd .circleci/ && chmod +x amplify_init.exp
-        - run: expect .circleci/amplify_init.exp ../aws-amplify-cypress-auth
-        - run: expect .circleci/enable_auth.exp
-        - run: cd ../aws-amplify-cypress-auth
-        - run: yarn --frozen-lockfile
-        - run: cd ../aws-amplify-cypress-auth/src && cat $(find . -type f -name 'aws-exports*')
-        - run:
-            name: "Start Auth test server in background"
-            command: |
-              cd ../aws-amplify-cypress-auth
-              pwd
-              yarn start
-            background: true
-        - run: cat $(find ../repo -type f -name 'auth_spec*')
-        - run:
-            name: "Run cypress tests for auth"
-            command: |
-              cd ../aws-amplify-cypress-auth
-              yarn add cypress --save
-              cp ../repo/cypress.json .
-              cp -R ../repo/cypress .
-              node_modules/.bin/cypress run --spec $(find . -type f -name 'auth_spec*')
-        - run: sudo kill -9 $(lsof -t -i:3000)
-        - run: cd .circleci/ && chmod +x delete_auth.sh
-        - run: expect .circleci/delete_auth.exp
-        - run:
-            name: "Clone API test package"
-            command: |
-              cd ..
-              git clone $API_CLONE_URL
-              cd aws-amplify-cypress-api
-              yarn
-        - run: cd .circleci/ && chmod +x api.sh
-        - run: expect .circleci/amplify_init.exp ../aws-amplify-cypress-api
-        - run: expect .circleci/enable_api.exp
-        - run: cd ../aws-amplify-cypress-api
-        - run: yarn --frozen-lockfile
-        - run: cd ../aws-amplify-cypress-api/src && cat $(find . -type f -name 'aws-exports*')
-        - run:
-            name: "Start API test server in background"
-            command: |
-              cd ../aws-amplify-cypress-api
-              pwd
-              yarn start
-            background: true
-        - run:
-            name: "Run cypress tests for api"
-            command: |
-              cd ../aws-amplify-cypress-auth
-              yarn add cypress --save
-              cp ../repo/cypress.json .
-              cp -R ../repo/cypress .
-              node_modules/.bin/cypress run --spec $(find . -type f -name 'api_spec*')
-        - run: cd .circleci/ && chmod +x delete_api.sh
-        - run: expect .circleci/delete_api.exp
-        - store_artifacts:
-            path: ../../aws-amplify-cypress-auth/cypress/videos
-        - store_artifacts:
-            path: ../aws-amplify-cypress-auth/cypress/screenshots
-        - store_artifacts:
-            path: ../aws-amplify-cypress-api/cypress/videos
-        - store_artifacts:
-            path: ../aws-amplify-cypress-api/cypress/screenshots
+    working_directory: ~/repo
+    docker:
+      - image: cypress/base:10
+        environment:
+          TERM: dumb
+    steps:
+      - checkout
+      - run: apt-get install -y sudo
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y tcl
+      - run: sudo apt-get install -y expect
+      - run: sudo apt-get install -y zip
+      - run: sudo apt-get install -y lsof
+      - run: sudo apt-get install -y python
+      - run: sudo apt-get install -y python-pip libpython-dev
+      - run: sudo apt-get install -y jq
+      - run: pip install awscli
+      - run: cd .circleci/ && chmod +x aws.sh
+      - run: expect .circleci/aws_configure.exp
+      - run: yarn setup-dev
+      - run: amplify-dev
+      - run:
+          name: 'Clone auth test package'
+          command: |
+            cd ..
+            git clone $AUTH_CLONE_URL
+            cd aws-amplify-cypress-auth
+            yarn
+      - run: cd .circleci/ && chmod +x auth.sh
+      - run: cd .circleci/ && chmod +x amplify_init.sh
+      - run: cd .circleci/ && chmod +x amplify_init.exp
+      - run: expect .circleci/amplify_init.exp ../aws-amplify-cypress-auth
+      - run: expect .circleci/enable_auth.exp
+      - run: cd ../aws-amplify-cypress-auth
+      - run: yarn --frozen-lockfile
+      - run: cd ../aws-amplify-cypress-auth/src && cat $(find . -type f -name 'aws-exports*')
+      - run:
+          name: 'Start Auth test server in background'
+          command: |
+            cd ../aws-amplify-cypress-auth
+            pwd
+            yarn start
+          background: true
+      - run: cat $(find ../repo -type f -name 'auth_spec*')
+      - run:
+          name: 'Run cypress tests for auth'
+          command: |
+            cd ../aws-amplify-cypress-auth
+            yarn add cypress --save
+            cp ../repo/cypress.json .
+            cp -R ../repo/cypress .
+            node_modules/.bin/cypress run --spec $(find . -type f -name 'auth_spec*')
+      - run: sudo kill -9 $(lsof -t -i:3000)
+      - run: cd .circleci/ && chmod +x delete_auth.sh
+      - run: expect .circleci/delete_auth.exp
+      - run:
+          name: 'Clone API test package'
+          command: |
+            cd ..
+            git clone $API_CLONE_URL
+            cd aws-amplify-cypress-api
+            yarn
+      - run: cd .circleci/ && chmod +x api.sh
+      - run: expect .circleci/amplify_init.exp ../aws-amplify-cypress-api
+      - run: expect .circleci/enable_api.exp
+      - run: cd ../aws-amplify-cypress-api
+      - run: yarn --frozen-lockfile
+      - run: cd ../aws-amplify-cypress-api/src && cat $(find . -type f -name 'aws-exports*')
+      - run:
+          name: 'Start API test server in background'
+          command: |
+            cd ../aws-amplify-cypress-api
+            pwd
+            yarn start
+          background: true
+      - run:
+          name: 'Run cypress tests for api'
+          command: |
+            cd ../aws-amplify-cypress-auth
+            yarn add cypress --save
+            cp ../repo/cypress.json .
+            cp -R ../repo/cypress .
+            node_modules/.bin/cypress run --spec $(find . -type f -name 'api_spec*')
+      - run: cd .circleci/ && chmod +x delete_api.sh
+      - run: expect .circleci/delete_api.exp
+      - store_artifacts:
+          path: ../../aws-amplify-cypress-auth/cypress/videos
+      - store_artifacts:
+          path: ../aws-amplify-cypress-auth/cypress/screenshots
+      - store_artifacts:
+          path: ../aws-amplify-cypress-api/cypress/videos
+      - store_artifacts:
+          path: ../aws-amplify-cypress-api/cypress/screenshots
   deploy:
     <<: *defaults
     steps:
@@ -200,7 +200,7 @@ jobs:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run:
-          name: "Publish Amplify CLI"
+          name: 'Publish Amplify CLI'
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
               git config --global user.email $GITHUB_EMAIL
@@ -225,26 +225,26 @@ jobs:
             sudo apt-get install -y lsof
             sudo apt-get install -y python
             sudo apt-get update && sudo apt-get install -y python-pip libpython-dev
-          name: "Install AWS CLI dependencies"
+          name: 'Install AWS CLI dependencies'
       - run:
           command: |
             cd ..
             mkdir videos
             mkdir screenshots
             npm install cypress
-          name: "Install Cypress Binary"
+          name: 'Install Cypress Binary'
       - run:
-          name: "Install AWS CLI"
+          name: 'Install AWS CLI'
           command: pip install awscli
       - run:
-          name: "Configure AWS CLI"
+          name: 'Configure AWS CLI'
           command: |
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
             aws configure set region $CLI_REGION --profile default
       - run:
-          command: "cd packages/amplify-ui-tests && npm run ui"
-          name: "Run ui tests in JS SDK"
+          command: 'cd packages/amplify-ui-tests && npm run ui'
+          name: 'Run ui tests in JS SDK'
           no_output_timeout: 45m
       - store_artifacts:
           path: /root/videos
@@ -254,53 +254,53 @@ jobs:
           path: packages/amplify-ui-tests/
   integration_test_ios:
     macos:
-      xcode: "10.3.0"
+      xcode: '10.3.0'
     steps:
       - attach_workspace:
           at: ./
       - run:
-          name: "Set up environment variables"
+          name: 'Set up environment variables'
           command: |
             cd ..
             circleci_root_directory=$(pwd)
             echo "export circleci_root_directory=$circleci_root_directory" >> $BASH_ENV
       - run:
-          name: "Checkout sample apps repository"
+          name: 'Checkout sample apps repository'
           command: |
             cd ..
             git clone https://github.com/awslabs/aws-sdk-ios-samples.git -b e2e-testing
       - run:
-          name: "Install AWS CLI"
+          name: 'Install AWS CLI'
           command: pip install awscli
       - run:
-          name: "Configure AWS CLI"
+          name: 'Configure AWS CLI'
           command: |
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
             aws configure set region $CLI_REGION --profile default
       - run:
-          name: "Set-Up configuration for UITests"
+          name: 'Set-Up configuration for UITests'
           command: |
             cd ../aws-sdk-ios-samples/CircleciScripts
             python3 setup_uitest_config.py -s master -l uitest_logs
       - run:
-          name: "Set-Up Mobile SDK Dependencies"
+          name: 'Set-Up Mobile SDK Dependencies'
           command: |
             cd ../aws-sdk-ios-samples/CircleciScripts
             python3 run_setup_mobile_sdk_dependencies.py -n PhotoAlbum -a ${circleci_root_directory}/aws-sdk-ios-samples
       - run:
-          name: "Configure AWS Resources"
+          name: 'Configure AWS Resources'
           command: |
             cd packages/amplify-ui-tests
             cp ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum/simple_model.graphql ./schemas/simple_model.graphql
             npm run config ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum ios auth storage api
       - run:
-          name: "Build and UITest"
+          name: 'Build and UITest'
           command: |
             cd ../aws-sdk-ios-samples/CircleciScripts
             python3 run_build_and_uitest.py -n PhotoAlbum -a ${circleci_root_directory}/aws-sdk-ios-samples -c ${circleci_root_directory}
       - run:
-          name: "Clean-Up UITest"
+          name: 'Clean-Up UITest'
           command: |
             cd packages/amplify-ui-tests
             npm run delete ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum
@@ -326,12 +326,12 @@ jobs:
             sudo yes | sdkmanager "platforms;android-18" "platforms;android-21" "platforms;android-23"
             sdkmanager --update
       - run:
-         name: Install Maven
-         command: |
+          name: Install Maven
+          command: |
             sudo apt-get update
             sudo apt-get install maven
       - run:
-          name: "Checkout PhotoAlbum Sample App Repo"
+          name: 'Checkout PhotoAlbum Sample App Repo'
           command: |
             cd ..
             git clone https://github.com/awslabs/aws-sdk-android-samples.git -b e2e-tests-sample-app sample_app_repo
@@ -358,10 +358,10 @@ jobs:
           command: |
             sudo apt-get -y install python3-pip
       - run:
-          name: "Install AWS CLI"
+          name: 'Install AWS CLI'
           command: sudo pip3 install awscli
       - run:
-          name: "Configure AWS CLI"
+          name: 'Configure AWS CLI'
           command: |
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
@@ -379,13 +379,13 @@ jobs:
             bash gradlew app:dependencies
             sudo npm install -g apollo-codegen@0.19.1
       - run:
-          name: "Configure AWS Resources"
+          name: 'Configure AWS Resources'
           command: |
             cd packages/amplify-ui-tests
             cp ${circleci_root_directory}/sample_app_repo/PhotoAlbumSample/simple_model.graphql schemas/simple_model.graphql
             npm run config ${app_root} android auth storage api
       - run:
-          name: "Set-Up Mobile SDK Dependencies"
+          name: 'Set-Up Mobile SDK Dependencies'
           command: |
             cd ${circleci_root_directory}/sample_app_repo/CircleciScripts
             python3 run_setup_mobile_sdk_dependencies.py -n PhotoAlbumSample -a ${circleci_root_directory}/sample_app_repo
@@ -403,8 +403,7 @@ jobs:
           background: true
       - run:
           name: Launch logcat
-          command:
-            adb logcat > logcat.log
+          command: adb logcat > logcat.log
           background: true
       - run:
           name: Wait emulator
@@ -412,12 +411,12 @@ jobs:
             circle-android wait-for-boot
             python3 ${circleci_root_directory}/sample_app_repo/CircleciScripts/unlock_emulatorscreen.py
       - run:
-          name: "Build and UITest"
+          name: 'Build and UITest'
           command: |
             cd ${circleci_root_directory}/sample_app_repo/CircleciScripts
             python3 run_build_and_uitest.py -n PhotoAlbumSample -a ${circleci_root_directory}/sample_app_repo -c ${circleci_root_directory}
       - run:
-          name: "Clean-Up UITest"
+          name: 'Clean-Up UITest'
           command: |
             cd packages/amplify-ui-tests
             npm run delete ${app_root}
@@ -441,7 +440,6 @@ workflows:
           requires:
             - build
             - integration_test_ios
-            - integration_test_js
             - mock_e2e_tests
       - mock_e2e_tests:
           requires:
@@ -455,7 +453,6 @@ workflows:
           requires:
             - build
             - integration_test_ios
-            - integration_test_js
             - mock_e2e_tests
       - amplify_e2e_tests:
           filters:
@@ -465,7 +462,6 @@ workflows:
           requires:
             - build
             - integration_test_ios
-            - integration_test_js
             - mock_e2e_tests
       - deploy:
           requires:


### PR DESCRIPTION
Cypress tests that run on circle ci have been unreliable and flaky. These tests are stopping our CI
from running the rest of the tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.