### PR TITLE
fix: randomize role-names and bucket-name for auth and storage category

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -73,7 +73,7 @@ Resources:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',[ 'sns', !Select [3, !Split ['-', !Ref 'AWS::StackId']], '-', !Ref env]]]
+      RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',[ 'sns', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"
         Statement: 
@@ -325,7 +325,7 @@ Resources:
   # Created to execute Lambda which gets userpool app client config values
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',['upClientLambdaRole', !Select [3, !Split ['-', !Ref 'AWS::StackId']], '-', !Ref env]]]
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',['upClientLambdaRole', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -73,7 +73,7 @@ Resources:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',['<%=`${props.resourceNameTruncated}_sns-role`%>', '-', !Ref env]]]
+      RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',[ 'sns', !Select [3, !Split ['-', !Ref 'AWS::StackId']], '-', !Ref env]]]
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"
         Statement: 
@@ -325,7 +325,7 @@ Resources:
   # Created to execute Lambda which gets userpool app client config values
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',['upClientLambdaRole', !Select [3, !Split ['-', !Ref 'AWS::StackId']], '-', !Ref env]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -381,7 +381,7 @@ Resources:
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_userpoolclient_lambda_iam_policy`%>
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -398,7 +398,7 @@ Resources:
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_userpoolclient_lambda_log_policy`%>
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -505,7 +505,7 @@ Resources:
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUI']]
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -525,7 +525,7 @@ Resources:
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUILogPolicy']]
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -634,7 +634,7 @@ Resources:
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUIProvider']]
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -652,7 +652,7 @@ Resources:
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUIProviderLogPolicy']]
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -733,7 +733,7 @@ Resources:
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'OAuth']]
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -748,7 +748,7 @@ Resources:
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'OAuthLogPolicy']]
       Roles: 
-        - !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',[!Ref userpoolClientLambdaRole, '-', !Ref env]]]
+        - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -198,7 +198,7 @@
                                               "Fn::Split": [
                                                   "-",
                                                   {
-                                                      "Ref": "AWS::StackId"
+                                                      "Ref": "AWS::StackName"
                                                   }
                                               ]
                                           }
@@ -343,7 +343,7 @@
                                             "Fn::Split": [
                                                 "-",
                                                 {
-                                                    "Ref": "AWS::StackId"
+                                                    "Ref": "AWS::StackName"
                                                 }
                                             ]
                                           }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -191,6 +191,19 @@
                                     {
                                         "Ref": "bucketName"
                                     },
+                                    {
+                                      "Fn::Select": [
+                                          3,
+                                          {
+                                              "Fn::Split": [
+                                                  "-",
+                                                  {
+                                                      "Ref": "AWS::StackId"
+                                                  }
+                                              ]
+                                          }
+                                      ]
+                                    },
                                     "-",
                                     {
                                         "Ref": "env"
@@ -295,49 +308,62 @@
       <% } %>
 	    <% if (props.triggerFunction && props.triggerFunction != "NONE") { %> 
 	    "TriggerPermissions": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "Action": "lambda:InvokeFunction",
-                "FunctionName": {
-                    "Ref": "function<%= props.triggerFunction %>Name"
-                },
-                "Principal": "s3.amazonaws.com",
-                "SourceAccount": {
-                    "Ref": "AWS::AccountId"
-                },
-                "SourceArn": {
-					"Fn::Join": [
-						"",
-						[
-							"arn:aws:s3:::",
-							{
-			                    "Fn::If": [
-			                        "ShouldNotCreateEnvResources",
-			                        {
-			                            "Ref": "bucketName"
-			                        },
-			                        {
-			                            "Fn::Join": [
-			                                "",
-			                                [
-			                                    {
-			                                        "Ref": "bucketName"
-			                                    },
-			                                    "-",
-			                                    {
-			                                        "Ref": "env"
-			                                    }
-			                                ]
-			                            ]
-			                        }
-			                    ]
-			                }
-						]
-					]
-                }
+          "Type": "AWS::Lambda::Permission",
+          "Properties": {
+              "Action": "lambda:InvokeFunction",
+              "FunctionName": {
+                  "Ref": "function<%= props.triggerFunction %>Name"
+              },
+              "Principal": "s3.amazonaws.com",
+              "SourceAccount": {
+                  "Ref": "AWS::AccountId"
+              },
+              "SourceArn": {
+      					"Fn::Join": [
+      						"",
+      						[
+      							"arn:aws:s3:::",
+      							{
+                      "Fn::If": [
+                          "ShouldNotCreateEnvResources",
+                          {
+                              "Ref": "bucketName"
+                          },
+                          {
+                              "Fn::Join": [
+                                  "",
+                                  [
+                                      {
+                                          "Ref": "bucketName"
+                                      },
+                                      {
+                                        "Fn::Select": [
+                                          3,
+                                          {
+                                            "Fn::Split": [
+                                                "-",
+                                                {
+                                                    "Ref": "AWS::StackId"
+                                                }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "-",
+                                      {
+                                          "Ref": "env"
+                                      }
+                                  ]
+                              ]
+                          }
+                      ]
+      			        }
+      						]
+				        ]
+              }
             }
-        },
-         "S3TriggerBucketPolicy": {
+          },
+          "S3TriggerBucketPolicy": {
             "DependsOn": [
                 "S3Bucket"
             ],

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -909,7 +909,7 @@ async function addTrigger(context, resourceName, triggerFunction, adminTriggerFu
                               'Fn::Split': [
                                 '-',
                                 {
-                                  Ref: 'AWS::StackId',
+                                  Ref: 'AWS::StackName',
                                 },
                               ],
                             },
@@ -1103,7 +1103,7 @@ function migrate(context, projectPath, resourceName) {
                   'Fn::Split': [
                     '-',
                     {
-                      Ref: 'AWS::StackId',
+                      Ref: 'AWS::StackName',
                     },
                   ],
                 },

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -902,6 +902,19 @@ async function addTrigger(context, resourceName, triggerFunction, adminTriggerFu
                         {
                           Ref: 'bucketName',
                         },
+                        {
+                          'Fn::Select': [
+                            3,
+                            {
+                              'Fn::Split': [
+                                '-',
+                                {
+                                  Ref: 'AWS::StackId',
+                                },
+                              ],
+                            },
+                          ],
+                        },
                         '-',
                         {
                           Ref: 'env',
@@ -1082,6 +1095,19 @@ function migrate(context, projectPath, resourceName) {
           [
             {
               Ref: 'bucketName',
+            },
+            {
+              'Fn::Select': [
+                3,
+                {
+                  'Fn::Split': [
+                    '-',
+                    {
+                      Ref: 'AWS::StackId',
+                    },
+                  ],
+                },
+              ],
             },
             '-',
             {


### PR DESCRIPTION

*Description of changes:*

Randomizing account-wide unique names like IAM role names, S3 bucket names (based on the Cloudformation Stack ID).
This prevents deployment issues for S3Buckets and Auth resources (when deploying same project in the same account).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.