### PR TITLE
fix(mock): #2606 - mocking does not start when there are LSIs in DynamoDB table

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -39,9 +39,13 @@ export function dynamoDBResourceHandler(resourceName, resource, cfnContext: Clou
       BillingMode: 'PAY_PER_REQUEST',
       KeySchema: resource.Properties.KeySchema,
       AttributeDefinitions: resource.Properties.AttributeDefinitions,
-      LocalSecondaryIndexes: resource.Properties.LocalSecondaryIndexes,
     },
   };
+
+  if (resource.Properties.LocalSecondaryIndexes) {
+    processedResource.Properties.LocalSecondaryIndexes = resource.Properties.LocalSecondaryIndexes;
+  }
+
   if (gsis.length) {
     processedResource.Properties.GlobalSecondaryIndexes = gsis;
   }

--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -39,6 +39,7 @@ export function dynamoDBResourceHandler(resourceName, resource, cfnContext: Clou
       BillingMode: 'PAY_PER_REQUEST',
       KeySchema: resource.Properties.KeySchema,
       AttributeDefinitions: resource.Properties.AttributeDefinitions,
+      LocalSecondaryIndexes: resource.Properties.LocalSecondaryIndexes,
     },
   };
   if (gsis.length) {

--- a/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
@@ -46,6 +46,18 @@ beforeAll(async () => {
         status: Status
         name: String
     }
+    # Issue #2606 test type to ensure mocking starts successfully with 2 LSIs
+    type TypeWithLSI @model
+        @key(fields: ["id", "updatedAt"])
+        @key(name: "BySpending", fields: ["id", "totalSpending"])
+        @key(name: "ByAttendance", fields: ["id", "totalAttendance"])
+    {
+        id: ID!
+        totalSpending: Int!
+        totalAttendance: Int!
+        createdAt: AWSDateTime
+        updatedAt: AWSDateTime!
+    }
     `;
   const transformer = new GraphQLTransform({
     transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],


### PR DESCRIPTION
*Issue #, if available:*

#2606

*Description of changes:*

LSIs were not copied to tables definitions passed to DynamoDB Local when using mock services.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.