### PR TITLE
Add condition support to mutations

### DIFF
--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -673,7 +673,8 @@ Either make the field optional, set auth on the object and not the field, or dis
         // If we've any modes to check, then add the authMode check code block
         // to the start of the resolver.
         if (authModesToCheck.size > 0) {
-          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck));
+          const isUserPoolTheDefault = this.configuredAuthProviders.default === 'userPools';
+          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck, isUserPoolTheDefault));
         }
 
         // These statements will be wrapped into an authMode check if statement
@@ -959,7 +960,8 @@ All @auth directives used on field definitions are performed when the field is r
       }
 
       if (authModesToCheck.size > 0) {
-        expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck));
+        const isUserPoolTheDefault = this.configuredAuthProviders.default === 'userPools';
+        expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck, isUserPoolTheDefault));
       }
 
       // Update the existing resolver with the authorization checks.
@@ -1094,7 +1096,8 @@ All @auth directives used on field definitions are performed when the field is r
       }
 
       if (authModesToCheck.size > 0) {
-        expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck));
+        const isUserPoolTheDefault = this.configuredAuthProviders.default === 'userPools';
+        expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck, isUserPoolTheDefault));
       }
 
       // These statements will be wrapped into an authMode check if statement
@@ -1198,7 +1201,8 @@ All @auth directives used on field definitions are performed when the field is r
         }
 
         if (authModesToCheck.size > 0) {
-          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck));
+          const isUserPoolTheDefault = this.configuredAuthProviders.default === 'userPools';
+          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck, isUserPoolTheDefault));
         }
 
         // These statements will be wrapped into an authMode check if statement
@@ -1334,7 +1338,8 @@ All @auth directives used on field definitions are performed when the field is r
         }
 
         if (authModesToCheck.size > 0) {
-          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck));
+          const isUserPoolTheDefault = this.configuredAuthProviders.default === 'userPools';
+          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck, isUserPoolTheDefault));
         }
 
         // These statements will be wrapped into an authMode check if statement
