### PR TITLE
Pass object, not json, to generateFilterExpression

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/util/transform/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/transform/index.ts
@@ -1,7 +1,7 @@
 import { generateFilterExpression } from './dynamodb-filter';
 export const transformUtils = {
   toDynamoDBFilterExpression: filter => {
-    const result = generateFilterExpression(filter.toJSON());
+    const result = generateFilterExpression(filter);
     return JSON.stringify({
       expression: result.expressions.join(' ').trim(),
       expressionNames: result.expressionNames,


### PR DESCRIPTION
*Issue #, if available:*
I did a search and didn't find any issues specifically about this.

*Description of changes:*
Remove `toJSON` on filter before passing to generateFilterExpression.  Looking at generateFilterExpression, I think it expects an object, not a string.

NB: 
 * I don't have any experience with typescript, 
 * I tested this change locally in the generated javascript
 * I wasn't using amplify-cli directly, I was pulling out `amplify-appsync-simulator/lib/velocity/util` and using it with velocityjs
 * I was getting this error
    >filter.toJSON is not a function on $util.transform.toDynamoDBFilterExpression

     which lead me to making this change.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.