### PR TITLE
fix: mitigate push failuer when graphql api backend is missing

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -148,6 +148,19 @@ async function transformGraphQLSchema(context, options) {
   // Compilation during the push step
   const { resourcesToBeCreated, resourcesToBeUpdated, allResources } = await context.amplify.getResourceStatus(category);
   let resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
+
+  // When build folder is missing include the API
+  // to be compiled. Without the current cloud backend
+  // cloud formation push will fail
+  // https://github.com/aws-amplify/amplify-console/issues/10
+  const resourceNeedCompile = allResources
+    .filter(r => !resources.includes(r))
+    .filter(r => {
+      const buildDir = path.normalize(path.join(backEndDir, category, r.resourceName, 'build'));
+      return !fs.existsSync(buildDir);
+    });
+  resources = resources.concat(resourceNeedCompile);
+
   if (forceCompile) {
     resources = resources.concat(allResources);
   }

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -150,8 +150,8 @@ async function transformGraphQLSchema(context, options) {
   let resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
 
   // When build folder is missing include the API
-  // to be compiled. Without the current cloud backend
-  // cloud formation push will fail
+  // to be compiled. Without the backend/api/<api-name>/build 
+  // cloud formation push will fail even if there is no changes in the GraphQL API
   // https://github.com/aws-amplify/amplify-console/issues/10
   const resourceNeedCompile = allResources
     .filter(r => !resources.includes(r))

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -150,7 +150,7 @@ async function transformGraphQLSchema(context, options) {
   let resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
 
   // When build folder is missing include the API
-  // to be compiled. Without the backend/api/<api-name>/build 
+  // to be compiled without the backend/api/<api-name>/build
   // cloud formation push will fail even if there is no changes in the GraphQL API
   // https://github.com/aws-amplify/amplify-console/issues/10
   const resourceNeedCompile = allResources


### PR DESCRIPTION
Cloud formation push fails in amplify console when a project has GraphQL API but changes are in non
GraphQL API resource. When pushing resources to cloud, Amplify CLI expects the api build directory
to present. When the push is running in the console,  API build directory will be missing because of
the gitignore rule. Updating the build steps to generate build folder when they are missing

https://github.com/aws-amplify/amplify-console/issues/10

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.