@@ -1635,7 +1640,8 @@ All @auth directives used on field definitions are performed when the field is r
         // If we've any modes to check, then add the authMode check code block
         // to the start of the resolver.
         if (authModesToCheck.size > 0) {
-          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck));
+          const isUserPoolTheDefault = this.configuredAuthProviders.default === 'userPools';
+          expressions.push(this.resources.getAuthModeDeterminationExpression(authModesToCheck, isUserPoolTheDefault));
         }
 
         const authCheckExpressions = [

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -20,12 +20,14 @@ import {
   InterfaceTypeDefinitionNode,
   valueFromASTUntyped,
   NamedTypeNode,
+  InputObjectTypeDefinitionNode,
 } from 'graphql';
 import {
   ResourceConstants,
   ResolverResourceIDs,
   isListType,
   getBaseType,
+  getDirectiveArgument,
   makeDirective,
   makeNamedType,
   makeInputValueDefinition,
@@ -34,6 +36,7 @@ import {
   extendFieldWithDirectives,
   makeNonNullType,
   makeField,
+  ModelResourceIDs,
 } from 'graphql-transformer-common';
 import { Expression, print, raw, iff, forEach, set, ref, list, compoundExpression, or, newline, comment } from 'graphql-mapping-template';
 import { ModelDirectiveConfiguration, ModelDirectiveOperationType, ModelSubscriptionLevel } from './ModelDirectiveConfiguration';
@@ -394,6 +397,9 @@ export class ModelAuthTransformer extends Transformer {
       this.protectOnUpdateSubscription(ctx, operationRules.update, def, modelConfiguration);
       this.protectOnDeleteSubscription(ctx, operationRules.delete, def, modelConfiguration);
     }
+
+    // Update ModelXConditionInput type
+    this.updateMutationConditionInput(ctx, def, rules);
   };
 
   public field = (
@@ -2062,6 +2068,61 @@ found '${rule.provider}' assigned.`
 
   private isOperationExpressionSet(operationTypeName: string, template: string): boolean {
     return template.includes(`$context.result.operation = "${operationTypeName}"`);
+  }
+
+  private updateMutationConditionInput(ctx: TransformerContext, type: ObjectTypeDefinitionNode, rules: Array<AuthRule>): void {
+    // Get the existing ModelXConditionInput
+    const tableXMutationConditionInputName = ModelResourceIDs.ModelConditionInputTypeName(type.name.value);
+
+    if (this.typeExist(tableXMutationConditionInputName, ctx)) {
+      const tableXMutationConditionInput = <InputObjectTypeDefinitionNode>ctx.getType(tableXMutationConditionInputName);
+
+      const fieldNames = new Set<String>();
+
+      // Get auth related field names from @auth directive rules
+      const getAuthFieldNames = (): void => {
+        if (rules.length > 0) {
+          // Process owner rules
+          const ownerRules = this.getOwnerRules(rules);
+          const ownerFieldNameArgs = ownerRules.filter(rule => !!rule.ownerField).map(rule => rule.ownerField);
+
+          ownerFieldNameArgs.forEach((f: string) => fieldNames.add(f));
+
+          // Add 'owner' to field list if we've owner rules without ownerField argument
+          if (ownerRules.find(rule => !rule.ownerField)) {
+            fieldNames.add('owner');
+          }
+
+          // Process owner rules
+          const groupsRules = rules.filter(rule => rule.allow === 'groups');
+          const groupFieldNameArgs = groupsRules.filter(rule => !!rule.groupsField).map(rule => rule.groupsField);
+
+          groupFieldNameArgs.forEach((f: string) => fieldNames.add(f));
+
+          // Add 'groups' to field list if we've groups rules without groupsField argument
+          if (groupsRules.find(rule => !rule.groupsField)) {
+            fieldNames.add('groups');
+          }
+        }
+      };
+
+      getAuthFieldNames();
+
+      if (fieldNames.size > 0) {
+        const reducedFields = tableXMutationConditionInput.fields.filter(field => !fieldNames.has(field.name.value));
+
+        const updatedInput = {
+          ...tableXMutationConditionInput,
+          fields: reducedFields,
+        };
+
+        ctx.putType(updatedInput);
+      }
+    }
+  }
+
+  private typeExist(type: string, ctx: TransformerContext): boolean {
+    return Boolean(type in ctx.nodeMap);
   }
 }
 

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -45,6 +45,19 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 $util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
@@ -52,12 +65,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
-  \\"condition\\": {
-      \\"expression\\": \\"attribute_not_exists(#id)\\",
-      \\"expressionNames\\": {
-          \\"#id\\": \\"id\\"
-    }
-  }
+  \\"condition\\": $util.toJson($condition)
 }
 ## [End] Prepare DynamoDB PutItem Request. **"
 `;
@@ -196,6 +204,12 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
   $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
   $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -404,6 +418,15 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
   #set( $expressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
   $util.qr($expressionValues.putAll($versionedCondition.expressionValues))
   #set( $condition.expressionValues = $expressionValues )
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  #set( $conditionExpressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
+  $util.qr($conditionExpressionValues.putAll($conditionFilterExpressions.expressionValues))
+  #set( $condition.expressionValues = $conditionExpressionValues )
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -631,6 +654,19 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 $util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
 {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
@@ -638,12 +674,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
-  \\"condition\\": {
-      \\"expression\\": \\"attribute_not_exists(#id)\\",
-      \\"expressionNames\\": {
-          \\"#id\\": \\"id\\"
-    }
-  }
+  \\"condition\\": $util.toJson($condition)
 }
 ## [End] Prepare DynamoDB PutItem Request. **"
 `;
@@ -782,6 +813,12 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
   $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
   $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -990,6 +1027,15 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
   #set( $expressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
   $util.qr($expressionValues.putAll($versionedCondition.expressionValues))
   #set( $condition.expressionValues = $expressionValues )
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  #set( $conditionExpressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
+  $util.qr($conditionExpressionValues.putAll($conditionFilterExpressions.expressionValues))
+  #set( $condition.expressionValues = $conditionExpressionValues )
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 {
   \\"version\\": \\"2017-02-28\\",

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -104,9 +104,17 @@ input DeletePostInput {
 }
 
 type Mutation {
-  createPost(input: CreatePostInput!): Post @aws_api_key @aws_iam
-  updatePost(input: UpdatePostInput!): Post @aws_api_key @aws_iam
-  deletePost(input: DeletePostInput!): Post @aws_api_key @aws_iam
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam
+}
+
+input ModelPostConditionInput {
+  content: ModelStringFilterInput
+  secret: ModelStringFilterInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
 }
 
 type Subscription {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -160,7 +160,7 @@ test('Test DynamoDBModelTransformer with multiple model directives', () => {
   expect(verifyInputCount(parsed, 'ModelUserFilterInput', 1)).toBeTruthy();
 });
 
-test('Test DynamoDBModelTransformer with filter', () => {
+test('Test DynamoDBModelTransformer with filter and condition', () => {
   const validSchema = `
     type Post @model {
         id: ID!
@@ -190,6 +190,7 @@ test('Test DynamoDBModelTransformer with filter', () => {
   expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelPostConditionInput', 1)).toBeTruthy();
 });
 
 test('Test DynamoDBModelTransformer with mutations set to null', () => {

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -342,17 +342,13 @@ export function makeModelXFilterInputObject(
 
 export function makeModelXConditionInputObject(
   obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
-  ctx: TransformerContext,
-  fieldsToExclude: Set<String>
+  ctx: TransformerContext
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelConditionInputTypeName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.getType(getBaseType(field.type));
-      if (
-        (isScalar(field.type) || (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)) &&
-        !fieldsToExclude.has(field.name.value)
-      ) {
+      if (isScalar(field.type) || (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)) {
         return true;
       }
     })

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -343,7 +343,7 @@ export function makeModelXFilterInputObject(
 export function makeModelXConditionInputObject(
   obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
   ctx: TransformerContext,
-  fieldsToExclude: Array<String>
+  fieldsToExclude: Set<String>
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelConditionInputTypeName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -351,7 +351,7 @@ export function makeModelXConditionInputObject(
       const fieldType = ctx.getType(getBaseType(field.type));
       if (
         (isScalar(field.type) || (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)) &&
-        !fieldsToExclude.includes(field.name.value)
+        !fieldsToExclude.has(field.name.value)
       ) {
         return true;
       }

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -340,6 +340,94 @@ export function makeModelXFilterInputObject(
   };
 }
 
+export function makeModelXConditionInputObject(
+  obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  ctx: TransformerContext,
+  fieldsToExclude: Array<String>
+): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelConditionInputTypeName(obj.name.value);
+  const fields: InputValueDefinitionNode[] = obj.fields
+    .filter((field: FieldDefinitionNode) => {
+      const fieldType = ctx.getType(getBaseType(field.type));
+      if (
+        (isScalar(field.type) || (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)) &&
+        !fieldsToExclude.includes(field.name.value)
+      ) {
+        return true;
+      }
+    })
+    .map((field: FieldDefinitionNode) => {
+      const baseType = getBaseType(field.type);
+      const fieldType = ctx.getType(baseType);
+      const isList = isListType(field.type);
+      const isEnumType = fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
+      const conditionTypeName =
+        isEnumType && isList
+          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType)
+          : ModelResourceIDs.ModelFilterInputTypeName(baseType);
+
+      return {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: field.name,
+        type: makeNamedType(conditionTypeName),
+        // TODO: Service does not support new style descriptions so wait.
+        // description: field.description,
+        directives: [],
+      };
+    });
+
+  fields.push(
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'and',
+      },
+      type: makeListType(makeNamedType(name)),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'or',
+      },
+      type: makeListType(makeNamedType(name)),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'not',
+      },
+      type: makeNamedType(name),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    }
+  );
+
+  return {
+    kind: 'InputObjectTypeDefinition',
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
 export function makeEnumFilterInputObjects(obj: ObjectTypeDefinitionNode, ctx: TransformerContext): InputObjectTypeDefinitionNode[] {
   return obj.fields
     .filter((field: FieldDefinitionNode) => {

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -716,9 +716,9 @@ function replaceUpdateInput(
     fields: input.fields.map(f => {
       if (keyFields.find(k => k === f.name.value)) {
         return makeInputValueDefinition(f.name.value, wrapNonNull(withNamedNodeNamed(f.type, getBaseType(f.type))));
-      } else {
-        return f;
       }
+
+      return f;
     }),
   };
 }
@@ -729,9 +729,14 @@ function replaceDeleteInput(
   input: InputObjectTypeDefinitionNode,
   keyFields: string[]
 ): InputObjectTypeDefinitionNode {
+  const idFields = primaryIdFields(definition, keyFields);
+  // Existing fields will contain extra fields in input type that was added/updated by other transformers
+  // like @versioned adds expectedVersion.
+  const existingFields = input.fields.filter(f => !idFields.find(pf => pf.name.value === f.name.value));
+
   return {
     ...input,
-    fields: primaryIdFields(definition, keyFields),
+    fields: [...idFields, ...existingFields],
   };
 }
 

--- a/packages/graphql-mapping-template/src/dynamodb.ts
+++ b/packages/graphql-mapping-template/src/dynamodb.ts
@@ -31,7 +31,7 @@ export class DynamoDBMappingTemplate {
   }: {
     key: ObjectNode | Expression;
     attributeValues: Expression;
-    condition?: ObjectNode;
+    condition?: ObjectNode | ReferenceNode;
   }): ObjectNode {
     return obj({
       version: str('2017-02-28'),

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -21,6 +21,13 @@ export class ModelResourceIDs {
     }
     return `Model${name}FilterInput`;
   }
+  static ModelConditionInputTypeName(name: string): string {
+    const nameOverride = DEFAULT_SCALARS[name];
+    if (nameOverride) {
+      return `Model${nameOverride}ConditionInput`;
+    }
+    return `Model${name}ConditionInput`;
+  }
   static ModelKeyConditionInputTypeName(name: string): string {
     const nameOverride = DEFAULT_SCALARS[name];
     if (nameOverride) {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -1,0 +1,508 @@
+import GraphQLTransform from 'graphql-transformer-core';
+import KeyTransformer from 'graphql-key-transformer';
+import DynamoDBModelTransformer from 'graphql-dynamodb-transformer';
+import { parse } from 'graphql/language/parser';
+import { DocumentNode, InputObjectTypeDefinitionNode, InputValueDefinitionNode, DefinitionNode, Kind } from 'graphql';
+import VersionedModelTransformer from 'graphql-versioned-transformer';
+import ModelConnectionTransformer from 'graphql-connection-transformer';
+import ModelAuthTransformer from 'graphql-auth-transformer';
+
+const transformAndParseSchema = (schema: string): DocumentNode => {
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new DynamoDBModelTransformer(),
+      new VersionedModelTransformer(),
+      new KeyTransformer(),
+      new ModelConnectionTransformer(),
+      new ModelAuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [],
+        },
+      }),
+    ],
+  });
+
+  const out = transformer.transform(schema);
+
+  return parse(out.schema);
+};
+
+const getInputType = (doc: DocumentNode, typeName: string): InputObjectTypeDefinitionNode => {
+  const type = doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === typeName);
+
+  expect(type).toBeDefined();
+
+  return <InputObjectTypeDefinitionNode>type;
+};
+
+const expectFieldsOnInputType = (type: InputObjectTypeDefinitionNode, fields: string[]) => {
+  expect(type.fields.length).toEqual(fields.length);
+
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: InputValueDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeDefined();
+  }
+};
+
+const doNotExpectFieldsOnInputType = (type: InputObjectTypeDefinitionNode, fields: string[]) => {
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: InputValueDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeUndefined();
+  }
+};
+
+describe(`Local Mutation Condition tests`, () => {
+  beforeAll(() => {});
+
+  it('Type without directives', () => {
+    const validSchema = `
+            type Post
+            @model
+            # @versioned
+            # @versioned(versionField: "vv", versionInput: "ww")
+            # @auth(rules: [
+            #   {
+            #     allow: owner
+            #   }
+            #   {
+            #     allow: groups
+            #   }
+            #   {
+            #     allow: owner
+            #     ownerField: "author"
+            #   }
+            #   {
+            #     allow: groups
+            #     groupsField: "editors"
+            #   }
+            # ])
+            # @key(fields: ["id", "type", "slug"])
+            # @key(name: "byTypeSlugCounter", fields: ["type", "slug", "likeCount"])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'editors',
+      'owner',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id']);
+  });
+
+  it('Type with primary @key - single field - directive', () => {
+    const validSchema = `
+            type Post
+            @model
+            @key(fields: ["id"])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'editors',
+      'owner',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id']);
+  });
+
+  it('Type with primary @key - multiple field - directive', () => {
+    const validSchema = `
+            type Post
+            @model
+            @key(fields: ["id", "type", "slug"])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'category',
+      'author',
+      'editors',
+      'owner',
+      'groups',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id', 'type', 'slug']);
+  });
+
+  it('Type with @auth directive - owner', () => {
+    const validSchema = `
+            type Post
+            @model
+            @auth(rules: [
+                {
+                    allow: owner
+                }
+            ])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'editors',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id', 'owner']);
+  });
+
+  it('Type with @auth directive - owner custom field name', () => {
+    const validSchema = `
+            type Post
+            @model
+            @auth(rules: [
+                {
+                    allow: owner
+                    ownerField: "author"
+                }
+            ])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'editors',
+      'owner',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id', 'author']);
+  });
+
+  it('Type with @auth directive - groups', () => {
+    const validSchema = `
+            type Post
+            @model
+            @auth(rules: [
+                {
+                    allow: groups
+                }
+            ])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'editors',
+      'owner',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id', 'groups']);
+  });
+
+  it('Type with @auth directive - groups custom field name', () => {
+    const validSchema = `
+            type Post
+            @model
+            @auth(rules: [
+                {
+                    allow: groups
+                    groupsField: "editors"
+                }
+            ])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'owner',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id', 'editors']);
+  });
+
+  it('Type with @auth directive - multiple rules', () => {
+    const validSchema = `
+            type Post
+            @model
+            @auth(rules: [
+            {
+                allow: owner
+            }
+            {
+                allow: groups
+            }
+            {
+                allow: owner
+                ownerField: "author"
+            }
+            {
+                allow: groups
+                groupsField: "editors"
+            }
+            ])
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, ['content', 'type', 'category', 'slug', 'likeCount', 'rating', 'and', 'or', 'not']);
+    doNotExpectFieldsOnInputType(type, ['id', 'author', 'editors', 'owner', 'groups']);
+  });
+
+  it('Type with @versioned directive - no changes on condition', () => {
+    const validSchema = `
+            type Post
+            @model
+            @versioned
+            # @versioned(versionField: "vv", versionInput: "ww")
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'editors',
+      'owner',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id']);
+  });
+
+  it('Type with @versioned directive - custom field, no changes on condition', () => {
+    const validSchema = `
+            type Post
+            @model
+            @versioned(versionField: "version", versionInput: "requiredVersion")
+            {
+                id: ID!
+                content: String
+                type: String!
+                category: String
+                author: String
+                editors: [String!]
+                owner: String
+                groups: [String!]
+                slug: String!
+                likeCount: Int
+                rating: Int
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema);
+
+    const type = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(type, [
+      'content',
+      'type',
+      'category',
+      'author',
+      'editors',
+      'owner',
+      'groups',
+      'slug',
+      'likeCount',
+      'rating',
+      'and',
+      'or',
+      'not',
+    ]);
+    doNotExpectFieldsOnInputType(type, ['id']);
+  });
+});
+
+describe(`"Deployed Mutation Condition tests`, () => {
+  beforeAll(() => {});
+
+  afterAll(() => {});
+});

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -7,6 +7,29 @@ import VersionedModelTransformer from 'graphql-versioned-transformer';
 import ModelConnectionTransformer from 'graphql-connection-transformer';
 import ModelAuthTransformer from 'graphql-auth-transformer';
 
