### PR TITLE
fix: include api build directory in cloud zip

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/archiver.js
+++ b/packages/amplify-provider-awscloudformation/src/utils/archiver.js
@@ -20,6 +20,11 @@ function run(folder, zipFilePath, ignorePattern = DEFAULT_IGNORE_PATTERN) {
 
     const zip = archiver.create('zip', {});
     zip.pipe(output);
+    // Include the build directory of APIs because sanity check requires it.
+    zip.glob('api/*/build/**', {
+      cwd: folder,
+      dot: true,
+    });
     zip.glob('**', {
       cwd: folder,
       ignore: ignorePattern,


### PR DESCRIPTION
*Description of changes:*

The zip file the CLI uploads to the cloud requires the build folder of the APIs, because sanity check requires it to succeed. A change in CLI push phases surfaced this existing error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.