### PR TITLE
Remove incorrect apostrophe in command description

### DIFF
--- a/packages/amplify-category-api/commands/api.js
+++ b/packages/amplify-category-api/commands/api.js
@@ -19,7 +19,7 @@ module.exports = {
       },
       {
         name: 'push',
-        description: `Provisions ${featureName} cloud resources and it's dependencies with the latest local developments`,
+        description: `Provisions ${featureName} cloud resources and its dependencies with the latest local developments`,
       },
       {
         name: 'remove',


### PR DESCRIPTION
s/it's/its/ in output of `amplify api help`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.