### PR TITLE
fix: api key creation/deletion logic

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.js
@@ -32,6 +32,8 @@ function updateAwsMetaFile(filePath, category, resourceName, attribute, value, t
   const jsonString = JSON.stringify(amplifyMeta, null, 4);
 
   fs.writeFileSync(filePath, jsonString, 'utf8');
+
+  return amplifyMeta;
 }
 
 function moveBackendResourcesToCurrentCloudBackend(resources) {
@@ -107,10 +109,12 @@ function updateamplifyMetaAfterResourceUpdate(category, resourceName, attribute,
   if (attribute === 'dependsOn') {
     checkForCyclicDependencies(category, resourceName, value);
   }
-  updateAwsMetaFile(amplifyMetaFilePath, category, resourceName, attribute, value, currentTimestamp);
+  const updatedMeta = updateAwsMetaFile(amplifyMetaFilePath, category, resourceName, attribute, value, currentTimestamp);
   if (['dependsOn', 'service'].includes(attribute)) {
     updateBackendConfigDependsOn(category, resourceName, attribute, value);
   }
+
+  return updatedMeta;
 }
 
 async function updateamplifyMetaAfterPush(resources) {

--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -1,21 +1,18 @@
 {
-    "compilerOptions": {
-      "target": "es5",
-      "module": "commonjs",
-      "sourceMap": true,
-      "mapRoot": "lib",
-      "lib": ["es6", "es2015", "dom"],
-      "declaration": false,
-      "allowJs": true,
-      "outDir": "lib",
-      // "rootDir": "src",
-      "strict": true,
-      "esModuleInterop": true,
-      "resolveJsonModule": true,
-    },
-    "include": ["src/**/*"],
-    "exclude": [
-        "node_modules",
-        "lib"
-    ]
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "sourceMap": true,
+    "mapRoot": "lib",
+    "lib": ["es6", "es2015", "dom"],
+    "declaration": false,
+    "allowJs": true,
+    "outDir": "lib",
+    // "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
 }

--- a/packages/amplify-provider-awscloudformation/lib/display-helpful-urls.js
+++ b/packages/amplify-provider-awscloudformation/lib/display-helpful-urls.js
@@ -57,7 +57,13 @@ function showGraphQLURL(context, resourcesToBeCreated) {
 
     context.print.info(chalk`GraphQL endpoint: {blue.underline ${GraphQLAPIEndpointOutput}}`);
     if (hasApiKey) {
-      context.print.info(chalk`GraphQL API KEY: {blue.underline ${GraphQLAPIKeyOutput}}`);
+      if (GraphQLAPIKeyOutput) {
+        context.print.info(chalk`GraphQL API KEY: {blue.underline ${GraphQLAPIKeyOutput}}`);
+      } else {
+        context.print.warning(
+          chalk`GraphQL API is configured to use API_KEY authentication, but API Key deployment is disabled, don't forget to create one.`
+        );
+      }
     }
   }
 }

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -21,72 +21,69 @@ const nestedStackFileName = 'nested-cloudformation-stack.yml';
 const optionalBuildDirectoryName = 'build';
 
 async function run(context, resourceDefinition) {
-  const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = resourceDefinition;
+  try {
+    const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = resourceDefinition;
 
-  const resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
-  let projectDetails = context.amplify.getProjectDetails();
+    const resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
+    let projectDetails = context.amplify.getProjectDetails();
 
-  validateCfnTemplates(context, resources);
+    validateCfnTemplates(context, resources);
 
-  return packageResources(context, resources)
-    .then(() =>
-      transformGraphQLSchema(context, {
-        handleMigration: opts => updateStackForAPIMigration(context, 'api', undefined, opts),
-      })
-    )
-    .then(() => uploadAppSyncFiles(context, resources, allResources))
-    .then(() => prePushAuthTransform(context, resources))
-    .then(() => prePushGraphQLCodegen(context, resourcesToBeCreated, resourcesToBeUpdated))
-    .then(() => updateS3Templates(context, resources, projectDetails.amplifyMeta))
-    .then(() => {
-      spinner.start();
-      projectDetails = context.amplify.getProjectDetails();
-      if (resources.length > 0 || resourcesToBeDeleted.length > 0) {
-        return updateCloudFormationNestedStack(
-          context,
-          formNestedStack(context, projectDetails),
-          resourcesToBeCreated,
-          resourcesToBeUpdated
-        );
-      }
-    })
-    .then(() => postPushGraphQLCodegen(context))
-    .then(async () => {
-      if (resources.length > 0) {
-        await context.amplify.updateamplifyMetaAfterPush(resources);
-      }
-      for (let i = 0; i < resourcesToBeDeleted.length; i += 1) {
-        context.amplify.updateamplifyMetaAfterResourceDelete(resourcesToBeDeleted[i].category, resourcesToBeDeleted[i].resourceName);
-      }
-    })
-    .then(() => uploadAuthTriggerFiles(context, resourcesToBeCreated, resourcesToBeUpdated))
-    .then(async () => {
-      let { allResources } = await context.amplify.getResourceStatus();
+    await packageResources(context, resources);
 
-      const newAPIresources = [];
-
-      allResources = allResources.filter(resource => resource.service === 'API Gateway');
-
-      for (let i = 0; i < allResources.length; i += 1) {
-        if (resources.findIndex(resource => resource.resourceName === allResources[i].resourceName) > -1) {
-          newAPIresources.push(allResources[i]);
-        }
-      }
-
-      return downloadAPIModels(context, newAPIresources);
-    })
-    .then(() =>
-      // Store current cloud backend in S3 deployment bcuket
-      storeCurrentCloudBackend(context)
-    )
-    .then(() => {
-      spinner.succeed('All resources are updated in the cloud');
-      displayHelpfulURLs(context, resources);
-    })
-    .catch(err => {
-      spinner.fail('An error occurred when pushing the resources to the cloud');
-      throw err;
+    await transformGraphQLSchema(context, {
+      handleMigration: opts => updateStackForAPIMigration(context, 'api', undefined, opts),
     });
+
+    await uploadAppSyncFiles(context, resources, allResources);
+    await prePushAuthTransform(context, resources);
+    await prePushGraphQLCodegen(context, resourcesToBeCreated, resourcesToBeUpdated);
+    await updateS3Templates(context, resources, projectDetails.amplifyMeta);
+
+    spinner.start();
+
+    projectDetails = context.amplify.getProjectDetails();
+
+    if (resources.length > 0 || resourcesToBeDeleted.length > 0) {
+      await updateCloudFormationNestedStack(context, formNestedStack(context, projectDetails), resourcesToBeCreated, resourcesToBeUpdated);
+    }
+
+    await postPushGraphQLCodegen(context);
+
+    if (resources.length > 0) {
+      await context.amplify.updateamplifyMetaAfterPush(resources);
+    }
+
+    for (let i = 0; i < resourcesToBeDeleted.length; i++) {
+      context.amplify.updateamplifyMetaAfterResourceDelete(resourcesToBeDeleted[i].category, resourcesToBeDeleted[i].resourceName);
+    }
+
+    await uploadAuthTriggerFiles(context, resourcesToBeCreated, resourcesToBeUpdated);
+
+    let updatedAllResources = (await context.amplify.getResourceStatus()).allResources;
+
+    const newAPIresources = [];
+
+    updatedAllResources = updatedAllResources.filter(resource => resource.service === 'API Gateway');
+
+    for (let i = 0; i < updatedAllResources.length; i++) {
+      if (resources.findIndex(resource => resource.resourceName === updatedAllResources[i].resourceName) > -1) {
+        newAPIresources.push(updatedAllResources[i]);
+      }
+    }
+
+    await downloadAPIModels(context, newAPIresources);
+
+    // Store current cloud backend in S3 deployment bcuket
+    await storeCurrentCloudBackend(context);
+
+    spinner.succeed('All resources are updated in the cloud');
+
+    displayHelpfulURLs(context, resources);
+  } catch (err) {
+    spinner.fail('An error occurred when pushing the resources to the cloud');
+    throw err;
+  }
 }
 
 async function updateStackForAPIMigration(context, category, resourceName, options) {
@@ -270,7 +267,7 @@ function packageResources(context, resources) {
   return Promise.all(promises);
 }
 
-function updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated) {
+async function updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated) {
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
   const nestedStackFilepath = path.normalize(path.join(backEndDir, providerName, nestedStackFileName));
 
@@ -301,9 +298,9 @@ function updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCrea
   const jsonString = JSON.stringify(nestedStack, null, '\t');
   context.filesystem.write(nestedStackFilepath, jsonString);
 
-  return new Cloudformation(context, userAgentAction).then(cfnItem =>
-    cfnItem.updateResourceStack(path.normalize(path.join(backEndDir, providerName)), nestedStackFileName)
-  );
+  const cfnItem = await new Cloudformation(context, userAgentAction);
+
+  await cfnItem.updateResourceStack(path.normalize(path.join(backEndDir, providerName)), nestedStackFileName);
 }
 
 function getAllUniqueCategories(resources) {

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -105,7 +105,14 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
           };
         }
 
-        // If the customer explicitly disabled API Key creation, show a warning and
+        if (personalParams.CreateAPIKey !== undefined && personalParams.APIKeyExpirationEpoch !== undefined) {
+          context.print.warning(
+            'APIKeyExpirationEpoch and CreateAPIKey parameters should not used together because it can cause ' +
+              'unwanted behavior. In the future APIKeyExpirationEpoch will be removed, use CreateAPIKey instead.'
+          );
+        }
+
+        // If the customer explicitly disabled API Key creation via legacy setting, show a warning and
         // honor the setting.
         if (personalParams.APIKeyExpirationEpoch) {
           if (personalParams.APIKeyExpirationEpoch === -1) {
@@ -120,7 +127,13 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
           } else {
             currentParameters.CreateAPIKey = 1;
           }
-        } else {
+        }
+
+        // We've to honor if customers are setting CreateAPIKey to 0 in their parameters file
+        // to preserve the same behavior if APIKeyExpirationEpoch would be -1, so if it
+        // was defined then its already copied over to currentParameters and we'll not overwrite it
+        // based on the security configuration.
+        if (personalParams.CreateAPIKey === undefined) {
           currentParameters.CreateAPIKey = apiKeyConfigured ? 1 : 0;
         }
       } catch (e) {

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -317,12 +317,36 @@ class CloudFormation {
               const logicalResourceId = category + resource;
               const index = resources.findIndex(resourceItem => resourceItem.LogicalResourceId === logicalResourceId);
               if (index !== -1) {
-                this.context.amplify.updateamplifyMetaAfterResourceUpdate(
+                const formattedOutputs = formatOutputs(stackResult[index].Stacks[0].Outputs);
+
+                const updatedMeta = this.context.amplify.updateamplifyMetaAfterResourceUpdate(
                   category,
                   resource,
                   'output',
-                  formatOutputs(stackResult[index].Stacks[0].Outputs)
+                  formattedOutputs
                 );
+
+                // Check to see if this is an AppSync resource and if we've to remove the GraphQLAPIKeyOutput from meta or not
+                if (amplifyMeta[category][resource]) {
+                  const resourceObject = amplifyMeta[category][resource];
+
+                  if (
+                    resourceObject.service === 'AppSync' &&
+                    resourceObject.output &&
+                    resourceObject.output.GraphQLAPIKeyOutput &&
+                    !formattedOutputs.GraphQLAPIKeyOutput
+                  ) {
+                    const updatedResourceObject = updatedMeta[category][resource];
+
+                    if (updatedResourceObject.output.GraphQLAPIKeyOutput) {
+                      delete updatedResourceObject.output.GraphQLAPIKeyOutput;
+                    }
+                  }
+
+                  const amplifyMetaFilePath = this.context.amplify.pathManager.getAmplifyMetaFilePath();
+                  const jsonString = JSON.stringify(updatedMeta, null, 4);
+                  fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
+                }
               }
             });
           });


### PR DESCRIPTION
*Description of changes:*

This PR is fixing some API key management related issues:
- Setting CreateAPIKey: 0 will be honored even if API_KEY authentication is used, just like it was before multi-auth with  APIKeyExpirationEpoch: -1.
- After an API was deployed with CreateAPIKey: 1 and then it is deployed with CreateAPIKey: 0 the API key will be correctly removed from the CloudFormation templates and ```amplify-meta.json```.
- When an API is deployed without an actual API key but with API_KEY auth a warning will be printed after push.
- When CreateAPIKey and APIKeyExpirationEpoch is used together a warning is printed.

Chore:
- Upload is "asyncified"
- CLI is compiled to ES6 target

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.