### PR TITLE
fix: amplify e2e test deps,lint,cleanup,standardize

### DIFF
--- a/packages/amplify-e2e-tests/Readme.md
+++ b/packages/amplify-e2e-tests/Readme.md
@@ -25,10 +25,8 @@ npm run e2e __tests__/init.test.ts
 E2E tests internally use [nexpect](https://www.npmjs.com/package/nexpect) to run the CLI. There are helper methods that helps you to set up and delete project. The recommended pattern is to create a helper method that creates a resources as a helper method so these method could be used in other tests. For instance, `initJSProjectWithProfile` is a helper method that is used in `init` tests and also used in all the other tests to initalize a new Javascript project. The tests should have all the assertions to make sure the resource created by the helper method is setup correctly. We recommend using `aws-sdk` to make assert the resource configuration.
 
 ```typescript
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPush } from '../src/init';
-
-import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../src/utils';
+import { initJSProjectWithProfile, deleteProject, amplifyPush } from '../init';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../utils';
 
 describe('amplify your test', () => {
   let projRoot: string;

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -5,44 +5,46 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "e2e": "npm run setup-profile && jest --maxWorkers=3",
-    "setup-profile": "tsc && node ./lib/configure_tests.js",
-    "build": "tsc",
-    "clean": "rm -rf ./lib"
+    "e2e": "npm run setup-profile && jest",
+    "setup-profile": "ts-node ./src/configure_tests.ts"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "23.1.6",
-    "@types/nexpect": "0.4.30",
-    "@types/node": "^8.10.51",
-    "aws-amplify": "^1.1.36",
-    "dotenv": "6.2.0",
-    "jest": "23.1.0",
-    "jest-junit": "^8.0.0",
-    "nexpect": "file:./src/utils/nexpect-modified",
+    "@types/jest": "^24.0.23",
+    "@types/node": "^8.10.59",
+    "aws-amplify": "^2.1.0",
+    "dotenv": "^8.2.0",
+    "jest": "^24.9.0",
+    "jest-circus": "^24.9.0",
+    "jest-junit": "^9.0.0",
+    "nexpect": "./src/utils/nexpect-modified",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^22.4.6",
+    "ts-jest": "^24.2.0",
+    "ts-node": "^8.5.2",
     "tslint": "^5.18.0",
     "typescript": "^3.6.4"
   },
   "jest": {
+    "verbose": false,
+    "preset": "ts-jest",
+    "testRunner": "jest-circus/runner",
+    "testEnvironment": "node",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
     "testURL": "http://localhost",
-    "testRegex": "(__tests__/.*.test.*)$",
+    "testRegex": "(src/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "src"
+      "lib"
     ],
-    "testEnvironment": "node",
     "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.ts",
       "!**/node_modules/**",
-      "!__tests__/**",
+      "!src/__tests__/**",
       "!**/*.d.ts"
     ],
     "reporters": [
@@ -57,17 +59,18 @@
       "json",
       "node"
     ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/setup-tests.ts"
+    ],
     "globals": {
       "window": {}
     }
   },
   "dependencies": {
-    "aws-sdk": "^2.577.0",
+    "aws-sdk": "^2.580.0",
     "esm": "^3.2.25",
     "fs-extra": "^8.1.0",
-    "graphql-transformer-core": "6.0.0",
-    "mime-types": "^2.1.24",
-    "ora": "^3.4.0"
+    "graphql-transformer-core": "6.0.0"
   },
   "jest-junit": {
     "outputDirectory": "reports/junit/",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -18,7 +18,7 @@
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
     "jest-junit": "^9.0.0",
-    "nexpect": "./src/utils/nexpect-modified",
+    "nexpect": "file:./src/utils/nexpect-modified",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.2.0",

--- a/packages/amplify-e2e-tests/src/__tests__/analytics.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/analytics.test.ts
@@ -1,15 +1,13 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile } from '../src/init';
-import { addAnalytics, removeAnalytics } from '../src/categories/analytics';
-import { createNewProjectDir, deleteProjectDir } from '../src/utils';
-import * as fs from 'fs';
+import { initJSProjectWithProfile } from '../init';
+import { addAnalytics, removeAnalytics } from '../categories/analytics';
+import { createNewProjectDir, deleteProjectDir } from '../utils';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 
 describe('amplify add analytics', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/api.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api.test.ts
@@ -1,25 +1,14 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from '../src/init';
+import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from '../init';
 import * as path from 'path';
 import { existsSync } from 'fs';
-import { addApiWithSchema, updateApiSchema, updateApiWithMultiAuth } from '../src/categories/api';
-import {
-  createNewProjectDir,
-  deleteProjectDir,
-  getProjectMeta,
-  getTransformConfig,
-  updateConfig,
-  getTable,
-  deleteTable,
-  getAppSyncApi,
-} from '../src/utils';
+import { addApiWithSchema, updateApiSchema, updateApiWithMultiAuth } from '../categories/api';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getTransformConfig, getAppSyncApi } from '../utils';
 import { TRANSFORM_CURRENT_VERSION, TRANSFORM_BASE_VERSION, writeTransformerConfiguration } from 'graphql-transformer-core';
 
 describe('amplify add api', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {
@@ -60,9 +49,9 @@ describe('amplify add api', () => {
     const { output } = getProjectMeta(projRoot).api[projectName];
     const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
 
-    await expect(GraphQLAPIIdOutput).toBeDefined();
-    await expect(GraphQLAPIEndpointOutput).toBeDefined();
-    await expect(GraphQLAPIKeyOutput).toBeDefined();
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
   });
 
   it('init a project and add the simple_model api with multiple authorization providers', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth.test.ts
@@ -1,6 +1,5 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-const fs = require('fs');
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush } from '../src/init';
+import * as fs from 'fs-extra';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush } from '../init';
 import {
   addAuthWithDefault,
   addAuthWithDefaultSocial,
@@ -10,8 +9,8 @@ import {
   updateAuthWithoutCustomTrigger,
   addAuthViaAPIWithTrigger,
   addAuthWithMaxOptions,
-} from '../src/categories/auth';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool, getUserPoolClients, getLambdaFunction } from '../src/utils';
+} from '../categories/auth';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool, getUserPoolClients, getLambdaFunction } from '../utils';
 
 const defaultsSettings = {
   name: 'authTest',
@@ -21,7 +20,6 @@ describe('amplify add auth...', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {
@@ -36,7 +34,7 @@ describe('amplify add auth...', () => {
     const meta = getProjectMeta(projRoot);
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    await expect(userPool.UserPool).toBeDefined();
+    expect(userPool.UserPool).toBeDefined();
   });
 
   it('...should init a project and add auth with defaultSocial', async () => {
@@ -47,11 +45,11 @@ describe('amplify add auth...', () => {
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
     const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
-    await expect(userPool.UserPool).toBeDefined();
-    await expect(clients).toHaveLength(2);
-    await expect(clients[0].UserPoolClient.CallbackURLs[0]).toEqual('https://www.google.com/');
-    await expect(clients[0].UserPoolClient.LogoutURLs[0]).toEqual('https://www.nytimes.com/');
-    await expect(clients[0].UserPoolClient.SupportedIdentityProviders).toHaveLength(4);
+    expect(userPool.UserPool).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(clients[0].UserPoolClient.CallbackURLs[0]).toEqual('https://www.google.com/');
+    expect(clients[0].UserPoolClient.LogoutURLs[0]).toEqual('https://www.nytimes.com/');
+    expect(clients[0].UserPoolClient.SupportedIdentityProviders).toHaveLength(4);
   });
 
   it('...should init a project and add auth a PostConfirmation: add-to-group trigger', async () => {
@@ -65,10 +63,10 @@ describe('amplify add auth...', () => {
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
     const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
-    await expect(userPool.UserPool).toBeDefined();
-    await expect(clients).toHaveLength(2);
-    await expect(lambdaFunction).toBeDefined();
-    await expect(lambdaFunction.Configuration.Environment.Variables.GROUP).toEqual('mygroup');
+    expect(userPool.UserPool).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(lambdaFunction).toBeDefined();
+    expect(lambdaFunction.Configuration.Environment.Variables.GROUP).toEqual('mygroup');
   });
 
   it('...should allow the user to add auth via API category, with a trigger', async () => {
@@ -82,10 +80,10 @@ describe('amplify add auth...', () => {
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
     const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
-    await expect(userPool.UserPool).toBeDefined();
-    await expect(clients).toHaveLength(2);
-    await expect(lambdaFunction).toBeDefined();
-    await expect(lambdaFunction.Configuration.Environment.Variables.GROUP).toEqual('mygroup');
+    expect(userPool.UserPool).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(lambdaFunction).toBeDefined();
+    expect(lambdaFunction.Configuration.Environment.Variables.GROUP).toEqual('mygroup');
   });
 
   it('...should init a project and add 3 custom auth flow triggers for Google reCaptcha', async () => {
@@ -103,12 +101,12 @@ describe('amplify add auth...', () => {
     const defineFunction = await getLambdaFunction(defineFunctionName, meta.providers.awscloudformation.Region);
     const verifyFunction = await getLambdaFunction(verifyFunctionName, meta.providers.awscloudformation.Region);
 
-    await expect(userPool.UserPool).toBeDefined();
-    await expect(clients).toHaveLength(2);
-    await expect(createFunction).toBeDefined();
-    await expect(defineFunction).toBeDefined();
-    await expect(verifyFunction).toBeDefined();
-    await expect(verifyFunction.Configuration.Environment.Variables.RECAPTCHASECRET).toEqual('dummykey');
+    expect(userPool.UserPool).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(createFunction).toBeDefined();
+    expect(defineFunction).toBeDefined();
+    expect(verifyFunction).toBeDefined();
+    expect(verifyFunction.Configuration.Environment.Variables.RECAPTCHASECRET).toEqual('dummykey');
   });
 
   it('...should init a project where all possible options are selected', async () => {
@@ -124,13 +122,13 @@ describe('amplify add auth...', () => {
     const createFunction = await getLambdaFunction(createFunctionName, meta.providers.awscloudformation.Region);
     const defineFunction = await getLambdaFunction(defineFunctionName, meta.providers.awscloudformation.Region);
 
-    await expect(userPool.UserPool).toBeDefined();
-    await expect(clients).toHaveLength(2);
-    await expect(createFunction).toBeDefined();
-    await expect(defineFunction).toBeDefined();
+    expect(userPool.UserPool).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(createFunction).toBeDefined();
+    expect(defineFunction).toBeDefined();
 
-    await expect(createFunction.Configuration.Environment.Variables.MODULES).toEqual('custom');
-    await expect(defineFunction.Configuration.Environment.Variables.MODULES).toEqual('custom');
+    expect(createFunction.Configuration.Environment.Variables.MODULES).toEqual('custom');
+    expect(defineFunction.Configuration.Environment.Variables.MODULES).toEqual('custom');
   });
 });
 
@@ -138,7 +136,6 @@ describe('amplify updating auth...', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {
@@ -157,18 +154,18 @@ describe('amplify updating auth...', () => {
     const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     const dirContents = fs.readdirSync(`${projRoot}/amplify/backend/function/${Object.keys(meta.auth)[0]}PreSignup/src`);
-    await expect(dirContents.includes('custom.js')).toBeTruthy();
-    await expect(userPool.UserPool).toBeDefined();
-    await expect(clients).toHaveLength(2);
-    await expect(lambdaFunction).toBeDefined();
-    await expect(lambdaFunction.Configuration.Environment.Variables.MODULES).toEqual('email-filter-blacklist,custom');
+    expect(dirContents.includes('custom.js')).toBeTruthy();
+    expect(userPool.UserPool).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(lambdaFunction).toBeDefined();
+    expect(lambdaFunction.Configuration.Environment.Variables.MODULES).toEqual('email-filter-blacklist,custom');
 
     await updateAuthWithoutCustomTrigger(projRoot, {});
     await amplifyPushAuth(projRoot);
     const updatedFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     const updatedDirContents = fs.readdirSync(`${projRoot}/amplify/backend/function/${Object.keys(meta.auth)[0]}PreSignup/src`);
-    await expect(updatedDirContents.includes('custom.js')).toBeFalsy();
-    await expect(updatedDirContents.includes('email-filter-blacklist.js')).toBeTruthy();
-    await expect(updatedFunction.Configuration.Environment.Variables.MODULES).toEqual('email-filter-blacklist');
+    expect(updatedDirContents.includes('custom.js')).toBeFalsy();
+    expect(updatedDirContents.includes('email-filter-blacklist.js')).toBeTruthy();
+    expect(updatedFunction.Configuration.Environment.Variables.MODULES).toEqual('email-filter-blacklist');
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -1,23 +1,13 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-const path = require('path');
-import fs from 'fs-extra';
-import * as AWS from 'aws-sdk';
-import {
-  initJSProjectWithProfile,
-  initIosProjectWithProfile,
-  initAndroidProjectWithProfile,
-  deleteProject,
-  amplifyPush,
-} from '../src/init';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../src/utils';
-import { addEnvironment } from '../src/environment/add-env';
-import { addApiWithoutSchema } from '../src/categories/api';
-import { addCodegen } from '../src/codegen/add';
+import { S3 } from 'aws-sdk';
+import { initJSProjectWithProfile, initIosProjectWithProfile, initAndroidProjectWithProfile, deleteProject } from '../init';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../utils';
+import { addEnvironment } from '../environment/add-env';
+import { addApiWithoutSchema } from '../categories/api';
+import { addCodegen } from '../codegen/add';
 
 describe('amplify delete', () => {
   let projRoot: string;
   beforeEach(async () => {
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
     projRoot = createNewProjectDir();
   });
 
@@ -41,7 +31,7 @@ describe('amplify delete', () => {
   });
 });
 
-async function testDeletion(projRoot, settings) {
+async function testDeletion(projRoot: string, settings: { ios?: Boolean; android?: Boolean }) {
   const amplifyMeta = getProjectMeta(projRoot);
   const meta = amplifyMeta.providers.awscloudformation;
   const deploymentBucketName1 = meta.DeploymentBucketName;
@@ -56,12 +46,12 @@ async function testDeletion(projRoot, settings) {
   await deleteProject(projRoot, true);
   await expect(await bucketExists(deploymentBucketName1)).toBe(false);
   await expect(await bucketExists(deploymentBucketName2)).toBe(false);
-  await expect(AuthRoleName).not.toBeIAMRoleWithArn();
-  await expect(UnauthRoleName).not.toBeIAMRoleWithArn();
+  await expect(AuthRoleName).not.toBeIAMRoleWithArn(AuthRoleName);
+  await expect(UnauthRoleName).not.toBeIAMRoleWithArn(UnauthRoleName);
 }
 
 async function bucketExists(bucket: string) {
-  const s3 = new AWS.S3();
+  const s3 = new S3();
   const options = {
     Bucket: bucket,
   };

--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -1,13 +1,11 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../src/init';
-import { addHelloWorldFunction, functionBuild } from '../src/categories/function';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getFunction } from '../src/utils';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../init';
+import { addHelloWorldFunction, functionBuild } from '../categories/function';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getFunction } from '../utils';
 
 describe('amplify add function', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
@@ -1,15 +1,13 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile } from '../src/init';
-import { addHosting, removeHosting, amplifyPush } from '../src/categories/hosting';
-import { createNewProjectDir, deleteProjectDir } from '../src/utils';
-import * as fs from 'fs';
+import { initJSProjectWithProfile } from '../init';
+import { addHosting, removeHosting, amplifyPush } from '../categories/hosting';
+import { createNewProjectDir, deleteProjectDir } from '../utils';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 
 describe('amplify add hosting', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/init.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init.test.ts
@@ -1,19 +1,10 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import {
-  initJSProjectWithProfile,
-  deleteProject,
-  initProjectWithAccessKey,
-  initNewEnvWithAccessKey,
-  initNewEnvWithProfile,
-} from '../src/init';
-import { createNewProjectDir, deleteProjectDir, getEnvVars, getProjectMeta } from '../src/utils';
-import { access } from 'fs';
+import { initJSProjectWithProfile, deleteProject, initProjectWithAccessKey, initNewEnvWithAccessKey, initNewEnvWithProfile } from '../init';
+import { createNewProjectDir, deleteProjectDir, getEnvVars, getProjectMeta } from '../utils';
 
 describe('amplify init', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {
@@ -27,9 +18,9 @@ describe('amplify init', () => {
     expect(meta.Region).toBeDefined();
     const { AuthRoleName, UnauthRoleName, UnauthRoleArn, AuthRoleArn, DeploymentBucketName } = meta;
 
-    await expect(UnauthRoleName).toBeIAMRoleWithArn(UnauthRoleArn);
-    await expect(AuthRoleName).toBeIAMRoleWithArn(AuthRoleArn);
-    await expect(DeploymentBucketName).toBeAS3Bucket();
+    expect(UnauthRoleName).toBeIAMRoleWithArn(UnauthRoleArn);
+    expect(AuthRoleName).toBeIAMRoleWithArn(AuthRoleArn);
+    expect(DeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
 
     // init new env
     await initNewEnvWithProfile(projRoot, { envName: 'foo' });
@@ -49,9 +40,9 @@ describe('amplify init', () => {
     expect(AuthRoleArn).not.toEqual(newEnvAuthRoleArn);
     expect(DeploymentBucketName).not.toEqual(newEnvDeploymentBucketName);
 
-    await expect(newEnvUnAuthRoleName).toBeIAMRoleWithArn(newEnvUnauthRoleArn);
-    await expect(newEnvAuthRoleName).toBeIAMRoleWithArn(newEnvAuthRoleArn);
-    await expect(newEnvDeploymentBucketName).toBeAS3Bucket();
+    expect(newEnvUnAuthRoleName).toBeIAMRoleWithArn(newEnvUnauthRoleArn);
+    expect(newEnvAuthRoleName).toBeIAMRoleWithArn(newEnvAuthRoleArn);
+    expect(newEnvDeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
   });
 
   it('should init project without profile', async () => {
@@ -68,9 +59,9 @@ describe('amplify init', () => {
     expect(meta.Region).toBeDefined();
     const { AuthRoleName, UnauthRoleName, UnauthRoleArn, AuthRoleArn, DeploymentBucketName } = meta;
 
-    await expect(UnauthRoleName).toBeIAMRoleWithArn(UnauthRoleArn);
-    await expect(AuthRoleName).toBeIAMRoleWithArn(AuthRoleArn);
-    await expect(DeploymentBucketName).toBeAS3Bucket();
+    expect(UnauthRoleName).toBeIAMRoleWithArn(UnauthRoleArn);
+    expect(AuthRoleName).toBeIAMRoleWithArn(AuthRoleArn);
+    expect(DeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
 
     // init new env
     await initNewEnvWithAccessKey(projRoot, {
@@ -94,8 +85,8 @@ describe('amplify init', () => {
     expect(AuthRoleArn).not.toEqual(newEnvAuthRoleArn);
     expect(DeploymentBucketName).not.toEqual(newEnvDeploymentBucketName);
 
-    await expect(newEnvUnAuthRoleName).toBeIAMRoleWithArn(newEnvUnauthRoleArn);
-    await expect(newEnvAuthRoleName).toBeIAMRoleWithArn(newEnvAuthRoleArn);
-    await expect(newEnvDeploymentBucketName).toBeAS3Bucket();
+    expect(newEnvUnAuthRoleName).toBeIAMRoleWithArn(newEnvUnauthRoleArn);
+    expect(newEnvAuthRoleName).toBeIAMRoleWithArn(newEnvAuthRoleArn);
+    expect(newEnvDeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/interactions.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/interactions.test.ts
@@ -1,13 +1,11 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../src/init';
-import { addSampleInteraction } from '../src/categories/interactions';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getBot } from '../src/utils';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../init';
+import { addSampleInteraction } from '../categories/interactions';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getBot } from '../utils';
 
 describe('amplify add interactions', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
@@ -1,13 +1,11 @@
-require('../../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from '../../src/init';
-import { addApiWithSchema, updateApiSchema } from '../../src/categories/api';
-import { createNewProjectDir, deleteProjectDir } from '../../src/utils';
+import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from '../../init';
+import { addApiWithSchema, updateApiSchema } from '../../categories/api';
+import { createNewProjectDir, deleteProjectDir } from '../../utils';
 
 describe('amplify add api', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration.test.ts
@@ -1,13 +1,11 @@
-require('../../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from '../../src/init';
-import { addApiWithSchema, updateApiSchema } from '../../src/categories/api';
-import { createNewProjectDir, deleteProjectDir } from '../../src/utils';
+import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from '../../init';
+import { addApiWithSchema, updateApiSchema } from '../../categories/api';
+import { createNewProjectDir, deleteProjectDir } from '../../utils';
 
 describe('amplify add api', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/predictions.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/predictions.test.ts
@@ -1,14 +1,12 @@
-require('../src/aws-matchers');
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../src/init';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getAWSExports, getCollection } from '../src/utils';
-import { addConvert, addInterpret, addIdentifyCollection } from '../src/categories/predictions';
-import { addAuthWithDefault } from '../src/categories/auth';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../init';
+import { createNewProjectDir, deleteProjectDir, getAWSExports, getCollection } from '../utils';
+import { addConvert, addInterpret, addIdentifyCollection } from '../categories/predictions';
+import { addAuthWithDefault } from '../categories/auth';
 
 describe('amplify add predictions', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage.test.ts
@@ -1,6 +1,5 @@
-require('../src/aws-matchers/'); // custom matcher for assertion
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../src/init';
-import { addAuthWithDefault } from '../src/categories/auth';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from '../init';
+import { addAuthWithDefault } from '../categories/auth';
 import {
   addSimpleDDB,
   addDDBWithTrigger,
@@ -8,14 +7,13 @@ import {
   addS3WithTrigger,
   addSimpleDDBwithGSI,
   updateSimpleDDBwithGSI,
-} from '../src/categories/storage';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getDDBTable, checkIfBucketExists } from '../src/utils';
+} from '../categories/storage';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getDDBTable, checkIfBucketExists } from '../utils';
 
 describe('amplify add/update storage(S3)', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {
@@ -44,7 +42,6 @@ describe('amplify add/update storage(DDB) with GSI', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {
@@ -65,7 +62,6 @@ describe('amplify add/update storage(DDB)', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir();
-    jest.setTimeout(1000 * 60 * 60); // 1 hour
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
+++ b/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
@@ -1,4 +1,5 @@
-import { IAM, AWSError } from 'aws-sdk';
+import { IAM } from 'aws-sdk';
+
 expect.extend({
   async toBeIAMRoleWithArn(roleName: string, arn?: string) {
     const iam = new IAM();

--- a/packages/amplify-e2e-tests/src/aws-matchers/index.ts
+++ b/packages/amplify-e2e-tests/src/aws-matchers/index.ts
@@ -1,2 +1,2 @@
-require('./s3matcher');
-require('./iamMatcher');
+import './iamMatcher';
+import './s3matcher';

--- a/packages/amplify-e2e-tests/src/aws-matchers/s3matcher.ts
+++ b/packages/amplify-e2e-tests/src/aws-matchers/s3matcher.ts
@@ -1,4 +1,5 @@
 import { S3 } from 'aws-sdk';
+
 expect.extend({
   async toBeAS3Bucket(bucketName: string) {
     const s3 = new S3();

--- a/packages/amplify-e2e-tests/src/categories/analytics.ts
+++ b/packages/amplify-e2e-tests/src/categories/analytics.ts
@@ -1,4 +1,4 @@
-import * as nexpect from 'nexpect';
+import * as nexpect from '../utils/nexpect-modified';
 import { getCLIPath, isCI } from '../utils';
 
 export function addAnalytics(cwd: string, settings: any, verbose: boolean = !isCI()) {
@@ -16,8 +16,11 @@ export function addAnalytics(cwd: string, settings: any, verbose: boolean = !isC
       .wait(`Successfully added resource ${settings.rightName} locally`)
       .sendEof()
       .run((err: Error) => {
-        if (!err) resolve();
-        else reject(err);
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
       });
   });
 }
@@ -30,13 +33,16 @@ export function removeAnalytics(cwd: string, settings: any, verbose: boolean = !
       .send('j')
       .sendline('\r')
       .wait('Are you sure you want to delete the resource?')
-      .send('Y')
+      .send('y')
       .sendline('\r')
       .wait('Successfully removed resource')
       .sendEof()
       .run((err: Error) => {
-        if (!err) resolve();
-        else reject(err);
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
       });
   });
 }

--- a/packages/amplify-e2e-tests/src/categories/api.ts
+++ b/packages/amplify-e2e-tests/src/categories/api.ts
@@ -1,21 +1,8 @@
 import * as nexpect from 'nexpect';
-import { join } from 'path';
 import { updateSchema } from '../utils';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 
 import { getCLIPath, isCI } from '../utils';
-const defaultSettings = {
-  projectName: 'CLIIntegTestApi',
-};
-
-function readSchemaDocument(schemaName: string): string {
-  const docPath = `${__dirname}/../../schemas/${schemaName}.graphql`;
-  if (fs.existsSync(docPath)) {
-    return fs.readFileSync(docPath).toString();
-  } else {
-    throw new Error(`Could not find schema at path '${docPath}'`);
-  }
-}
 
 function getSchemaPath(schemaName: string): string {
   return `${__dirname}/../../schemas/${schemaName}`;
@@ -45,11 +32,10 @@ export function addApiWithoutSchema(cwd: string, verbose: boolean = !isCI()) {
       .sendline('\r')
       .wait('Do you want to edit the schema now?')
       .sendline('n')
-      // tslint:disable-next-line
       .wait(
         '"amplify publish" will build all your local backend and frontend resources (if you have hosting category added) and provision it in the cloud'
       )
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -80,11 +66,10 @@ export function addApiWithSchema(cwd: string, schemaFile: string, verbose: boole
       .sendline('y')
       .wait('Provide your schema file path:')
       .sendline(schemaPath)
-      // tslint:disable-next-line
       .wait(
         '"amplify publish" will build all your local backend and frontend resources (if you have hosting category added) and provision it in the cloud'
       )
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -138,7 +123,7 @@ export function updateApiWithMultiAuth(cwd: string, settings: any, verbose: bool
       .sendline('2000')
       .wait(/.*Successfully updated resource.*/)
       .sendEof()
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/categories/auth.ts
+++ b/packages/amplify-e2e-tests/src/categories/auth.ts
@@ -1,6 +1,4 @@
-import * as nexpect from 'nexpect';
-import { join } from 'path';
-import * as fs from 'fs';
+import * as nexpect from '../utils/nexpect-modified';
 
 import { getCLIPath, isCI, getEnvVars } from '../utils';
 
@@ -15,8 +13,7 @@ export function addAuthWithDefault(cwd: string, settings: any, verbose: boolean 
       .wait('Do you want to configure advanced settings?')
       .sendline('\r')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -48,7 +45,7 @@ export function addAuthWithGroupTrigger(cwd: string, settings: any, verbose: boo
       .wait('Do you want to edit your add-to-group function now?')
       .send('n')
       .send('\r')
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -100,7 +97,7 @@ export function addAuthViaAPIWithTrigger(cwd: string, settings: any, verbose: bo
       .wait('Do you want to edit the schema now?')
       .send('n')
       .send('\r')
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -179,7 +176,7 @@ export function addAuthWithCustomTrigger(cwd: string, settings: any, verbose: bo
       .wait('Do you want to edit your custom function now?')
       .send('n')
       .send('\r')
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -233,7 +230,7 @@ export function updateAuthWithoutCustomTrigger(cwd: string, settings: any, verbo
       .send('jjj')
       .send(' ')
       .send('\r')
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -271,7 +268,7 @@ export function addAuthWithRecaptchaTrigger(cwd: string, settings: any, verbose:
       .wait('Do you want to edit your captcha-verify function now?')
       .send('n')
       .send('\r')
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -353,7 +350,7 @@ export function addAuthWithDefaultSocial(cwd: string, settings: any, verbose: bo
       .send(AMAZON_APP_SECRET)
       .send('\r')
       .sendEof()
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -550,7 +547,7 @@ export function addAuthWithMaxOptions(cwd: string, settings: any, verbose: boole
       .send('n')
       .send('\r')
       .sendEof()
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/categories/function.ts
+++ b/packages/amplify-e2e-tests/src/categories/function.ts
@@ -1,11 +1,5 @@
 import * as nexpect from 'nexpect';
-import { join } from 'path';
-import * as fs from 'fs';
-
-import { getCLIPath, isCI, getEnvVars } from '../utils';
-const defaultSettings = {
-  projectName: 'CLI Function test',
-};
+import { getCLIPath, isCI } from '../utils';
 
 export function addHelloWorldFunction(cwd: string, settings: any, verbose: boolean = !isCI()) {
   return new Promise((resolve, reject) => {
@@ -22,8 +16,7 @@ export function addHelloWorldFunction(cwd: string, settings: any, verbose: boole
       .wait('Do you want to edit the local lambda function now')
       .sendline('n')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -40,8 +33,7 @@ export function functionBuild(cwd: string, settings: any, verbose: boolean = !is
       .wait('Are you sure you want to continue building the resources?')
       .sendline('Y')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/categories/hosting.ts
+++ b/packages/amplify-e2e-tests/src/categories/hosting.ts
@@ -7,27 +7,34 @@ export function addHosting(cwd: string, verbose: boolean = !isCI()) {
       .spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true, verbose })
       .wait('Select the environment setup:')
       .sendline('\r')
-      .wait("hosting bucket name")
+      .wait('hosting bucket name')
       .sendline('\r')
-      .wait("index doc for the website")
+      .wait('index doc for the website')
       .sendline('\r')
-      .wait("error doc for the website")
+      .wait('error doc for the website')
       .sendline('\r')
       .run((err: Error) => {
-        if (!err) resolve();
-        else reject(err);
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
       });
   });
 }
 
-export function amplifyPush(cwd: string, verbose: boolean = !isCI()) {  return new Promise((resolve, reject) => {
+export function amplifyPush(cwd: string, verbose: boolean = !isCI()) {
+  return new Promise((resolve, reject) => {
     nexpect
-      .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })  
+      .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })
       .wait('Are you sure you want to continue?')
       .sendline('\r')
       .run((err: Error) => {
-        if (!err) resolve();
-        else reject(err);
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
       });
   });
 }
@@ -42,8 +49,11 @@ export function removeHosting(cwd: string, verbose: boolean = !isCI()) {
       .sendline('\r')
       .wait('Successfully removed resource')
       .run((err: Error) => {
-        if (!err) resolve();
-        else reject(err);
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
       });
   });
 }

--- a/packages/amplify-e2e-tests/src/categories/interactions.ts
+++ b/packages/amplify-e2e-tests/src/categories/interactions.ts
@@ -1,11 +1,6 @@
 import * as nexpect from 'nexpect';
-import { join } from 'path';
-import * as fs from 'fs';
 
-import { getCLIPath, isCI, getEnvVars } from '../utils';
-const defaultSettings = {
-  projectName: 'CLI Interaction test',
-};
+import { getCLIPath, isCI } from '../utils';
 
 export function addSampleInteraction(cwd: string, settings: any, verbose: boolean = !isCI()) {
   return new Promise((resolve, reject) => {
@@ -20,8 +15,7 @@ export function addSampleInteraction(cwd: string, settings: any, verbose: boolea
       .wait("Please indicate if your use of this bot is subject to the Children's")
       .sendline('y')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/categories/predictions.ts
+++ b/packages/amplify-e2e-tests/src/categories/predictions.ts
@@ -1,5 +1,5 @@
-import { isCI } from '../utils';
 import * as nexpect from 'nexpect';
+import { isCI } from '../utils';
 import { getCLIPath } from '../utils/index';
 
 // add convert resource
@@ -24,10 +24,9 @@ export function addConvert(cwd: string, settings: any, verbose: boolean = !isCI(
       .sendline('j')
       .sendline('\r')
       .sendEof()
-      // .send
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
-          resolve(resourceName);
+          resolve();
         } else {
           reject(err);
         }
@@ -42,8 +41,6 @@ export function addIdentifyCollection(cwd: string, settings: any, verbose: boole
     nexpect
       .spawn(getCLIPath(), ['predictions', 'add'], { cwd, stripColors: true, verbose })
       .wait('Please select from one of the categories below')
-      // j = down arrow
-      // .sendline('j')
       .sendline('\r')
       .wait('What would you like to identify?')
       .sendline('j')
@@ -66,10 +63,9 @@ export function addIdentifyCollection(cwd: string, settings: any, verbose: boole
       .wait('The CLI would be provisioning an S3 bucket')
       .sendline('\r')
       .sendEof()
-      // .send
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
-          resolve(resourceName);
+          resolve();
         } else {
           reject(err);
         }
@@ -95,9 +91,9 @@ export function addInterpret(cwd: string, settings: any, verbose: boolean = !isC
       .wait('Who should have access?')
       .sendline('j')
       .sendEof()
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
-          resolve(resourceName);
+          resolve();
         } else {
           reject(err);
         }

--- a/packages/amplify-e2e-tests/src/categories/storage.ts
+++ b/packages/amplify-e2e-tests/src/categories/storage.ts
@@ -1,11 +1,5 @@
-import * as nexpect from 'nexpect';
-import { join } from 'path';
-import * as fs from 'fs';
-
-import { getCLIPath, isCI, getEnvVars } from '../utils';
-const defaultSettings = {
-  projectName: 'CLI Storage test',
-};
+import * as nexpect from '../utils/nexpect-modified';
+import { getCLIPath, isCI } from '../utils';
 
 export function addSimpleDDB(cwd: string, settings: any, verbose: boolean = !isCI()) {
   return new Promise((resolve, reject) => {
@@ -39,8 +33,7 @@ export function addSimpleDDB(cwd: string, settings: any, verbose: boolean = !isC
       .sendline('n')
       .sendline('\r')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -89,8 +82,7 @@ export function addDDBWithTrigger(cwd: string, settings: any, verbose: boolean =
       .sendline('n')
       .sendline('\r')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -129,8 +121,7 @@ export function updateDDBWithTrigger(cwd: string, settings: any, verbose: boolea
       .wait('overwrite')
       .sendline('y')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -166,8 +157,7 @@ export function addS3WithTrigger(cwd: string, settings: any, verbose: boolean = 
       .sendline('n')
       .sendline('\r')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -219,11 +209,11 @@ export function updateSimpleDDBwithGSI(cwd: string, settings: any, verbose: bool
       .sendline('y')
       .sendline('\r')
       .sendEof()
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
-          reject();
+          reject(err);
         }
       });
   });
@@ -276,8 +266,7 @@ export function addSimpleDDBwithGSI(cwd: string, settings: any, verbose: boolean
       .sendline('n')
       .sendline('\r')
       .sendEof()
-      // tslint:disable-next-line
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/codegen/add.ts
+++ b/packages/amplify-e2e-tests/src/codegen/add.ts
@@ -21,10 +21,12 @@ export function addCodegen(cwd: string, settings: any, verbose: boolean = !isCI(
         .wait('Do you want to generate code for your newly created GraphQL API')
         .sendline('\r');
     }
-    //.wait(`Generated GraphQL operations successfully and saved at`)
     run.run((err: Error) => {
-      if (!err) resolve();
-      else reject(err);
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
     });
   });
 }

--- a/packages/amplify-e2e-tests/src/configure/index.ts
+++ b/packages/amplify-e2e-tests/src/configure/index.ts
@@ -1,5 +1,4 @@
 import * as nexpect from 'nexpect';
-import { join } from 'path';
 
 import { getCLIPath, isCI } from '../utils';
 type AmplifyConfiguration = {
@@ -7,6 +6,7 @@ type AmplifyConfiguration = {
   secretAccessKey: string;
   profileName?: string;
 };
+
 const defaultSettings = {
   profileName: 'amplify-integ-test-user',
   region: '\r',
@@ -40,7 +40,7 @@ export default function amplifyConfigure(settings: AmplifyConfiguration, verbose
       .wait('Profile Name:')
       .sendline(s.profileName)
       .wait('Successfully set up the new user.')
-      .run(function(err) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/configure_tests.ts
+++ b/packages/amplify-e2e-tests/src/configure_tests.ts
@@ -1,19 +1,10 @@
-import { config } from 'dotenv';
-import { existsSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
-
 import configure from './configure';
 import { isCI } from './utils';
 
-const AWS_CREDENTIAL_PATH = join(homedir(), '.aws', 'credentials');
-
-async function setUpAmplify() {
+async function setupAmplify() {
   if (isCI()) {
-    let AWS_ACCESS_KEY_ID;
-    let AWS_SECRET_ACCESS_KEY;
-    AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-    AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+    const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+    const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
     if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
       throw new Error('Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in .env');
     }
@@ -29,7 +20,7 @@ async function setUpAmplify() {
 
 process.nextTick(async () => {
   try {
-    await setUpAmplify();
+    await setupAmplify();
   } catch (e) {
     console.log(e.stack);
     process.exit(1);

--- a/packages/amplify-e2e-tests/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-tests/src/init/amplifyPush.ts
@@ -1,7 +1,7 @@
 import * as nexpect from 'nexpect';
 import { getCLIPath, isCI } from '../utils';
 
-function amplifyPush(cwd: string, verbose: Boolean = isCI() ? false : true) {
+export function amplifyPush(cwd: string, verbose: Boolean = isCI() ? false : true) {
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })
@@ -10,7 +10,7 @@ function amplifyPush(cwd: string, verbose: Boolean = isCI() ? false : true) {
       .wait('Do you want to generate code for your newly created GraphQL API')
       .sendline('n')
       .wait(/.*/)
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -20,14 +20,14 @@ function amplifyPush(cwd: string, verbose: Boolean = isCI() ? false : true) {
   });
 }
 
-function amplifyPushUpdate(cwd: string, waitForText?: RegExp, verbose: Boolean = isCI() ? false : true) {
+export function amplifyPushUpdate(cwd: string, waitForText?: RegExp, verbose: Boolean = isCI() ? false : true) {
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })
       .wait('Are you sure you want to continue?')
       .sendline('y')
       .wait(waitForText || /.*/)
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -37,14 +37,14 @@ function amplifyPushUpdate(cwd: string, waitForText?: RegExp, verbose: Boolean =
   });
 }
 
-function amplifyPushAuth(cwd: string, verbose: Boolean = isCI() ? false : true) {
+export function amplifyPushAuth(cwd: string, verbose: Boolean = isCI() ? false : true) {
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['push'], { cwd, stripColors: true, verbose })
       .wait('Are you sure you want to continue?')
       .sendline('y')
       .wait(/.*/)
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {
@@ -53,5 +53,3 @@ function amplifyPushAuth(cwd: string, verbose: Boolean = isCI() ? false : true) 
       });
   });
 }
-
-export { amplifyPush, amplifyPushUpdate, amplifyPushAuth };

--- a/packages/amplify-e2e-tests/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-tests/src/init/deleteProject.ts
@@ -1,7 +1,7 @@
 import * as nexpect from 'nexpect';
 import { getCLIPath, isCI } from '../utils';
 
-export default function deleteProject(cwd: string, deleteDeploymentBucket: Boolean = true, verbose: Boolean = isCI() ? false : true) {
+export function deleteProject(cwd: string, deleteDeploymentBucket: Boolean = true, verbose: Boolean = isCI() ? false : true) {
   return new Promise((resolve, reject) => {
     nexpect
       .spawn(getCLIPath(), ['delete'], { cwd, stripColors: true, verbose })
@@ -9,7 +9,7 @@ export default function deleteProject(cwd: string, deleteDeploymentBucket: Boole
       .sendline('y')
       .sendline('')
       .wait('Project deleted locally.')
-      .run(async function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/init/index.ts
+++ b/packages/amplify-e2e-tests/src/init/index.ts
@@ -1,11 +1,4 @@
-export {
-  default as initJSProjectWithProfile,
-  initProjectWithAccessKey,
-  initNewEnvWithAccessKey,
-  initIosProjectWithProfile,
-  initAndroidProjectWithProfile,
-  initNewEnvWithProfile,
-} from './initProjectHelper';
+export * from './initProjectHelper';
 export * from './amplifyPush';
+export * from './deleteProject';
 export { getProjectMeta } from '../utils';
-export { default as deleteProject } from './deleteProject';

--- a/packages/amplify-e2e-tests/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-tests/src/init/initProjectHelper.ts
@@ -1,7 +1,6 @@
-import * as nexpect from 'nexpect';
-import { join } from 'path';
-
+import * as nexpect from '../utils/nexpect-modified';
 import { getCLIPath, isCI } from '../utils';
+
 const defaultSettings = {
   name: '\r',
   envName: 'integtest',
@@ -16,7 +15,7 @@ const defaultSettings = {
   profileName: '\r',
 };
 
-export default function initJSProjectWithProfile(cwd: string, settings: Object, verbose: Boolean = isCI() ? false : true) {
+export function initJSProjectWithProfile(cwd: string, settings: Object, verbose: Boolean = isCI() ? false : true) {
   const s = { ...defaultSettings, ...settings };
   return new Promise((resolve, reject) => {
     nexpect
@@ -209,7 +208,7 @@ export function initNewEnvWithProfile(cwd: string, s: { envName: string }, verbo
       .wait('Please choose the profile you want to use')
       .sendline('\r')
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
-      .run(function(err: Error) {
+      .run((err: Error) => {
         if (!err) {
           resolve();
         } else {

--- a/packages/amplify-e2e-tests/src/setup-tests.ts
+++ b/packages/amplify-e2e-tests/src/setup-tests.ts
@@ -1,0 +1,6 @@
+import './aws-matchers';
+
+// tslint:disable-next-line: no-magic-numbers
+const JEST_TIMEOUT = 1000 * 60 * 60; // 1 hour
+
+jest.setTimeout(JEST_TIMEOUT);

--- a/packages/amplify-e2e-tests/src/utils/api.ts
+++ b/packages/amplify-e2e-tests/src/utils/api.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 import { TRANSFORM_CONFIG_FILE_NAME } from 'graphql-transformer-core';
 
 export function updateSchema(projectDir: string, projectName: string, schemaText: string) {

--- a/packages/amplify-e2e-tests/src/utils/awsExports.ts
+++ b/packages/amplify-e2e-tests/src/utils/awsExports.ts
@@ -1,6 +1,7 @@
 require = require('esm')(module);
-import { join } from 'path';
+import * as path from 'path';
+
 export function getAWSExports(projectRoot: string) {
-  const metaFilePath = join(projectRoot, 'src', 'aws-exports.js');
+  const metaFilePath = path.join(projectRoot, 'src', 'aws-exports.js');
   return require(metaFilePath);
 }

--- a/packages/amplify-e2e-tests/src/utils/index.ts
+++ b/packages/amplify-e2e-tests/src/utils/index.ts
@@ -1,5 +1,5 @@
-import { join } from 'path';
-import { mkdirSync } from 'fs';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
 export * from './projectMeta';
@@ -12,14 +12,14 @@ export * from './api';
 config();
 
 export function getCLIPath() {
-  return join(__dirname, '..', '..', '..', 'amplify-cli', 'bin', 'amplify');
+  return path.join(__dirname, '..', '..', '..', 'amplify-cli', 'bin', 'amplify');
 }
 
 export function createNewProjectDir(root?: string): string {
   if (!root) {
-    root = join(__dirname, '../../../..', `amplify-integ-${Math.round(Math.random() * 100)}-test-${Math.round(Math.random() * 1000)}`);
+    root = path.join(__dirname, '../../../..', `amplify-integ-${Math.round(Math.random() * 100)}-test-${Math.round(Math.random() * 1000)}`);
   }
-  mkdirSync(root);
+  fs.mkdirSync(root);
   return root;
 }
 
@@ -31,6 +31,6 @@ export function isCI(): Boolean {
   return process.env.CI ? true : false;
 }
 
-export function getEnvVars(): {} {
-  return { ...process.env };
+export function getEnvVars(): { ACCESS_KEY_ID: string; SECRET_ACCESS_KEY: string } {
+  return { ...process.env } as { ACCESS_KEY_ID: string; SECRET_ACCESS_KEY: string };
 }

--- a/packages/amplify-e2e-tests/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-tests/src/utils/projectMeta.ts
@@ -1,6 +1,7 @@
-import { join } from 'path';
-import { readFileSync } from 'fs';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
 export function getProjectMeta(projectRoot: string) {
-  const metaFilePath = join(projectRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
-  return JSON.parse(readFileSync(metaFilePath, 'utf8'));
+  const metaFilePath = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+  return JSON.parse(fs.readFileSync(metaFilePath, 'utf8'));
 }

--- a/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
@@ -1,18 +1,17 @@
-import * as AWS from 'aws-sdk';
+import { config, DynamoDB, S3, CognitoIdentityServiceProvider, Lambda, LexModelBuildingService, Rekognition, AppSync } from 'aws-sdk';
 
 const getDDBTable = async (tableName: string, region: string) => {
-  const service = new AWS.DynamoDB({ region });
+  const service = new DynamoDB({ region });
   return await service.describeTable({ TableName: tableName }).promise();
 };
 
 const checkIfBucketExists = async (bucketName: string, region: string) => {
-  const service = new AWS.S3({ region });
+  const service = new S3({ region });
   return await service.headBucket({ Bucket: bucketName }).promise();
 };
 
 const getUserPool = async (userpoolId, region) => {
-  AWS.config.update({ region });
-  const CognitoIdentityServiceProvider = AWS.CognitoIdentityServiceProvider;
+  config.update({ region });
   let res;
   try {
     res = await new CognitoIdentityServiceProvider().describeUserPool({ UserPoolId: userpoolId }).promise();
@@ -23,8 +22,8 @@ const getUserPool = async (userpoolId, region) => {
 };
 
 const getLambdaFunction = async (functionName, region) => {
-  AWS.config.update({ region });
-  const lambda = new AWS.Lambda();
+  config.update({ region });
+  const lambda = new Lambda();
   let res;
   try {
     res = await lambda.getFunction({ FunctionName: functionName }).promise();
@@ -35,14 +34,13 @@ const getLambdaFunction = async (functionName, region) => {
 };
 
 const getUserPoolClients = async (userpoolId, region) => {
-  AWS.config.update({ region });
-  const CognitoIdentityServiceProvider = AWS.CognitoIdentityServiceProvider;
+  config.update({ region });
   const provider = new CognitoIdentityServiceProvider();
-  let res = [];
+  const res = [];
   try {
-    let clients = await provider.listUserPoolClients({ UserPoolId: userpoolId }).promise();
+    const clients = await provider.listUserPoolClients({ UserPoolId: userpoolId }).promise();
     for (let i = 0; i < clients.UserPoolClients.length; i++) {
-      let clientData = await provider
+      const clientData = await provider
         .describeUserPoolClient({
           UserPoolId: userpoolId,
           ClientId: clients.UserPoolClients[i].ClientId,
@@ -57,32 +55,32 @@ const getUserPoolClients = async (userpoolId, region) => {
 };
 
 const getBot = async (botName: string, region: string) => {
-  const service = new AWS.LexModelBuildingService({ region });
+  const service = new LexModelBuildingService({ region });
   return await service.getBot({ name: botName, versionOrAlias: '$LATEST' }).promise();
 };
 
 const getFunction = async (functionName: string, region: string) => {
-  const service = new AWS.Lambda({ region });
+  const service = new Lambda({ region });
   return await service.getFunction({ FunctionName: functionName }).promise();
 };
 
 const getCollection = async (collectionId: string, region: string) => {
-  const service = new AWS.Rekognition({ region });
+  const service = new Rekognition({ region });
   return await service.describeCollection({ CollectionId: collectionId }).promise();
 };
 
 const getTable = async (tableName: string, region: string) => {
-  const service = new AWS.DynamoDB({ region });
+  const service = new DynamoDB({ region });
   return await service.describeTable({ TableName: tableName }).promise();
 };
 
 const deleteTable = async (tableName: string, region: string) => {
-  const service = new AWS.DynamoDB({ region });
+  const service = new DynamoDB({ region });
   return await service.deleteTable({ TableName: tableName }).promise();
 };
 
 const getAppSyncApi = async (appSyncApiId: string, region: string) => {
-  const service = new AWS.AppSync({ region });
+  const service = new AppSync({ region });
   return await service.getGraphqlApi({ apiId: appSyncApiId }).promise();
 };
 

--- a/packages/amplify-e2e-tests/src/utils/transformConfig.ts
+++ b/packages/amplify-e2e-tests/src/utils/transformConfig.ts
@@ -1,7 +1,8 @@
-import { join } from 'path';
-import { readFileSync } from 'fs-extra';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import { TRANSFORM_CONFIG_FILE_NAME, TransformConfig } from 'graphql-transformer-core';
+
 export function getTransformConfig(projectRoot: string, apiName: string): TransformConfig {
-  const metaFilePath = join(projectRoot, 'amplify', 'backend', 'api', apiName, TRANSFORM_CONFIG_FILE_NAME);
-  return <TransformConfig>JSON.parse(readFileSync(metaFilePath, 'utf8'));
+  const metaFilePath = path.join(projectRoot, 'amplify', 'backend', 'api', apiName, TRANSFORM_CONFIG_FILE_NAME);
+  return <TransformConfig>JSON.parse(fs.readFileSync(metaFilePath, 'utf8'));
 }

--- a/packages/amplify-e2e-tests/tsconfig.json
+++ b/packages/amplify-e2e-tests/tsconfig.json
@@ -1,23 +1,15 @@
 {
-    "compilerOptions": {
-        "skipLibCheck": true,
-        "target": "es5",
-        "module": "commonjs",
-        "sourceMap": true,
-        "rootDir": "./src",
-        "types": ["jest"],
-        "outDir": "lib",
-        "lib": [
-            "es2015",
-            "es2016.array.include",
-            "esnext.asynciterable",
-            "dom"
-        ],
-        "declaration": true
-    },
-    "exclude": [
-        "node_modules",
-        "lib",
-        "__tests__"
-    ]
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "target": "es5",
+    "module": "commonjs",
+    "sourceMap": true,
+    "rootDir": "./src",
+    "types": ["jest"],
+    "outDir": "lib",
+    "lib": ["es2015", "es2016.array.include", "esnext.asynciterable", "dom"],
+    "declaration": true,
+    "typeRoots": ["node_modules/@types", "./typings"]
+  },
+  "exclude": ["node_modules", "lib", "__tests__"]
 }

--- a/packages/amplify-e2e-tests/typings/aws-matchers.d.ts
+++ b/packages/amplify-e2e-tests/typings/aws-matchers.d.ts
@@ -1,0 +1,6 @@
+namespace jest {
+  interface Matchers<R> {
+    toBeIAMRoleWithArn(roleName: string, arn?: string): R;
+    toBeAS3Bucket(bucketName: string): R;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,11 +2915,6 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.1.1.tgz#c54ab1a5f41aa693c0957222dd10414416d0c87b"
   integrity sha512-x3zfj6ZjmmhoQK9FjBNZN7j5xDQ+Dd2VpxGdll74WUEF8NmTIYSaZTMbzsB5lqNuReuyC75695wM/cNKoJomZA==
 
-"@types/jest@23.1.6":
-  version "23.1.6"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.1.6.tgz#11c88f738f5b57d1a9dd4970c576a6639b8f0f37"
-  integrity sha512-lBu2tjrfGuj0gARErNmHZJrnWBdRrYk2XqlBY3LRv8Dqxk3w3461uuFMKmwfDDiOa5kzXocUnunCBBacGwF3+A==
-
 "@types/jest@23.3.1":
   version "23.3.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
@@ -2937,7 +2932,7 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
   integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
-"@types/jest@^24.0.15", "@types/jest@^24.0.16":
+"@types/jest@^24.0.15", "@types/jest@^24.0.16", "@types/jest@^24.0.23":
   version "24.0.23"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.23.tgz#046f8e2ade026fe831623e361a36b6fb9a4463e4"
   integrity sha512-L7MBvwfNpe7yVPTXLn32df/EK+AMBFAFvZrRuArGs7npEWnlziUXK+5GMIUTI4NIuwok3XibsjXCs5HxviYXjg==
@@ -3014,7 +3009,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.6.tgz#2f8d551aef252de78f42acdccd53f5a8ce0cac4d"
   integrity sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ==
 
-"@types/node@^8.10.51":
+"@types/node@^8.10.51", "@types/node@^8.10.59":
   version "8.10.59"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.59.tgz#9e34261f30183f9777017a13d185dfac6b899e04"
   integrity sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==
@@ -3896,6 +3891,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.2.tgz#e70c90579e02c63d80e3ad4e31d8bfdb8bd50064"
+  integrity sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -4317,6 +4317,21 @@ aws-sdk@^2.577.0:
   version "2.577.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.577.0.tgz#3718021182aa3058fda2ce968b72b7e4ffe4360a"
   integrity sha512-c+8AbZuosYnqYvgFLVScIxcZBFPSiFer+46k7fe/dV1EY3TUJI8Rarcmj7E3ljtZtssTxbSmor8I5Xyii40h3g==
+  dependencies:
+    buffer "^4.9.1"
+    events "^1.1.1"
+    ieee754 "^1.1.13"
+    jmespath "^0.15.0"
+    querystring "^0.2.0"
+    sax "^1.2.1"
+    url "^0.10.3"
+    uuid "^3.3.2"
+    xml2js "^0.4.19"
+
+aws-sdk@^2.580.0:
+  version "2.580.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.580.0.tgz#b411168ab3b92a1c2977e9c020406af2a5b74cf7"
+  integrity sha512-YUn/LgaSjWuFDCAIOiOvyXbuRpNEzTPLbwRs3GpEmrP1hJrOChXh0p7GH61sTZdeJZarCSETUOWU5ngjpCOjKA==
   dependencies:
     buffer "^4.9.1"
     events "^1.1.1"
@@ -7388,6 +7403,11 @@ dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
+
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 download-cli@^1.1.1:
   version "1.1.1"
@@ -11456,6 +11476,28 @@ jest-changed-files@^24.9.0:
     execa "^1.0.0"
     throat "^4.0.0"
 
+jest-circus@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-24.9.0.tgz#8a557683636807d537507eac02ba64c95b686485"
+  integrity sha512-dwkvwFtRc9Anmk1XTc+bonVL8rVMZ3CeGMoFWmv1oaQThdAgvfI9bwaFlZp+gLVphNVz6ZLfCWo3ERhS5CeVvA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^24.9.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^24.9.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^24.9.0"
+    jest-matcher-utils "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-snapshot "^24.9.0"
+    jest-util "^24.9.0"
+    pretty-format "^24.9.0"
+    stack-utils "^1.0.1"
+    throat "^4.0.0"
+
 jest-cli@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
@@ -11929,6 +11971,17 @@ jest-junit@^8.0.0:
     jest-validate "^24.0.0"
     mkdirp "^0.5.1"
     strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
+jest-junit@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-9.0.0.tgz#9eb247dda7a8d2e1647a92f58a03a1490c74aea5"
+  integrity sha512-jnABGjL5pd2lhE1w3RIslZSufFbWQZGx8O3eluDES7qKxQuonXMtsPIi+4AKl4rtjb4DvMAjwLi4eHukc2FP/Q==
+  dependencies:
+    jest-validate "^24.9.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^5.2.0"
+    uuid "^3.3.3"
     xml "^1.0.1"
 
 jest-leak-detector@^23.6.0:
@@ -19442,6 +19495,22 @@ ts-jest@24.1.0, ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
+ts-jest@^24.2.0:
+  version "24.2.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.2.0.tgz#7abca28c2b4b0a1fdd715cd667d65d047ea4e768"
+  integrity sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
+
 ts-node@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-5.0.1.tgz#78e5d1cb3f704de1b641e43b76be2d4094f06f81"
@@ -19455,6 +19524,17 @@ ts-node@^5.0.1:
     mkdirp "^0.5.1"
     source-map-support "^0.5.3"
     yn "^2.0.0"
+
+ts-node@^8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.2.tgz#434f6c893bafe501a30b32ac94ee36809ba2adce"
+  integrity sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
 
 ts-pnp@1.1.4:
   version "1.1.4"
@@ -20950,6 +21030,11 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zen-observable-ts@^0.8.10, zen-observable-ts@^0.8.20:
   version "0.8.20"


### PR DESCRIPTION
*Description of changes:*

amplify-e2e:
- update jest to 24.9
- add jest circus as runner
- standardize jest config
- remove build step, running it with ts-node
- remove and fix lint ignores
- remove unused code
- standardize imports (path, fs-extra)
- make customer matchers typescript friendly for ts-node, ts-jest
- move __tests__ under src to follow the convention
- removed extra 'await' statement from expects

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.