### PR TITLE
test(amplify-e2e-tests): fix auth e2e tests

### DIFF
--- a/packages/amplify-e2e-tests/__tests__/auth.test.ts
+++ b/packages/amplify-e2e-tests/__tests__/auth.test.ts
@@ -1,6 +1,6 @@
 require('../src/aws-matchers/'); // custom matcher for assertion
 const fs = require('fs');
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush } from '../src/init';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPushAuthWithLambdaTriggers, amplifyPush } from '../src/init';
 import {
   addAuthWithDefault,
   addAuthWithDefaultSocial,
@@ -114,7 +114,7 @@ describe('amplify add auth...', () => {
   it('...should init a project where all possible options are selected', async () => {
     await initJSProjectWithProfile(projRoot, defaultsSettings);
     await addAuthWithMaxOptions(projRoot, {});
-    await amplifyPushAuth(projRoot);
+    await amplifyPushAuthWithLambdaTriggers(projRoot);
     const meta = getProjectMeta(projRoot);
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[1].output.UserPoolId;
     const createFunctionName = `${Object.keys(meta.auth)[1]}CreateAuthChallenge-integtest`;
@@ -149,7 +149,7 @@ describe('amplify updating auth...', () => {
   it('...should init a project and add auth with a custom trigger, and then update to remove the custom js while leaving the other js', async () => {
     await initJSProjectWithProfile(projRoot, defaultsSettings);
     await addAuthWithCustomTrigger(projRoot, {});
-    await amplifyPushAuth(projRoot);
+    await amplifyPushAuthWithLambdaTriggers(projRoot);
     const meta = getProjectMeta(projRoot);
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const functionName = `${Object.keys(meta.auth)[0]}PreSignup-integtest`;
@@ -164,7 +164,7 @@ describe('amplify updating auth...', () => {
     await expect(lambdaFunction.Configuration.Environment.Variables.MODULES).toEqual('email-filter-blacklist,custom');
 
     await updateAuthWithoutCustomTrigger(projRoot, {});
-    await amplifyPushAuth(projRoot);
+    await amplifyPushAuthWithLambdaTriggers(projRoot);
     const updatedFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     const updatedDirContents = fs.readdirSync(`${projRoot}/amplify/backend/function/${Object.keys(meta.auth)[0]}PreSignup/src`);
     await expect(updatedDirContents.includes('custom.js')).toBeFalsy();

--- a/packages/amplify-e2e-tests/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-tests/src/init/amplifyPush.ts
@@ -54,4 +54,23 @@ function amplifyPushAuth(cwd: string, verbose: Boolean = isCI() ? false : true) 
   });
 }
 
-export { amplifyPush, amplifyPushUpdate, amplifyPushAuth };
+function amplifyPushAuthWithLambdaTriggers(cwd: string, verbose: Boolean = isCI() ? false : true) {
+  return new Promise((resolve, reject) => {
+    nexpect
+      .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })
+      .wait('Do you want to configure Lambda Triggers')
+      .sendline('n')
+      .wait('Are you sure you want to continue?')
+      .sendline('y')
+      .wait(/.*/)
+      .run(function(err: Error) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
+export { amplifyPush, amplifyPushUpdate, amplifyPushAuth, amplifyPushAuthWithLambdaTriggers };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the new push workflow, a pull is executed first, this leads to extra prompt to the user if API category is added, which causes the e2e tests to fail. this PR fixes the broken auth e2e tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.