### PR TITLE
fix(amplify-category-api): use standard json read

### DIFF
--- a/packages/amplify-category-analytics/commands/analytics/add.js
+++ b/packages/amplify-category-analytics/commands/analytics/add.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-
 const subcommand = 'add';
 const category = 'analytics';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 let options;
 
@@ -10,7 +7,7 @@ module.exports = {
   name: subcommand,
   run: async context => {
     const { amplify } = context;
-
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)
       .then(result => {

--- a/packages/amplify-category-api/commands/api/add-graphql-datasource.js
+++ b/packages/amplify-category-api/commands/api/add-graphql-datasource.js
@@ -9,7 +9,6 @@ const subcommand = 'add-graphql-datasource';
 const categories = 'categories';
 const category = 'api';
 const providerName = 'awscloudformation';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-datasources.json`));
 
 const rdsRegion = 'rdsRegion';
 const rdsIdentifier = 'rdsClusterIdentifier';
@@ -23,6 +22,7 @@ module.exports = {
   name: subcommand,
   run: async context => {
     const { amplify } = context;
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-datasources.json`);
     let resourceName;
     let datasource;
     let databaseName;

--- a/packages/amplify-category-api/commands/api/add.js
+++ b/packages/amplify-category-api/commands/api/add.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-
 const subcommand = 'add';
 const category = 'api';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 let options;
 
@@ -10,6 +7,7 @@ module.exports = {
   name: subcommand,
   run: async context => {
     const { amplify } = context;
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)
       .then(result => {

--- a/packages/amplify-category-api/commands/api/console.js
+++ b/packages/amplify-category-api/commands/api/console.js
@@ -1,13 +1,11 @@
-const fs = require('fs');
-
 const subcommand = 'console';
 const category = 'api';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 module.exports = {
   name: subcommand,
   run: async context => {
     const { amplify } = context;
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)
       .then(result => {

--- a/packages/amplify-category-api/commands/api/update.js
+++ b/packages/amplify-category-api/commands/api/update.js
@@ -1,14 +1,12 @@
-const fs = require('fs');
-
 const subcommand = 'update';
 const category = 'api';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 module.exports = {
   name: subcommand,
   alias: ['configure'],
   run: async context => {
     const { amplify } = context;
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
 
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)

--- a/packages/amplify-category-function/commands/function/add.js
+++ b/packages/amplify-category-function/commands/function/add.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-
 const subcommand = 'add';
 const category = 'function';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 let options;
 
@@ -10,7 +7,7 @@ module.exports = {
   name: subcommand,
   run: async context => {
     const { amplify } = context;
-
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)
       .then(result => {

--- a/packages/amplify-category-function/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.js
+++ b/packages/amplify-category-function/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.js
@@ -123,7 +123,7 @@ async function updateWalkthrough(context, lambdaToUpdate) {
   const parametersFilePath = path.join(resourceDirPath, functionParametersFileName);
   let currentParameters;
   try {
-    currentParameters = JSON.parse(fs.readFileSync(parametersFilePath));
+    currentParameters = context.amplify.readJsonFile(parametersFilePath);
   } catch (e) {
     currentParameters = {};
   }
@@ -148,7 +148,7 @@ async function updateWalkthrough(context, lambdaToUpdate) {
 
     const cfnFileName = `${resourceAnswer.resourceName}-cloudformation-template.json`;
     const cfnFilePath = path.join(resourceDirPath, cfnFileName);
-    const cfnContent = JSON.parse(fs.readFileSync(cfnFilePath));
+    const cfnContent = context.amplify.readJsonFile(cfnFilePath);
     const dependsOnParams = { env: { Type: 'String' } };
 
     Object.keys(answers.resourcePropertiesJSON).forEach(resourceProperty => {
@@ -319,7 +319,7 @@ function getNewCFNParameters(oldCFNParameters, currentDefaults, newCFNResourcePa
 
 async function askExecRolePermissionsQuestions(context, allDefaultValues, parameters, currentDefaults) {
   const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
 
   let categories = Object.keys(amplifyMeta);
   categories = categories.filter(category => category !== 'providers');

--- a/packages/amplify-category-storage/commands/storage/add.js
+++ b/packages/amplify-category-storage/commands/storage/add.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-
 const subcommand = 'add';
 const category = 'storage';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 let options;
 
@@ -10,7 +7,7 @@ module.exports = {
   name: subcommand,
   run: async context => {
     const { amplify } = context;
-
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)
       .then(result => {

--- a/packages/amplify-category-storage/commands/storage/update.js
+++ b/packages/amplify-category-storage/commands/storage/update.js
@@ -1,14 +1,12 @@
-const fs = require('fs');
-
 const subcommand = 'update';
 const category = 'storage';
-const servicesMetadata = JSON.parse(fs.readFileSync(`${__dirname}/../../provider-utils/supported-services.json`));
 
 module.exports = {
   name: subcommand,
   alias: ['configure'],
   run: async context => {
     const { amplify } = context;
+    const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
 
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.js
@@ -7,7 +7,7 @@ const { removeResourceParameters } = require('./envResourceParams');
 
 async function forceRemoveResource(context, category, name, dir) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
   if (!amplifyMeta[category] || Object.keys(amplifyMeta[category]).length === 0) {
     context.print.error('No resources added for this category');
     process.exit(1);
@@ -30,7 +30,7 @@ async function forceRemoveResource(context, category, name, dir) {
 
 function removeResource(context, category) {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
   if (!amplifyMeta[category] || Object.keys(amplifyMeta[category]).length === 0) {
     context.print.error('No resources added for this category');
     process.exit(1);
@@ -71,7 +71,7 @@ function removeResource(context, category) {
 
 const deleteResourceFiles = async (context, category, resourceName, resourceDir, force) => {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = JSON.parse(fs.readFileSync(amplifyMetaFilePath));
+  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
   if (!force) {
     const { allResources } = await context.amplify.getResourceStatus();
     allResources.forEach(resourceItem => {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.js
@@ -6,6 +6,7 @@ const fsExtra = require('fs-extra');
 const { flattenDeep } = require('lodash');
 const { join } = require('path');
 const { uniq } = require('lodash');
+const { readJsonFile } = require('./read-json-file');
 
 /** ADD A TRIGGER
  * @function addTrigger
@@ -361,7 +362,7 @@ const choicesFromMetadata = (path, selection, isDir) => {
 };
 
 // get metadata from a particular file
-const getTriggerMetadata = (path, selection) => JSON.parse(fs.readFileSync(`${path}/${selection}.map.json`));
+const getTriggerMetadata = (path, selection) => readJsonFile(`${path}/${selection}.map.json`);
 
 // open customer's text editor
 async function openEditor(context, path, name) {

--- a/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
+++ b/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
@@ -31,7 +31,7 @@ module.exports = async (context, apiDetails) => {
   fs.write(amplifyMetaFilePath, JSON.stringify(amplifyMeta, null, 4));
 
   const currentAmplifyMetaFilePath = context.amplify.pathManager.getCurentAmplifyMetaFilePath();
-  const currentAmplifyMeta = JSON.parse(fs.read(currentAmplifyMetaFilePath));
+  const currentAmplifyMeta = context.amplify.readJsonFile(currentAmplifyMetaFilePath);
   if (!currentAmplifyMeta.api) {
     currentAmplifyMeta.api = {};
   }

--- a/packages/amplify-util-mock/src/utils/lambda/load.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/load.ts
@@ -16,8 +16,8 @@ export function getAllLambdaFunctions(context, backendPath: string): LambdaFunct
         const cfnPath = path.join(lambdaDir, `${resourceName}-cloudformation-template.json`);
         const cfnParams = path.join(lambdaDir, 'function-parameters.json');
         try {
-          const lambdaCfn = JSON.parse(fs.readFileSync(cfnPath, 'utf-8'));
-          const lambdaCfnParams = fs.existsSync(cfnParams) ? JSON.parse(fs.readFileSync(cfnParams, 'utf-8')) : {};
+          const lambdaCfn = context.amplify.readJsonFile(cfnPath);
+          const lambdaCfnParams = fs.existsSync(cfnParams) ? context.amplify.readJsonFile(cfnParams) : {};
           const lambdaConfig = processResources(lambdaCfn.Resources, {}, { ...lambdaCfnParams, env: 'NONE' });
           lambdaConfig.basePath = path.join(lambdaDir, 'src');
           lambdas.push(lambdaConfig);


### PR DESCRIPTION
use standard amplify cli provided json read to avoid json parse bug

fix #2580 #2550

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.