+import { Auth } from 'aws-amplify';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+import { ResourceConstants } from 'graphql-transformer-common';
+import * as fs from 'fs';
+import { CloudFormationClient } from '../CloudFormationClient';
+import { Output } from 'aws-sdk/clients/cloudformation';
+import * as CognitoClient from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import * as S3 from 'aws-sdk/clients/s3';
+import { S3Client } from '../S3Client';
+import * as path from 'path';
+import { deploy } from '../deployNestedStacks';
+import * as moment from 'moment';
+import emptyBucket from '../emptyBucket';
+import { createUserPool, createUserPoolClient, deleteUserPool, signupAndAuthenticateUser, configureAmplify } from '../cognitoUtils';
+import Role from 'cloudform-types/types/iam/role';
+import UserPoolClient from 'cloudform-types/types/cognito/userPoolClient';
+import IdentityPool from 'cloudform-types/types/cognito/identityPool';
+import IdentityPoolRoleAttachment from 'cloudform-types/types/cognito/identityPoolRoleAttachment';
+import AWS = require('aws-sdk');
+
+jest.setTimeout(2000000);
+
 const transformAndParseSchema = (schema: string): DocumentNode => {
   const transformer = new GraphQLTransform({
     transformers: [
@@ -55,8 +78,6 @@ const doNotExpectFieldsOnInputType = (type: InputObjectTypeDefinitionNode, field
 };
 
 describe(`Local Mutation Condition tests`, () => {
-  beforeAll(() => {});
-
   it('Type without directives', () => {
     const validSchema = `
             type Post
@@ -501,8 +522,653 @@ describe(`Local Mutation Condition tests`, () => {
   });
 });
 
-describe(`"Deployed Mutation Condition tests`, () => {
-  beforeAll(() => {});
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
 
-  afterAll(() => {});
+// To overcome of the way of how AmplifyJS picks up currentUserCredentials
+const anyAWS = AWS as any;
+
+if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
+  delete anyAWS.config.credentials;
+}
+
+describe(`Deployed Mutation Condition tests`, () => {
+  const REGION = 'us-west-2';
+  const cf = new CloudFormationClient(REGION);
+
+  const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+  const STACK_NAME = `MutationConditionTest-${BUILD_TIMESTAMP}`;
+  const BUCKET_NAME = `appsync-mutation-condition-test-bucket-${BUILD_TIMESTAMP}`;
+  const LOCAL_FS_BUILD_DIR = '/tmp/mutation_condition_tests/';
+  const S3_ROOT_DIR_KEY = 'deployments';
+  const AUTH_ROLE_NAME = `${STACK_NAME}-authRole`;
+  const UNAUTH_ROLE_NAME = `${STACK_NAME}-unauthRole`;
+  const IDENTITY_POOL_NAME = `MutationConditionTest_${BUILD_TIMESTAMP}_identity_pool`;
+  const USER_POOL_CLIENTWEB_NAME = `mutationcondition_${BUILD_TIMESTAMP}_clientweb`;
+  const USER_POOL_CLIENT_NAME = `mutationcondition_${BUILD_TIMESTAMP}_client`;
+
+  let GRAPHQL_ENDPOINT = undefined;
+
+  let APIKEY_CLIENT: AWSAppSyncClient<any> = undefined;
+  let USER_POOL_AUTH_CLIENT_1: AWSAppSyncClient<any> = undefined;
+  let USER_POOL_AUTH_CLIENT_2: AWSAppSyncClient<any> = undefined;
+
+  let USER_POOL_ID = undefined;
+
+  const USERNAME1 = 'user1@test.com';
+  const USERNAME2 = 'user2@test.com';
+
+  const TMP_PASSWORD = 'Password123!';
+  const REAL_PASSWORD = 'Password1234!';
+
+  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: REGION });
+  const customS3Client = new S3Client(REGION);
+  const awsS3Client = new S3({ region: REGION });
+
+  const conditionRegexMatch = /GraphQL error: The conditional request failed \(Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ConditionalCheckFailedException; .*/gm;
+
+  function outputValueSelector(key: string) {
+    return (outputs: Output[]) => {
+      const output = outputs.find((o: Output) => o.OutputKey === key);
+      return output ? output.OutputValue : null;
+    };
+  }
+
+  beforeAll(async () => {
+    const validSchema = `
+    type Post
+    @model
+    @versioned
+    @auth(rules: [
+      { allow: owner }
+      { allow: public }
+    ])
+    @key(fields: ["id", "type"])
+    {
+        id: ID!
+        type: String!
+        owner: String
+        category: String
+        content: String
+        slug: String
+        rating: Int
+    }
+`;
+
+    const transformer = new GraphQLTransform({
+      transformers: [
+        new DynamoDBModelTransformer(),
+        new VersionedModelTransformer(),
+        new ModelConnectionTransformer(),
+        new KeyTransformer(),
+        new ModelAuthTransformer({
+          authConfig: {
+            defaultAuthentication: {
+              authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+            },
+            additionalAuthenticationProviders: [
+              {
+                authenticationType: 'API_KEY',
+                apiKeyConfig: {
+                  description: 'E2E Test API Key',
+                  apiKeyExpirationDays: 300,
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    try {
+      await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+    } catch (e) {
+      console.error(`Failed to create bucket: ${e}`);
+    }
+    const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+    USER_POOL_ID = userPoolResponse.UserPool.Id;
+    const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+    const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+
+    try {
+      const out = transformer.transform(validSchema);
+
+      const authRole = new Role({
+        RoleName: AUTH_ROLE_NAME,
+        AssumeRolePolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Sid: '',
+              Effect: 'Allow',
+              Principal: {
+                Federated: 'cognito-identity.amazonaws.com',
+              },
+              Action: 'sts:AssumeRoleWithWebIdentity',
+              Condition: {
+                'ForAnyValue:StringLike': {
+                  'cognito-identity.amazonaws.com:amr': 'authenticated',
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const unauthRole = new Role({
+        RoleName: UNAUTH_ROLE_NAME,
+        AssumeRolePolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Sid: '',
+              Effect: 'Allow',
+              Principal: {
+                Federated: 'cognito-identity.amazonaws.com',
+              },
+              Action: 'sts:AssumeRoleWithWebIdentity',
+              Condition: {
+                'ForAnyValue:StringLike': {
+                  'cognito-identity.amazonaws.com:amr': 'unauthenticated',
+                },
+              },
+            },
+          ],
+        },
+        Policies: [
+          new Role.Policy({
+            PolicyName: 'appsync-unauthrole-policy',
+            PolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Action: ['appsync:GraphQL'],
+                  Resource: [
+                    {
+                      'Fn::Join': [
+                        '',
+                        [
+                          'arn:aws:appsync:',
+                          { Ref: 'AWS::Region' },
+                          ':',
+                          { Ref: 'AWS::AccountId' },
+                          ':apis/',
+                          {
+                            'Fn::GetAtt': ['GraphQLAPI', 'ApiId'],
+                          },
+                          '/*',
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        ],
+      });
+
+      const identityPool = new IdentityPool({
+        IdentityPoolName: IDENTITY_POOL_NAME,
+        CognitoIdentityProviders: [
+          {
+            ClientId: {
+              Ref: 'UserPoolClient',
+            },
+            ProviderName: {
+              'Fn::Sub': [
+                'cognito-idp.${region}.amazonaws.com/${client}',
+                {
+                  region: {
+                    Ref: 'AWS::Region',
+                  },
+                  client: USER_POOL_ID,
+                },
+              ],
+            },
+          } as unknown,
+          {
+            ClientId: {
+              Ref: 'UserPoolClientWeb',
+            },
+            ProviderName: {
+              'Fn::Sub': [
+                'cognito-idp.${region}.amazonaws.com/${client}',
+                {
+                  region: {
+                    Ref: 'AWS::Region',
+                  },
+                  client: USER_POOL_ID,
+                },
+              ],
+            },
+          } as unknown,
+        ],
+        AllowUnauthenticatedIdentities: true,
+      });
+
+      const identityPoolRoleMap = new IdentityPoolRoleAttachment({
+        IdentityPoolId: ({ Ref: 'IdentityPool' } as unknown) as string,
+        Roles: {
+          unauthenticated: { 'Fn::GetAtt': ['UnauthRole', 'Arn'] },
+          authenticated: { 'Fn::GetAtt': ['AuthRole', 'Arn'] },
+        },
+      });
+
+      const userPoolClientWeb = new UserPoolClient({
+        ClientName: USER_POOL_CLIENTWEB_NAME,
+        RefreshTokenValidity: 30,
+        UserPoolId: USER_POOL_ID,
+      });
+
+      const userPoolClient = new UserPoolClient({
+        ClientName: USER_POOL_CLIENT_NAME,
+        GenerateSecret: true,
+        RefreshTokenValidity: 30,
+        UserPoolId: USER_POOL_ID,
+      });
+
+      out.rootStack.Resources.IdentityPool = identityPool;
+      out.rootStack.Resources.IdentityPoolRoleMap = identityPoolRoleMap;
+      out.rootStack.Resources.UserPoolClientWeb = userPoolClientWeb;
+      out.rootStack.Resources.UserPoolClient = userPoolClient;
+      out.rootStack.Outputs.IdentityPoolId = { Value: { Ref: 'IdentityPool' } };
+      out.rootStack.Outputs.IdentityPoolName = { Value: { 'Fn::GetAtt': ['IdentityPool', 'Name'] } };
+
+      out.rootStack.Resources.AuthRole = authRole;
+      out.rootStack.Outputs.AuthRoleArn = { Value: { 'Fn::GetAtt': ['AuthRole', 'Arn'] } };
+      out.rootStack.Resources.UnauthRole = unauthRole;
+      out.rootStack.Outputs.UnauthRoleArn = { Value: { 'Fn::GetAtt': ['UnauthRole', 'Arn'] } };
+
+      // Since we're doing the policy here we've to remove the transformer generated artifacts from
+      // the generated stack.
+      delete out.rootStack.Resources[ResourceConstants.RESOURCES.UnauthRolePolicy];
+      delete out.rootStack.Parameters.unauthRoleName;
+      delete out.rootStack.Resources[ResourceConstants.RESOURCES.AuthRolePolicy];
+      delete out.rootStack.Parameters.authRoleName;
+
+      for (const key of Object.keys(out.rootStack.Resources)) {
+        if (
+          out.rootStack.Resources[key].Properties &&
+          out.rootStack.Resources[key].Properties.Parameters &&
+          out.rootStack.Resources[key].Properties.Parameters.unauthRoleName
+        ) {
+          delete out.rootStack.Resources[key].Properties.Parameters.unauthRoleName;
+        }
+
+        if (
+          out.rootStack.Resources[key].Properties &&
+          out.rootStack.Resources[key].Properties.Parameters &&
+          out.rootStack.Resources[key].Properties.Parameters.authRoleName
+        ) {
+          delete out.rootStack.Resources[key].Properties.Parameters.authRoleName;
+        }
+      }
+
+      for (const stackKey of Object.keys(out.stacks)) {
+        const stack = out.stacks[stackKey];
+
+        for (const key of Object.keys(stack.Resources)) {
+          if (stack.Parameters && stack.Parameters.unauthRoleName) {
+            delete stack.Parameters.unauthRoleName;
+          }
+          if (stack.Parameters && stack.Parameters.authRoleName) {
+            delete stack.Parameters.authRoleName;
+          }
+          if (
+            stack.Resources[key].Properties &&
+            stack.Resources[key].Properties.Parameters &&
+            stack.Resources[key].Properties.Parameters.unauthRoleName
+          ) {
+            delete stack.Resources[key].Properties.Parameters.unauthRoleName;
+          }
+          if (
+            stack.Resources[key].Properties &&
+            stack.Resources[key].Properties.Parameters &&
+            stack.Resources[key].Properties.Parameters.authRoleName
+          ) {
+            delete stack.Resources[key].Properties.Parameters.authRoleName;
+          }
+        }
+      }
+
+      const params = {
+        CreateAPIKey: '1',
+        AuthCognitoUserPoolId: USER_POOL_ID,
+      };
+
+      const finishedStack = await deploy(
+        customS3Client,
+        cf,
+        STACK_NAME,
+        out,
+        params,
+        LOCAL_FS_BUILD_DIR,
+        BUCKET_NAME,
+        S3_ROOT_DIR_KEY,
+        BUILD_TIMESTAMP
+      );
+      expect(finishedStack).toBeDefined();
+      const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+      const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+      GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+      console.log(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
+
+      const apiKey = getApiKey(finishedStack.Outputs);
+      console.log(`API KEY: ${apiKey}`);
+      expect(apiKey).toBeTruthy();
+
+      const getIdentityPoolId = outputValueSelector('IdentityPoolId');
+      const identityPoolId = getIdentityPoolId(finishedStack.Outputs);
+      expect(identityPoolId).toBeTruthy();
+      console.log(`Identity Pool Id: ${identityPoolId}`);
+
+      console.log(`User pool Id: ${USER_POOL_ID}`);
+      console.log(`User pool ClientId: ${userPoolClientId}`);
+
+      // Verify we have all the details
+      expect(GRAPHQL_ENDPOINT).toBeTruthy();
+      expect(USER_POOL_ID).toBeTruthy();
+      expect(userPoolClientId).toBeTruthy();
+
+      // Configure Amplify, create users, and sign in.
+      configureAmplify(USER_POOL_ID, userPoolClientId, identityPoolId);
+
+      const authRes1 = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+      const idToken1 = authRes1.getIdToken().getJwtToken();
+
+      const authRes2 = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+      const idToken2 = authRes2.getIdToken().getJwtToken();
+
+      USER_POOL_AUTH_CLIENT_1 = new AWSAppSyncClient({
+        url: GRAPHQL_ENDPOINT,
+        region: REGION,
+        auth: {
+          type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+          jwtToken: () => idToken1,
+        },
+        offlineConfig: {
+          keyPrefix: 'userPools',
+        },
+        disableOffline: true,
+      });
+
+      USER_POOL_AUTH_CLIENT_2 = new AWSAppSyncClient({
+        url: GRAPHQL_ENDPOINT,
+        region: REGION,
+        auth: {
+          type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+          jwtToken: () => idToken2,
+        },
+        offlineConfig: {
+          keyPrefix: 'userPools',
+        },
+        disableOffline: true,
+      });
+
+      APIKEY_CLIENT = new AWSAppSyncClient({
+        url: GRAPHQL_ENDPOINT,
+        region: REGION,
+        auth: {
+          type: AUTH_TYPE.API_KEY,
+          apiKey,
+        },
+        offlineConfig: {
+          keyPrefix: 'apikey',
+        },
+        disableOffline: true,
+      });
+
+      // Wait for any propagation to avoid random
+      // "The security token included in the request is invalid" errors
+      await new Promise(res => setTimeout(() => res(), 5000));
+    } catch (e) {
+      console.error(e);
+      expect(true).toEqual(false);
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      console.log('Deleting stack ' + STACK_NAME);
+      await cf.deleteStack(STACK_NAME);
+      await deleteUserPool(cognitoClient, USER_POOL_ID);
+      await cf.waitForStack(STACK_NAME);
+      console.log('Successfully deleted stack ' + STACK_NAME);
+    } catch (e) {
+      if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
+        // The stack was deleted. This is good.
+        expect(true).toEqual(true);
+        console.log('Successfully deleted stack ' + STACK_NAME);
+      } else {
+        console.error(e);
+        expect(true).toEqual(false);
+      }
+    }
+    try {
+      await emptyBucket(BUCKET_NAME);
+    } catch (e) {
+      console.error(`Failed to empty S3 bucket: ${e}`);
+    }
+  });
+
+  it('Create Mutation with failing condition', async () => {
+    const createMutation = gql(`
+    mutation {
+      createPost(input: {
+        id: "P1"
+        type: "Post"
+        category: "T1"
+        content: "Content #1"
+        slug: "content-1"
+        rating: 4
+      }, condition: {
+        category: { eq: "T" }
+      }) {
+        id
+      }
+    }
+    `);
+
+    try {
+      await APIKEY_CLIENT.mutate({
+        mutation: createMutation,
+        fetchPolicy: 'no-cache',
+      });
+    } catch (e) {
+      expect(e.message).toMatch(conditionRegexMatch);
+    }
+  });
+
+  it('Update Mutation with failing and succeeding condition', async () => {
+    const createMutation = gql(`
+    mutation {
+      createPost(input: {
+        id: "P1"
+        type: "Post"
+        category: "T1"
+        content: "Content #1"
+        slug: "content-1"
+        rating: 4
+      }) {
+        id
+      }
+    }
+    `);
+
+    const createResponse = await APIKEY_CLIENT.mutate({
+      mutation: createMutation,
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createResponse.data.createPost.id).toBeDefined();
+
+    // Update P1 if rating === 5 (but it is 4)
+    const updateMutationFailure = gql(`
+    mutation {
+      updatePost(input: {
+        id: "P1"
+        type: "Post"
+        content: "Content #1 - Update"
+        expectedVersion: 1
+      }, condition: {
+        rating: { eq: 5 }
+      }) {
+        id
+      }
+    }
+    `);
+
+    try {
+      await APIKEY_CLIENT.mutate({
+        mutation: updateMutationFailure,
+        fetchPolicy: 'no-cache',
+      });
+    } catch (e) {
+      expect(e.message).toMatch(conditionRegexMatch);
+    }
+
+    // Update P1 if rating === 4
+    const updateMutationSuccess = gql(`
+    mutation {
+      updatePost(input: {
+        id: "P1"
+        type: "Post"
+        content: "Content #1 - Update"
+        expectedVersion: 1
+      }, condition: {
+        rating: { eq: 4 }
+      }) {
+        id
+        content
+      }
+    }
+    `);
+
+    const updateResponse = await APIKEY_CLIENT.mutate({
+      mutation: updateMutationSuccess,
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(updateResponse.data.updatePost.id).toBeDefined();
+    expect(updateResponse.data.updatePost.content).toEqual('Content #1 - Update');
+  });
+
+  it('Update Mutation with failing and succeeding complex conditions', async () => {
+    const createMutation = gql(`
+    mutation {
+      createPost(input: {
+        id: "P2"
+        type: "Post"
+        category: "T1"
+        content: "Content #2"
+        slug: "content-2"
+        rating: 4
+      }) {
+        id
+      }
+    }
+    `);
+
+    const createResponse = await APIKEY_CLIENT.mutate({
+      mutation: createMutation,
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createResponse.data.createPost.id).toBeDefined();
+
+    // Update P2 if (content beginsWith "Content #2" AND rating === [4-5]) OR content is null
+    const updateMutation = gql(`
+    mutation {
+      updatePost(input: {
+        id: "P2"
+        type: "Post"
+        content: "Content #2 - UpdateComplex"
+        expectedVersion: 1
+      }, condition: {
+        or: [
+          {
+            and: [
+              { content: { beginsWith: "Content #2" } }
+              { rating: { between: [4, 5] } }
+            ]
+          }
+          {
+            content: { eq: null }
+          }
+        ]
+      }) {
+        id
+        content
+      }
+    }
+    `);
+
+    const updateResponse = await APIKEY_CLIENT.mutate({
+      mutation: updateMutation,
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(updateResponse.data.updatePost.id).toBeDefined();
+    expect(updateResponse.data.updatePost.content).toEqual('Content #2 - UpdateComplex');
+  });
+
+  it.only('Delete Mutation with failing and succeeding complex conditions', async () => {
+    const createMutation = gql(`
+    mutation {
+      createPost(input: {
+        id: "P3"
+        type: "Post"
+        category: "T1"
+        content: "Content #3"
+        slug: "content-3"
+        rating: 4
+      }) {
+        id
+      }
+    }
+    `);
+
+    const createResponse = await APIKEY_CLIENT.mutate({
+      mutation: createMutation,
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createResponse.data.createPost.id).toBeDefined();
+
+    // Delete P3 if (content equals "Content #3" AND rating === [4-5]) OR content is null
+    const deleteMutation = gql(`
+    mutation {
+      deletePost(input: {
+        id: "P3"
+        type: "Post"
+        expectedVersion: 1
+      }, condition: {
+        or: [
+          {
+            and: [
+              { content: { eq: "Content #3" } }
+              { rating: { between: [4, 5] } }
+            ]
+          }
+          {
+            content: { eq: null }
+          }
+        ]
+      }) {
+        id
+        content
+      }
+    }
+    `);
+
+    const deleteResponse = await APIKEY_CLIENT.mutate({
+      mutation: deleteMutation,
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(deleteResponse.data.deletePost.id).toBeDefined();
+    expect(deleteResponse.data.deletePost.content).toEqual('Content #3');
+  });
 });


### PR DESCRIPTION
*Description of changes:*

This PR adds a new parameter to the generated mutations where additional conditions can be specified for the mutation.

Beside the new parameter, a new input type is also added to the schema for each type that has mutations generated, the naming follows the ```Model{name}ConditionInput``` convention.

It works together with the existing directives like ```@key```, ```@versioned```, ```@auth```, ```@connection```, the ones that modifying the schema.

From this source schema: 
```graphql
type Post
@model
@versioned
@auth(rules: [
  { allow: owner }
  { allow: groups }
])
@key(fields: ["id", "type", "slug"])
@key(name: "byTypeSlugLikeCount", fields: ["type", "slug", "likeCount"])
{
  id: ID!
  content: String
  type: String!
  category: String
  owner: String
  groups: [String!]
  slug: String!
  likeCount: Int
  rating: Int
}
```

These new objects are getting generated:
```graphql
type Mutation {
  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
}

input ModelPostConditionInput {
  content: ModelStringFilterInput
  category: ModelStringFilterInput
  likeCount: ModelIntFilterInput
  rating: ModelIntFilterInput
  and: [ModelPostConditionInput]
  or: [ModelPostConditionInput]
  not: ModelPostConditionInput
}
``` 

Note that the primary ```@key``` and ```@auth``` related fields are not part of the condition. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.