### PR TITLE
fix: e2e test failures with node env

### DIFF
--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -43,7 +43,7 @@
       "src/**/*.ts",
       "!**/node_modules/**",
       "!__tests__/**",
-      "!**/*.d.ts"      
+      "!**/*.d.ts"
     ],
     "reporters": [
       "default",
@@ -56,7 +56,10 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "globals": {
+      "window": {}
+    }
   },
   "dependencies": {
     "aws-sdk": "^2.577.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -39,7 +39,6 @@
     "graphql-transformer-common": "3.32.0",
     "graphql-transformer-core": "5.18.0",
     "graphql-versioned-transformer": "3.28.0",
-    "isomorphic-fetch": "^2.2.1",
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "jest-junit": "^8.0.0",

--- a/packages/amplify-util-mock/tsconfig.json
+++ b/packages/amplify-util-mock/tsconfig.json
@@ -1,25 +1,16 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
-        "sourceMap": true,
-        "outDir": "lib",
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-        "sourceRoot": "src",
-        "lib": [
-            "es2017",
-            "esnext.asynciterable"
-        ],
-        "declaration": true,
-        "skipLibCheck": true
-    },
-    "exclude": [
-        "node_modules",
-        "lib",
-        "__tests__"
-    ],
-    "include": [
-        "src/"
-    ]
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "sourceMap": true,
+    "outDir": "lib",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "sourceRoot": "src",
+    "lib": ["es2017", "esnext.asynciterable", "dom"],
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "lib", "__tests__"],
+  "include": ["src/"]
 }

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.4",
-    "@types/isomorphic-fetch": "0.0.35",
     "@types/jest": "23.1.1",
     "@types/node": "^8.10.51",
     "aws-amplify": "^1.1.36",

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.4",
+    "@types/isomorphic-fetch": "0.0.35",
     "@types/jest": "23.1.1",
     "@types/node": "^8.10.51",
     "aws-amplify": "^1.1.36",
@@ -80,7 +81,10 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "globals": {
+      "window": {}
+    }
   },
   "jest-junit": {
     "outputDirectory": "reports/junit/",

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
@@ -1,4 +1,3 @@
-import Amplify from 'aws-amplify';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { GraphQLTransform } from 'graphql-transformer-core';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
@@ -24,6 +23,7 @@ import {
   addUserToGroup,
   configureAmplify,
 } from '../cognitoUtils';
+import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
@@ -23,6 +23,7 @@ import {
   addUserToGroup,
   configureAmplify,
 } from '../cognitoUtils';
+import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -23,6 +23,7 @@ import {
   addUserToGroup,
   configureAmplify,
 } from '../cognitoUtils';
+import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -23,6 +23,7 @@ import UserPoolClient from 'cloudform-types/types/cognito/userPoolClient';
 import IdentityPool from 'cloudform-types/types/cognito/identityPool';
 import IdentityPoolRoleAttachment from 'cloudform-types/types/cognito/identityPoolRoleAttachment';
 import AWS = require('aws-sdk');
+import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -35,6 +35,7 @@ import UserPoolClient from 'cloudform-types/types/cognito/userPoolClient';
 import IdentityPool from 'cloudform-types/types/cognito/identityPool';
 import IdentityPoolRoleAttachment from 'cloudform-types/types/cognito/identityPoolRoleAttachment';
 import AWS = require('aws-sdk');
+import 'isomorphic-fetch';
 
 jest.setTimeout(2000000);
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionWithAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionWithAuth.e2e.test.ts
@@ -24,6 +24,7 @@ import {
   addUserToGroup,
   configureAmplify,
 } from '../cognitoUtils';
+import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
@@ -1,4 +1,3 @@
-import Amplify from 'aws-amplify';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { GraphQLTransform } from 'graphql-transformer-core';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
@@ -24,6 +23,7 @@ import {
   addUserToGroup,
   configureAmplify,
 } from '../cognitoUtils';
+import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2934,6 +2934,11 @@
   resolved "https://registry.yarnpkg.com/@types/inflected/-/inflected-1.1.29.tgz#8ef717dcf618d84584f506108ea85cd852f6d3ab"
   integrity sha1-jvcX3PYY2EWE9QYQjqhc2FL206s=
 
+"@types/isomorphic-fetch@0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz#c1c0d402daac324582b6186b91f8905340ea3361"
+  integrity sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2934,11 +2934,6 @@
   resolved "https://registry.yarnpkg.com/@types/inflected/-/inflected-1.1.29.tgz#8ef717dcf618d84584f506108ea85cd852f6d3ab"
   integrity sha1-jvcX3PYY2EWE9QYQjqhc2FL206s=
 
-"@types/isomorphic-fetch@0.0.35":
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz#c1c0d402daac324582b6186b91f8905340ea3361"
-  integrity sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
*Description of changes:*

Fix: Jest is now configured to use node test environment and that caused some e2e tests for fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.