### PR TITLE
fix: update lambda runtime from nodejs8.10 to nodejs10.x

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
@@ -1,428 +1,368 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "Pinpoint resource stack creation using Amplify CLI",
-    "Parameters": {
-        "appName": {
-            "Type": "String"
-        },
-        "appId": {
-            "Type": "String",
-            "Default": "NONE"
-        },
-        "roleName": {
-            "Type": "String"
-        },
-        "cloudWatchPolicyName": {
-            "Type": "String"
-        },
-        "pinpointPolicyName": {
-            "Type": "String"
-        },
-        "authPolicyName": {
-            "Type": "String"
-        },
-        "unauthPolicyName": {
-            "Type": "String"
-        },
-        "authRoleName": {
-            "Type":  "String"
-        },
-        "unauthRoleName": {
-            "Type":  "String"
-        },
-        "authRoleArn": {
-            "Type":  "String"
-        },
-        "env": {
-            "Type":  "String"
-        }
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Pinpoint resource stack creation using Amplify CLI",
+  "Parameters": {
+    "appName": {
+      "Type": "String"
     },
-    "Metadata": {
-        "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [
-                {
-                    "Label": {
-                        "default": "Creating pinpoint app"
-                    },
-                    "Parameters": [
-                        "appName"
-                    ]
-                }
-            ]
-        }
+    "appId": {
+      "Type": "String",
+      "Default": "NONE"
     },
-    "Conditions": {
-        "ShouldCreatePinpointApp": {
-            "Fn::Equals": [
-                {
-                    "Ref": "appId"
-                },
-                "NONE"
-            ]
-        },
-        "ShouldNotCreateEnvResources": {
-            "Fn::Equals": [
-                {
-                    "Ref": "env"
-                },
-                "NONE"
-            ]
-        }
+    "roleName": {
+      "Type": "String"
     },
-    "Resources": {
-        "LambdaExecutionRole": {
-            "Condition": "ShouldCreatePinpointApp",
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "RoleName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        {
-                           "Ref": "roleName"
-                        }, 
-                        {
-
-                            "Fn::Join": [
-                                "",
-                                [
-                                  {
-                                    "Ref": "roleName"
-                                  },
-                                  "-",
-                                  {
-                                    "Ref": "env"
-                                  }
-                                ]
-                            ]
-                        }       
-                    ]
-                },
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": [
-                                    "lambda.amazonaws.com"
-                                ]
-                            },
-                            "Action": [
-                                "sts:AssumeRole"
-                            ]
-                        }
-                    ]
-                },
-                "Policies": [
-                    {
-                        "PolicyName": {
-                            "Ref": "cloudWatchPolicyName"
-                        },
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "logs:CreateLogGroup",
-                                        "logs:CreateLogStream",
-                                        "logs:PutLogEvents"
-                                    ],
-                                    "Resource": "arn:aws:logs:*:*:*"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": {
-                            "Ref": "pinpointPolicyName"
-                        },
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "mobileanalytics:*",
-                                        "mobiletargeting:*"
-                                    ],
-                                    "Resource": "*"
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "PinpointFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-                "Code": {
-                    "ZipFile": {
-                        "Fn::Join": [
-                            "\n",
-                            [
-                                "const response = require('cfn-response');",
-                                "const aws = require('aws-sdk');",
-                                "exports.handler = function(event, context) {",
-                                "    if (event.RequestType == 'Delete') {",
-                                "        response.send(event, context, response.SUCCESS);",
-                                "        return;",
-                                "    }",
-                                "    if (event.RequestType == 'Update') {",
-                                "        response.send(event, context, response.SUCCESS);",
-                                "        return;",
-                                "    }",
-                                "    if (event.RequestType == 'Create') {",
-                                "       const appName = event.ResourceProperties.appName;",
-                                "       let responseData = {};",
-                                "       const params = {",
-                                "           CreateApplicationRequest: {",
-                                "               Name: appName",
-                                "           }",
-                                "       };",
-                                "       const pinpoint = new aws.Pinpoint({ apiVersion: '2016-12-01', region: event.ResourceProperties.region });",
-                                "       pinpoint.createApp(params).promise()",
-                                "           .then((res) => {",
-                                "               responseData = res.ApplicationResponse;",
-                                "               response.send(event, context, response.SUCCESS, responseData);",
-                                "           }).catch((err) => {",
-                                "               console.log(err.stack);",
-                                "               responseData = {Error: err};",
-                                "               response.send(event, context, response.FAILED, responseData);",
-                                "               throw err;",
-                                "           });",
-                                "    }",
-                                "};"
-                            ]
-                        ]
-                    }
-                },
-                "Handler": "index.handler",
-                "Runtime": "nodejs8.10",
-                "Timeout": "300",
-                "Role": {
-                    "Fn::GetAtt": [
-                        "LambdaExecutionRole",
-                        "Arn"
-                    ]
-                }
-            }
-        },
-        "PinpointFunctionOutputs": {
-            "Type": "Custom::LambdaCallout",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-                "ServiceToken": {
-                    "Fn::GetAtt": [
-                        "PinpointFunction",
-                        "Arn"
-                    ]
-                },
-                "region": { 
-                    "Fn::FindInMap" : [ 
-                        "RegionMapping", 
-                        { "Ref" : "AWS::Region" }, 
-                        "pinpointRegion"
-                    ]
-                },
-                "appName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        {
-                           "Ref": "appName"
-                        }, 
-                        {
-
-                            "Fn::Join": [
-                                "",
-                                [
-                                  {
-                                    "Ref": "appName"
-                                  },
-                                  "-",
-                                  {
-                                    "Ref": "env"
-                                  }
-                                ]
-                            ]
-                        }       
-                    ]
-                }
-            }
-        },
-        "CognitoUnauthPolicy": {
-            "Type": "AWS::IAM::Policy",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-              "PolicyName": {"Ref": "unauthPolicyName" },
-              "Roles": [ 
-                {"Ref": "unauthRoleName" }
-              ],
-              "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Action": [
-                        "mobiletargeting:PutEvents",
-                        "mobiletargeting:UpdateEndpoint",
-                        "mobiletargeting:GetUserEndpoints"
-                    ],
-                    "Resource": [
-                        {
-
-                            "Fn::If": [
-                                "ShouldCreatePinpointApp",
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Fn::GetAtt": [
-                                                "PinpointFunctionOutputs",
-                                                "Id"
-                                            ]
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                },
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Ref": "appId"
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                }
-                            ]
-                        }
-                
-                    ]
-                  }
-                ]
-              }
-            }
-        },
-        "CognitoAuthPolicy": {
-            "Type": "AWS::IAM::Policy",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-              "PolicyName": {"Ref": "authPolicyName" },
-              "Roles": [ 
-                {"Ref": "authRoleName" }
-              ],
-              "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Action": [
-                        "mobiletargeting:PutEvents",
-                        "mobiletargeting:UpdateEndpoint",
-                        "mobiletargeting:GetUserEndpoints"
-                    ],
-                    "Resource": [
-                        {
-
-                            "Fn::If": [
-                                "ShouldCreatePinpointApp",
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Fn::GetAtt": [
-                                                "PinpointFunctionOutputs",
-                                                "Id"
-                                            ]
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                },
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Ref": "appId"
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                  }
-                ]
-              }
-            }
-        }
+    "cloudWatchPolicyName": {
+      "Type": "String"
     },
