### PR TITLE
chore: add : to "Please select from one of the below mentioned services"

### DIFF
--- a/.circleci/enable_api.exp
+++ b/.circleci/enable_api.exp
@@ -1,6 +1,6 @@
 #!/usr/bin/expect
 spawn ./.circleci/api.sh
-expect "Please select from one of the below mentioned services\r"
+expect "Please select from one of the below mentioned services:\r"
 send -- "\033\[B\r"
 expect "Provide a friendly name for your resource to be used as a label for this category in the project:"
 send -- "myAPI\r"

--- a/packages/amplify-cli/src/extensions/amplify-helpers/service-select-prompt.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/service-select-prompt.js
@@ -51,7 +51,7 @@ function serviceQuestionWalkthrough(context, supportedServices, category) {
   const question = [
     {
       name: 'service',
-      message: 'Please select from one of the below mentioned services',
+      message: 'Please select from one of the below mentioned services:',
       type: 'list',
       choices: options,
     },

--- a/packages/amplify-e2e-tests/src/categories/api.ts
+++ b/packages/amplify-e2e-tests/src/categories/api.ts
@@ -26,7 +26,7 @@ export function addApiWithSchema(cwd: string, schemaFile: string, verbose: boole
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'api'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       .sendline('\r')
       .wait('Provide API name:')
       .sendline('\r')
@@ -66,7 +66,7 @@ export function updateApiWithMultiAuth(cwd: string, settings: any, verbose: bool
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['update', 'api'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       .sendline('')
       .wait(/.*Choose the default authorization type for the API.*/)
       .sendline('')

--- a/packages/amplify-e2e-tests/src/categories/auth.ts
+++ b/packages/amplify-e2e-tests/src/categories/auth.ts
@@ -62,7 +62,7 @@ export function addAuthViaAPIWithTrigger(cwd: string, settings: any, verbose: bo
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'api'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       .send('\r')
       .wait('Provide API name')
       .send('\r')

--- a/packages/amplify-e2e-tests/src/categories/storage.ts
+++ b/packages/amplify-e2e-tests/src/categories/storage.ts
@@ -11,7 +11,7 @@ export function addSimpleDDB(cwd: string, settings: any, verbose: boolean = !isC
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       // j = down arrow
       .sendline('j')
       .sendline('\r')
@@ -54,7 +54,7 @@ export function addDDBWithTrigger(cwd: string, settings: any, verbose: boolean =
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       // j = down arrow
       .sendline('j')
       .sendline('\r')
@@ -104,7 +104,7 @@ export function updateDDBWithTrigger(cwd: string, settings: any, verbose: boolea
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['update', 'storage'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       // j = down arrow
       .sendline('j')
       .sendline('\r')
@@ -142,7 +142,7 @@ export function addS3WithTrigger(cwd: string, settings: any, verbose: boolean = 
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       .sendline('\r')
       .wait('Please provide a friendly name')
       .sendline('\r')

--- a/packages/amplify-ui-tests/src/categories/api.ts
+++ b/packages/amplify-ui-tests/src/categories/api.ts
@@ -26,7 +26,7 @@ export function addApiWithSimpleModel(cwd: string, settings: any = {}, verbose: 
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'api'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       .sendline('\r')
       .wait('Provide API name:')
       .sendline(settings.apiName)

--- a/packages/amplify-ui-tests/src/categories/storage.ts
+++ b/packages/amplify-ui-tests/src/categories/storage.ts
@@ -7,7 +7,7 @@ export function addStorageWithDefault(cwd: string, settings: any = {}, verbose: 
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true, verbose })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Please select from one of the below mentioned services:')
       .sendline('\r')
       .wait('Please provide a friendly name for your resource that will be used to label')
       .sendline('\r')


### PR DESCRIPTION
*Description of changes:*

In the CLI, the current output looks like:

> ? Please select from one of the below mentioned services Content (Images, audio, video, etc.)

This adds a `:` to make the output clearer.  _(This originated as a nit in a PR)_


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.