### PR TITLE
fix(amplify-appsync-simulator): add js-string-escape to package.json

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -50,7 +50,8 @@
     "retimer": "2.0.0",
     "steed": "^1.1.3",
     "uuid": "^3.3.3",
-    "websocket-stream": "^5.5.0"
+    "websocket-stream": "^5.5.0",
+    "js-string-escape": "^1.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.5",

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -3,12 +3,13 @@ import * as autoId from 'uuid/v4';
 import { JavaString } from '../value-mapper/string';
 import { JavaArray } from '../value-mapper/array';
 import { JavaMap } from '../value-mapper/map';
+import * as jsStringEscape from 'js-string-escape';
 export const generalUtils = {
   errors: [],
   quiet: () => '',
   qr: () => '',
   escapeJavaScript(value) {
-    return require('js-string-escape')(value);
+    return jsStringEscape(value);
   },
   urlEncode(value) {
     return encodeURI(value);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.