-    "Outputs": {
-        "Region": {
-            "Value":{ 
-                "Fn::FindInMap" : [ 
-                    "RegionMapping", 
-                    { "Ref" : "AWS::Region" }, 
-                    "pinpointRegion"
-                ]
-            }
-        },
-        "Id": {
-            "Value": {
-                "Fn::If": [
-                    "ShouldCreatePinpointApp",
-                    {
-                        "Fn::GetAtt": [
-                            "PinpointFunctionOutputs",
-                            "Id"
-                        ]
-                    }, 
-                    {
-                        "Ref": "appId"
-                    }       
-                ]
-            }
-        },
-        "appName": {
-            "Value": {
-                "Fn::If": [
-                    "ShouldCreatePinpointApp",
-                    {
-                        "Fn::GetAtt": [
-                            "PinpointFunctionOutputs",
-                            "Name"
-                        ]
-                    }, 
-                    {
-                        "Ref": "appName"
-                    }       
-                ]
-            }
-        }
+    "pinpointPolicyName": {
+      "Type": "String"
+    },
+    "authPolicyName": {
+      "Type": "String"
+    },
+    "unauthPolicyName": {
+      "Type": "String"
+    },
+    "authRoleName": {
+      "Type": "String"
+    },
+    "unauthRoleName": {
+      "Type": "String"
+    },
+    "authRoleArn": {
+      "Type": "String"
+    },
+    "env": {
+      "Type": "String"
     }
+  },
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "Creating pinpoint app"
+          },
+          "Parameters": ["appName"]
+        }
+      ]
+    }
+  },
+  "Conditions": {
+    "ShouldCreatePinpointApp": {
+      "Fn::Equals": [
+        {
+          "Ref": "appId"
+        },
+        "NONE"
+      ]
+    },
+    "ShouldNotCreateEnvResources": {
+      "Fn::Equals": [
+        {
+          "Ref": "env"
+        },
+        "NONE"
+      ]
+    }
+  },
+  "Resources": {
+    "LambdaExecutionRole": {
+      "Condition": "ShouldCreatePinpointApp",
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            {
+              "Ref": "roleName"
+            },
+            {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "roleName"
+                  },
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["lambda.amazonaws.com"]
+              },
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": {
+              "Ref": "cloudWatchPolicyName"
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+                  "Resource": "arn:aws:logs:*:*:*"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": {
+              "Ref": "pinpointPolicyName"
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["mobileanalytics:*", "mobiletargeting:*"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "PinpointFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "\n",
+              [
+                "const response = require('cfn-response');",
+                "const aws = require('aws-sdk');",
+                "exports.handler = function(event, context) {",
+                "    if (event.RequestType == 'Delete') {",
+                "        response.send(event, context, response.SUCCESS);",
+                "        return;",
+                "    }",
+                "    if (event.RequestType == 'Update') {",
+                "        response.send(event, context, response.SUCCESS);",
+                "        return;",
+                "    }",
+                "    if (event.RequestType == 'Create') {",
+                "       const appName = event.ResourceProperties.appName;",
+                "       let responseData = {};",
+                "       const params = {",
+                "           CreateApplicationRequest: {",
+                "               Name: appName",
+                "           }",
+                "       };",
+                "       const pinpoint = new aws.Pinpoint({ apiVersion: '2016-12-01', region: event.ResourceProperties.region });",
+                "       pinpoint.createApp(params).promise()",
+                "           .then((res) => {",
+                "               responseData = res.ApplicationResponse;",
+                "               response.send(event, context, response.SUCCESS, responseData);",
+                "           }).catch((err) => {",
+                "               console.log(err.stack);",
+                "               responseData = {Error: err};",
+                "               response.send(event, context, response.FAILED, responseData);",
+                "               throw err;",
+                "           });",
+                "    }",
+                "};"
+              ]
+            ]
+          }
+        },
+        "Handler": "index.handler",
+        "Runtime": "nodejs10.x",
+        "Timeout": "300",
+        "Role": {
+          "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]
+        }
+      }
+    },
+    "PinpointFunctionOutputs": {
+      "Type": "Custom::LambdaCallout",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": ["PinpointFunction", "Arn"]
+        },
+        "region": {
+          "Fn::FindInMap": ["RegionMapping", { "Ref": "AWS::Region" }, "pinpointRegion"]
+        },
+        "appName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            {
+              "Ref": "appName"
+            },
+            {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "appName"
+                  },
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CognitoUnauthPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "PolicyName": { "Ref": "unauthPolicyName" },
+        "Roles": [{ "Ref": "unauthRoleName" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["mobiletargeting:PutEvents", "mobiletargeting:UpdateEndpoint", "mobiletargeting:GetUserEndpoints"],
+              "Resource": [
+                {
+                  "Fn::If": [
+                    "ShouldCreatePinpointApp",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Fn::GetAtt": ["PinpointFunctionOutputs", "Id"]
+                          },
+                          "*"
+                        ]
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Ref": "appId"
+                          },
+                          "*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CognitoAuthPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "PolicyName": { "Ref": "authPolicyName" },
+        "Roles": [{ "Ref": "authRoleName" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["mobiletargeting:PutEvents", "mobiletargeting:UpdateEndpoint", "mobiletargeting:GetUserEndpoints"],
+              "Resource": [
+                {
+                  "Fn::If": [
+                    "ShouldCreatePinpointApp",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Fn::GetAtt": ["PinpointFunctionOutputs", "Id"]
+                          },
+                          "*"
+                        ]
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Ref": "appId"
+                          },
+                          "*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "Region": {
+      "Value": {
+        "Fn::FindInMap": ["RegionMapping", { "Ref": "AWS::Region" }, "pinpointRegion"]
+      }
+    },
+    "Id": {
+      "Value": {
+        "Fn::If": [
+          "ShouldCreatePinpointApp",
+          {
+            "Fn::GetAtt": ["PinpointFunctionOutputs", "Id"]
+          },
+          {
+            "Ref": "appId"
+          }
+        ]
+      }
+    },
+    "appName": {
+      "Value": {
+        "Fn::If": [
+          "ShouldCreatePinpointApp",
+          {
+            "Fn::GetAtt": ["PinpointFunctionOutputs", "Name"]
+          },
+          {
+            "Ref": "appName"
+          }
+        ]
+      }
+    }
+  }
 }

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
@@ -104,7 +104,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
@@ -121,7 +121,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
@@ -97,7 +97,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
@@ -97,7 +97,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
@@ -104,7 +104,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
@@ -97,7 +97,7 @@
               }
           },
           "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-          "Runtime": "nodejs8.10",
