### PR TITLE
fix(graphql-auth-transformer): remove enforce model check for field

### DIFF
--- a/packages/amplify-util-mock/src/__e2e__/per-field-auth-tests.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/per-field-auth-tests.e2e.test.ts
@@ -104,6 +104,10 @@ beforeAll(async () => {
       owner1: String! @auth(rules: [{allow: owner, ownerField: "notAllowed", operations: [update]}])
       text: String @auth(rules: [{ allow: owner, ownerField: "owner1", operations : [update]}])
   }
+  # add auth on a field
+  type Query {
+    someFunction: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+  }
     `;
   const transformer = new GraphQLTransform({
     transformers: [
@@ -561,4 +565,27 @@ test('AND per-field dynamic auth rule test', async () => {
   logDebug(correctUpdatePostResponse);
   expect(correctUpdatePostResponse.data.updatePost.owner1).toEqual(USERNAME1);
   expect(correctUpdatePostResponse.data.updatePost.text).toEqual('newText');
+});
+
+test('test field auth on an operation type as user in admin group', async () => {
+  const queryResponse = await GRAPHQL_CLIENT_1.query(`
+    query SomeFunction {
+      someFunction
+    }
+  `);
+  // no errors though it should return null
+  logDebug(queryResponse);
+  expect(queryResponse.data.someFunction).toBeNull();
+});
+
+test('test field auth on an operation type as user not in admin group', async () => {
+  const queryResponse = await GRAPHQL_CLIENT_3.query(`
+    query SomeFunction {
+      someFunction
+    }
+  `);
+  // should return an error
+  logDebug(queryResponse);
+  expect(queryResponse.errors).toBeDefined();
+  expect(queryResponse.errors[0].message).toEqual('Unauthorized');
 });

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -477,10 +477,11 @@ Static group authorization should perform as expected.`
       // Delete operations are only protected by @auth directives on objects.
       const deleteRules = rules.filter((rule: AuthRule) => isDeleteRule(rule));
       this.protectDeleteForField(ctx, parent, definition, deleteRules, modelConfiguration);
+    } else {
+      // if @auth is used without @model only generate static group rules
+      const staticGroupRules = rules.filter((rule: AuthRule) => rule.groups);
+      this.protectField(ctx, parent, definition, staticGroupRules);
     }
-    // if @auth is used without @model only generate static group rules
-    const staticGroupRules = rules.filter((rule: AuthRule) => rule.groups);
-    this.protectField(ctx, parent, definition, staticGroupRules);
   };
 
   private protectField(

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -407,10 +407,6 @@ export class ModelAuthTransformer extends Transformer {
         `The @auth directive cannot be placed on an interface's field. See ${parent.name.value}${definition.name.value}`
       );
     }
-    const modelDirective = parent.directives.find(dir => dir.name.value === 'model');
-    if (!modelDirective) {
-      throw new InvalidDirectiveError('Types annotated with @auth must also be annotated with @model.');
-    }
 
     // Retrieve the configuration options for the related @model directive
     const modelConfiguration = new ModelDirectiveConfiguration(modelDirective, parent);

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -407,6 +407,7 @@ export class ModelAuthTransformer extends Transformer {
         `The @auth directive cannot be placed on an interface's field. See ${parent.name.value}${definition.name.value}`
       );
     }
+    const modelDirective = parent.directives.find(dir => dir.name.value === 'model');
 
     // Retrieve the configuration options for the related @model directive
     const modelConfiguration = new ModelDirectiveConfiguration(modelDirective, parent);

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -408,9 +408,6 @@ export class ModelAuthTransformer extends Transformer {
       );
     }
     const modelDirective = parent.directives.find(dir => dir.name.value === 'model');
