### PR TITLE
feat: conditions update

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -14,7 +14,12 @@ const resolversDirName = 'resolvers';
 const stacksDirName = 'stacks';
 const defaultStackName = 'CustomResources.json';
 
-const { collectDirectivesByTypeNames, readTransformerConfiguration, writeTransformerConfiguration } = TransformPackage;
+const {
+  collectDirectivesByTypeNames,
+  readTransformerConfiguration,
+  writeTransformerConfiguration,
+  TRANSFORM_CURRENT_VERSION,
+} = TransformPackage;
 
 const authProviderChoices = [
   {
@@ -136,6 +141,9 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
   if (!fs.existsSync(stacksDirectoryPath)) {
     fs.mkdirSync(stacksDirectoryPath);
   }
+
+  // During API add, make sure we're creating a transform.conf.json file with the latest version the CLI supports.
+  await updateTransformerConfigVersion(resourceDir);
 
   // Write the default custom resources stack out to disk.
   const defaultCustomResourcesStack = fs.readFileSync(`${__dirname}/defaultCustomResources.json`);
@@ -287,6 +295,12 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
 async function writeResolverConfig(context, syncConfig, resourceDir) {
   const localTransformerConfig = await readTransformerConfiguration(resourceDir);
   localTransformerConfig.ResolverConfig = syncConfig;
+  await writeTransformerConfiguration(resourceDir, localTransformerConfig);
+}
+
+async function updateTransformerConfigVersion(resourceDir) {
+  const localTransformerConfig = await readTransformerConfiguration(resourceDir);
+  localTransformerConfig.Version = TRANSFORM_CURRENT_VERSION;
   await writeTransformerConfiguration(resourceDir, localTransformerConfig);
 }
 

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -25,7 +25,7 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/fs-extra": "^8.0.0",
+    "@types/fs-extra": "^8.0.1",
     "@types/global-prefix": "^3.0.0",
     "@types/ora": "^3.2.0",
     "amplify-category-analytics": "1.28.0",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "aws-sdk": "^2.510.0",
     "esm": "^3.2.25",
+    "fs-extra": "^8.1.0",
     "mime-types": "^2.1.24",
     "ora": "^3.4.0",
     "graphql-transformer-core": "^5.18.0"

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -60,7 +60,8 @@
     "aws-sdk": "^2.510.0",
     "esm": "^3.2.25",
     "mime-types": "^2.1.24",
-    "ora": "^3.4.0"
+    "ora": "^3.4.0",
+    "graphql-transformer-core": "^5.18.0"
   },
   "jest-junit": {
     "outputDirectory": "reports/junit/",

--- a/packages/amplify-e2e-tests/src/utils/api.ts
+++ b/packages/amplify-e2e-tests/src/utils/api.ts
@@ -1,11 +1,13 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import { TRANSFORM_CONFIG_FILE_NAME } from 'graphql-transformer-core';
+
 export function updateSchema(projectDir: string, projectName: string, schemaText: string) {
   const schemaPath = path.join(projectDir, 'amplify', 'backend', 'api', projectName, 'schema.graphql');
   fs.writeFileSync(schemaPath, schemaText);
 }
 
 export function updateConfig(projectDir: string, projectName: string, config: any = {}) {
-  const configPath = path.join(projectDir, 'amplify', 'backend', 'api', projectName, 'transform.conf.json');
+  const configPath = path.join(projectDir, 'amplify', 'backend', 'api', projectName, TRANSFORM_CONFIG_FILE_NAME);
   fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
 }

--- a/packages/amplify-e2e-tests/src/utils/awsExports.ts
+++ b/packages/amplify-e2e-tests/src/utils/awsExports.ts
@@ -1,6 +1,6 @@
 require = require('esm')(module);
 import { join } from 'path';
-export default function getAWSExports(projectRoot: string) {
+export function getAWSExports(projectRoot: string) {
   const metaFilePath = join(projectRoot, 'src', 'aws-exports.js');
   return require(metaFilePath);
 }

--- a/packages/amplify-e2e-tests/src/utils/index.ts
+++ b/packages/amplify-e2e-tests/src/utils/index.ts
@@ -2,8 +2,9 @@ import { join } from 'path';
 import { mkdirSync } from 'fs';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
-export { default as getProjectMeta } from './projectMeta';
-export { default as getAWSExports } from './awsExports';
+export * from './projectMeta';
+export * from './transformConfig';
+export * from './awsExports';
 export * from './sdk-calls';
 export * from './api';
 

--- a/packages/amplify-e2e-tests/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-tests/src/utils/projectMeta.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
-export default function getProjectMeta(projectRoot: string) {
+export function getProjectMeta(projectRoot: string) {
   const metaFilePath = join(projectRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
   return JSON.parse(readFileSync(metaFilePath, 'utf8'));
 }

--- a/packages/amplify-e2e-tests/src/utils/transformConfig.ts
+++ b/packages/amplify-e2e-tests/src/utils/transformConfig.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'fs-extra';
 import { TRANSFORM_CONFIG_FILE_NAME, TransformConfig } from 'graphql-transformer-core';
 export function getTransformConfig(projectRoot: string, apiName: string): TransformConfig {
   const metaFilePath = join(projectRoot, 'amplify', 'backend', 'api', apiName, TRANSFORM_CONFIG_FILE_NAME);

--- a/packages/amplify-e2e-tests/src/utils/transformConfig.ts
+++ b/packages/amplify-e2e-tests/src/utils/transformConfig.ts
@@ -1,0 +1,7 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { TRANSFORM_CONFIG_FILE_NAME, TransformConfig } from 'graphql-transformer-core';
+export function getTransformConfig(projectRoot: string, apiName: string): TransformConfig {
+  const metaFilePath = join(projectRoot, 'amplify', 'backend', 'api', apiName, TRANSFORM_CONFIG_FILE_NAME);
+  return <TransformConfig>JSON.parse(readFileSync(metaFilePath, 'utf8'));
+}

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -19,6 +19,8 @@ const {
   readTransformerConfiguration,
   writeTransformerConfiguration,
   TRANSFORM_CONFIG_FILE_NAME,
+  TRANSFORM_BASE_VERSION,
+  CLOUDFORMATION_FILE_NAME,
 } = TransformPackage;
 
 const category = 'api';
@@ -91,7 +93,7 @@ function getTransformerFactory(context, resourceDir, authConfig) {
  */
 async function transformerVersionCheck(context, resourceDir, cloudBackendDirectory, updatedResources, usedDirectives) {
   const versionChangeMessage =
-    'The default behaviour for @auth has changed in the latest version of Amplify\nRead here for details: https://aws-amplify.github.io/docs/cli-toolchain/graphql#authorizing-subscriptions';
+    'The default behavior for @auth has changed in the latest version of Amplify\nRead here for details: https://aws-amplify.github.io/docs/cli-toolchain/graphql#authorizing-subscriptions';
   const checkVersionExist = config => config && config.Version;
 
   // this is where we check if there is a prev version of the transformer being used
@@ -126,8 +128,10 @@ async function transformerVersionCheck(context, resourceDir, cloudBackendDirecto
   }
 
   // Only touch the file if it misses the Version property
+  // Always set to the base version, to not to break existing projects when coming
+  // from an older version of the CLI.
   if (!localTransformerConfig.Version) {
-    localTransformerConfig.Version = 4.0;
+    localTransformerConfig.Version = TRANSFORM_BASE_VERSION;
     await writeTransformerConfiguration(resourceDir, localTransformerConfig);
   }
 }
@@ -137,7 +141,7 @@ function apiProjectIsFromOldVersion(pathToProject, resourcesToBeCreated) {
   if (!pathToProject || resources.length > 0) {
     return false;
   }
-  return fs.existsSync(`${pathToProject}/cloudformation-template.json`) && !fs.existsSync(`${pathToProject}/transform.conf.json`);
+  return fs.existsSync(`${pathToProject}/${CLOUDFORMATION_FILE_NAME}`) && !fs.existsSync(`${pathToProject}/${TRANSFORM_CONFIG_FILE_NAME}`);
 }
 
 /**

--- a/packages/amplify-ui-tests/src/utils/index.ts
+++ b/packages/amplify-ui-tests/src/utils/index.ts
@@ -3,7 +3,7 @@ import { mkdirSync, readFileSync } from 'fs';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
 import { writeFile } from 'fs';
-export { default as getProjectMeta } from './projectMeta';
+export * from './projectMeta';
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-ui-tests/src/utils/projectMeta.ts
+++ b/packages/amplify-ui-tests/src/utils/projectMeta.ts
@@ -7,7 +7,7 @@ const metaFilePathDic = {
   ios: 'awsconfiguration.json',
 };
 
-export default function getProjectMeta(projectRoot: string) {
+export function getProjectMeta(projectRoot: string) {
   const metaFilePath = join(projectRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
   return JSON.parse(readFileSync(metaFilePath, 'utf8'));
 }

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -53,10 +53,16 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
-  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
   $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -206,10 +212,16 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
 #end
 #if( $context.args.condition )
-  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
   $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -420,13 +432,19 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
   #set( $condition.expressionValues = $expressionValues )
 #end
 #if( $context.args.condition )
-  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
   $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
   #set( $conditionExpressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
   $util.qr($conditionExpressionValues.putAll($conditionFilterExpressions.expressionValues))
   #set( $condition.expressionValues = $conditionExpressionValues )
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -662,10 +680,16 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
-  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
   $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -815,10 +839,16 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
 #end
 #if( $context.args.condition )
-  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
   $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -1029,13 +1059,19 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
   #set( $condition.expressionValues = $expressionValues )
 #end
 #if( $context.args.condition )
-  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBFilterExpression($context.args.condition)) )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
   $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
   $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
   #set( $conditionExpressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
   $util.qr($conditionExpressionValues.putAll($conditionFilterExpressions.expressionValues))
   #set( $condition.expressionValues = $conditionExpressionValues )
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -59,10 +59,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = {
-  \\"expression\\": $condition.expression,
-  \\"expressionNames\\": $condition.expressionNames
-} )
+  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -218,10 +215,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = {
-  \\"expression\\": $condition.expression,
-  \\"expressionNames\\": $condition.expressionNames
-} )
+  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -441,10 +435,7 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = {
-  \\"expression\\": $condition.expression,
-  \\"expressionNames\\": $condition.expressionNames
-} )
+  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -686,10 +677,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = {
-  \\"expression\\": $condition.expression,
-  \\"expressionNames\\": $condition.expressionNames
-} )
+  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -845,10 +833,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = {
-  \\"expression\\": $condition.expression,
-  \\"expressionNames\\": $condition.expressionNames
-} )
+  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -1068,10 +1053,7 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = {
-  \\"expression\\": $condition.expression,
-  \\"expressionNames\\": $condition.expressionNames
-} )
+  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
 #end
 {
   \\"version\\": \\"2017-02-28\\",

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -59,7 +59,10 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -215,7 +218,10 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -435,7 +441,10 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -677,7 +686,10 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",
@@ -833,7 +845,10 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 #set( $expNames = {} )
 #set( $expValues = {} )
@@ -1053,7 +1068,10 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
   $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
 #end
 #if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
-  #set( $condition = $util.map.copyAndRemoveAllKeys($condition, [\\"expressionValues\\"]) )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
 #end
 {
   \\"version\\": \\"2017-02-28\\",

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -50,8 +50,6 @@ input ModelIntFilterInput {
   lt: Int
   ge: Int
   gt: Int
-  contains: Int
-  notContains: Int
   between: [Int]
 }
 
@@ -62,8 +60,6 @@ input ModelFloatFilterInput {
   lt: Float
   ge: Float
   gt: Float
-  contains: Float
-  notContains: Float
   between: [Float]
 }
 
@@ -104,17 +100,9 @@ input DeletePostInput {
 }
 
 type Mutation {
-  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam
-  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam
-  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam
-}
-
-input ModelPostConditionInput {
-  content: ModelStringFilterInput
-  secret: ModelStringFilterInput
-  and: [ModelPostConditionInput]
-  or: [ModelPostConditionInput]
-  not: ModelPostConditionInput
+  createPost(input: CreatePostInput!): Post @aws_api_key @aws_iam
+  updatePost(input: UpdatePostInput!): Post @aws_api_key @aws_iam
+  deletePost(input: DeletePostInput!): Post @aws_api_key @aws_iam
 }
 
 type Subscription {

--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -664,7 +664,7 @@ export class ModelConnectionTransformer extends Transformer {
     }
 
     // Create the ModelXFilterInput
-    const tableXQueryFilterInput = makeModelXFilterInputObject(field, ctx);
+    const tableXQueryFilterInput = makeModelXFilterInputObject(field, ctx, this.supportsConditions(ctx));
     if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
       ctx.addInput(tableXQueryFilterInput);
     }

--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -17,6 +17,7 @@ import {
   makeModelXFilterInputObject,
   makeModelSortDirectionEnumObject,
   SortKeyFieldInfoTypeName,
+  CONDITIONS_MINIMUM_VERSION,
 } from 'graphql-dynamodb-transformer';
 import {
   getBaseType,
@@ -655,7 +656,7 @@ export class ModelConnectionTransformer extends Transformer {
     field: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
     sortKeyInfo?: { fieldName: string; typeName: SortKeyFieldInfoTypeName }
   ): void {
-    const scalarFilters = makeScalarFilterInputs();
+    const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
     for (const filter of scalarFilters) {
       if (!this.typeExist(filter.name.value, ctx)) {
         ctx.addInput(filter);
@@ -677,6 +678,10 @@ export class ModelConnectionTransformer extends Transformer {
         ctx.addInput(sortKeyConditionInput);
       }
     }
+  }
+
+  private supportsConditions(context: TransformerContext) {
+    return context.getTransformerVersion() >= CONDITIONS_MINIMUM_VERSION;
   }
 
   private extendTypeWithConnection(

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -41,7 +41,7 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testURL": "http://localhost",
-    "testRegex": "(src/__tests__/.*.test.*)$",
+    "testRegex": "(src/__tests__/.*.test.ts)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -507,7 +507,7 @@ export class DynamoDBModelTransformer extends Transformer {
     }
 
     // Create the Enum filters
-    const enumFilters = makeEnumFilterInputObjects(def, ctx);
+    const enumFilters = makeEnumFilterInputObjects(def, ctx, this.supportsConditions(ctx));
     for (const filter of enumFilters) {
       if (!this.typeExist(filter.name.value, ctx)) {
         ctx.addInput(filter);
@@ -515,7 +515,7 @@ export class DynamoDBModelTransformer extends Transformer {
     }
 
     // Create the ModelXFilterInput
-    const tableXQueryFilterInput = makeModelXFilterInputObject(def, ctx);
+    const tableXQueryFilterInput = makeModelXFilterInputObject(def, ctx, this.supportsConditions(ctx));
     if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
       ctx.addInput(tableXQueryFilterInput);
     }
@@ -530,7 +530,7 @@ export class DynamoDBModelTransformer extends Transformer {
     }
 
     // Create the Enum filters
-    const enumFilters = makeEnumFilterInputObjects(def, ctx);
+    const enumFilters = makeEnumFilterInputObjects(def, ctx, this.supportsConditions(ctx));
     for (const filter of enumFilters) {
       if (!this.typeExist(filter.name.value, ctx)) {
         ctx.addInput(filter);
@@ -539,7 +539,7 @@ export class DynamoDBModelTransformer extends Transformer {
 
     if (this.supportsConditions(ctx)) {
       // Create the ModelXConditionInput
-      const tableXMutationConditionInput = makeModelXConditionInputObject(def, ctx);
+      const tableXMutationConditionInput = makeModelXConditionInputObject(def, ctx, this.supportsConditions(ctx));
       if (!this.typeExist(tableXMutationConditionInput.name.value, ctx)) {
         ctx.addInput(tableXMutationConditionInput);
       }

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -42,7 +42,7 @@ export interface DynamoDBModelTransformerOptions {
 // flags and transformers should be feature and not version dependent.
 
 // To support generation of conditions and new naming, version 5 was introduced
-const CONDITIONS_MINIMUM_VERSION = 5;
+export const CONDITIONS_MINIMUM_VERSION = 5;
 
 /**
  * The @model transformer.

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -27,6 +27,7 @@ import {
   makeSubscriptionField,
   makeUpdateInputObject,
   makeModelXConditionInputObject,
+  makeAttributeTypeEnum,
 } from './definitions';
 import { ModelDirectiveArgs } from './ModelDirectiveArgs';
 import { ResourceFactory } from './resources';
@@ -35,6 +36,13 @@ export interface DynamoDBModelTransformerOptions {
   EnableDeletionProtection?: boolean;
   SyncConfig?: SyncConfig;
 }
+
+// Transform config version constants
+// We have constants instead of magic number all around, later these should be moved to feature
+// flags and transformers should be feature and not version dependent.
+
+// To support generation of conditions and new naming, version 5 was introduced
+const CONDITIONS_MINIMUM_VERSION = 5;
 
 /**
  * The @model transformer.
@@ -157,6 +165,7 @@ export class DynamoDBModelTransformer extends Transformer {
 
     // Update ModelXConditionInput type
     this.updateMutationConditionInput(ctx, def);
+
     // change type to include sync related fields if sync is enabled
     if (isSyncEnabled) {
       const obj = ctx.getObject(def.name.value);
@@ -231,16 +240,11 @@ export class DynamoDBModelTransformer extends Transformer {
       const resourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
       ctx.setResource(resourceId, createResolver);
       ctx.mapResourceToStack(typeName, resourceId);
-      mutationFields.push(
-        makeField(
-          createResolver.Properties.FieldName,
-          [
-            makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value))),
-            makeInputValueDefinition('condition', makeNamedType(conditionInputName)),
-          ],
-          makeNamedType(def.name.value)
-        )
-      );
+      const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))];
+      if (this.supportsConditions(ctx)) {
+        args.push(makeInputValueDefinition('condition', makeNamedType(conditionInputName)));
+      }
+      mutationFields.push(makeField(createResolver.Properties.FieldName, args, makeNamedType(def.name.value)));
     }
 
     if (shouldMakeUpdate) {
@@ -256,16 +260,11 @@ export class DynamoDBModelTransformer extends Transformer {
       const resourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName);
       ctx.setResource(resourceId, updateResolver);
       ctx.mapResourceToStack(typeName, resourceId);
-      mutationFields.push(
-        makeField(
-          updateResolver.Properties.FieldName,
-          [
-            makeInputValueDefinition('input', makeNonNullType(makeNamedType(updateInput.name.value))),
-            makeInputValueDefinition('condition', makeNamedType(conditionInputName)),
-          ],
-          makeNamedType(def.name.value)
-        )
-      );
+      const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(updateInput.name.value)))];
+      if (this.supportsConditions(ctx)) {
+        args.push(makeInputValueDefinition('condition', makeNamedType(conditionInputName)));
+      }
+      mutationFields.push(makeField(updateResolver.Properties.FieldName, args, makeNamedType(def.name.value)));
     }
 
     if (shouldMakeDelete) {
@@ -281,16 +280,11 @@ export class DynamoDBModelTransformer extends Transformer {
       const resourceId = ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName);
       ctx.setResource(resourceId, deleteResolver);
       ctx.mapResourceToStack(typeName, resourceId);
-      mutationFields.push(
-        makeField(
-          deleteResolver.Properties.FieldName,
-          [
-            makeInputValueDefinition('input', makeNonNullType(makeNamedType(deleteInput.name.value))),
-            makeInputValueDefinition('condition', makeNamedType(conditionInputName)),
-          ],
-          makeNamedType(def.name.value)
-        )
-      );
+      const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(deleteInput.name.value)))];
+      if (this.supportsConditions(ctx)) {
+        args.push(makeInputValueDefinition('condition', makeNamedType(conditionInputName)));
+      }
+      mutationFields.push(makeField(deleteResolver.Properties.FieldName, args, makeNamedType(def.name.value)));
     }
     ctx.addMutationFields(mutationFields);
 
@@ -505,7 +499,7 @@ export class DynamoDBModelTransformer extends Transformer {
   }
 
   private generateFilterInputs(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {
-    const scalarFilters = makeScalarFilterInputs();
+    const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
     for (const filter of scalarFilters) {
       if (!this.typeExist(filter.name.value, ctx)) {
         ctx.addInput(filter);
@@ -528,7 +522,7 @@ export class DynamoDBModelTransformer extends Transformer {
   }
 
   private generateConditionInputs(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {
-    const scalarFilters = makeScalarFilterInputs();
+    const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
     for (const filter of scalarFilters) {
       if (!this.typeExist(filter.name.value, ctx)) {
         ctx.addInput(filter);
@@ -543,10 +537,17 @@ export class DynamoDBModelTransformer extends Transformer {
       }
     }
 
-    // Create the ModelXConditionInput
-    const tableXMutationConditionInput = makeModelXConditionInputObject(def, ctx);
-    if (!this.typeExist(tableXMutationConditionInput.name.value, ctx)) {
-      ctx.addInput(tableXMutationConditionInput);
+    if (this.supportsConditions(ctx)) {
+      // Create the ModelXConditionInput
+      const tableXMutationConditionInput = makeModelXConditionInputObject(def, ctx);
+      if (!this.typeExist(tableXMutationConditionInput.name.value, ctx)) {
+        ctx.addInput(tableXMutationConditionInput);
+      }
+
+      const attributeTypeEnum = makeAttributeTypeEnum();
+      if (!this.typeExist(attributeTypeEnum.name.value, ctx)) {
+        ctx.addType(attributeTypeEnum);
+      }
     }
   }
 
@@ -581,32 +582,38 @@ export class DynamoDBModelTransformer extends Transformer {
   // here, because KeyTranformer will not be invoked if there are no @key directives declared
   // on the type.
   private updateMutationConditionInput(ctx: TransformerContext, type: ObjectTypeDefinitionNode): void {
-    // Get the existing ModelXConditionInput
-    const tableXMutationConditionInputName = ModelResourceIDs.ModelConditionInputTypeName(type.name.value);
+    if (this.supportsConditions(ctx)) {
+      // Get the existing ModelXConditionInput
+      const tableXMutationConditionInputName = ModelResourceIDs.ModelConditionInputTypeName(type.name.value);
 
-    if (this.typeExist(tableXMutationConditionInputName, ctx)) {
-      const tableXMutationConditionInput = <InputObjectTypeDefinitionNode>ctx.getType(tableXMutationConditionInputName);
+      if (this.typeExist(tableXMutationConditionInputName, ctx)) {
+        const tableXMutationConditionInput = <InputObjectTypeDefinitionNode>ctx.getType(tableXMutationConditionInputName);
 
-      const keyDirectives = type.directives.filter(d => d.name.value === 'key');
+        const keyDirectives = type.directives.filter(d => d.name.value === 'key');
 
-      // If there are @key directives defined we've nothing to do, it will handle everything
-      if (keyDirectives && keyDirectives.length > 0) {
-        return;
-      }
+        // If there are @key directives defined we've nothing to do, it will handle everything
+        if (keyDirectives && keyDirectives.length > 0) {
+          return;
+        }
 
-      // Remove the field named 'id' from the condition if there is one
-      const idField = tableXMutationConditionInput.fields.find(f => f.name.value === 'id');
+        // Remove the field named 'id' from the condition if there is one
+        const idField = tableXMutationConditionInput.fields.find(f => f.name.value === 'id');
 
-      if (idField) {
-        const reducedFields = tableXMutationConditionInput.fields.filter(f => Boolean(f.name.value !== 'id'));
+        if (idField) {
+          const reducedFields = tableXMutationConditionInput.fields.filter(f => Boolean(f.name.value !== 'id'));
 
-        const updatedInput = {
-          ...tableXMutationConditionInput,
-          fields: reducedFields,
-        };
+          const updatedInput = {
+            ...tableXMutationConditionInput,
+            fields: reducedFields,
+          };
 
-        ctx.putType(updatedInput);
+          ctx.putType(updatedInput);
+        }
       }
     }
+  }
+
+  private supportsConditions(context: TransformerContext) {
+    return context.getTransformerVersion() >= CONDITIONS_MINIMUM_VERSION;
   }
 }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -11,7 +11,7 @@ import {
   TypeNode,
   NamedTypeNode,
 } from 'graphql';
-import { GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform, TRANSFORM_BASE_VERSION, TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { DynamoDBModelTransformer } from '../DynamoDBModelTransformer';
 
@@ -160,7 +160,7 @@ test('Test DynamoDBModelTransformer with multiple model directives', () => {
   expect(verifyInputCount(parsed, 'ModelUserFilterInput', 1)).toBeTruthy();
 });
 
-test('Test DynamoDBModelTransformer with filter and condition', () => {
+test('Test DynamoDBModelTransformer with filter', () => {
   const validSchema = `
     type Post @model {
         id: ID!
@@ -190,7 +190,6 @@ test('Test DynamoDBModelTransformer with filter and condition', () => {
   expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy();
-  expect(verifyInputCount(parsed, 'ModelPostConditionInput', 1)).toBeTruthy();
 });
 
 test('Test DynamoDBModelTransformer with mutations set to null', () => {
@@ -461,6 +460,37 @@ test('Test non model objects contain id as a type for fields', () => {
   const commentInputIDField = getFieldOnInputType(commentInputObject, 'id');
   verifyMatchingTypes(commentObjectIDField.type, commentInputIDField.type);
 });
+
+test(`V${TRANSFORM_BASE_VERSION} transformer snapshot test`, () => {
+  const schema = transformerVersionSnapshot(TRANSFORM_BASE_VERSION);
+  expect(schema).toMatchSnapshot();
+});
+
+test(`V${TRANSFORM_CURRENT_VERSION} transformer snapshot test`, () => {
+  const schema = transformerVersionSnapshot(TRANSFORM_CURRENT_VERSION);
+  expect(schema).toMatchSnapshot();
+});
+
+function transformerVersionSnapshot(version: number): string {
+  const validSchema = `
+        type Post @model
+        {
+          id: ID!
+          content: String
+        }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+    transformConfig: {
+      Version: version,
+    },
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  return out.schema;
+}
 
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
   for (const fieldName of fields) {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -466,7 +466,12 @@ test(`V${TRANSFORM_BASE_VERSION} transformer snapshot test`, () => {
   expect(schema).toMatchSnapshot();
 });
 
-test(`V${TRANSFORM_CURRENT_VERSION} transformer snapshot test`, () => {
+test(`V5 transformer snapshot test`, () => {
+  const schema = transformerVersionSnapshot(5);
+  expect(schema).toMatchSnapshot();
+});
+
+test(`Current version transformer snapshot test`, () => {
   const schema = transformerVersionSnapshot(TRANSFORM_CURRENT_VERSION);
   expect(schema).toMatchSnapshot();
 });

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -1,0 +1,259 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`V4 transformer snapshot test 1`] = `
+"type Post {
+  id: ID!
+  content: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  content: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  content: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  content: String
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`V5 transformer snapshot test 1`] = `
+"type Post {
+  id: ID!
+  content: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPostFilterInput {
+  id: ModelIDInput
+  content: ModelStringInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  content: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  content: String
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
+}
+
+input ModelPostConditionInput {
+  content: ModelStringInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
+}
+
+enum ModelAttributeTypes {
+  B
+  BS
+  BOOL
+  L
+  M
+  N
+  NS
+  S
+  SS
+  NULL
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -130,16 +130,16 @@ input ModelPostConditionInput {
 }
 
 enum ModelAttributeTypes {
-  B
-  BS
-  BOOL
-  L
-  M
-  N
-  NS
-  S
-  SS
-  NULL
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
 }
 
 type Subscription {
@@ -388,16 +388,16 @@ input ModelPostConditionInput {
 }
 
 enum ModelAttributeTypes {
-  B
-  BS
-  BOOL
-  L
-  M
-  N
-  NS
-  S
-  SS
-  NULL
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
 }
 
 type Subscription {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -1,5 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Current version transformer snapshot test 1`] = `
+"type Post {
+  id: ID!
+  content: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPostFilterInput {
+  id: ModelIDInput
+  content: ModelStringInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  content: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  content: String
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
+}
+
+input ModelPostConditionInput {
+  content: ModelStringInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
+}
+
+enum ModelAttributeTypes {
+  B
+  BS
+  BOOL
+  L
+  M
+  N
+  NS
+  S
+  SS
+  NULL
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
 exports[`V4 transformer snapshot test 1`] = `
 "type Post {
   id: ID!

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -302,7 +302,8 @@ export function makeDeleteInputObject(obj: ObjectTypeDefinitionNode, isSync: boo
 
 export function makeModelXFilterInputObject(
   obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
-  ctx: TransformerContext
+  ctx: TransformerContext,
+  supportsConditions: Boolean
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelFilterInputTypeName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -319,8 +320,8 @@ export function makeModelXFilterInputObject(
       const isEnumType = fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
       const filterTypeName =
         isEnumType && isList
-          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, !(ctx.getTransformerVersion() >= 5))
-          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, !(ctx.getTransformerVersion() >= 5));
+          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, !supportsConditions)
+          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, !supportsConditions);
 
       return {
         kind: Kind.INPUT_VALUE_DEFINITION,
@@ -386,7 +387,8 @@ export function makeModelXFilterInputObject(
 
 export function makeModelXConditionInputObject(
   obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
-  ctx: TransformerContext
+  ctx: TransformerContext,
+  supportsConditions: Boolean
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelConditionInputTypeName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -403,8 +405,8 @@ export function makeModelXConditionInputObject(
       const isEnumType = fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
       const conditionTypeName =
         isEnumType && isList
-          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, !(ctx.getTransformerVersion() >= 5))
-          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, !(ctx.getTransformerVersion() >= 5));
+          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, !supportsConditions)
+          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, !supportsConditions);
 
       return {
         kind: Kind.INPUT_VALUE_DEFINITION,
@@ -468,7 +470,11 @@ export function makeModelXConditionInputObject(
   };
 }
 
-export function makeEnumFilterInputObjects(obj: ObjectTypeDefinitionNode, ctx: TransformerContext): InputObjectTypeDefinitionNode[] {
+export function makeEnumFilterInputObjects(
+  obj: ObjectTypeDefinitionNode,
+  ctx: TransformerContext,
+  supportsConditions: Boolean
+): InputObjectTypeDefinitionNode[] {
   return obj.fields
     .filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.getType(getBaseType(field.type));
@@ -478,8 +484,8 @@ export function makeEnumFilterInputObjects(obj: ObjectTypeDefinitionNode, ctx: T
       const typeName = getBaseType(enumField.type);
       const isList = isListType(enumField.type);
       const name = isList
-        ? ModelResourceIDs.ModelFilterListInputTypeName(typeName, !(ctx.getTransformerVersion() >= 5))
-        : ModelResourceIDs.ModelScalarFilterInputTypeName(typeName, !(ctx.getTransformerVersion() >= 5));
+        ? ModelResourceIDs.ModelFilterListInputTypeName(typeName, !supportsConditions)
+        : ModelResourceIDs.ModelScalarFilterInputTypeName(typeName, !supportsConditions);
       const fields = [];
 
       fields.push({

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -47,28 +47,7 @@ const INT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
 const FLOAT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
 const BOOLEAN_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
 
-const ATTRIBUTE_TYPES = [
-  'B',
-  'BS',
-  'BOOL',
-  'L',
-  'M',
-  'N',
-  'NS',
-  'S',
-  'SS',
-  'NULL',
-  // 'binary',
-  // 'binarySet',
-  // 'bool',
-  // 'list',
-  // 'map',
-  // 'number',
-  // 'numberSet',
-  // 'string',
-  // 'stringSet',
-  // '_null'
-];
+const ATTRIBUTE_TYPES = ['binary', 'binarySet', 'bool', 'list', 'map', 'number', 'numberSet', 'string', 'stringSet', '_null'];
 
 export function getNonModelObjectArray(
   obj: ObjectTypeDefinitionNode,

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -416,13 +416,7 @@ export class ResourceFactory {
           ),
           iff(
             and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
-            set(
-              ref('condition'),
-              obj({
-                expression: ref('condition.expression'),
-                expressionNames: ref('condition.expressionNames'),
-              })
-            )
+            set(ref('condition'), ref('util.map.copyAndRemoveAllKeys($condition, ["expressionValues"])'))
           ),
           DynamoDBMappingTemplate.putItem(
             {
@@ -535,13 +529,7 @@ export class ResourceFactory {
           ),
           iff(
             and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
-            set(
-              ref('condition'),
-              obj({
-                expression: ref('condition.expression'),
-                expressionNames: ref('condition.expressionNames'),
-              })
-            )
+            set(ref('condition'), ref('util.map.copyAndRemoveAllKeys($condition, ["expressionValues"])'))
           ),
           DynamoDBMappingTemplate.updateItem({
             key: ifElse(
@@ -806,13 +794,7 @@ export class ResourceFactory {
           ),
           iff(
             and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
-            set(
-              ref('condition'),
-              obj({
-                expression: ref('condition.expression'),
-                expressionNames: ref('condition.expressionNames'),
-              })
-            )
+            set(ref('condition'), ref('util.map.copyAndRemoveAllKeys($condition, ["expressionValues"])'))
           ),
           DynamoDBMappingTemplate.deleteItem({
             key: ifElse(

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -416,7 +416,13 @@ export class ResourceFactory {
           ),
           iff(
             and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
-            set(ref('condition'), ref('util.map.copyAndRemoveAllKeys($condition, ["expressionValues"])'))
+            set(
+              ref('condition'),
+              obj({
+                expression: ref('condition.expression'),
+                expressionNames: ref('condition.expressionNames'),
+              })
+            )
           ),
           DynamoDBMappingTemplate.putItem(
             {
@@ -529,7 +535,13 @@ export class ResourceFactory {
           ),
           iff(
             and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
-            set(ref('condition'), ref('util.map.copyAndRemoveAllKeys($condition, ["expressionValues"])'))
+            set(
+              ref('condition'),
+              obj({
+                expression: ref('condition.expression'),
+                expressionNames: ref('condition.expressionNames'),
+              })
+            )
           ),
           DynamoDBMappingTemplate.updateItem({
             key: ifElse(
@@ -794,7 +806,13 @@ export class ResourceFactory {
           ),
           iff(
             and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
-            set(ref('condition'), ref('util.map.copyAndRemoveAllKeys($condition, ["expressionValues"])'))
+            set(
+              ref('condition'),
+              obj({
+                expression: ref('condition.expression'),
+                expressionNames: ref('condition.expressionNames'),
+              })
+            )
           ),
           DynamoDBMappingTemplate.deleteItem({
             key: ifElse(

--- a/packages/graphql-relational-schema-transformer/package.json
+++ b/packages/graphql-relational-schema-transformer/package.json
@@ -25,7 +25,7 @@
     "mysql": "^2.16.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^8.0.0",
+    "@types/fs-extra": "^8.0.1",
     "@types/graphql": "^0.13.4",
     "@types/jest": "23.1.1",
     "@types/mysql": "^2.15.5",

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -66,6 +66,10 @@ export class ModelResourceIDs {
   }
 
   static ModelScalarFilterInputTypeName(name: string, includeFilter: Boolean): string {
+    const nameOverride = DEFAULT_SCALARS[name];
+    if (nameOverride) {
+      return `Model${nameOverride}${includeFilter ? 'Filter' : ''}Input`;
+    }
     return `Model${name}${includeFilter ? 'Filter' : ''}Input`;
   }
   static ModelConnectionTypeName(typeName: string): string {

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -21,6 +21,13 @@ export class ModelResourceIDs {
     }
     return `Model${name}FilterInput`;
   }
+  static ModelFilterScalarInputTypeName(name: string, includeFilter: Boolean): string {
+    const nameOverride = DEFAULT_SCALARS[name];
+    if (nameOverride) {
+      return `Model${nameOverride}${includeFilter ? 'Filter' : ''}Input`;
+    }
+    return `Model${name}${includeFilter ? 'Filter' : ''}Input`;
+  }
   static ModelConditionInputTypeName(name: string): string {
     const nameOverride = DEFAULT_SCALARS[name];
     if (nameOverride) {
@@ -50,16 +57,16 @@ export class ModelResourceIDs {
   static ModelCompositeKeyInputTypeName(modelName: string, keyName: string): string {
     return `Model${modelName}${keyName}CompositeKeyInput`;
   }
-  static ModelFilterListInputTypeName(name: string): string {
+  static ModelFilterListInputTypeName(name: string, includeFilter: Boolean): string {
     const nameOverride = DEFAULT_SCALARS[name];
     if (nameOverride) {
-      return `Model${nameOverride}ListFilterInput`;
+      return `Model${nameOverride}List${includeFilter ? 'Filter' : ''}Input`;
     }
-    return `Model${name}ListFilterInput`;
+    return `Model${name}List${includeFilter ? 'Filter' : ''}Input`;
   }
 
-  static ModelScalarFilterInputTypeName(name: string): string {
-    return `Model${name}FilterInput`;
+  static ModelScalarFilterInputTypeName(name: string, includeFilter: Boolean): string {
+    return `Model${name}${includeFilter ? 'Filter' : ''}Input`;
   }
   static ModelConnectionTypeName(typeName: string): string {
     return `Model${typeName}Connection`;
@@ -81,6 +88,12 @@ export class ModelResourceIDs {
   }
   static ModelOnDeleteSubscriptionName(typeName: string): string {
     return graphqlName(`onDelete` + toUpper(typeName));
+  }
+  static ModelAttributeTypesName(): string {
+    return `ModelAttributeTypes`;
+  }
+  static ModelSizeInputTypeName(): string {
+    return `ModelSizeInput`;
   }
   static NonModelInputObjectName(typeName: string): string {
     return graphqlName(toUpper(typeName) + 'Input');

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -18,7 +18,7 @@
   "author": "Michael Paris",
   "license": "MIT",
   "devDependencies": {
-    "@types/fs-extra": "^8.0.0",
+    "@types/fs-extra": "^8.0.1",
     "@types/graphql": "^0.13.4",
     "@types/jest": "23.1.0",
     "@types/node": "^8.10.51",

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -248,6 +248,9 @@ export class GraphQLTransform {
       context.setResolverConfig(this.transformConfig.ResolverConfig);
     }
 
+    // Transformer version is populated, store it in the transformer context, to make it accessible to transformers
+    context.setTransformerVersion(this.transformConfig.Version!);
+
     for (const transformer of this.transformers) {
       if (isFunction(transformer.before)) {
         transformer.before(context);
@@ -312,8 +315,8 @@ export class GraphQLTransform {
 
   private createResourcesForSyncEnabledProject(context: TransformerContext) {
     const syncResources = {
-      [SyncResourceIDs.syncDataSourceID]: SyncUtils.createSyncTable()
-    }
+      [SyncResourceIDs.syncDataSourceID]: SyncUtils.createSyncTable(),
+    };
     context.mergeResources(syncResources);
   }
 

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -111,6 +111,8 @@ export class TransformerContext {
 
   private resolverConfig: ResolverConfig;
 
+  private transformerVersion: Number;
+
   constructor(inputSDL: string) {
     const doc: DocumentNode = parse(inputSDL);
     for (const def of doc.definitions) {
@@ -702,12 +704,20 @@ export class TransformerContext {
    */
   public setResolverConfig(resolverConfig: ResolverConfig) {
     if (this.resolverConfig) {
-      throw new Error(`Resolver Configuration has already been added to the context`)
+      throw new Error(`Resolver Configuration has already been added to the context`);
     }
     this.resolverConfig = resolverConfig;
   }
 
   public getResolverConfig(): ResolverConfig {
     return this.resolverConfig;
+  }
+
+  public setTransformerVersion(version: Number) {
+    this.transformerVersion = version;
+  }
+
+  public getTransformerVersion(): Number {
+    return this.transformerVersion;
   }
 }

--- a/packages/graphql-transformer-core/src/index.ts
+++ b/packages/graphql-transformer-core/src/index.ts
@@ -17,6 +17,8 @@ import {
   loadConfig as readTransformerConfiguration,
   writeConfig as writeTransformerConfiguration,
   TRANSFORM_CONFIG_FILE_NAME,
+  TRANSFORM_BASE_VERSION,
+  TRANSFORM_CURRENT_VERSION,
   TransformConfig,
   SyncConfig,
 } from './util/transformConfig';
@@ -42,5 +44,7 @@ export {
   writeTransformerConfiguration,
   revertAPIMigration,
   TRANSFORM_CONFIG_FILE_NAME,
+  TRANSFORM_BASE_VERSION,
+  TRANSFORM_CURRENT_VERSION,
   SyncConfig,
 };

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -8,7 +8,6 @@ import { walkDirPosix, readFromPath, writeToPath, throwIfNotJSONExt, emptyDirect
 import { writeConfig, TransformConfig, TransformMigrationConfig, loadProject, readSchema, loadConfig } from './transformConfig';
 import * as Sanity from './sanity-check';
 
-export const TRANSFORM_CONFIG_FILE_NAME = `transform.conf.json`;
 const CLOUDFORMATION_FILE_NAME = 'cloudformation-template.json';
 const PARAMETERS_FILE_NAME = 'parameters.json';
 

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -4,6 +4,7 @@ import { diff as getDiffs } from 'deep-diff';
 import { readFromPath } from './fileUtils';
 import { InvalidMigrationError } from '../errors';
 import { Template } from 'cloudform-types';
+import { TRANSFORM_CONFIG_FILE_NAME } from '..';
 
 interface Diff {
   kind: 'N' | 'E' | 'D' | 'A';
@@ -264,7 +265,7 @@ export function cantHaveMoreThan200Resources(diffs: Diff[], currentBuild: Diffab
         'CloudFormation templates may contain at most 200 resources.',
         'If the stack is a custom stack, break the stack up into multiple files in stacks/. ' +
           'If the stack was generated, you have hit a limit and can use the StackMapping argument in ' +
-          'transform.conf.json to fine tune how resources are assigned to stacks.'
+          `${TRANSFORM_CONFIG_FILE_NAME} to fine tune how resources are assigned to stacks.`
       );
     }
   }

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -1,9 +1,12 @@
-export const TRANSFORM_CONFIG_FILE_NAME = `transform.conf.json`;
 import * as path from 'path';
 import { Template } from 'cloudform-types';
 import { throwIfNotJSONExt } from './fileUtils';
 import { ProjectOptions } from './amplifyUtils';
 const fs = require('fs-extra');
+
+export const TRANSFORM_CONFIG_FILE_NAME = `transform.conf.json`;
+export const TRANSFORM_BASE_VERSION = 4;
+export const TRANSFORM_CURRENT_VERSION = 5;
 
 export interface TransformMigrationConfig {
   V1?: {
@@ -13,36 +16,36 @@ export interface TransformMigrationConfig {
 
 // Sync Config
 export declare enum ConflictHandlerType {
-  OPTIMISTIC = "OPTIMISTIC_CONCURRENCY",
-  AUTOMERGE = "AUTOMERGE",
-  LAMBDA = "LAMBDA"
+  OPTIMISTIC = 'OPTIMISTIC_CONCURRENCY',
+  AUTOMERGE = 'AUTOMERGE',
+  LAMBDA = 'LAMBDA',
 }
 export type ConflictDectionType = 'VERSION' | 'NONE';
 export type SyncConfigOPTIMISTIC = {
   ConflictDetection: ConflictDectionType;
   ConflictHandler: ConflictHandlerType.OPTIMISTIC;
-}
+};
 export type SyncConfigSERVER = {
   ConflictDetection: ConflictDectionType;
   ConflictHandler: ConflictHandlerType.AUTOMERGE;
-}
+};
 export type SyncConfigLAMBDA = {
   ConflictDetection: ConflictDectionType;
   ConflictHandler: ConflictHandlerType.LAMBDA;
   LambdaConflictHandler: {
-    name: string,
-    region?: string,
-    lambdaArn?: any,
-  }
-}
+    name: string;
+    region?: string;
+    lambdaArn?: any;
+  };
+};
 export type SyncConfig = SyncConfigOPTIMISTIC | SyncConfigSERVER | SyncConfigLAMBDA;
 
 export type ResolverConfig = {
   project: SyncConfig;
   models: {
     [key: string]: SyncConfig;
-  }
-}
+  };
+};
 /**
  * The transform config is specified in transform.conf.json within an Amplify
  * API project directory.
@@ -91,7 +94,7 @@ export interface TransformConfig {
    * Object which states info about a resolver's configuration
    * Such as sync configuration for appsync local support
    */
-  ResolverConfig?: ResolverConfig
+  ResolverConfig?: ResolverConfig;
 }
 /**
  * try to load transformer config from specified projectDir
@@ -99,7 +102,10 @@ export interface TransformConfig {
  *  */
 
 export async function loadConfig(projectDir: string): Promise<TransformConfig> {
-  let config = {};
+  // Initialize the config always with the latest version, other members are optional for now.
+  let config = {
+    Version: TRANSFORM_CURRENT_VERSION,
+  };
   try {
     const configPath = path.join(projectDir, TRANSFORM_CONFIG_FILE_NAME);
     const configExists = await fs.exists(configPath);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -1,8 +1,16 @@
-import { GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform, TRANSFORM_CURRENT_VERSION, TRANSFORM_BASE_VERSION } from 'graphql-transformer-core';
 import { KeyTransformer } from 'graphql-key-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { parse } from 'graphql/language/parser';
-import { DocumentNode, InputObjectTypeDefinitionNode, InputValueDefinitionNode, DefinitionNode, Kind } from 'graphql';
+import {
+  DocumentNode,
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+  DefinitionNode,
+  Kind,
+  ObjectTypeDefinitionNode,
+  FieldDefinitionNode,
+} from 'graphql';
 import { VersionedModelTransformer } from 'graphql-versioned-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
@@ -30,7 +38,7 @@ import AWS = require('aws-sdk');
 
 jest.setTimeout(2000000);
 
-const transformAndParseSchema = (schema: string): DocumentNode => {
+const transformAndParseSchema = (schema: string, version: number = TRANSFORM_CURRENT_VERSION): DocumentNode => {
   const transformer = new GraphQLTransform({
     transformers: [
       new DynamoDBModelTransformer(),
@@ -46,6 +54,9 @@ const transformAndParseSchema = (schema: string): DocumentNode => {
         },
       }),
     ],
+    transformConfig: {
+      Version: version,
+    },
   });
 
   const out = transformer.transform(schema);
@@ -59,6 +70,26 @@ const getInputType = (doc: DocumentNode, typeName: string): InputObjectTypeDefin
   expect(type).toBeDefined();
 
   return <InputObjectTypeDefinitionNode>type;
+};
+
+const expectInputTypeDefined = (doc: DocumentNode, typeName: string) => {
+  const type = doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === typeName);
+  expect(type).toBeDefined();
+};
+
+const expectInputTypeUndefined = (doc: DocumentNode, typeName: string) => {
+  const type = doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === typeName);
+  expect(type).toBeUndefined();
+};
+
+const expectEnumTypeDefined = (doc: DocumentNode, typeName: string) => {
+  const type = doc.definitions.find((def: DefinitionNode) => def.kind === Kind.ENUM_TYPE_DEFINITION && def.name.value === typeName);
+  expect(type).toBeDefined();
+};
+
+const expectEnumTypeUndefined = (doc: DocumentNode, typeName: string) => {
+  const type = doc.definitions.find((def: DefinitionNode) => def.kind === Kind.ENUM_TYPE_DEFINITION && def.name.value === typeName);
+  expect(type).toBeUndefined();
 };
 
 const expectFieldsOnInputType = (type: InputObjectTypeDefinitionNode, fields: string[]) => {
@@ -82,26 +113,6 @@ describe(`Local Mutation Condition tests`, () => {
     const validSchema = `
             type Post
             @model
-            # @versioned
-            # @versioned(versionField: "vv", versionInput: "ww")
-            # @auth(rules: [
-            #   {
-            #     allow: owner
-            #   }
-            #   {
-            #     allow: groups
-            #   }
-            #   {
-            #     allow: owner
-            #     ownerField: "author"
-            #   }
-            #   {
-            #     allow: groups
-            #     groupsField: "editors"
-            #   }
-            # ])
-            # @key(fields: ["id", "type", "slug"])
-            # @key(name: "byTypeSlugCounter", fields: ["type", "slug", "likeCount"])
             {
                 id: ID!
                 content: String
@@ -618,6 +629,9 @@ describe(`Deployed Mutation Condition tests`, () => {
           },
         }),
       ],
+      transformConfig: {
+        Version: TRANSFORM_CURRENT_VERSION,
+      },
     });
 
     try {
@@ -1369,5 +1383,115 @@ describe(`Deployed Mutation Condition tests`, () => {
     expect(deleteResponse.data.deletePost.id).toBeDefined();
     expect(deleteResponse.data.deletePost.content).toEqual('Content #5');
     expect(deleteResponse.data.deletePost.version).toEqual(1);
+  });
+});
+
+describe(`Local V4-V5 Transformer tests`, () => {
+  it('V4 transform result', () => {
+    const validSchema = `
+            type Post
+            @model
+            {
+                id: ID!
+                content: String
+                rating: Int
+                state: State
+                stateList: [State]
+            }
+
+            enum State {
+              DRAFT,
+              PUBLISHED
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema, TRANSFORM_BASE_VERSION);
+
+    const filterType = getInputType(schema, 'ModelPostFilterInput');
+    expectFieldsOnInputType(filterType, ['id', 'content', 'rating', 'state', 'stateList', 'and', 'or', 'not']);
+    doNotExpectFieldsOnInputType(filterType, ['attributeExists']);
+    doNotExpectFieldsOnInputType(filterType, ['attributeType']);
+
+    expectInputTypeUndefined(schema, 'ModelPostConditionInput');
+
+    expectInputTypeDefined(schema, 'ModelStringFilterInput');
+    expectInputTypeDefined(schema, 'ModelIDFilterInput');
+    expectInputTypeDefined(schema, 'ModelIntFilterInput');
+    expectInputTypeDefined(schema, 'ModelFloatFilterInput');
+    expectInputTypeDefined(schema, 'ModelBooleanFilterInput');
+    expectInputTypeDefined(schema, 'ModelStateFilterInput');
+    expectInputTypeDefined(schema, 'ModelStateListFilterInput');
+
+    expectInputTypeUndefined(schema, 'ModelSizeInput');
+    expectEnumTypeUndefined(schema, 'ModelAttributeTypes');
+
+    const mutation = <ObjectTypeDefinitionNode>(
+      schema.definitions.find((def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === 'Mutation')
+    );
+    expect(mutation).toBeDefined();
+
+    const checkMutation = (name: string) => {
+      const field = <FieldDefinitionNode>mutation.fields.find(f => f.name.value === `${name}Post`);
+      expect(field).toBeDefined();
+      const conditionArg = field.arguments.find(a => a.name.value === 'condition');
+      expect(conditionArg).toBeUndefined();
+    };
+
+    checkMutation('create');
+    checkMutation('update');
+    checkMutation('delete');
+  });
+
+  it(`V${TRANSFORM_CURRENT_VERSION} transform result`, () => {
+    const validSchema = `
+            type Post
+            @model
+            {
+                id: ID!
+                content: String
+                rating: Int
+                state: State
+                stateList: [State]
+            }
+
+            enum State {
+              DRAFT,
+              PUBLISHED
+            }
+        `;
+
+    const schema = transformAndParseSchema(validSchema, TRANSFORM_CURRENT_VERSION);
+
+    const filterType = getInputType(schema, 'ModelPostFilterInput');
+    expectFieldsOnInputType(filterType, ['id', 'content', 'rating', 'state', 'stateList', 'and', 'or', 'not']);
+
+    const conditionType = getInputType(schema, 'ModelPostConditionInput');
+    expectFieldsOnInputType(conditionType, ['content', 'rating', 'state', 'stateList', 'and', 'or', 'not']);
+
+    expectInputTypeDefined(schema, 'ModelStringInput');
+    expectInputTypeDefined(schema, 'ModelIDInput');
+    expectInputTypeDefined(schema, 'ModelIntInput');
+    expectInputTypeDefined(schema, 'ModelFloatInput');
+    expectInputTypeDefined(schema, 'ModelBooleanInput');
+    expectInputTypeDefined(schema, 'ModelStateInput');
+    expectInputTypeDefined(schema, 'ModelStateListInput');
+    expectInputTypeDefined(schema, 'ModelSizeInput');
+    expectEnumTypeDefined(schema, 'ModelAttributeTypes');
+
+    const mutation = <ObjectTypeDefinitionNode>(
+      schema.definitions.find((def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === 'Mutation')
+    );
+    expect(mutation).toBeDefined();
+
+    const checkMutation = (name: string) => {
+      const field = <FieldDefinitionNode>mutation.fields.find(f => f.name.value === `${name}Post`);
+      expect(field).toBeDefined();
+      const conditionArg = field.arguments.find(a => a.name.value === 'condition');
+      expect(conditionArg).toBeDefined();
+    };
+
+    checkMutation('create');
+    checkMutation('update');
+    checkMutation('delete');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,7 +2903,7 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
-"@types/fs-extra@^8.0.0":
+"@types/fs-extra@^8.0.1":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
   integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==


### PR DESCRIPTION
*Description of changes:*

feat:
- Update conditions support to not to break older projects
- Introduce Version 5 for ```transform.conf.json``` to support conditions and renamed filter/condition related input types
- Remove ```contains```, ```notContains``` for ```Int``` and ```Float``` input types
- Add support for DynamoDB functions in conditions: ```attributeExists```, ```attributeType```, ```size```
- Fix resolver logic for ```$condition``` where no ```expressionValues``` are set

test:
- Amplify e2e tests added for v4, v5
- DynamoDB transformer snapshot tests for v4, v5
- Transformers e2e tests for v4, v5

chore:
- Remove some default exports in utility files


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.