### PR TITLE
feat(graphql-auth-transformer): enable groups authentication for oidc

### DIFF
--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -693,12 +693,16 @@ Either make the field optional, set auth on the object and not the field, or dis
 
         if (
           ownerAuthorizationRules.find(r => r.provider === 'userPools') ||
-          staticGroupAuthorizationRules.length > 0 ||
-          dynamicGroupAuthorizationRules.length > 0
+          staticGroupAuthorizationRules.find(r => r.provider === 'userPools') ||
+          dynamicGroupAuthorizationRules.find(r => r.provider === 'userPools')
         ) {
           authModesToCheck.add('userPools');
         }
-        if (ownerAuthorizationRules.find(r => r.provider === 'oidc')) {
+        if (
+          ownerAuthorizationRules.find(r => r.provider === 'oidc') ||
+          staticGroupAuthorizationRules.find(r => r.provider === 'oidc') ||
+          dynamicGroupAuthorizationRules.find(r => r.provider === 'oidc')
+        ) {
           authModesToCheck.add('oidc');
         }
 
@@ -981,12 +985,16 @@ All @auth directives used on field definitions are performed when the field is r
 
       if (
         ownerAuthorizationRules.find(r => r.provider === 'userPools') ||
-        staticGroupAuthorizationRules.length > 0 ||
-        dynamicGroupAuthorizationRules.length > 0
+        staticGroupAuthorizationRules.find(r => r.provider === 'userPools') ||
+        dynamicGroupAuthorizationRules.find(r => r.provider === 'userPools')
       ) {
         authModesToCheck.add('userPools');
       }
-      if (ownerAuthorizationRules.find(r => r.provider === 'oidc')) {
+      if (
+        ownerAuthorizationRules.find(r => r.provider === 'oidc') ||
+        staticGroupAuthorizationRules.find(r => r.provider === 'oidc') ||
+        dynamicGroupAuthorizationRules.find(r => r.provider === 'oidc')
+      ) {
         authModesToCheck.add('oidc');
       }
 
@@ -1116,12 +1124,16 @@ All @auth directives used on field definitions are performed when the field is r
 
       if (
         ownerAuthorizationRules.find(r => r.provider === 'userPools') ||
-        staticGroupAuthorizationRules.length > 0 ||
-        dynamicGroupAuthorizationRules.length > 0
+        staticGroupAuthorizationRules.find(r => r.provider === 'userPools') ||
+        dynamicGroupAuthorizationRules.find(r => r.provider === 'userPools')
       ) {
         authModesToCheck.add('userPools');
       }
-      if (ownerAuthorizationRules.find(r => r.provider === 'oidc')) {
+      if (
+        ownerAuthorizationRules.find(r => r.provider === 'oidc') ||
+        staticGroupAuthorizationRules.find(r => r.provider === 'oidc') ||
+        dynamicGroupAuthorizationRules.find(r => r.provider === 'oidc')
+      ) {
         authModesToCheck.add('oidc');
       }
 
@@ -1220,12 +1232,16 @@ All @auth directives used on field definitions are performed when the field is r
 
         if (
           ownerAuthorizationRules.find(r => r.provider === 'userPools') ||
-          staticGroupAuthorizationRules.length > 0 ||
-          dynamicGroupAuthorizationRules.length > 0
+          staticGroupAuthorizationRules.find(r => r.provider === 'userPools') ||
+          dynamicGroupAuthorizationRules.find(r => r.provider === 'userPools')
         ) {
           authModesToCheck.add('userPools');
         }
-        if (ownerAuthorizationRules.find(r => r.provider === 'oidc')) {
+        if (
+          ownerAuthorizationRules.find(r => r.provider === 'oidc') ||
+          staticGroupAuthorizationRules.find(r => r.provider === 'oidc') ||
+          dynamicGroupAuthorizationRules.find(r => r.provider === 'oidc')
+        ) {
           authModesToCheck.add('oidc');
         }
 
@@ -1356,12 +1372,16 @@ All @auth directives used on field definitions are performed when the field is r
 
         if (
           ownerAuthorizationRules.find(r => r.provider === 'userPools') ||
-          staticGroupAuthorizationRules.length > 0 ||
-          dynamicGroupAuthorizationRules.length > 0
+          staticGroupAuthorizationRules.find(r => r.provider === 'userPools') ||
+          dynamicGroupAuthorizationRules.find(r => r.provider === 'userPools')
         ) {
           authModesToCheck.add('userPools');
         }
-        if (ownerAuthorizationRules.find(r => r.provider === 'oidc')) {
+        if (
+          ownerAuthorizationRules.find(r => r.provider === 'oidc') ||
+          staticGroupAuthorizationRules.find(r => r.provider === 'oidc') ||
+          dynamicGroupAuthorizationRules.find(r => r.provider === 'oidc')
+        ) {
           authModesToCheck.add('oidc');
         }
 
@@ -1657,10 +1677,13 @@ All @auth directives used on field definitions are performed when the field is r
         const authModesToCheck = new Set<AuthProvider>();
         const expressions: Array<Expression> = new Array();
 
-        if (ownerAuthorizationRules.find(r => r.provider === 'userPools') || staticGroupAuthorizationRules.length > 0) {
+        if (
+          ownerAuthorizationRules.find(r => r.provider === 'userPools') ||
+          staticGroupAuthorizationRules.find(r => r.provider === 'userPools')
+        ) {
           authModesToCheck.add('userPools');
         }
-        if (ownerAuthorizationRules.find(r => r.provider === 'oidc')) {
+        if (ownerAuthorizationRules.find(r => r.provider === 'oidc') || staticGroupAuthorizationRules.find(r => r.provider === 'oidc')) {
           authModesToCheck.add('oidc');
         }
 
@@ -1891,9 +1914,9 @@ All @auth directives used on field definitions are performed when the field is r
     // Groups
     //
 
-    if (rule.allow === 'groups' && rule.provider !== 'userPools') {
+    if (rule.allow === 'groups' && rule.provider !== 'userPools' && rule.provider !== 'oidc') {
       throw new InvalidDirectiveError(
-        `@auth directive with 'groups' strategy only supports 'userPools' provider, but found '${rule.provider}' assigned.`
+        `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found '${rule.provider}' assigned.`
       );
     }
 

--- a/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
@@ -191,7 +191,7 @@ authentication provider configured.`
     validationTest(
       groupsWithProviderAuthDirective,
       userPoolsDefaultConfig,
-      `@auth directive with 'groups' strategy only supports 'userPools' provider, but found \
+      `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found \
 'iam' assigned`
     );
   });


### PR DESCRIPTION
Currently, amplify-cli doesn't support groups authorization for oidc provider.

https://aws-amplify.github.io/docs/cli-toolchain/graphql#allowed-authorization-mode-vs-provider-combinations

However, generated VTLs are already generalized enough to reuse it for oidc. I try to enable it.