### PR TITLE
fix: Give ddb trigger policy different name from lambda execution policy

### DIFF
--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -638,7 +638,7 @@ async function addTrigger(context, resourceName, triggerList) {
       DependsOn: ['LambdaExecutionRole'],
       Type: 'AWS::IAM::Policy',
       Properties: {
-        PolicyName: 'lambda-execution-policy',
+        PolicyName: 'lambda-trigger-policy',
         Roles: [
           {
             Ref: 'LambdaExecutionRole',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes e2e test that fails due to two policies having the same name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.