+          "Runtime": "nodejs10.x",
           "Timeout": "25"
         }
       },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
@@ -111,7 +111,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
@@ -97,7 +97,7 @@
               }
           },
           "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-          "Runtime": "nodejs8.10",
+          "Runtime": "nodejs10.x",
           "Timeout": "25"
         }
       },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
@@ -105,7 +105,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/cloudformation-templates/lex-cloudformation-template.json.ejs
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/cloudformation-templates/lex-cloudformation-template.json.ejs
@@ -65,7 +65,7 @@
                 },
                 "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
                 "Environment": {"Variables" : { "ENV": {"Ref": "env"}}},
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "300"
             }
         },

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/identify-template.json.ejs
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/identify-template.json.ejs
@@ -353,7 +353,7 @@
                         }
                     },
                     "Handler": "index.handler",
-                    "Runtime": "nodejs8.10",
+                    "Runtime": "nodejs10.x",
                     "Timeout": "300",
                     "Role": {
                         "Fn::GetAtt": [

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
@@ -69,7 +69,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "900"
           }
         },

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
@@ -52,7 +52,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
@@ -52,7 +52,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-provider-awscloudformation/lib/update-idp-roles-cfn.json
+++ b/packages/amplify-provider-awscloudformation/lib/update-idp-roles-cfn.json
@@ -1,172 +1,145 @@
 {
-
-    "UpdateRolesWithIDPFunction": {
-        "DependsOn": [
-            "AuthRole",
-            "UnauthRole"
-        ],
-        "Type": "AWS::Lambda::Function",
-        "Properties": {
-            "Code": {
-                "ZipFile": {
-                    "Fn::Join": [
-                        "\n",
-                        [
-                            "const response = require('cfn-response');",
-                            "const aws = require('aws-sdk');",
-                            "let responseData = {};",
-                            "exports.handler = function(event, context) {",
-                            "  try {",
-                            "    let authRoleName = event.ResourceProperties.authRoleName;",
-                            "    let unauthRoleName = event.ResourceProperties.unauthRoleName;",
-                            "    let idpId = event.ResourceProperties.idpId;",
-                            "    let promises = [];",
-                            "    let authParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'authenticated'}}}]};",
-                            "    let unauthParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'unauthenticated'}}}]};",
-                            "    if (event.RequestType == 'Delete') {",
-                            "        delete authParamsJson.Statement.Condition;",
-                            "        delete unauthParamsJson.Statement.Condition;",
-                            "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
-                            "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
-                            "        const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
-                            "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
-                            "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
-                            "        Promise.all(promises)",
-                            "         .then((res) => {",
-                            "            console.log(\"delete response data\" + JSON.stringify(res));",
-                            "            response.send(event, context, response.SUCCESS, {});",
-                            "         });",
-                            "    }",
-                            "    if (event.RequestType == 'Update' || event.RequestType == 'Create') {",
-                            "       const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
-                            "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
-                            "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
-                            "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
-                            "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
-                            "        Promise.all(promises)",
-                            "         .then((res) => {",
-                            "            console.log(\"createORupdate\" + res);",
-                            "            console.log(\"response data\" + JSON.stringify(res));",
-                            "            response.send(event, context, response.SUCCESS, {});",
-                            "         });",
-                            "    }",
-                            "  } catch(err) {",
-                            "       console.log(err.stack);",
-                            "       responseData = {Error: err};",
-                            "       response.send(event, context, response.FAILED, responseData);",
-                            "       throw err;",
-                            "  }",
-                            "};"
-                        ]
-                    ]
-                }
-            },
-            "Handler": "index.handler",
-            "Runtime": "nodejs8.10",
-            "Timeout": "300",
-            "Role": {
-                "Fn::GetAtt": [
-                    "UpdateRolesWithIDPFunctionRole",
-                    "Arn"
-                ]
-            }
-        }
-    },
-    "UpdateRolesWithIDPFunctionOutputs": {
-        "Type": "Custom::LambdaCallout",
-        "Properties": {
-            "ServiceToken": {
-                "Fn::GetAtt": [
-                    "UpdateRolesWithIDPFunction",
-                    "Arn"
-                ]
-            },
-            "region": {
-                "Ref": "AWS::Region"
-            },
-            "idpId": {
-                "Fn::GetAtt": [
-
-                    "Outputs.IdentityPoolId"
-                ]
-            },
-            "authRoleName": {
-                "Ref": "AuthRoleName"
-            },
-            "unauthRoleName": {
-                "Ref": "UnauthRoleName"
-            }
-        }
-    },
-    "UpdateRolesWithIDPFunctionRole": {
-        "Type": "AWS::IAM::Role",
-        "Properties": {
-            "RoleName": {
-                "Fn::Join": [
-                    "",
-                    [
-                        {
-                            "Ref": "AuthRoleName"
-                        },
-                        "-idp"
-                    ]
-                ]
-            },
-            "AssumeRolePolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": [
-                                "lambda.amazonaws.com"
-                            ]
-                        },
-                        "Action": [
-                            "sts:AssumeRole"
-                        ]
-                    }
-                ]
-            },
-            "Policies": [
-                {
-                    "PolicyName": "UpdateRolesWithIDPFunctionPolicy",
-                    "PolicyDocument": {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    "logs:CreateLogGroup",
-                                    "logs:CreateLogStream",
-                                    "logs:PutLogEvents"
-                                ],
-                                "Resource": "arn:aws:logs:*:*:*"
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": "iam:UpdateAssumeRolePolicy",
-                                "Resource": {
-                                    "Fn::GetAtt": [
-                                        "AuthRole",
-                                        "Arn"
-                                    ]
-                                }
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": "iam:UpdateAssumeRolePolicy",
-                                "Resource": {
-                                    "Fn::GetAtt": [
-                                        "UnauthRole",
-                                        "Arn"
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
+  "UpdateRolesWithIDPFunction": {
+    "DependsOn": ["AuthRole", "UnauthRole"],
+    "Type": "AWS::Lambda::Function",
+    "Properties": {
+      "Code": {
+        "ZipFile": {
+          "Fn::Join": [
+            "\n",
+            [
+              "const response = require('cfn-response');",
+              "const aws = require('aws-sdk');",
+              "let responseData = {};",
+              "exports.handler = function(event, context) {",
+              "  try {",
+              "    let authRoleName = event.ResourceProperties.authRoleName;",
+              "    let unauthRoleName = event.ResourceProperties.unauthRoleName;",
+              "    let idpId = event.ResourceProperties.idpId;",
+              "    let promises = [];",
+              "    let authParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'authenticated'}}}]};",
+              "    let unauthParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'unauthenticated'}}}]};",
+              "    if (event.RequestType == 'Delete') {",
+              "        delete authParamsJson.Statement.Condition;",
+              "        delete unauthParamsJson.Statement.Condition;",
+              "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
+              "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
+              "        const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
+              "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
+              "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
+              "        Promise.all(promises)",
+              "         .then((res) => {",
+              "            console.log(\"delete response data\" + JSON.stringify(res));",
+              "            response.send(event, context, response.SUCCESS, {});",
+              "         });",
+              "    }",
+              "    if (event.RequestType == 'Update' || event.RequestType == 'Create') {",
+              "       const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
+              "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
+              "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
+              "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
+              "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
+              "        Promise.all(promises)",
+              "         .then((res) => {",
+              "            console.log(\"createORupdate\" + res);",
+              "            console.log(\"response data\" + JSON.stringify(res));",
+              "            response.send(event, context, response.SUCCESS, {});",
+              "         });",
+              "    }",
+              "  } catch(err) {",
+              "       console.log(err.stack);",
+              "       responseData = {Error: err};",
+              "       response.send(event, context, response.FAILED, responseData);",
+              "       throw err;",
+              "  }",
+              "};"
             ]
+          ]
         }
+      },
+      "Handler": "index.handler",
+      "Runtime": "nodejs10.x",
+      "Timeout": "300",
+      "Role": {
+        "Fn::GetAtt": ["UpdateRolesWithIDPFunctionRole", "Arn"]
+      }
     }
+  },
+  "UpdateRolesWithIDPFunctionOutputs": {
+    "Type": "Custom::LambdaCallout",
+    "Properties": {
+      "ServiceToken": {
+        "Fn::GetAtt": ["UpdateRolesWithIDPFunction", "Arn"]
+      },
+      "region": {
+        "Ref": "AWS::Region"
+      },
+      "idpId": {
+        "Fn::GetAtt": ["Outputs.IdentityPoolId"]
+      },
+      "authRoleName": {
+        "Ref": "AuthRoleName"
+      },
+      "unauthRoleName": {
+        "Ref": "UnauthRoleName"
+      }
+    }
+  },
+  "UpdateRolesWithIDPFunctionRole": {
+    "Type": "AWS::IAM::Role",
+    "Properties": {
+      "RoleName": {
+        "Fn::Join": [
+          "",
+          [
+            {
+              "Ref": "AuthRoleName"
+            },
+            "-idp"
+          ]
+        ]
+      },
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": ["lambda.amazonaws.com"]
+            },
+            "Action": ["sts:AssumeRole"]
+          }
+        ]
+      },
+      "Policies": [
+        {
+          "PolicyName": "UpdateRolesWithIDPFunctionPolicy",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+                "Resource": "arn:aws:logs:*:*:*"
+              },
+              {
+                "Effect": "Allow",
+                "Action": "iam:UpdateAssumeRolePolicy",
+                "Resource": {
+                  "Fn::GetAtt": ["AuthRole", "Arn"]
+                }
+              },
+              {
+                "Effect": "Allow",
+                "Action": "iam:UpdateAssumeRolePolicy",
+                "Resource": {
+                  "Fn::GetAtt": ["UnauthRole", "Arn"]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
I just received the following email:

> Node.js 8.10 is EOL, please migrate your functions to a newer runtime version
>
> We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using Node.js 8.10, which will reach its EOL at the end of 2019.

Based on https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html, I updated the cloudformation template files to use `nodejs10.x` instead of `nodejs8.10`.

Though `nodejs8.10` will be disabled in January/February, new lambdas should start development against `nodejs10.x` immediately for customers to start preparing _before_ holidays begin:

> ...We encourage you to update all of your Node.js 8.10 functions to the newer available runtime version, Node.js 10.x[3]. You should test your functions for compatibility with the Node.js 10.x language version before applying changes to your production functions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.