### PR TITLE
fix(cli): fix appsync api native config file for legacy metadata

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.js
@@ -326,10 +326,9 @@ const learnMoreLoop = async (key, map, metaData, question) => {
   ) {
     let prefix;
     if (metaData.URL) {
-      prefix = `\nAdditional information about the ${key} available for ${map} can be found here: ${chalkpipe(
-        null,
-        chalk.blue.underline
-      )(metaData.URL)}\n`;
+      prefix = `\nAdditional information about the ${key} available for ${map} can be found here: ${chalkpipe(null, chalk.blue.underline)(
+        metaData.URL
+      )}\n`;
       prefix = prefix.concat('\n');
     } else {
       prefix = `\nThe following ${key} are available in ${map}\n`;

--- a/packages/amplify-cli/src/lib/pull-backend.js
+++ b/packages/amplify-cli/src/lib/pull-backend.js
@@ -32,8 +32,6 @@ async function pullBackend(context, inputParams) {
   await initializeEnv(context);
   ensureBackendConfigFile(context);
   await postPullCodeGenCheck(context);
-  context.print.success('Successfully pulled backend environment from the cloud.');
-  context.print.info('');
   context.print.info('Post-pull status:');
   await context.amplify.showResourceTable();
   context.print.info('');

--- a/packages/amplify-frontend-android/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-android/lib/amplify-config-helper.js
@@ -47,11 +47,17 @@ function constructApi(metadata, amplifyConfig) {
         amplifyConfig[categoryName].plugins[pluginName] = amplifyConfig[categoryName].plugins[pluginName] || {};
 
         if (resourceMeta.service === 'AppSync') {
+          let authorizationType;
+          if (resourceMeta.output.authConfig && resourceMeta.output.authConfig.defaultAuthentication) {
+            authorizationType = resourceMeta.output.authConfig.defaultAuthentication.authenticationType;
+          } else if (resourceMeta.output.securityType) {
+            authorizationType = resourceMeta.output.securityType;
+          }
           amplifyConfig[categoryName].plugins[pluginName][r] = {
             endpointType: 'GraphQL',
             endpoint: resourceMeta.output.GraphQLAPIEndpointOutput,
             region,
-            authorizationType: resourceMeta.output.authConfig.defaultAuthentication.authenticationType,
+            authorizationType,
             apiKey: resourceMeta.output.GraphQLAPIKeyOutput,
           };
         } else if (resourceMeta.service === 'API Gateway') {

--- a/packages/amplify-frontend-ios/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-ios/lib/amplify-config-helper.js
@@ -47,11 +47,17 @@ function constructApi(metadata, amplifyConfig) {
         amplifyConfig[categoryName].plugins[pluginName] = amplifyConfig[categoryName].plugins[pluginName] || {};
 
         if (resourceMeta.service === 'AppSync') {
+          let authorizationType;
+          if (resourceMeta.output.authConfig && resourceMeta.output.authConfig.defaultAuthentication) {
+            authorizationType = resourceMeta.output.authConfig.defaultAuthentication.authenticationType;
+          } else if (resourceMeta.output.securityType) {
+            authorizationType = resourceMeta.output.securityType;
+          }
           amplifyConfig[categoryName].plugins[pluginName][r] = {
             endpointType: 'GraphQL',
             endpoint: resourceMeta.output.GraphQLAPIEndpointOutput,
             region,
-            authorizationType: resourceMeta.output.authConfig.defaultAuthentication.authenticationType,
+            authorizationType,
             apiKey: resourceMeta.output.GraphQLAPIKeyOutput,
           };
         } else if (resourceMeta.service === 'API Gateway') {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The latest CLI (4.x.x) generates amplifyconfiguration.json for native projects. It's based on the latest amplify-meta format, in which, for the AppSync API, the default auth type is under `output.authConfig.defaultAuthentication.authenticationType`, but if the amplify-meta was generated by older versions of the CLI, the default auth type is under `output.securityType`. 

This PR update allows for the legacy amplify-meta format when generating the amplifyconfiguration.json file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.