-
-    // Retrieve the configuration options for the related @model directive
-    const modelConfiguration = new ModelDirectiveConfiguration(modelDirective, parent);
     if (
       parent.name.value === ctx.getQueryTypeName() ||
       parent.name.value === ctx.getMutationTypeName() ||
@@ -449,31 +446,74 @@ Static group authorization should perform as expected.`
       if (rule.operations) {
         const matchesOp = rule.operations.find(o => o === op);
         return Boolean(matchesOp);
-      } else if (rule.operations === null) {
+      }
+      if (rule.operations === null) {
         return false;
       }
       return true;
     };
-    const isReadRule = isOpRule('read');
-    const isCreateRule = isOpRule('create');
-    const isUpdateRule = isOpRule('update');
-    const isDeleteRule = isOpRule('delete');
-    // The field handler adds the read rule on the object
-    const readRules = rules.filter((rule: AuthRule) => isReadRule(rule));
-    this.protectReadForField(ctx, parent, definition, readRules, modelConfiguration);
 
-    // Protect mutations when objects including this field are trying to be created.
-    const createRules = rules.filter((rule: AuthRule) => isCreateRule(rule));
-    this.protectCreateForField(ctx, parent, definition, createRules, modelConfiguration);
+    // add rules if per field @auth is used with @model
+    if (modelDirective) {
+      const isReadRule = isOpRule('read');
+      const isCreateRule = isOpRule('create');
+      const isUpdateRule = isOpRule('update');
+      const isDeleteRule = isOpRule('delete');
 
-    // Protect update mutations when objects inluding this field are trying to be updated.
-    const updateRules = rules.filter((rule: AuthRule) => isUpdateRule(rule));
-    this.protectUpdateForField(ctx, parent, definition, updateRules, modelConfiguration);
+      // Retrieve the configuration options for the related @model directive
+      const modelConfiguration = new ModelDirectiveConfiguration(modelDirective, parent);
+      // The field handler adds the read rule on the object
+      const readRules = rules.filter((rule: AuthRule) => isReadRule(rule));
+      this.protectReadForField(ctx, parent, definition, readRules, modelConfiguration);
 
-    // Delete operations are only protected by @auth directives on objects.
-    const deleteRules = rules.filter((rule: AuthRule) => isDeleteRule(rule));
-    this.protectDeleteForField(ctx, parent, definition, deleteRules, modelConfiguration);
+      // Protect mutations when objects including this field are trying to be created.
+      const createRules = rules.filter((rule: AuthRule) => isCreateRule(rule));
+      this.protectCreateForField(ctx, parent, definition, createRules, modelConfiguration);
+
+      // Protect update mutations when objects inluding this field are trying to be updated.
+      const updateRules = rules.filter((rule: AuthRule) => isUpdateRule(rule));
+      this.protectUpdateForField(ctx, parent, definition, updateRules, modelConfiguration);
+
+      // Delete operations are only protected by @auth directives on objects.
+      const deleteRules = rules.filter((rule: AuthRule) => isDeleteRule(rule));
+      this.protectDeleteForField(ctx, parent, definition, deleteRules, modelConfiguration);
+    }
+    // if @auth is used without @model only generate static group rules
+    const staticGroupRules = rules.filter((rule: AuthRule) => rule.groups);
+    this.protectField(ctx, parent, definition, staticGroupRules);
   };
+
+  private protectField(
+    ctx: TransformerContext,
+    parent: ObjectTypeDefinitionNode,
+    field: FieldDefinitionNode,
+    staticGroupRules: AuthRule[]
+  ) {
+    const typeName = parent.name.value;
+    const fieldName = field.name.value;
+    const resolverResourceId = ResolverResourceIDs.ResolverResourceID(typeName, fieldName);
+    let fieldResolverResource = ctx.getResource(resolverResourceId);
+    // add logic here to only use static group rules
+    const staticGroupAuthorizationRules = this.getStaticGroupRules(staticGroupRules);
+    const staticGroupAuthorizationExpression = this.resources.staticGroupAuthorizationExpression(staticGroupAuthorizationRules, field);
+    const throwIfUnauthorizedExpression = this.resources.throwIfUnauthorized(field);
+    const authCheckExpressions = [staticGroupAuthorizationExpression, newline(), throwIfUnauthorizedExpression];
+    const templateParts = [print(compoundExpression(authCheckExpressions))];
+    // if the field resolver does not exist create it
+    if (!fieldResolverResource) {
+      fieldResolverResource = this.resources.blankResolver(typeName, fieldName);
+      ctx.setResource(resolverResourceId, fieldResolverResource);
+      // add none ds if that does not exist
+      const noneDS = ctx.getResource(ResourceConstants.RESOURCES.NoneDataSource);
+      if (!noneDS) {
+        ctx.setResource(ResourceConstants.RESOURCES.NoneDataSource, this.resources.noneDataSource());
+      }
+    } else {
+      templateParts.push(fieldResolverResource.Properties.RequestMappingTemplate);
+    }
+    fieldResolverResource.Properties.RequestMappingTemplate = templateParts.join('\n\n');
+    ctx.setResource(resolverResourceId, fieldResolverResource);
+  }
 
   private protectReadForField(
     ctx: TransformerContext,

--- a/packages/graphql-auth-transformer/src/__tests__/PerFieldAuthArgument.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/PerFieldAuthArgument.test.ts
@@ -49,3 +49,33 @@ test('Test that subscriptions are only generated if the respective mutation oper
   expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toContain('#set( $context.result.operation = "Mutation" )');
   expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toMatchSnapshot();
 });
+
+test('Test per-field @auth without model', () => {
+  const validSchema = `
+    type Query {
+      listContext: String @auth(rules: [{ allow: groups, groups: ["Allowed"] }])
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new DynamoDBModelTransformer(),
+      new ModelAuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [],
+        },
+      }),
+    ],
+  });
+
+  const out = transformer.transform(validSchema);
+
+  expect(out).toBeDefined();
+  expect(out.resolvers['Query.listContext.req.vtl']).toContain(
+    '## Authorization rule: { allow: groups, groups: ["Allowed"], groupClaim: "cognito:groups" } **'
+  );
+  expect(out.resolvers['Query.listContext.req.vtl']).toMatchSnapshot();
+});

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test per-field @auth without model 1`] = `
+"## [Start] Static Group Authorization Checks **
+#set($listContext_isStaticGroupAuthorized = $util.defaultIfNull(
+            $listContext_isStaticGroupAuthorized, false))
+## Authorization rule: { allow: groups, groups: [\\"Allowed\\"], groupClaim: \\"cognito:groups\\" } **
+#set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+#set( $allowedGroups = [\\"Allowed\\"] )
+#foreach( $userGroup in $userGroups )
+  #if( $allowedGroups.contains($userGroup) )
+    #set( $listContext_isStaticGroupAuthorized = true )
+    #break
+  #end
+#end
+## [End] Static Group Authorization Checks **
+
+
+## [Start] Throw if unauthorized **
+#if( !($listContext_isStaticGroupAuthorized == true || $isDynamicGroupAuthorized == true || $isOwnerAuthorized == true) )
+  $util.unauthorized()
+#end
+## [End] Throw if unauthorized **"
+`;
+
 exports[`Test that subscriptions are only generated if the respective mutation operation exists 1`] = `
 "## [Start] Checking for allowed operations which can return this field **
 #set( $operation = $util.defaultIfNull($context.source.operation, \\"null\\") )


### PR DESCRIPTION
*Issue #, if available:*
#2591 
*Description of changes:*
removing unnecessary enforce check for @model in when adding @auth on a field

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.