### PR TITLE
fix(amplify-category-hosting): fix hosting bug

### DIFF
--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -75,6 +75,7 @@ function removeCDN(context) {
   delete context.exeInfo.template.Outputs.CloudFrontDistributionID;
   delete context.exeInfo.template.Outputs.CloudFrontDomainName;
   delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
+  delete context.exeInfo.template.Outputs.CloudFrontOriginAccessIdentity;
 }
 
 function makeBucketPrivate(context) {

--- a/packages/amplify-e2e-tests/__tests__/hosting.test.ts
+++ b/packages/amplify-e2e-tests/__tests__/hosting.test.ts
@@ -1,0 +1,27 @@
+require('../src/aws-matchers/'); // custom matcher for assertion
+import { initProjectWithProfile } from '../src/init';
+import { addHosting, removeHosting, amplifyPush } from '../src/categories/hosting';
+import { createNewProjectDir, deleteProjectDir} from '../src/utils';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('amplify add analytics', () => {
+  let projRoot: string;
+  beforeEach(() => {
+    projRoot = createNewProjectDir();
+    jest.setTimeout(1000 * 60 * 60); // 1 hour
+  });
+
+  afterEach(async () => {
+    await removeHosting(projRoot);
+    await amplifyPush(projRoot); 
+    deleteProjectDir(projRoot);
+  });
+
+  it('add hosting', async () => {
+    await initProjectWithProfile(projRoot, {});
+    await addHosting(projRoot);
+    await amplifyPush(projRoot); 
+    expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'hosting', "S3AndCloudFront"))).toBe(true);
+  });
+});

--- a/packages/amplify-e2e-tests/__tests__/hosting.test.ts
+++ b/packages/amplify-e2e-tests/__tests__/hosting.test.ts
@@ -5,7 +5,7 @@ import { createNewProjectDir, deleteProjectDir} from '../src/utils';
 import * as fs from 'fs';
 import * as path from 'path';
 
-describe('amplify add analytics', () => {
+describe('amplify add hosting', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();

--- a/packages/amplify-e2e-tests/src/categories/hosting.ts
+++ b/packages/amplify-e2e-tests/src/categories/hosting.ts
@@ -1,0 +1,49 @@
+import * as nexpect from 'nexpect';
+import { getCLIPath, isCI } from '../utils';
+
+export function addHosting(cwd: string, verbose: boolean = !isCI()) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true, verbose })
+      .wait('Select the environment setup:')
+      .sendline('\r')
+      .wait("hosting bucket name")
+      .sendline('\r')
+      .wait("index doc for the website")
+      .sendline('\r')
+      .wait("error doc for the website")
+      .sendline('\r')
+      .run((err: Error) => {
+        if (!err) resolve();
+        else reject(err);
+      });
+  });
+}
+
+export function amplifyPush(cwd: string, verbose: boolean = !isCI()) {  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })  
+      .wait('Are you sure you want to continue?')
+      .sendline('\r')
+      .run((err: Error) => {
+        if (!err) resolve();
+        else reject(err);
+      });
+  });
+}
+
+export function removeHosting(cwd: string, verbose: boolean = !isCI()) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['remove', 'hosting'], { cwd, stripColors: true, verbose })
+      .wait('Choose the resource you would want to remove')
+      .sendline('\r')
+      .wait('Are you sure you want to delete the resource?')
+      .sendline('\r')
+      .wait('Successfully removed resource')
+      .run((err: Error) => {
+        if (!err) resolve();
+        else reject(err);
+      });
+  });
+}


### PR DESCRIPTION
remove CloudFrontOriginAccessIdentity from the hosting template output when CloudFront is not
enabled

fix #2551

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.