### PR TITLE
fix(amplify-category-auth): removes deprecated props for external auth

### DIFF
--- a/packages/amplify-category-auth/index.js
+++ b/packages/amplify-category-auth/index.js
@@ -12,6 +12,7 @@ const {
   saveResourceParameters,
   ENV_SPECIFIC_PARAMS,
   migrate,
+  removeDeprecatedProps,
 } = require('./provider-utils/awscloudformation');
 
 // this function is being kept for temporary compatability.
@@ -110,12 +111,13 @@ async function externalAuthEnable(context, externalCategory, resourceName, requi
       }); //eslint-disable-line
   /* eslint-enable */
   const { roles } = defaults;
-  const authProps = {
+  let authProps = {
     ...authPropsValues,
     ...roles,
   };
 
   try {
+    authProps = removeDeprecatedProps(authProps);
     await copyCfnTemplate(context, category, authProps, cfnFilename);
     saveResourceParameters(context, provider, category, authProps.resourceName, authProps, ENV_SPECIFIC_PARAMS);
     if (!authExists) {

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -575,7 +575,7 @@ function removeDeprecatedProps(props) {
   if (props.openIdRolePolicy) {
     delete props.openIdRolePolicy;
   }
-  if (props.openIdRopenIdLambdaIAMPolicyolePolicy) {
+  if (props.openIdLambdaIAMPolicy) {
     delete props.openIdLambdaIAMPolicy;
   }
   if (props.openIdLogPolicy) {
@@ -617,4 +617,5 @@ module.exports = {
   migrate,
   console,
   getPermissionPolicies,
+  removeDeprecatedProps,
 };


### PR DESCRIPTION
*Issue #, if available:*
fix(#2309 )

*Description of changes:*
Calls removeDeprecatedProps before passing values to CFN in externalAuthEnable. Also fixes copy/paste error in removeDeprecatedProps function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.