### PR TITLE
fix: use managedpolicies and slice them, fixes: #2703

### DIFF
--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -27,7 +27,6 @@ import {
   ResolverResourceIDs,
   isListType,
   getBaseType,
-  getDirectiveArgument,
   makeDirective,
   makeNamedType,
   makeInputValueDefinition,
@@ -38,23 +37,7 @@ import {
   makeField,
   ModelResourceIDs,
 } from 'graphql-transformer-common';
-import {
-  Expression,
-  print,
-  raw,
-  iff,
-  forEach,
-  set,
-  ref,
-  list,
-  compoundExpression,
-  or,
-  newline,
-  comment,
-  and,
-  not,
-  parens,
-} from 'graphql-mapping-template';
+import { Expression, print, raw, iff, forEach, set, ref, list, compoundExpression, newline, comment, not } from 'graphql-mapping-template';
 import { ModelDirectiveConfiguration, ModelDirectiveOperationType, ModelSubscriptionLevel } from './ModelDirectiveConfiguration';
 
 import { OWNER_AUTH_STRATEGY, GROUPS_AUTH_STRATEGY, DEFAULT_OWNER_FIELD } from './constants';
@@ -296,9 +279,15 @@ export class ModelAuthTransformer extends Transformer {
         }),
       });
 
-      ctx.mergeResources({
-        [ResourceConstants.RESOURCES.AuthRolePolicy]: this.resources.makeIAMPolicyForRole(true, this.authPolicyResources),
-      });
+      const authPolicies = this.resources.makeIAMPolicyForRole(true, this.authPolicyResources);
+
+      for (let i = 0; i < authPolicies.length; i++) {
+        const paddedIndex = `${i + 1}`.padStart(2, '0');
+        const resourceName = `${ResourceConstants.RESOURCES.AuthRolePolicy}${paddedIndex}`;
+        ctx.mergeResources({
+          [resourceName]: authPolicies[i],
+        });
+      }
     }
 
     if (this.generateIAMPolicyforUnauthRole === true) {
@@ -313,9 +302,15 @@ export class ModelAuthTransformer extends Transformer {
         }),
       });
 
-      ctx.mergeResources({
-        [ResourceConstants.RESOURCES.UnauthRolePolicy]: this.resources.makeIAMPolicyForRole(false, this.unauthPolicyResources),
-      });
+      const unauthPolicies = this.resources.makeIAMPolicyForRole(false, this.unauthPolicyResources);
+
+      for (let i = 0; i < unauthPolicies.length; i++) {
+        const paddedIndex = `${i + 1}`.padStart(2, '0');
+        const resourceName = `${ResourceConstants.RESOURCES.UnauthRolePolicy}${paddedIndex}`;
+        ctx.mergeResources({
+          [resourceName]: unauthPolicies[i],
+        });
+      }
     }
   };
 

--- a/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
@@ -1,6 +1,5 @@
 import { ObjectTypeDefinitionNode, parse, DocumentNode, Kind } from 'graphql';
 import { GraphQLTransform } from 'graphql-transformer-core';
-import { ResourceConstants } from 'graphql-transformer-common';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { ModelAuthTransformer, AppSyncAuthConfiguration, AppSyncAuthMode } from '../ModelAuthTransformer';
@@ -320,7 +319,7 @@ describe('Type directive transformation tests', () => {
 
     const out = transformer.transform(schema);
 
-    expect(out.rootStack.Resources[ResourceConstants.RESOURCES.UnauthRolePolicy]).toBeDefined();
+    expect(out.rootStack.Resources.UnauthRolePolicy01).toBeDefined();
   });
 
   test(`Field level @auth is propagated to type and the type related operations`, () => {
@@ -437,4 +436,77 @@ describe('Type directive transformation tests', () => {
   //     const modelPostConnectionType = getObjectType(schemaDoc, 'ModelPostConnection');
   //     expect (expectOne(modelPostConnectionType, 'aws_cognito_user_pools'));
   // });
+});
+
+describe(`Policy slicing tests`, () => {
+  test(`'For the long Todo type there should be 2 auth role managed policies generated`, () => {
+    const schema = `
+    type TodoWithExtraLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName @model(subscriptions:null) @auth(rules:[{allow: private, provider: iam}])
+    {
+      id: ID!
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename001: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename002: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename003: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename004: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename005: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename006: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename007: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename008: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename009: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename010: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename011: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename012: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename013: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename014: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename015: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename016: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename017: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename018: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename019: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename020: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename021: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename022: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename023: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename024: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename025: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename026: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename027: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename028: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename029: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename030: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename031: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename032: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename033: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename034: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename035: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename036: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename037: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename038: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename039: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename040: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename041: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename042: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename043: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename044: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename045: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename046: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename047: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename048: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename049: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename050: String! @auth(rules:[{allow: private, provider: iam}])
+      description: String
+    }
+    `;
+    const authConfig = withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS', 'AWS_IAM']);
+    const transformer = getTransformer(authConfig);
+    const out = transformer.transform(schema);
+
+    expect(out.rootStack.Resources.AuthRolePolicy01).toBeTruthy();
+    expect(out.rootStack.Resources.AuthRolePolicy01.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(27);
+    expect(out.rootStack.Resources.AuthRolePolicy02).toBeTruthy();
+    expect(out.rootStack.Resources.AuthRolePolicy02.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(27);
+    expect(out.rootStack.Resources.AuthRolePolicy03).toBeTruthy();
+    expect(out.rootStack.Resources.AuthRolePolicy03.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(2);
+    expect(out.rootStack.Resources.UnauthRolePolicy01).toBeFalsy();
+  });
 });

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -1,5 +1,4 @@
 import Template from 'cloudform-types/types/template';
-import Policy from 'cloudform-types/types/iam/policy';
 import { AppSync, Fn, StringParameter, Refs, NumberParameter, IAM, Value } from 'cloudform-types';
 import { AuthRule, AuthProvider } from './AuthRule';
 import {
@@ -37,6 +36,7 @@ import * as Transformer from './ModelAuthTransformer';
 import { FieldDefinitionNode } from 'graphql';
 
 import { DEFAULT_OWNER_FIELD, DEFAULT_IDENTITY_FIELD, DEFAULT_GROUPS_FIELD, DEFAULT_GROUP_CLAIM } from './constants';
+import ManagedPolicy from 'cloudform-types/types/iam/managedPolicy';
 
 function replaceIfUsername(identityClaim: string): string {
   return identityClaim === 'username' ? 'cognito:username' : identityClaim;
@@ -973,9 +973,34 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
       : ResourceConstants.SNIPPETS.IsStaticGroupAuthorizedVariable;
   }
 
-  public makeIAMPolicyForRole(isAuthPolicy: Boolean, resources: Set<string>): Policy {
+  public makeIAMPolicyForRole(isAuthPolicy: Boolean, resources: Set<string>): ManagedPolicy[] {
+    const policies = new Array<ManagedPolicy>();
     const authPiece = isAuthPolicy ? 'auth' : 'unauth';
-    const policyResources: object[] = [];
+    let policyResources: object[] = [];
+    let resourceSize = 0;
+
+    // 6144 bytes is the maximum policy payload size, but there is structural overhead, hence the 6000 bytes
+    const MAX_BUILT_SIZE_BYTES = 6000;
+    // The overhead is the amount of static policy arn contents like region, accountid, etc.
+    const RESOURCE_OVERHEAD = 90;
+
+    const createPolicy = newPolicyResources =>
+      new IAM.ManagedPolicy({
+        Roles: [
+          //HACK double casting needed because it cannot except Ref
+          ({ Ref: `${authPiece}RoleName` } as unknown) as Value<string>,
+        ],
+        PolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: ['appsync:GraphQL'],
+              Resource: newPolicyResources,
+            },
+          ],
+        },
+      });
 
     for (const resource of resources) {
       // We always have 2 parts, no need to check
@@ -991,6 +1016,8 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
             fieldName: resourceParts[1],
           })
         );
+
+        resourceSize += RESOURCE_OVERHEAD + resourceParts[0].length + resourceParts[1].length;
       } else {
         policyResources.push(
           Fn.Sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:apis/${apiId}/types/${typeName}/*', {
@@ -1000,26 +1027,33 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
             typeName: resourceParts[0],
           })
         );
+
+        resourceSize += RESOURCE_OVERHEAD + resourceParts[0].length;
+      }
+
+      //
+      // Check policy size and if needed create a new one and clear the resources, reset
+      // accumulated size
+      //
+
+      if (resourceSize > MAX_BUILT_SIZE_BYTES) {
+        const policy = createPolicy(policyResources.slice(0, policyResources.length - 1));
+
+        policies.push(policy);
+
+        // Remove all but the last item
+        policyResources = policyResources.slice(-1);
+        resourceSize = 0;
       }
     }
 
-    return new IAM.Policy({
-      PolicyName: `appsync-${authPiece}role-policy`,
-      Roles: [
-        //HACK double casting needed because it cannot except Ref
-        ({ Ref: `${authPiece}RoleName` } as unknown) as Value<string>,
-      ],
-      PolicyDocument: {
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Effect: 'Allow',
-            Action: ['appsync:GraphQL'],
-            Resource: policyResources,
-          },
-        ],
-      },
-    });
+    if (policyResources.length > 0) {
+      const policy = createPolicy(policyResources);
+
+      policies.push(policy);
+    }
+
+    return policies;
   }
 
   /**

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -30,2812 +30,2858 @@ import 'isomorphic-fetch';
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
+describe(`ModelAuthTests`, async () => {
+  const cf = new CloudFormationClient('us-west-2');
 
-const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
-const STACK_NAME = `ModelAuthTransformerTest-${BUILD_TIMESTAMP}`;
-const BUCKET_NAME = `appsync-auth-transformer-test-bucket-${BUILD_TIMESTAMP}`;
-const LOCAL_FS_BUILD_DIR = '/tmp/model_auth_transform_tests/';
-const S3_ROOT_DIR_KEY = 'deployments';
+  const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+  const STACK_NAME = `ModelAuthTransformerTest-${BUILD_TIMESTAMP}`;
+  const BUCKET_NAME = `appsync-auth-transformer-test-bucket-${BUILD_TIMESTAMP}`;
+  const LOCAL_FS_BUILD_DIR = '/tmp/model_auth_transform_tests/';
+  const S3_ROOT_DIR_KEY = 'deployments';
 
-let GRAPHQL_ENDPOINT = undefined;
+  let GRAPHQL_ENDPOINT = undefined;
 
-/**
- * Client 1 is logged in and is a member of the Admin group.
- */
-let GRAPHQL_CLIENT_1 = undefined;
+  /**
+   * Client 1 is logged in and is a member of the Admin group.
+   */
+  let GRAPHQL_CLIENT_1 = undefined;
 
-/**
- * Client 1 is logged in and is a member of the Admin group via an access token.
- */
-let GRAPHQL_CLIENT_1_ACCESS = undefined;
+  /**
+   * Client 1 is logged in and is a member of the Admin group via an access token.
+   */
+  let GRAPHQL_CLIENT_1_ACCESS = undefined;
 
-/**
- * Client 2 is logged in and is a member of the Devs group.
- */
-let GRAPHQL_CLIENT_2 = undefined;
+  /**
+   * Client 2 is logged in and is a member of the Devs group.
+   */
+  let GRAPHQL_CLIENT_2 = undefined;
 
-/**
- * Client 3 is logged in and has no group memberships.
- */
-let GRAPHQL_CLIENT_3 = undefined;
+  /**
+   * Client 3 is logged in and has no group memberships.
+   */
+  let GRAPHQL_CLIENT_3 = undefined;
 
-let USER_POOL_ID = undefined;
+  let USER_POOL_ID = undefined;
 
-const USERNAME1 = 'user1@test.com';
-const USERNAME2 = 'user2@test.com';
-const USERNAME3 = 'user3@test.com';
-const TMP_PASSWORD = 'Password123!';
-const REAL_PASSWORD = 'Password1234!';
+  const USERNAME1 = 'user1@test.com';
+  const USERNAME2 = 'user2@test.com';
+  const USERNAME3 = 'user3@test.com';
+  const TMP_PASSWORD = 'Password123!';
+  const REAL_PASSWORD = 'Password1234!';
 
-const ADMIN_GROUP_NAME = 'Admin';
-const DEVS_GROUP_NAME = 'Devs';
-const PARTICIPANT_GROUP_NAME = 'Participant';
-const WATCHER_GROUP_NAME = 'Watcher';
+  const ADMIN_GROUP_NAME = 'Admin';
+  const DEVS_GROUP_NAME = 'Devs';
+  const PARTICIPANT_GROUP_NAME = 'Participant';
+  const WATCHER_GROUP_NAME = 'Watcher';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
+  const customS3Client = new S3Client('us-west-2');
+  const awsS3Client = new S3({ region: 'us-west-2' });
 
-function outputValueSelector(key: string) {
-  return (outputs: Output[]) => {
-    const output = outputs.find((o: Output) => o.OutputKey === key);
-    return output ? output.OutputValue : null;
-  };
-}
+  function outputValueSelector(key: string) {
+    return (outputs: Output[]) => {
+      const output = outputs.find((o: Output) => o.OutputKey === key);
+      return output ? output.OutputValue : null;
+    };
+  }
 
-function deleteDirectory(directory: string) {
-  const files = fs.readdirSync(directory);
-  for (const file of files) {
-    const contentPath = path.join(directory, file);
-    if (fs.lstatSync(contentPath).isDirectory()) {
-      deleteDirectory(contentPath);
-      fs.rmdirSync(contentPath);
-    } else {
-      fs.unlinkSync(contentPath);
+  function deleteDirectory(directory: string) {
+    const files = fs.readdirSync(directory);
+    for (const file of files) {
+      const contentPath = path.join(directory, file);
+      if (fs.lstatSync(contentPath).isDirectory()) {
+        deleteDirectory(contentPath);
+        fs.rmdirSync(contentPath);
+      } else {
+        fs.unlinkSync(contentPath);
+      }
     }
   }
-}
 
-beforeAll(async () => {
-  // Create a stack for the post model with auth enabled.
-  const validSchema = `
-    type Post @model @auth(rules: [{ allow: owner }]) {
-        id: ID!
-        title: String!
-        createdAt: String
-        updatedAt: String
-        owner: String
-    }
-    type Salary @model @auth(
-        rules: [
-            {allow: owner},
-            {allow: groups, groups: ["Admin"]}
-        ]
-    ) {
-        id: ID!
-        wage: Int
-        owner: String
-    }
-    type AdminNote @model @auth(
-        rules: [
-            {allow: groups, groups: ["Admin"], groupClaim: "cognito:groups"}
-        ]
-    ) {
-        id: ID!
-        content: String!
-    }
-    type ManyGroupProtected @model @auth(rules: [{allow: groups, groupsField: "groups"}]) {
-        id: ID!
-        value: Int
-        groups: [String]
-    }
-    type SingleGroupProtected @model @auth(rules: [{allow: groups, groupsField: "group"}]) {
-        id: ID!
-        value: Int
-        group: String
-    }
-    type PWProtected
-        @auth(rules: [
-            {allow: groups, groupsField: "participants", mutations: [update, delete], queries: [get, list]},
-            {allow: groups, groupsField: "watchers", mutations: [], queries: [get, list]}
-        ])
-        @model
-    {
-        id: ID!
-        content: String!
-        participants: String
-        watchers: String
-    }
-    type AllThree
-        @auth(rules: [
-            {allow: owner, identityField: "username" },
-            {allow: owner, ownerField: "editors", identityField: "cognito:username" },
-            {allow: groups, groups: ["Admin"]},
-            {allow: groups, groups: ["Execs"]},
-            {allow: groups, groupsField: "groups"},
-            {allow: groups, groupsField: "alternativeGroup"}
-        ])
-        @model
-    {
-        id: ID!
-        owner: String
-        editors: [String]
-        groups: [String]
-        alternativeGroup: String
-    }
-    # The owner should always start with https://cognito-idp
-    type TestIdentity @model @auth(rules: [{ allow: owner, identityField: "iss" }]) {
-        id: ID!
-        title: String!
-        owner: String
-    }
-    type OwnerReadProtected @model @auth(rules: [{ allow: owner, operations: [read] }]) {
-        id: ID!
-        content: String
-        owner: String
-    }
-    type OwnerCreateUpdateDeleteProtected @model @auth(rules: [{ allow: owner, operations: [create, update, delete] }]) {
-        id: ID!
-        content: String
-        owner: String
-    }
-    type Performance @model @auth(rules: [{ allow: groups, groups: ["Admin"]}, { allow: private, operations: [read] }]) {
-        id: ID!
-        performer: String!
-        description: String!
-        time: AWSDateTime
-        stage: Stage! @connection
-    }
-    type Stage @model @auth(rules: [{ allow: groups, groups: ["Admin"]}, { allow: private, operations: [read] }]) {
-        id: ID!
-        name: String!
-    }
-    `;
-  const transformer = new GraphQLTransform({
-    transformers: [
-      new DynamoDBModelTransformer(),
-      new ModelConnectionTransformer(),
-      new ModelAuthTransformer({
-        authConfig: {
-          defaultAuthentication: {
-            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+  beforeAll(async () => {
+    // Create a stack for the post model with auth enabled.
+    const validSchema = `
+      type Post @model @auth(rules: [{ allow: owner }]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+          owner: String
+      }
+      type Salary @model @auth(
+          rules: [
+              {allow: owner},
+              {allow: groups, groups: ["Admin"]}
+          ]
+      ) {
+          id: ID!
+          wage: Int
+          owner: String
+      }
+      type AdminNote @model @auth(
+          rules: [
+              {allow: groups, groups: ["Admin"], groupClaim: "cognito:groups"}
+          ]
+      ) {
+          id: ID!
+          content: String!
+      }
+      type ManyGroupProtected @model @auth(rules: [{allow: groups, groupsField: "groups"}]) {
+          id: ID!
+          value: Int
+          groups: [String]
+      }
+      type SingleGroupProtected @model @auth(rules: [{allow: groups, groupsField: "group"}]) {
+          id: ID!
+          value: Int
+          group: String
+      }
+      type PWProtected
+          @auth(rules: [
+              {allow: groups, groupsField: "participants", mutations: [update, delete], queries: [get, list]},
+              {allow: groups, groupsField: "watchers", mutations: [], queries: [get, list]}
+          ])
+          @model
+      {
+          id: ID!
+          content: String!
+          participants: String
+          watchers: String
+      }
+      type AllThree
+          @auth(rules: [
+              {allow: owner, identityField: "username" },
+              {allow: owner, ownerField: "editors", identityField: "cognito:username" },
+              {allow: groups, groups: ["Admin"]},
+              {allow: groups, groups: ["Execs"]},
+              {allow: groups, groupsField: "groups"},
+              {allow: groups, groupsField: "alternativeGroup"}
+          ])
+          @model
+      {
+          id: ID!
+          owner: String
+          editors: [String]
+          groups: [String]
+          alternativeGroup: String
+      }
+      # The owner should always start with https://cognito-idp
+      type TestIdentity @model @auth(rules: [{ allow: owner, identityField: "iss" }]) {
+          id: ID!
+          title: String!
+          owner: String
+      }
+      type OwnerReadProtected @model @auth(rules: [{ allow: owner, operations: [read] }]) {
+          id: ID!
+          content: String
+          owner: String
+      }
+      type OwnerCreateUpdateDeleteProtected @model @auth(rules: [{ allow: owner, operations: [create, update, delete] }]) {
+          id: ID!
+          content: String
+          owner: String
+      }
+      type Performance @model @auth(rules: [{ allow: groups, groups: ["Admin"]}, { allow: private, operations: [read] }]) {
+          id: ID!
+          performer: String!
+          description: String!
+          time: AWSDateTime
+          stage: Stage! @connection
+      }
+      type Stage @model @auth(rules: [{ allow: groups, groups: ["Admin"]}, { allow: private, operations: [read] }]) {
+          id: ID!
+          name: String!
+      }
+      `;
+    const transformer = new GraphQLTransform({
+      transformers: [
+        new DynamoDBModelTransformer(),
+        new ModelConnectionTransformer(),
+        new ModelAuthTransformer({
+          authConfig: {
+            defaultAuthentication: {
+              authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+            },
+            additionalAuthenticationProviders: [],
           },
-          additionalAuthenticationProviders: [],
-        },
-      }),
-    ],
-  });
-  try {
-    await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
-  } catch (e) {
-    console.error(`Failed to create bucket: ${e}`);
-  }
-  const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
-  USER_POOL_ID = userPoolResponse.UserPool.Id;
-  const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
-  const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
-  try {
-    // Clean the bucket
-    const out = transformer.transform(validSchema);
-    const finishedStack = await deploy(
-      customS3Client,
-      cf,
-      STACK_NAME,
-      out,
-      { AuthCognitoUserPoolId: USER_POOL_ID },
-      LOCAL_FS_BUILD_DIR,
-      BUCKET_NAME,
-      S3_ROOT_DIR_KEY,
-      BUILD_TIMESTAMP
-    );
-    expect(finishedStack).toBeDefined();
-    const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
-    const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
-    GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
-    console.log(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
+        }),
+      ],
+    });
+    try {
+      await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+    } catch (e) {
+      console.error(`Failed to create bucket: ${e}`);
+    }
+    const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+    USER_POOL_ID = userPoolResponse.UserPool.Id;
+    const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+    const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+    try {
+      // Clean the bucket
+      const out = transformer.transform(validSchema);
+      const finishedStack = await deploy(
+        customS3Client,
+        cf,
+        STACK_NAME,
+        out,
+        { AuthCognitoUserPoolId: USER_POOL_ID },
+        LOCAL_FS_BUILD_DIR,
+        BUCKET_NAME,
+        S3_ROOT_DIR_KEY,
+        BUILD_TIMESTAMP
+      );
+      expect(finishedStack).toBeDefined();
+      const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+      const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+      GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+      console.log(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
 
-    const apiKey = getApiKey(finishedStack.Outputs);
-    console.log(`API KEY: ${apiKey}`);
-    expect(apiKey).not.toBeTruthy();
+      const apiKey = getApiKey(finishedStack.Outputs);
+      console.log(`API KEY: ${apiKey}`);
+      expect(apiKey).not.toBeTruthy();
 
-    // Verify we have all the details
-    expect(GRAPHQL_ENDPOINT).toBeTruthy();
-    expect(USER_POOL_ID).toBeTruthy();
-    expect(userPoolClientId).toBeTruthy();
+      // Verify we have all the details
+      expect(GRAPHQL_ENDPOINT).toBeTruthy();
+      expect(USER_POOL_ID).toBeTruthy();
+      expect(userPoolClientId).toBeTruthy();
 
-    // Configure Amplify, create users, and sign in.
-    configureAmplify(USER_POOL_ID, userPoolClientId);
+      // Configure Amplify, create users, and sign in.
+      configureAmplify(USER_POOL_ID, userPoolClientId);
 
-    const authRes: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
-    const authRes2: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
-    const authRes3: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
+      const authRes: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+      const authRes2: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+      const authRes3: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
 
-    await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
-    await createGroup(USER_POOL_ID, PARTICIPANT_GROUP_NAME);
-    await createGroup(USER_POOL_ID, WATCHER_GROUP_NAME);
-    await createGroup(USER_POOL_ID, DEVS_GROUP_NAME);
-    await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
-    await addUserToGroup(PARTICIPANT_GROUP_NAME, USERNAME1, USER_POOL_ID);
-    await addUserToGroup(WATCHER_GROUP_NAME, USERNAME1, USER_POOL_ID);
-    await addUserToGroup(DEVS_GROUP_NAME, USERNAME2, USER_POOL_ID);
-    const authResAfterGroup: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+      await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
+      await createGroup(USER_POOL_ID, PARTICIPANT_GROUP_NAME);
+      await createGroup(USER_POOL_ID, WATCHER_GROUP_NAME);
+      await createGroup(USER_POOL_ID, DEVS_GROUP_NAME);
+      await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
+      await addUserToGroup(PARTICIPANT_GROUP_NAME, USERNAME1, USER_POOL_ID);
+      await addUserToGroup(WATCHER_GROUP_NAME, USERNAME1, USER_POOL_ID);
+      await addUserToGroup(DEVS_GROUP_NAME, USERNAME2, USER_POOL_ID);
+      const authResAfterGroup: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
 
-    const idToken = authResAfterGroup.getIdToken().getJwtToken();
-    GRAPHQL_CLIENT_1 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken });
+      const idToken = authResAfterGroup.getIdToken().getJwtToken();
+      GRAPHQL_CLIENT_1 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken });
 
-    const accessToken = authResAfterGroup.getAccessToken().getJwtToken();
-    GRAPHQL_CLIENT_1_ACCESS = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: accessToken });
+      const accessToken = authResAfterGroup.getAccessToken().getJwtToken();
+      GRAPHQL_CLIENT_1_ACCESS = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: accessToken });
 
-    const authRes2AfterGroup: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
-    const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken();
-    GRAPHQL_CLIENT_2 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken2 });
+      const authRes2AfterGroup: any = await signupAndAuthenticateUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+      const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken();
+      GRAPHQL_CLIENT_2 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken2 });
 
-    const idToken3 = authRes3.getIdToken().getJwtToken();
-    GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 });
+      const idToken3 = authRes3.getIdToken().getJwtToken();
+      GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 });
 
-    // Wait for any propagation to avoid random
-    // "The security token included in the request is invalid" errors
-    await new Promise(res => setTimeout(() => res(), 5000));
-  } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
-  }
-});
-
-afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await deleteUserPool(cognitoClient, USER_POOL_ID);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
+      // Wait for any propagation to avoid random
+      // "The security token included in the request is invalid" errors
+      await new Promise(res => setTimeout(() => res(), 5000));
+    } catch (e) {
       console.error(e);
       expect(true).toEqual(false);
     }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.error(`Failed to empty S3 bucket: ${e}`);
-  }
-});
+  });
 
-/**
- * Test queries below
- */
-test('Test createPost mutation', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response);
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toEqual(USERNAME1);
-
-  const response2 = await GRAPHQL_CLIENT_1_ACCESS.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response2);
-  expect(response2.data.createPost.id).toBeDefined();
-  expect(response2.data.createPost.title).toEqual('Hello, World!');
-  expect(response2.data.createPost.createdAt).toBeDefined();
-  expect(response2.data.createPost.updatedAt).toBeDefined();
-  expect(response2.data.createPost.owner).toEqual(USERNAME1);
-});
-
-test('Test getPost query when authorized', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toEqual(USERNAME1);
-  const getResponse = await GRAPHQL_CLIENT_1.query(
-    `query {
-        getPost(id: "${response.data.createPost.id}") {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(getResponse.data.getPost.id).toBeDefined();
-  expect(getResponse.data.getPost.title).toEqual('Hello, World!');
-  expect(getResponse.data.getPost.createdAt).toBeDefined();
-  expect(getResponse.data.getPost.updatedAt).toBeDefined();
-  expect(getResponse.data.getPost.owner).toEqual(USERNAME1);
-
-  const getResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
-    `query {
-        getPost(id: "${response.data.createPost.id}") {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(getResponseAccess.data.getPost.id).toBeDefined();
-  expect(getResponseAccess.data.getPost.title).toEqual('Hello, World!');
-  expect(getResponseAccess.data.getPost.createdAt).toBeDefined();
-  expect(getResponseAccess.data.getPost.updatedAt).toBeDefined();
-  expect(getResponseAccess.data.getPost.owner).toEqual(USERNAME1);
-});
-
-test('Test getPost query when not authorized', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toBeDefined();
-  const getResponse = await GRAPHQL_CLIENT_2.query(
-    `query {
-        getPost(id: "${response.data.createPost.id}") {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(getResponse.data.getPost).toEqual(null);
-  expect(getResponse.errors.length).toEqual(1);
-  expect((getResponse.errors[0] as any).errorType).toEqual('Unauthorized');
-});
-
-test('Test updatePost mutation when authorized', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toEqual(USERNAME1);
-  const updateResponse = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(updateResponse.data.updatePost.id).toEqual(response.data.createPost.id);
-  expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
-  expect(updateResponse.data.updatePost.updatedAt > response.data.createPost.updatedAt).toEqual(true);
-
-  const updateResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
-    `mutation {
-        updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(updateResponseAccess.data.updatePost.id).toEqual(response.data.createPost.id);
-  expect(updateResponseAccess.data.updatePost.title).toEqual('Bye, World!');
-  expect(updateResponseAccess.data.updatePost.updatedAt > response.data.createPost.updatedAt).toEqual(true);
-});
-
-test('Test updatePost mutation when not authorized', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toBeDefined();
-  const updateResponse = await GRAPHQL_CLIENT_2.query(
-    `mutation {
-        updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(updateResponse.data.updatePost).toEqual(null);
-  expect(updateResponse.errors.length).toEqual(1);
-  expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
-});
-
-test('Test deletePost mutation when authorized', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toEqual(USERNAME1);
-  const deleteResponse = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        deletePost(input: { id: "${response.data.createPost.id}" }) {
-            id
-        }
-    }`,
-    {}
-  );
-  expect(deleteResponse.data.deletePost.id).toEqual(response.data.createPost.id);
-
-  const responseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(responseAccess.data.createPost.id).toBeDefined();
-  expect(responseAccess.data.createPost.title).toEqual('Hello, World!');
-  expect(responseAccess.data.createPost.createdAt).toBeDefined();
-  expect(responseAccess.data.createPost.updatedAt).toBeDefined();
-  expect(responseAccess.data.createPost.owner).toEqual(USERNAME1);
-  const deleteResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
-    `mutation {
-        deletePost(input: { id: "${responseAccess.data.createPost.id}" }) {
-            id
-        }
-    }`,
-    {}
-  );
-  expect(deleteResponseAccess.data.deletePost.id).toEqual(responseAccess.data.createPost.id);
-});
-
-test('Test deletePost mutation when not authorized', async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "Hello, World!" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(response.data.createPost.id).toBeDefined();
-  expect(response.data.createPost.title).toEqual('Hello, World!');
-  expect(response.data.createPost.createdAt).toBeDefined();
-  expect(response.data.createPost.updatedAt).toBeDefined();
-  expect(response.data.createPost.owner).toEqual(USERNAME1);
-  const deleteResponse = await GRAPHQL_CLIENT_2.query(
-    `mutation {
-        deletePost(input: { id: "${response.data.createPost.id}" }) {
-            id
-        }
-    }`,
-    {}
-  );
-  expect(deleteResponse.data.deletePost).toEqual(null);
-  expect(deleteResponse.errors.length).toEqual(1);
-  expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
-});
-
-test('Test listPosts query when authorized', async () => {
-  const firstPost = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createPost(input: { title: "testing list" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  expect(firstPost.data.createPost.id).toBeDefined();
-  expect(firstPost.data.createPost.title).toEqual('testing list');
-  expect(firstPost.data.createPost.createdAt).toBeDefined();
-  expect(firstPost.data.createPost.updatedAt).toBeDefined();
-  expect(firstPost.data.createPost.owner).toEqual(USERNAME1);
-  const secondPost = await GRAPHQL_CLIENT_2.query(
-    `mutation {
-        createPost(input: { title: "testing list" }) {
-            id
-            title
-            createdAt
-            updatedAt
-            owner
-        }
-    }`,
-    {}
-  );
-  // There are two posts but only 1 created by me.
-  const listResponse = await GRAPHQL_CLIENT_1.query(
-    `query {
-        listPosts(filter: { title: { eq: "testing list" } }, limit: 25) {
-            items {
-                id
-            }
-        }
-    }`,
-    {}
-  );
-  console.log(JSON.stringify(listResponse, null, 4));
-  expect(listResponse.data.listPosts.items.length).toEqual(1);
-
-  const listResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
-    `query {
-        listPosts(filter: { title: { eq: "testing list" } }, limit: 25) {
-            items {
-                id
-            }
-        }
-    }`,
-    {}
-  );
-  console.log(JSON.stringify(listResponseAccess, null, 4));
-  expect(listResponseAccess.data.listPosts.items.length).toEqual(1);
-});
-
-/**
- * Static Group Auth
- */
-test(`Test createSalary w/ Admin group protection authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 10 }) {
-            id
-            wage
-        }
+  afterAll(async () => {
+    try {
+      console.log('Deleting stack ' + STACK_NAME);
+      await cf.deleteStack(STACK_NAME);
+      await deleteUserPool(cognitoClient, USER_POOL_ID);
+      await cf.waitForStack(STACK_NAME);
+      console.log('Successfully deleted stack ' + STACK_NAME);
+    } catch (e) {
+      if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
+        // The stack was deleted. This is good.
+        expect(true).toEqual(true);
+        console.log('Successfully deleted stack ' + STACK_NAME);
+      } else {
+        console.error(e);
+        expect(true).toEqual(false);
+      }
     }
-    `);
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(10);
-});
+    try {
+      await emptyBucket(BUCKET_NAME);
+    } catch (e) {
+      console.error(`Failed to empty S3 bucket: ${e}`);
+    }
+  });
 
-test(`Test update my own salary without admin permission`, async () => {
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createSalary(input: { wage: 10 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.wage).toEqual(10);
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req2, null, 4));
-  expect(req2.data.updateSalary.wage).toEqual(14);
-});
+  /**
+   * Test queries below
+   */
+  test('Test createPost mutation', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response);
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toEqual(USERNAME1);
 
-test(`Test updating someone else's salary as an admin`, async () => {
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createSalary(input: { wage: 11 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(11);
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        updateSalary(input: { id: "${req.data.createSalary.id}", wage: 12 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req2, null, 4));
-  expect(req2.data.updateSalary.id).toEqual(req.data.createSalary.id);
-  expect(req2.data.updateSalary.wage).toEqual(12);
-});
+    const response2 = await GRAPHQL_CLIENT_1_ACCESS.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response2);
+    expect(response2.data.createPost.id).toBeDefined();
+    expect(response2.data.createPost.title).toEqual('Hello, World!');
+    expect(response2.data.createPost.createdAt).toBeDefined();
+    expect(response2.data.createPost.updatedAt).toBeDefined();
+    expect(response2.data.createPost.owner).toEqual(USERNAME1);
+  });
 
-test(`Test updating someone else's salary when I am not admin.`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 13 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(13);
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
-            id
-            wage
-        }
-    }
-    `);
-  expect(req2.data.updateSalary).toEqual(null);
-  expect(req2.errors.length).toEqual(1);
-  expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
-});
+  test('Test getPost query when authorized', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toEqual(USERNAME1);
+    const getResponse = await GRAPHQL_CLIENT_1.query(
+      `query {
+          getPost(id: "${response.data.createPost.id}") {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(getResponse.data.getPost.id).toBeDefined();
+    expect(getResponse.data.getPost.title).toEqual('Hello, World!');
+    expect(getResponse.data.getPost.createdAt).toBeDefined();
+    expect(getResponse.data.getPost.updatedAt).toBeDefined();
+    expect(getResponse.data.getPost.owner).toEqual(USERNAME1);
 
-test(`Test deleteSalary w/ Admin group protection authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 15 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(15);
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req2, null, 4));
-  expect(req2.data.deleteSalary.id).toEqual(req.data.createSalary.id);
-  expect(req2.data.deleteSalary.wage).toEqual(15);
-});
+    const getResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
+      `query {
+          getPost(id: "${response.data.createPost.id}") {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(getResponseAccess.data.getPost.id).toBeDefined();
+    expect(getResponseAccess.data.getPost.title).toEqual('Hello, World!');
+    expect(getResponseAccess.data.getPost.createdAt).toBeDefined();
+    expect(getResponseAccess.data.getPost.updatedAt).toBeDefined();
+    expect(getResponseAccess.data.getPost.owner).toEqual(USERNAME1);
+  });
 
-test(`Test deleteSalary w/ Admin group protection not authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 16 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(16);
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
-            id
-            wage
-        }
-    }
-    `);
-  expect(req2.data.deleteSalary).toEqual(null);
-  expect(req2.errors.length).toEqual(1);
-  expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
-});
+  test('Test getPost query when not authorized', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toBeDefined();
+    const getResponse = await GRAPHQL_CLIENT_2.query(
+      `query {
+          getPost(id: "${response.data.createPost.id}") {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(getResponse.data.getPost).toEqual(null);
+    expect(getResponse.errors.length).toEqual(1);
+    expect((getResponse.errors[0] as any).errorType).toEqual('Unauthorized');
+  });
 
-test(`Test and Admin can get a salary created by any user`, async () => {
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createSalary(input: { wage: 15 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(15);
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    query {
-        getSalary(id: "${req.data.createSalary.id}") {
-            id
-            wage
-        }
-    }
-    `);
-  expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id);
-  expect(req2.data.getSalary.wage).toEqual(15);
-});
+  test('Test updatePost mutation when authorized', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toEqual(USERNAME1);
+    const updateResponse = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(updateResponse.data.updatePost.id).toEqual(response.data.createPost.id);
+    expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
+    expect(updateResponse.data.updatePost.updatedAt > response.data.createPost.updatedAt).toEqual(true);
 
-test(`Test owner can create and get a salary when not admin`, async () => {
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createSalary(input: { wage: 15 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(15);
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getSalary(id: "${req.data.createSalary.id}") {
-            id
-            wage
-        }
-    }
-    `);
-  expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id);
-  expect(req2.data.getSalary.wage).toEqual(15);
-});
+    const updateResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
+      `mutation {
+          updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(updateResponseAccess.data.updatePost.id).toEqual(response.data.createPost.id);
+    expect(updateResponseAccess.data.updatePost.title).toEqual('Bye, World!');
+    expect(updateResponseAccess.data.updatePost.updatedAt > response.data.createPost.updatedAt).toEqual(true);
+  });
 
-test(`Test getSalary w/ Admin group protection not authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 16 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(16);
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getSalary(id: "${req.data.createSalary.id}") {
-            id
-            wage
-        }
-    }
-    `);
-  expect(req2.data.getSalary).toEqual(null);
-  expect(req2.errors.length).toEqual(1);
-  expect((req2.errors[0] as any).errorType).toEqual('Unauthorized');
-});
+  test('Test updatePost mutation when not authorized', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toBeDefined();
+    const updateResponse = await GRAPHQL_CLIENT_2.query(
+      `mutation {
+          updatePost(input: { id: "${response.data.createPost.id}", title: "Bye, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(updateResponse.data.updatePost).toEqual(null);
+    expect(updateResponse.errors.length).toEqual(1);
+    expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  });
 
-test(`Test listSalarys w/ Admin group protection authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 101 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(101);
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    query {
-        listSalarys(filter: { wage: { eq: 101 }}) {
-            items {
-                id
-                wage
-            }
-        }
-    }
-    `);
-  expect(req2.data.listSalarys.items.length).toEqual(1);
-  expect(req2.data.listSalarys.items[0].id).toEqual(req.data.createSalary.id);
-  expect(req2.data.listSalarys.items[0].wage).toEqual(101);
-});
+  test('Test deletePost mutation when authorized', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toEqual(USERNAME1);
+    const deleteResponse = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          deletePost(input: { id: "${response.data.createPost.id}" }) {
+              id
+          }
+      }`,
+      {}
+    );
+    expect(deleteResponse.data.deletePost.id).toEqual(response.data.createPost.id);
 
-test(`Test listSalarys w/ Admin group protection not authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSalary(input: { wage: 102 }) {
-            id
-            wage
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSalary.id).toBeDefined();
-  expect(req.data.createSalary.wage).toEqual(102);
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listSalarys(filter: { wage: { eq: 102 }}) {
-            items {
-                id
-                wage
-            }
-        }
-    }
-    `);
-  expect(req2.data.listSalarys.items).toEqual([]);
-});
+    const responseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(responseAccess.data.createPost.id).toBeDefined();
+    expect(responseAccess.data.createPost.title).toEqual('Hello, World!');
+    expect(responseAccess.data.createPost.createdAt).toBeDefined();
+    expect(responseAccess.data.createPost.updatedAt).toBeDefined();
+    expect(responseAccess.data.createPost.owner).toEqual(USERNAME1);
+    const deleteResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
+      `mutation {
+          deletePost(input: { id: "${responseAccess.data.createPost.id}" }) {
+              id
+          }
+      }`,
+      {}
+    );
+    expect(deleteResponseAccess.data.deletePost.id).toEqual(responseAccess.data.createPost.id);
+  });
 
-/**
- * Dynamic Group Auth
- */
-test(`Test createManyGroupProtected w/ dynamic group protection authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
-            id
-            value
-            groups
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createManyGroupProtected.id).toBeDefined();
-  expect(req.data.createManyGroupProtected.value).toEqual(10);
-  expect(req.data.createManyGroupProtected.groups).toEqual(['Admin']);
-});
+  test('Test deletePost mutation when not authorized', async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(response.data.createPost.id).toBeDefined();
+    expect(response.data.createPost.title).toEqual('Hello, World!');
+    expect(response.data.createPost.createdAt).toBeDefined();
+    expect(response.data.createPost.updatedAt).toBeDefined();
+    expect(response.data.createPost.owner).toEqual(USERNAME1);
+    const deleteResponse = await GRAPHQL_CLIENT_2.query(
+      `mutation {
+          deletePost(input: { id: "${response.data.createPost.id}" }) {
+              id
+          }
+      }`,
+      {}
+    );
+    expect(deleteResponse.data.deletePost).toEqual(null);
+    expect(deleteResponse.errors.length).toEqual(1);
+    expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  });
 
-test(`Test createManyGroupProtected w/ dynamic group protection when not authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
-            id
-            value
-            groups
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createManyGroupProtected).toEqual(null);
-  expect(req.errors.length).toEqual(1);
-  expect((req.errors[0] as any).errorType).toEqual('Unauthorized');
-});
+  test('Test listPosts query when authorized', async () => {
+    const firstPost = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createPost(input: { title: "testing list" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    expect(firstPost.data.createPost.id).toBeDefined();
+    expect(firstPost.data.createPost.title).toEqual('testing list');
+    expect(firstPost.data.createPost.createdAt).toBeDefined();
+    expect(firstPost.data.createPost.updatedAt).toBeDefined();
+    expect(firstPost.data.createPost.owner).toEqual(USERNAME1);
+    const secondPost = await GRAPHQL_CLIENT_2.query(
+      `mutation {
+          createPost(input: { title: "testing list" }) {
+              id
+              title
+              createdAt
+              updatedAt
+              owner
+          }
+      }`,
+      {}
+    );
+    // There are two posts but only 1 created by me.
+    const listResponse = await GRAPHQL_CLIENT_1.query(
+      `query {
+          listPosts(filter: { title: { eq: "testing list" } }, limit: 25) {
+              items {
+                  id
+              }
+          }
+      }`,
+      {}
+    );
+    console.log(JSON.stringify(listResponse, null, 4));
+    expect(listResponse.data.listPosts.items.length).toEqual(1);
 
-test(`Test createSingleGroupProtected w/ dynamic group protection authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
-            id
-            value
-            group
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSingleGroupProtected.id).toBeDefined();
-  expect(req.data.createSingleGroupProtected.value).toEqual(10);
-  expect(req.data.createSingleGroupProtected.group).toEqual('Admin');
-});
+    const listResponseAccess = await GRAPHQL_CLIENT_1_ACCESS.query(
+      `query {
+          listPosts(filter: { title: { eq: "testing list" } }, limit: 25) {
+              items {
+                  id
+              }
+          }
+      }`,
+      {}
+    );
+    console.log(JSON.stringify(listResponseAccess, null, 4));
+    expect(listResponseAccess.data.listPosts.items.length).toEqual(1);
+  });
 
-test(`Test createSingleGroupProtected w/ dynamic group protection when not authorized`, async () => {
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
-            id
-            value
-            group
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createSingleGroupProtected).toEqual(null);
-  expect(req.errors.length).toEqual(1);
-  expect((req.errors[0] as any).errorType).toEqual('Unauthorized');
-});
+  /**
+   * Static Group Auth
+   */
+  test(`Test createSalary w/ Admin group protection authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 10 }) {
+              id
+              wage
+          }
+      }
+      `);
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(10);
+  });
 
-test(`Test listPWProtecteds when the user is authorized.`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createPWProtected(input: { content: "Foobie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createPWProtected).toBeTruthy();
+  test(`Test update my own salary without admin permission`, async () => {
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createSalary(input: { wage: 10 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.wage).toEqual(10);
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req2, null, 4));
+    expect(req2.data.updateSalary.wage).toEqual(14);
+  });
 
-  const uReq = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(uReq, null, 4));
-  expect(uReq.data.updatePWProtected).toBeTruthy();
+  test(`Test updating someone else's salary as an admin`, async () => {
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createSalary(input: { wage: 11 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(11);
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          updateSalary(input: { id: "${req.data.createSalary.id}", wage: 12 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req2, null, 4));
+    expect(req2.data.updateSalary.id).toEqual(req.data.createSalary.id);
+    expect(req2.data.updateSalary.wage).toEqual(12);
+  });
 
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    query {
-        listPWProtecteds {
-            items {
-                id
-                content
-                participants
-                watchers
-            }
-            nextToken
-        }
-    }
-    `);
-  expect(req2.data.listPWProtecteds.items.length).toEqual(1);
-  expect(req2.data.listPWProtecteds.items[0].id).toEqual(req.data.createPWProtected.id);
-  expect(req2.data.listPWProtecteds.items[0].content).toEqual('Foobie2');
+  test(`Test updating someone else's salary when I am not admin.`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 13 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(13);
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateSalary(input: { id: "${req.data.createSalary.id}", wage: 14 }) {
+              id
+              wage
+          }
+      }
+      `);
+    expect(req2.data.updateSalary).toEqual(null);
+    expect(req2.errors.length).toEqual(1);
+    expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  });
 
-  const req3 = await GRAPHQL_CLIENT_1.query(`
-    query {
-        getPWProtected(id: "${req.data.createPWProtected.id}") {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(req3, null, 4));
-  expect(req3.data.getPWProtected).toBeTruthy();
+  test(`Test deleteSalary w/ Admin group protection authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 15 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(15);
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req2, null, 4));
+    expect(req2.data.deleteSalary.id).toEqual(req.data.createSalary.id);
+    expect(req2.data.deleteSalary.wage).toEqual(15);
+  });
 
-  const dReq = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(dReq, null, 4));
-  expect(dReq.data.deletePWProtected).toBeTruthy();
-});
+  test(`Test deleteSalary w/ Admin group protection not authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 16 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(16);
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          deleteSalary(input: { id: "${req.data.createSalary.id}" }) {
+              id
+              wage
+          }
+      }
+      `);
+    expect(req2.data.deleteSalary).toEqual(null);
+    expect(req2.errors.length).toEqual(1);
+    expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  });
 
-test(`Test listPWProtecteds when groups is null in dynamodb.`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createPWProtected(input: { content: "Foobie" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createPWProtected).toBeTruthy();
+  test(`Test and Admin can get a salary created by any user`, async () => {
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createSalary(input: { wage: 15 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(15);
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      query {
+          getSalary(id: "${req.data.createSalary.id}") {
+              id
+              wage
+          }
+      }
+      `);
+    expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id);
+    expect(req2.data.getSalary.wage).toEqual(15);
+  });
 
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    query {
-        listPWProtecteds {
-            items {
-                id
-                content
-                participants
-                watchers
-            }
-            nextToken
-        }
-    }
-    `);
-  expect(req2.data.listPWProtecteds.items.length).toEqual(0);
+  test(`Test owner can create and get a salary when not admin`, async () => {
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createSalary(input: { wage: 15 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(15);
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getSalary(id: "${req.data.createSalary.id}") {
+              id
+              wage
+          }
+      }
+      `);
+    expect(req2.data.getSalary.id).toEqual(req.data.createSalary.id);
+    expect(req2.data.getSalary.wage).toEqual(15);
+  });
 
-  const req3 = await GRAPHQL_CLIENT_1.query(`
-    query {
-        getPWProtected(id: "${req.data.createPWProtected.id}") {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(req3, null, 4));
-  expect(req3.data.getPWProtected).toEqual(null);
-  expect(req3.errors.length).toEqual(1);
-  expect((req3.errors[0] as any).errorType).toEqual('Unauthorized');
-});
+  test(`Test getSalary w/ Admin group protection not authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 16 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(16);
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getSalary(id: "${req.data.createSalary.id}") {
+              id
+              wage
+          }
+      }
+      `);
+    expect(req2.data.getSalary).toEqual(null);
+    expect(req2.errors.length).toEqual(1);
+    expect((req2.errors[0] as any).errorType).toEqual('Unauthorized');
+  });
 
-test(`Test Protecteds when the user is not authorized.`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createPWProtected(input: { content: "Barbie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createPWProtected).toBeTruthy();
+  test(`Test listSalarys w/ Admin group protection authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 101 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(101);
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      query {
+          listSalarys(filter: { wage: { eq: 101 }}) {
+              items {
+                  id
+                  wage
+              }
+          }
+      }
+      `);
+    expect(req2.data.listSalarys.items.length).toEqual(1);
+    expect(req2.data.listSalarys.items[0].id).toEqual(req.data.createSalary.id);
+    expect(req2.data.listSalarys.items[0].wage).toEqual(101);
+  });
 
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listPWProtecteds {
-            items {
-                id
-                content
-                participants
-                watchers
-            }
-            nextToken
-        }
-    }
-    `);
-  console.log(JSON.stringify(req2, null, 4));
-  expect(req2.data.listPWProtecteds.items.length).toEqual(0);
-  expect(req2.data.listPWProtecteds.nextToken).toBeNull();
+  test(`Test listSalarys w/ Admin group protection not authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSalary(input: { wage: 102 }) {
+              id
+              wage
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSalary.id).toBeDefined();
+    expect(req.data.createSalary.wage).toEqual(102);
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      query {
+          listSalarys(filter: { wage: { eq: 102 }}) {
+              items {
+                  id
+                  wage
+              }
+          }
+      }
+      `);
+    expect(req2.data.listSalarys.items).toEqual([]);
+  });
 
-  const uReq = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(uReq, null, 4));
-  expect(uReq.data.updatePWProtected).toBeNull();
+  /**
+   * Dynamic Group Auth
+   */
+  test(`Test createManyGroupProtected w/ dynamic group protection authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
+              id
+              value
+              groups
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createManyGroupProtected.id).toBeDefined();
+    expect(req.data.createManyGroupProtected.value).toEqual(10);
+    expect(req.data.createManyGroupProtected.groups).toEqual(['Admin']);
+  });
 
-  const req3 = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getPWProtected(id: "${req.data.createPWProtected.id}") {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(req3, null, 4));
-  expect(req3.data.getPWProtected).toBeNull();
+  test(`Test createManyGroupProtected w/ dynamic group protection when not authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createManyGroupProtected(input: { value: 10, groups: ["Admin"] }) {
+              id
+              value
+              groups
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createManyGroupProtected).toEqual(null);
+    expect(req.errors.length).toEqual(1);
+    expect((req.errors[0] as any).errorType).toEqual('Unauthorized');
+  });
 
-  const dReq = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(dReq, null, 4));
-  expect(dReq.data.deletePWProtected).toBeNull();
+  test(`Test createSingleGroupProtected w/ dynamic group protection authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
+              id
+              value
+              group
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSingleGroupProtected.id).toBeDefined();
+    expect(req.data.createSingleGroupProtected.value).toEqual(10);
+    expect(req.data.createSingleGroupProtected.group).toEqual('Admin');
+  });
 
-  // The record should still exist after delete.
-  const getReq = await GRAPHQL_CLIENT_1.query(`
-    query {
-        getPWProtected(id: "${req.data.createPWProtected.id}") {
-            id
-            content
-            participants
-            watchers
-        }
-    }
-    `);
-  console.log(JSON.stringify(getReq, null, 4));
-  expect(getReq.data.getPWProtected).toBeTruthy();
-});
+  test(`Test createSingleGroupProtected w/ dynamic group protection when not authorized`, async () => {
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createSingleGroupProtected(input: { value: 10, group: "Admin" }) {
+              id
+              value
+              group
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createSingleGroupProtected).toEqual(null);
+    expect(req.errors.length).toEqual(1);
+    expect((req.errors[0] as any).errorType).toEqual('Unauthorized');
+  });
 
-test(`Test creating, updating, and deleting an admin note as an admin`, async () => {
-  const req = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAdminNote(input: { content: "Hello" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.data.createAdminNote.id).toBeDefined();
-  expect(req.data.createAdminNote.content).toEqual('Hello');
-  const req2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        updateAdminNote(input: { id: "${req.data.createAdminNote.id}", content: "Hello 2" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(req2, null, 4));
-  expect(req2.data.updateAdminNote.id).toEqual(req.data.createAdminNote.id);
-  expect(req2.data.updateAdminNote.content).toEqual('Hello 2');
-  const req3 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        deleteAdminNote(input: { id: "${req.data.createAdminNote.id}" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(req3, null, 4));
-  expect(req3.data.deleteAdminNote.id).toEqual(req.data.createAdminNote.id);
-  expect(req3.data.deleteAdminNote.content).toEqual('Hello 2');
-});
+  test(`Test listPWProtecteds when the user is authorized.`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createPWProtected(input: { content: "Foobie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createPWProtected).toBeTruthy();
 
-test(`Test creating, updating, and deleting an admin note as a non admin`, async () => {
-  const adminReq = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAdminNote(input: { content: "Hello" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(adminReq, null, 4));
-  expect(adminReq.data.createAdminNote.id).toBeDefined();
-  expect(adminReq.data.createAdminNote.content).toEqual('Hello');
+    const uReq = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(uReq, null, 4));
+    expect(uReq.data.updatePWProtected).toBeTruthy();
 
-  const req = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAdminNote(input: { content: "Hello" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(req, null, 4));
-  expect(req.errors.length).toEqual(1);
-  expect((req.errors[0] as any).errorType).toEqual('Unauthorized');
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      query {
+          listPWProtecteds {
+              items {
+                  id
+                  content
+                  participants
+                  watchers
+              }
+              nextToken
+          }
+      }
+      `);
+    expect(req2.data.listPWProtecteds.items.length).toEqual(1);
+    expect(req2.data.listPWProtecteds.items[0].id).toEqual(req.data.createPWProtected.id);
+    expect(req2.data.listPWProtecteds.items[0].content).toEqual('Foobie2');
 
-  const req2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateAdminNote(input: { id: "${adminReq.data.createAdminNote.id}", content: "Hello 2" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(req2, null, 4));
-  expect(req2.errors.length).toEqual(1);
-  expect((req2.errors[0] as any).errorType).toEqual('Unauthorized');
+    const req3 = await GRAPHQL_CLIENT_1.query(`
+      query {
+          getPWProtected(id: "${req.data.createPWProtected.id}") {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(req3, null, 4));
+    expect(req3.data.getPWProtected).toBeTruthy();
 
-  const req3 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        deleteAdminNote(input: { id: "${adminReq.data.createAdminNote.id}" }) {
-            id
-            content
-        }
-    }
-    `);
-  console.log(JSON.stringify(req3, null, 4));
-  expect(req3.errors.length).toEqual(1);
-  expect((req3.errors[0] as any).errorType).toEqual('Unauthorized');
-});
+    const dReq = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(dReq, null, 4));
+    expect(dReq.data.deletePWProtected).toBeTruthy();
+  });
 
-/**
- * Get Query Tests
- */
+  test(`Test listPWProtecteds when groups is null in dynamodb.`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createPWProtected(input: { content: "Foobie" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createPWProtected).toBeTruthy();
 
-test(`Test getAllThree as admin.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com"
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      query {
+          listPWProtecteds {
+              items {
+                  id
+                  content
+                  participants
+                  watchers
+              }
+              nextToken
+          }
+      }
+      `);
+    expect(req2.data.listPWProtecteds.items.length).toEqual(0);
+
+    const req3 = await GRAPHQL_CLIENT_1.query(`
+      query {
+          getPWProtected(id: "${req.data.createPWProtected.id}") {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(req3, null, 4));
+    expect(req3.data.getPWProtected).toEqual(null);
+    expect(req3.errors.length).toEqual(1);
+    expect((req3.errors[0] as any).errorType).toEqual('Unauthorized');
+  });
+
+  test(`Test Protecteds when the user is not authorized.`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createPWProtected(input: { content: "Barbie", participants: "${PARTICIPANT_GROUP_NAME}", watchers: "${WATCHER_GROUP_NAME}" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createPWProtected).toBeTruthy();
+
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      query {
+          listPWProtecteds {
+              items {
+                  id
+                  content
+                  participants
+                  watchers
+              }
+              nextToken
+          }
+      }
+      `);
+    console.log(JSON.stringify(req2, null, 4));
+    expect(req2.data.listPWProtecteds.items.length).toEqual(0);
+    expect(req2.data.listPWProtecteds.nextToken).toBeNull();
+
+    const uReq = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updatePWProtected(input: { id: "${req.data.createPWProtected.id}", content: "Foobie2" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(uReq, null, 4));
+    expect(uReq.data.updatePWProtected).toBeNull();
+
+    const req3 = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getPWProtected(id: "${req.data.createPWProtected.id}") {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(req3, null, 4));
+    expect(req3.data.getPWProtected).toBeNull();
+
+    const dReq = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          deletePWProtected(input: { id: "${req.data.createPWProtected.id}" }) {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(dReq, null, 4));
+    expect(dReq.data.deletePWProtected).toBeNull();
+
+    // The record should still exist after delete.
+    const getReq = await GRAPHQL_CLIENT_1.query(`
+      query {
+          getPWProtected(id: "${req.data.createPWProtected.id}") {
+              id
+              content
+              participants
+              watchers
+          }
+      }
+      `);
+    console.log(JSON.stringify(getReq, null, 4));
+    expect(getReq.data.getPWProtected).toBeTruthy();
+  });
+
+  test(`Test creating, updating, and deleting an admin note as an admin`, async () => {
+    const req = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAdminNote(input: { content: "Hello" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.data.createAdminNote.id).toBeDefined();
+    expect(req.data.createAdminNote.content).toEqual('Hello');
+    const req2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          updateAdminNote(input: { id: "${req.data.createAdminNote.id}", content: "Hello 2" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(req2, null, 4));
+    expect(req2.data.updateAdminNote.id).toEqual(req.data.createAdminNote.id);
+    expect(req2.data.updateAdminNote.content).toEqual('Hello 2');
+    const req3 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          deleteAdminNote(input: { id: "${req.data.createAdminNote.id}" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(req3, null, 4));
+    expect(req3.data.deleteAdminNote.id).toEqual(req.data.createAdminNote.id);
+    expect(req3.data.deleteAdminNote.content).toEqual('Hello 2');
+  });
+
+  test(`Test creating, updating, and deleting an admin note as a non admin`, async () => {
+    const adminReq = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAdminNote(input: { content: "Hello" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(adminReq, null, 4));
+    expect(adminReq.data.createAdminNote.id).toBeDefined();
+    expect(adminReq.data.createAdminNote.content).toEqual('Hello');
+
+    const req = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAdminNote(input: { content: "Hello" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(req, null, 4));
+    expect(req.errors.length).toEqual(1);
+    expect((req.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const req2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateAdminNote(input: { id: "${adminReq.data.createAdminNote.id}", content: "Hello 2" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(req2, null, 4));
+    expect(req2.errors.length).toEqual(1);
+    expect((req2.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const req3 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          deleteAdminNote(input: { id: "${adminReq.data.createAdminNote.id}" }) {
+              id
+              content
+          }
+      }
+      `);
+    console.log(JSON.stringify(req3, null, 4));
+    expect(req3.errors.length).toEqual(1);
+    expect((req3.errors[0] as any).errorType).toEqual('Unauthorized');
+  });
+
+  /**
+   * Get Query Tests
+   */
+
+  test(`Test getAllThree as admin.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedBy2AsAdmin = await GRAPHQL_CLIENT_1.query(`
+      query {
+          getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4));
+    expect(fetchOwnedBy2AsAdmin.data.getAllThree).toBeTruthy();
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test getAllThree as owner.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedBy2AsOwner = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4));
+    expect(fetchOwnedBy2AsOwner.data.getAllThree).toBeTruthy();
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test getAllThree as one of a set of editors.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              editors: ["user2@test.com"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedBy2AsEditor = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4));
+    expect(fetchOwnedBy2AsEditor.data.getAllThree).toBeTruthy();
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test getAllThree as a member of a dynamic group.`, async () => {
+    const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              groups: ["Devs"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdmins, null, 4));
+    expect(ownedByAdmins.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsAdmin.data.getAllThree).toBeTruthy();
+
+    const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
+      query {
+          getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1);
+    expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
+  });
+
+  test(`Test getAllThree as a member of the alternative group.`, async () => {
+    const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdmins, null, 4));
+    expect(ownedByAdmins.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
+      query {
+          getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsAdmin.data.getAllThree).toBeTruthy();
+
+    const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
+      query {
+          getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1);
+    expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
+  });
+
+  /**
+   * List Query Tests
+   */
+
+  test(`Test listAllThrees as admin.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedBy2AsAdmin = await GRAPHQL_CLIENT_1.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4));
+    expect(fetchOwnedBy2AsAdmin.data.listAllThrees.items).toHaveLength(1);
+    expect(fetchOwnedBy2AsAdmin.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id);
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test listAllThrees as owner.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedBy2AsOwner = await GRAPHQL_CLIENT_2.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4));
+    expect(fetchOwnedBy2AsOwner.data.listAllThrees.items).toHaveLength(1);
+    expect(fetchOwnedBy2AsOwner.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id);
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test listAllThrees as one of a set of editors.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              editors: ["user2@test.com"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedBy2AsEditor = await GRAPHQL_CLIENT_2.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4));
+    expect(fetchOwnedBy2AsEditor.data.listAllThrees.items).toHaveLength(1);
+    expect(fetchOwnedBy2AsEditor.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id);
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test listAllThrees as a member of a dynamic group.`, async () => {
+    const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              groups: ["Devs"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdmins, null, 4));
+    expect(ownedByAdmins.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items).toHaveLength(1);
+    expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items[0].id).toEqual(ownedByAdmins.data.createAllThree.id);
+
+    const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsNonAdmin.data.listAllThrees.items).toHaveLength(0);
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
+  });
+
+  test(`Test getAllThree as a member of the alternative group.`, async () => {
+    const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdmins, null, 4));
+    expect(ownedByAdmins.data.createAllThree).toBeTruthy();
+
+    const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items).toHaveLength(1);
+    expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items[0].id).toEqual(ownedByAdmins.data.createAllThree.id);
+
+    const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
+      query {
+          listAllThrees {
+              items {
+                  id
+                  owner
+                  editors
+                  groups
+                  alternativeGroup
+              }
+          }
+      }
+      `);
+    console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
+    expect(fetchOwnedByAdminsAsNonAdmin.data.listAllThrees.items).toHaveLength(0);
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
+  });
+
+  /**
+   * Create Mutation Tests
+   */
+
+  test(`Test createAllThree as admin.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+    // set by input
+    expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
+    // auto filled as logged in user.
+    expect(ownedBy2.data.createAllThree.editors[0]).toEqual('user1@test.com');
+    expect(ownedBy2.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedBy2NoEditors = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com",
+              editors: []
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2NoEditors, null, 4));
+    expect(ownedBy2NoEditors.data.createAllThree).toBeTruthy();
+    // set by input
+    expect(ownedBy2NoEditors.data.createAllThree.owner).toEqual('user2@test.com');
+    // set by input
+    expect(ownedBy2NoEditors.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedBy2NoEditors.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2NoEditors.data.createAllThree.alternativeGroup).toBeNull();
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+
+    const deleteReq2 = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2NoEditors.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq2, null, 4));
+    expect(deleteReq2.data.deleteAllThree.id).toEqual(ownedBy2NoEditors.data.createAllThree.id);
+  });
+
+  test(`Test createAllThree as owner.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com",
+              editors: []
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+    expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
+    expect(ownedBy2.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedBy2.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedBy1 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user1@test.com",
+              editors: []
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy1, null, 4));
+    expect(ownedBy1.errors.length).toEqual(1);
+    expect((ownedBy1.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test createAllThree as one of a set of editors.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: ["user2@test.com"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+    expect(ownedBy2.data.createAllThree.owner).toBeNull();
+    expect(ownedBy2.data.createAllThree.editors[0]).toEqual('user2@test.com');
+    expect(ownedBy2.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedBy2WithDefaultOwner = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              editors: ["user2@test.com"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2WithDefaultOwner, null, 4));
+    expect(ownedBy2WithDefaultOwner.data.createAllThree).toBeTruthy();
+    expect(ownedBy2WithDefaultOwner.data.createAllThree.owner).toEqual('user2@test.com');
+    expect(ownedBy2WithDefaultOwner.data.createAllThree.editors[0]).toEqual('user2@test.com');
+    expect(ownedBy2WithDefaultOwner.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2WithDefaultOwner.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedByEditorsUnauthed = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: ["user1@test.com"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByEditorsUnauthed, null, 4));
+    expect(ownedByEditorsUnauthed.errors.length).toEqual(1);
+    expect((ownedByEditorsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+
+    const deleteReq2 = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2WithDefaultOwner.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq2, null, 4));
+    expect(deleteReq2.data.deleteAllThree.id).toEqual(ownedBy2WithDefaultOwner.data.createAllThree.id);
+  });
+
+  test(`Test createAllThree as a member of a dynamic group.`, async () => {
+    const ownedByDevs = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              groups: ["Devs"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByDevs, null, 4));
+    expect(ownedByDevs.data.createAllThree).toBeTruthy();
+    expect(ownedByDevs.data.createAllThree.owner).toBeNull();
+    expect(ownedByDevs.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedByDevs.data.createAllThree.groups[0]).toEqual('Devs');
+    expect(ownedByDevs.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_3.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              groups: ["Devs"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
+    expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
+    expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByDevs.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id);
+  });
+
+  test(`Test createAllThree as a member of the alternative group.`, async () => {
+    const ownedByAdmins = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdmins, null, 4));
+    expect(ownedByAdmins.data.createAllThree).toBeTruthy();
+    expect(ownedByAdmins.data.createAllThree.owner).toBeNull();
+    expect(ownedByAdmins.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedByAdmins.data.createAllThree.alternativeGroup).toEqual('Devs');
+
+    const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_3.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              alternativeGroup: "Admin"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
+    expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
+    expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
+  });
+
+  /**
+   * Update Mutation Tests
+   */
+
+  test(`Test updateAllThree and deleteAllThree as admin.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              editors: []
+              owner: "user2@test.com"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+    // set by input
+    expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
+    // auto filled as logged in user.
+    expect(ownedBy2.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedBy2.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedByTwoUpdate = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          updateAllThree(input: {
+              id: "${ownedBy2.data.createAllThree.id}",
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByTwoUpdate, null, 4));
+    expect(ownedByTwoUpdate.data.updateAllThree).toBeTruthy();
+    // set by input
+    expect(ownedByTwoUpdate.data.updateAllThree.owner).toEqual('user2@test.com');
+    // set by input
+    expect(ownedByTwoUpdate.data.updateAllThree.editors).toHaveLength(0);
+    expect(ownedByTwoUpdate.data.updateAllThree.groups).toBeNull();
+    expect(ownedByTwoUpdate.data.updateAllThree.alternativeGroup).toEqual('Devs');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test updateAllThree and deleteAllThree as owner.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: "user2@test.com",
+              editors: []
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+    expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
+    expect(ownedBy2.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedBy2.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedBy2Update = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateAllThree(input: {
+              id: "${ownedBy2.data.createAllThree.id}",
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2Update, null, 4));
+    expect(ownedBy2Update.data.updateAllThree).toBeTruthy();
+    // set by input
+    expect(ownedBy2Update.data.updateAllThree.owner).toEqual('user2@test.com');
+    // set by input
+    expect(ownedBy2Update.data.updateAllThree.editors).toHaveLength(0);
+    expect(ownedBy2Update.data.updateAllThree.groups).toBeNull();
+    expect(ownedBy2Update.data.updateAllThree.alternativeGroup).toEqual('Devs');
+
+    const deleteReq = await GRAPHQL_CLIENT_2.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test updateAllThree and deleteAllThree as one of a set of editors.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: ["user2@test.com"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createAllThree).toBeTruthy();
+    expect(ownedBy2.data.createAllThree.owner).toBeNull();
+    expect(ownedBy2.data.createAllThree.editors[0]).toEqual('user2@test.com');
+    expect(ownedBy2.data.createAllThree.groups).toBeNull();
+    expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedByUpdate = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateAllThree(input: {
+              id: "${ownedBy2.data.createAllThree.id}",
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByUpdate, null, 4));
+    expect(ownedByUpdate.data.updateAllThree).toBeTruthy();
+    // set by input
+    expect(ownedByUpdate.data.updateAllThree.owner).toBeNull();
+    // set by input
+    expect(ownedByUpdate.data.updateAllThree.editors[0]).toEqual('user2@test.com');
+    expect(ownedByUpdate.data.updateAllThree.groups).toBeNull();
+    expect(ownedByUpdate.data.updateAllThree.alternativeGroup).toEqual('Devs');
+
+    const deleteReq = await GRAPHQL_CLIENT_2.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
+  });
+
+  test(`Test updateAllThree and deleteAllThree as a member of a dynamic group.`, async () => {
+    const ownedByDevs = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              groups: ["Devs"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByDevs, null, 4));
+    expect(ownedByDevs.data.createAllThree).toBeTruthy();
+    expect(ownedByDevs.data.createAllThree.owner).toBeNull();
+    expect(ownedByDevs.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedByDevs.data.createAllThree.groups[0]).toEqual('Devs');
+    expect(ownedByDevs.data.createAllThree.alternativeGroup).toBeNull();
+
+    const ownedByUpdate = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateAllThree(input: {
+              id: "${ownedByDevs.data.createAllThree.id}",
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByUpdate, null, 4));
+    expect(ownedByUpdate.data.updateAllThree).toBeTruthy();
+    // set by input
+    expect(ownedByUpdate.data.updateAllThree.owner).toBeNull();
+    // set by input
+    expect(ownedByUpdate.data.updateAllThree.editors).toHaveLength(0);
+    expect(ownedByUpdate.data.updateAllThree.groups[0]).toEqual('Devs');
+    expect(ownedByUpdate.data.updateAllThree.alternativeGroup).toEqual('Devs');
+
+    const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_3.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              groups: ["Devs"]
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
+    expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
+    expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByDevs.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id);
+  });
+
+  test(`Test updateAllThree and deleteAllThree as a member of the alternative group.`, async () => {
+    const ownedByDevs = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByDevs, null, 4));
+    expect(ownedByDevs.data.createAllThree).toBeTruthy();
+    expect(ownedByDevs.data.createAllThree.owner).toBeNull();
+    expect(ownedByDevs.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedByDevs.data.createAllThree.alternativeGroup).toEqual('Devs');
+
+    const ownedByUpdate = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateAllThree(input: {
+              id: "${ownedByDevs.data.createAllThree.id}",
+              alternativeGroup: "Admin"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByUpdate, null, 4));
+    expect(ownedByUpdate.data.updateAllThree).toBeTruthy();
+    // set by input
+    expect(ownedByUpdate.data.updateAllThree.owner).toBeNull();
+    // set by input
+    expect(ownedByUpdate.data.updateAllThree.editors).toHaveLength(0);
+    expect(ownedByUpdate.data.updateAllThree.groups).toBeNull();
+    expect(ownedByUpdate.data.updateAllThree.alternativeGroup).toEqual('Admin');
+
+    const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_2.query(`
+      mutation {
+          updateAllThree(input: {
+              id: "${ownedByDevs.data.createAllThree.id}",
+              alternativeGroup: "Dev"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
+    expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
+    expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+
+    const ownedByDevs2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createAllThree(input: {
+              owner: null,
+              editors: [],
+              alternativeGroup: "Devs"
+          }) {
+              id
+              owner
+              editors
+              groups
+              alternativeGroup
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedByDevs2, null, 4));
+    expect(ownedByDevs2.data.createAllThree).toBeTruthy();
+    expect(ownedByDevs2.data.createAllThree.owner).toBeNull();
+    expect(ownedByDevs2.data.createAllThree.editors).toHaveLength(0);
+    expect(ownedByDevs2.data.createAllThree.alternativeGroup).toEqual('Devs');
+
+    const deleteReq2 = await GRAPHQL_CLIENT_2.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByDevs2.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq2, null, 4));
+    expect(deleteReq2.data.deleteAllThree.id).toEqual(ownedByDevs2.data.createAllThree.id);
+
+    const deleteReq = await GRAPHQL_CLIENT_1.query(`
+          mutation {
+              deleteAllThree(input: { id: "${ownedByDevs.data.createAllThree.id}" }) {
+                  id
+              }
+          }
+      `);
+    console.log(JSON.stringify(deleteReq, null, 4));
+    expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id);
+  });
+
+  test(`Test createTestIdentity as admin.`, async () => {
+    const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
+      mutation {
+          createTestIdentity(input: {
+              title: "Test title"
+          }) {
+              id
+              title
+              owner
+          }
+      }
+      `);
+    console.log(JSON.stringify(ownedBy2, null, 4));
+    expect(ownedBy2.data.createTestIdentity).toBeTruthy();
+    expect(ownedBy2.data.createTestIdentity.title).toEqual('Test title');
+    expect(ownedBy2.data.createTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
+
+    // user 2 should be able to update because they share the same issuer.
+    const update = await GRAPHQL_CLIENT_3.query(`
+      mutation {
+          updateTestIdentity(input: {
+              id: "${ownedBy2.data.createTestIdentity.id}",
+              title: "Test title update"
+          }) {
+              id
+              title
+              owner
+          }
+      }
+      `);
+    console.log(JSON.stringify(update, null, 4));
+    expect(update.data.updateTestIdentity).toBeTruthy();
+    expect(update.data.updateTestIdentity.title).toEqual('Test title update');
+    expect(update.data.updateTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
+
+    // user 2 should be able to get because they share the same issuer.
+    const getReq = await GRAPHQL_CLIENT_3.query(`
+      query {
+          getTestIdentity(id: "${ownedBy2.data.createTestIdentity.id}") {
+              id
+              title
+              owner
+          }
+      }
+      `);
+    console.log(JSON.stringify(getReq, null, 4));
+    expect(getReq.data.getTestIdentity).toBeTruthy();
+    expect(getReq.data.getTestIdentity.title).toEqual('Test title update');
+    expect(getReq.data.getTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
+
+    const listResponse = await GRAPHQL_CLIENT_3.query(
+      `query {
+          listTestIdentitys(filter: { title: { eq: "Test title update" } }, limit: 100) {
+              items {
+                  id
+                  title
+                  owner
+              }
+          }
+      }`,
+      {}
+    );
+    const relevantPost = listResponse.data.listTestIdentitys.items.find(p => p.id === getReq.data.getTestIdentity.id);
+    console.log(JSON.stringify(listResponse, null, 4));
+    expect(relevantPost).toBeTruthy();
+    expect(relevantPost.title).toEqual('Test title update');
+    expect(relevantPost.owner.slice(0, 19)).toEqual('https://cognito-idp');
+
+    // user 2 should be able to delete because they share the same issuer.
+    const delReq = await GRAPHQL_CLIENT_3.query(`
+      mutation {
+          deleteTestIdentity(input: {
+              id: "${ownedBy2.data.createTestIdentity.id}"
+          }) {
+              id
+              title
+              owner
+          }
+      }
+      `);
+    console.log(JSON.stringify(delReq, null, 4));
+    expect(delReq.data.deleteTestIdentity).toBeTruthy();
+    expect(delReq.data.deleteTestIdentity.title).toEqual('Test title update');
+    expect(delReq.data.deleteTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
+  });
+
+  /**
+   * Test 'operations' argument
+   */
+  test("Test get and list with 'read' operation set", async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createOwnerReadProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response);
+    expect(response.data.createOwnerReadProtected.id).toBeDefined();
+    expect(response.data.createOwnerReadProtected.content).toEqual('Hello, World!');
+    expect(response.data.createOwnerReadProtected.owner).toEqual(USERNAME1);
+
+    const response2 = await GRAPHQL_CLIENT_2.query(
+      `query {
+          getOwnerReadProtected(id: "${response.data.createOwnerReadProtected.id}") {
+              id content owner
+          }
+      }`,
+      {}
+    );
+    console.log(response2);
+    expect(response2.data.getOwnerReadProtected).toBeNull();
+    expect(response2.errors).toHaveLength(1);
+
+    const response3 = await GRAPHQL_CLIENT_1.query(
+      `query {
+          getOwnerReadProtected(id: "${response.data.createOwnerReadProtected.id}") {
+              id content owner
+          }
+      }`,
+      {}
+    );
+    console.log(response3);
+    expect(response3.data.getOwnerReadProtected.id).toBeDefined();
+    expect(response3.data.getOwnerReadProtected.content).toEqual('Hello, World!');
+    expect(response3.data.getOwnerReadProtected.owner).toEqual(USERNAME1);
+
+    const response4 = await GRAPHQL_CLIENT_1.query(
+      `query {
+          listOwnerReadProtecteds {
+              items {
+                  id content owner
+              }
+          }
+      }`,
+      {}
+    );
+    console.log(response4);
+    expect(response4.data.listOwnerReadProtecteds.items.length).toBeGreaterThanOrEqual(1);
+
+    const response5 = await GRAPHQL_CLIENT_2.query(
+      `query {
+          listOwnerReadProtecteds {
+              items {
+                  id content owner
+              }
+          }
+      }`,
+      {}
+    );
+    console.log(response5);
+    expect(response5.data.listOwnerReadProtecteds.items).toHaveLength(0);
+  });
+
+  test("Test createOwnerCreateUpdateDeleteProtected with 'create' operation set", async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response);
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
+
+    const response2 = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME2}" }) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response2);
+    expect(response2.data.createOwnerCreateUpdateDeleteProtected).toBeNull();
+    expect(response2.errors).toHaveLength(1);
+  });
+
+  test("Test updateOwnerCreateUpdateDeleteProtected with 'update' operation set", async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response);
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
+
+    const response2 = await GRAPHQL_CLIENT_2.query(
+      `mutation {
+          updateOwnerCreateUpdateDeleteProtected(
+              input: {
+                  id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}",
+                  content: "Bye, World!"
+              }
+          ) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response2);
+    expect(response2.data.updateOwnerCreateUpdateDeleteProtected).toBeNull();
+    expect(response2.errors).toHaveLength(1);
+
+    const response3 = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          updateOwnerCreateUpdateDeleteProtected(
+              input: {
+                  id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}",
+                  content: "Bye, World!"
+              }
+          ) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response3);
+    expect(response3.data.updateOwnerCreateUpdateDeleteProtected.id).toBeDefined();
+    expect(response3.data.updateOwnerCreateUpdateDeleteProtected.content).toEqual('Bye, World!');
+    expect(response3.data.updateOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
+  });
+
+  test("Test deleteOwnerCreateUpdateDeleteProtected with 'update' operation set", async () => {
+    const response = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response);
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
+    expect(response.data.createOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
+
+    const response2 = await GRAPHQL_CLIENT_2.query(
+      `mutation {
+          deleteOwnerCreateUpdateDeleteProtected(
+              input: {
+                  id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}"
+              }
+          ) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response2);
+    expect(response2.data.deleteOwnerCreateUpdateDeleteProtected).toBeNull();
+    expect(response2.errors).toHaveLength(1);
+
+    const response3 = await GRAPHQL_CLIENT_1.query(
+      `mutation {
+          deleteOwnerCreateUpdateDeleteProtected(
+              input: {
+                  id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}"
+              }
+          ) {
+              id
+              content
+              owner
+          }
+      }`,
+      {}
+    );
+    console.log(response3);
+    expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.id).toBeDefined();
+    expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
+    expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
+  });
+
+  test('Test allow private combined with groups as Admin and non-admin users', async () => {
+    const create = `mutation {
+        p1: createPerformance(input: {
+          id: "P1"
+          performer: "Perf #1"
+          description: "Description"
+          time: "2019-11-11T00:00:00Z"
+          performanceStageId: "S1"
         }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
+          id
         }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
 
-  const fetchOwnedBy2AsAdmin = await GRAPHQL_CLIENT_1.query(`
-    query {
-        getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4));
-  expect(fetchOwnedBy2AsAdmin.data.getAllThree).toBeTruthy();
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test getAllThree as owner.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com"
+        p2: createPerformance(input: {
+          id: "P2"
+          performer: "Perf #2"
+          description: "Description"
+          time: "2019-11-11T00:00:00Z"
+          performanceStageId: "S1"
         }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
+          id
         }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
 
-  const fetchOwnedBy2AsOwner = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4));
-  expect(fetchOwnedBy2AsOwner.data.getAllThree).toBeTruthy();
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test getAllThree as one of a set of editors.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            editors: ["user2@test.com"]
+        s1: createStage(input: {
+          id: "S1"
+          name: "Stage #1"
         }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedBy2AsEditor = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getAllThree(id: "${ownedBy2.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4));
-  expect(fetchOwnedBy2AsEditor.data.getAllThree).toBeTruthy();
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test getAllThree as a member of a dynamic group.`, async () => {
-  const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            groups: ["Devs"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdmins, null, 4));
-  expect(ownedByAdmins.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsAdmin.data.getAllThree).toBeTruthy();
-
-  const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
-    query {
-        getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1);
-  expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
-});
-
-test(`Test getAllThree as a member of the alternative group.`, async () => {
-  const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdmins, null, 4));
-  expect(ownedByAdmins.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
-    query {
-        getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsAdmin.data.getAllThree).toBeTruthy();
-
-  const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
-    query {
-        getAllThree(id: "${ownedByAdmins.data.createAllThree.id}") {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsNonAdmin.errors.length).toEqual(1);
-  expect((fetchOwnedByAdminsAsNonAdmin.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
-});
-
-/**
- * List Query Tests
- */
-
-test(`Test listAllThrees as admin.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedBy2AsAdmin = await GRAPHQL_CLIENT_1.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedBy2AsAdmin, null, 4));
-  expect(fetchOwnedBy2AsAdmin.data.listAllThrees.items).toHaveLength(1);
-  expect(fetchOwnedBy2AsAdmin.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id);
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test listAllThrees as owner.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedBy2AsOwner = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedBy2AsOwner, null, 4));
-  expect(fetchOwnedBy2AsOwner.data.listAllThrees.items).toHaveLength(1);
-  expect(fetchOwnedBy2AsOwner.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id);
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test listAllThrees as one of a set of editors.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            editors: ["user2@test.com"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedBy2AsEditor = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedBy2AsEditor, null, 4));
-  expect(fetchOwnedBy2AsEditor.data.listAllThrees.items).toHaveLength(1);
-  expect(fetchOwnedBy2AsEditor.data.listAllThrees.items[0].id).toEqual(ownedBy2.data.createAllThree.id);
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test listAllThrees as a member of a dynamic group.`, async () => {
-  const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            groups: ["Devs"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdmins, null, 4));
-  expect(ownedByAdmins.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items).toHaveLength(1);
-  expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items[0].id).toEqual(ownedByAdmins.data.createAllThree.id);
-
-  const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsNonAdmin.data.listAllThrees.items).toHaveLength(0);
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
-});
-
-test(`Test getAllThree as a member of the alternative group.`, async () => {
-  const ownedByAdmins = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdmins, null, 4));
-  expect(ownedByAdmins.data.createAllThree).toBeTruthy();
-
-  const fetchOwnedByAdminsAsAdmin = await GRAPHQL_CLIENT_2.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items).toHaveLength(1);
-  expect(fetchOwnedByAdminsAsAdmin.data.listAllThrees.items[0].id).toEqual(ownedByAdmins.data.createAllThree.id);
-
-  const fetchOwnedByAdminsAsNonAdmin = await GRAPHQL_CLIENT_3.query(`
-    query {
-        listAllThrees {
-            items {
-                id
-                owner
-                editors
-                groups
-                alternativeGroup
-            }
-        }
-    }
-    `);
-  console.log(JSON.stringify(fetchOwnedByAdminsAsNonAdmin, null, 4));
-  expect(fetchOwnedByAdminsAsNonAdmin.data.listAllThrees.items).toHaveLength(0);
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
-});
-
-/**
- * Create Mutation Tests
- */
-
-test(`Test createAllThree as admin.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-  // set by input
-  expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
-  // auto filled as logged in user.
-  expect(ownedBy2.data.createAllThree.editors[0]).toEqual('user1@test.com');
-  expect(ownedBy2.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedBy2NoEditors = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com",
-            editors: []
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2NoEditors, null, 4));
-  expect(ownedBy2NoEditors.data.createAllThree).toBeTruthy();
-  // set by input
-  expect(ownedBy2NoEditors.data.createAllThree.owner).toEqual('user2@test.com');
-  // set by input
-  expect(ownedBy2NoEditors.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedBy2NoEditors.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2NoEditors.data.createAllThree.alternativeGroup).toBeNull();
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-
-  const deleteReq2 = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2NoEditors.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq2, null, 4));
-  expect(deleteReq2.data.deleteAllThree.id).toEqual(ownedBy2NoEditors.data.createAllThree.id);
-});
-
-test(`Test createAllThree as owner.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com",
-            editors: []
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-  expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
-  expect(ownedBy2.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedBy2.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedBy1 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user1@test.com",
-            editors: []
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy1, null, 4));
-  expect(ownedBy1.errors.length).toEqual(1);
-  expect((ownedBy1.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test createAllThree as one of a set of editors.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: ["user2@test.com"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-  expect(ownedBy2.data.createAllThree.owner).toBeNull();
-  expect(ownedBy2.data.createAllThree.editors[0]).toEqual('user2@test.com');
-  expect(ownedBy2.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedBy2WithDefaultOwner = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            editors: ["user2@test.com"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2WithDefaultOwner, null, 4));
-  expect(ownedBy2WithDefaultOwner.data.createAllThree).toBeTruthy();
-  expect(ownedBy2WithDefaultOwner.data.createAllThree.owner).toEqual('user2@test.com');
-  expect(ownedBy2WithDefaultOwner.data.createAllThree.editors[0]).toEqual('user2@test.com');
-  expect(ownedBy2WithDefaultOwner.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2WithDefaultOwner.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedByEditorsUnauthed = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: ["user1@test.com"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByEditorsUnauthed, null, 4));
-  expect(ownedByEditorsUnauthed.errors.length).toEqual(1);
-  expect((ownedByEditorsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-
-  const deleteReq2 = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2WithDefaultOwner.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq2, null, 4));
-  expect(deleteReq2.data.deleteAllThree.id).toEqual(ownedBy2WithDefaultOwner.data.createAllThree.id);
-});
-
-test(`Test createAllThree as a member of a dynamic group.`, async () => {
-  const ownedByDevs = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            groups: ["Devs"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByDevs, null, 4));
-  expect(ownedByDevs.data.createAllThree).toBeTruthy();
-  expect(ownedByDevs.data.createAllThree.owner).toBeNull();
-  expect(ownedByDevs.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedByDevs.data.createAllThree.groups[0]).toEqual('Devs');
-  expect(ownedByDevs.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_3.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            groups: ["Devs"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
-  expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
-  expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByDevs.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id);
-});
-
-test(`Test createAllThree as a member of the alternative group.`, async () => {
-  const ownedByAdmins = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdmins, null, 4));
-  expect(ownedByAdmins.data.createAllThree).toBeTruthy();
-  expect(ownedByAdmins.data.createAllThree.owner).toBeNull();
-  expect(ownedByAdmins.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedByAdmins.data.createAllThree.alternativeGroup).toEqual('Devs');
-
-  const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_3.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            alternativeGroup: "Admin"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
-  expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
-  expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByAdmins.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByAdmins.data.createAllThree.id);
-});
-
-/**
- * Update Mutation Tests
- */
-
-test(`Test updateAllThree and deleteAllThree as admin.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            editors: []
-            owner: "user2@test.com"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-  // set by input
-  expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
-  // auto filled as logged in user.
-  expect(ownedBy2.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedBy2.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedByTwoUpdate = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        updateAllThree(input: {
-            id: "${ownedBy2.data.createAllThree.id}",
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByTwoUpdate, null, 4));
-  expect(ownedByTwoUpdate.data.updateAllThree).toBeTruthy();
-  // set by input
-  expect(ownedByTwoUpdate.data.updateAllThree.owner).toEqual('user2@test.com');
-  // set by input
-  expect(ownedByTwoUpdate.data.updateAllThree.editors).toHaveLength(0);
-  expect(ownedByTwoUpdate.data.updateAllThree.groups).toBeNull();
-  expect(ownedByTwoUpdate.data.updateAllThree.alternativeGroup).toEqual('Devs');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test updateAllThree and deleteAllThree as owner.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: "user2@test.com",
-            editors: []
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-  expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
-  expect(ownedBy2.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedBy2.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedBy2Update = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateAllThree(input: {
-            id: "${ownedBy2.data.createAllThree.id}",
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2Update, null, 4));
-  expect(ownedBy2Update.data.updateAllThree).toBeTruthy();
-  // set by input
-  expect(ownedBy2Update.data.updateAllThree.owner).toEqual('user2@test.com');
-  // set by input
-  expect(ownedBy2Update.data.updateAllThree.editors).toHaveLength(0);
-  expect(ownedBy2Update.data.updateAllThree.groups).toBeNull();
-  expect(ownedBy2Update.data.updateAllThree.alternativeGroup).toEqual('Devs');
-
-  const deleteReq = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test updateAllThree and deleteAllThree as one of a set of editors.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: ["user2@test.com"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createAllThree).toBeTruthy();
-  expect(ownedBy2.data.createAllThree.owner).toBeNull();
-  expect(ownedBy2.data.createAllThree.editors[0]).toEqual('user2@test.com');
-  expect(ownedBy2.data.createAllThree.groups).toBeNull();
-  expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedByUpdate = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateAllThree(input: {
-            id: "${ownedBy2.data.createAllThree.id}",
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByUpdate, null, 4));
-  expect(ownedByUpdate.data.updateAllThree).toBeTruthy();
-  // set by input
-  expect(ownedByUpdate.data.updateAllThree.owner).toBeNull();
-  // set by input
-  expect(ownedByUpdate.data.updateAllThree.editors[0]).toEqual('user2@test.com');
-  expect(ownedByUpdate.data.updateAllThree.groups).toBeNull();
-  expect(ownedByUpdate.data.updateAllThree.alternativeGroup).toEqual('Devs');
-
-  const deleteReq = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedBy2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedBy2.data.createAllThree.id);
-});
-
-test(`Test updateAllThree and deleteAllThree as a member of a dynamic group.`, async () => {
-  const ownedByDevs = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            groups: ["Devs"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByDevs, null, 4));
-  expect(ownedByDevs.data.createAllThree).toBeTruthy();
-  expect(ownedByDevs.data.createAllThree.owner).toBeNull();
-  expect(ownedByDevs.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedByDevs.data.createAllThree.groups[0]).toEqual('Devs');
-  expect(ownedByDevs.data.createAllThree.alternativeGroup).toBeNull();
-
-  const ownedByUpdate = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateAllThree(input: {
-            id: "${ownedByDevs.data.createAllThree.id}",
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByUpdate, null, 4));
-  expect(ownedByUpdate.data.updateAllThree).toBeTruthy();
-  // set by input
-  expect(ownedByUpdate.data.updateAllThree.owner).toBeNull();
-  // set by input
-  expect(ownedByUpdate.data.updateAllThree.editors).toHaveLength(0);
-  expect(ownedByUpdate.data.updateAllThree.groups[0]).toEqual('Devs');
-  expect(ownedByUpdate.data.updateAllThree.alternativeGroup).toEqual('Devs');
-
-  const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_3.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            groups: ["Devs"]
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
-  expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
-  expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByDevs.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id);
-});
-
-test(`Test updateAllThree and deleteAllThree as a member of the alternative group.`, async () => {
-  const ownedByDevs = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByDevs, null, 4));
-  expect(ownedByDevs.data.createAllThree).toBeTruthy();
-  expect(ownedByDevs.data.createAllThree.owner).toBeNull();
-  expect(ownedByDevs.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedByDevs.data.createAllThree.alternativeGroup).toEqual('Devs');
-
-  const ownedByUpdate = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateAllThree(input: {
-            id: "${ownedByDevs.data.createAllThree.id}",
-            alternativeGroup: "Admin"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByUpdate, null, 4));
-  expect(ownedByUpdate.data.updateAllThree).toBeTruthy();
-  // set by input
-  expect(ownedByUpdate.data.updateAllThree.owner).toBeNull();
-  // set by input
-  expect(ownedByUpdate.data.updateAllThree.editors).toHaveLength(0);
-  expect(ownedByUpdate.data.updateAllThree.groups).toBeNull();
-  expect(ownedByUpdate.data.updateAllThree.alternativeGroup).toEqual('Admin');
-
-  const ownedByAdminsUnauthed = await GRAPHQL_CLIENT_2.query(`
-    mutation {
-        updateAllThree(input: {
-            id: "${ownedByDevs.data.createAllThree.id}",
-            alternativeGroup: "Dev"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
-  expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
-  expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
-
-  const ownedByDevs2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createAllThree(input: {
-            owner: null,
-            editors: [],
-            alternativeGroup: "Devs"
-        }) {
-            id
-            owner
-            editors
-            groups
-            alternativeGroup
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedByDevs2, null, 4));
-  expect(ownedByDevs2.data.createAllThree).toBeTruthy();
-  expect(ownedByDevs2.data.createAllThree.owner).toBeNull();
-  expect(ownedByDevs2.data.createAllThree.editors).toHaveLength(0);
-  expect(ownedByDevs2.data.createAllThree.alternativeGroup).toEqual('Devs');
-
-  const deleteReq2 = await GRAPHQL_CLIENT_2.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByDevs2.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq2, null, 4));
-  expect(deleteReq2.data.deleteAllThree.id).toEqual(ownedByDevs2.data.createAllThree.id);
-
-  const deleteReq = await GRAPHQL_CLIENT_1.query(`
-        mutation {
-            deleteAllThree(input: { id: "${ownedByDevs.data.createAllThree.id}" }) {
-                id
-            }
-        }
-    `);
-  console.log(JSON.stringify(deleteReq, null, 4));
-  expect(deleteReq.data.deleteAllThree.id).toEqual(ownedByDevs.data.createAllThree.id);
-});
-
-test(`Test createTestIdentity as admin.`, async () => {
-  const ownedBy2 = await GRAPHQL_CLIENT_1.query(`
-    mutation {
-        createTestIdentity(input: {
-            title: "Test title"
-        }) {
-            id
-            title
-            owner
-        }
-    }
-    `);
-  console.log(JSON.stringify(ownedBy2, null, 4));
-  expect(ownedBy2.data.createTestIdentity).toBeTruthy();
-  expect(ownedBy2.data.createTestIdentity.title).toEqual('Test title');
-  expect(ownedBy2.data.createTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
-
-  // user 2 should be able to update because they share the same issuer.
-  const update = await GRAPHQL_CLIENT_3.query(`
-    mutation {
-        updateTestIdentity(input: {
-            id: "${ownedBy2.data.createTestIdentity.id}",
-            title: "Test title update"
-        }) {
-            id
-            title
-            owner
-        }
-    }
-    `);
-  console.log(JSON.stringify(update, null, 4));
-  expect(update.data.updateTestIdentity).toBeTruthy();
-  expect(update.data.updateTestIdentity.title).toEqual('Test title update');
-  expect(update.data.updateTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
-
-  // user 2 should be able to get because they share the same issuer.
-  const getReq = await GRAPHQL_CLIENT_3.query(`
-    query {
-        getTestIdentity(id: "${ownedBy2.data.createTestIdentity.id}") {
-            id
-            title
-            owner
-        }
-    }
-    `);
-  console.log(JSON.stringify(getReq, null, 4));
-  expect(getReq.data.getTestIdentity).toBeTruthy();
-  expect(getReq.data.getTestIdentity.title).toEqual('Test title update');
-  expect(getReq.data.getTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
-
-  const listResponse = await GRAPHQL_CLIENT_3.query(
-    `query {
-        listTestIdentitys(filter: { title: { eq: "Test title update" } }, limit: 100) {
-            items {
-                id
-                title
-                owner
-            }
-        }
-    }`,
-    {}
-  );
-  const relevantPost = listResponse.data.listTestIdentitys.items.find(p => p.id === getReq.data.getTestIdentity.id);
-  console.log(JSON.stringify(listResponse, null, 4));
-  expect(relevantPost).toBeTruthy();
-  expect(relevantPost.title).toEqual('Test title update');
-  expect(relevantPost.owner.slice(0, 19)).toEqual('https://cognito-idp');
-
-  // user 2 should be able to delete because they share the same issuer.
-  const delReq = await GRAPHQL_CLIENT_3.query(`
-    mutation {
-        deleteTestIdentity(input: {
-            id: "${ownedBy2.data.createTestIdentity.id}"
-        }) {
-            id
-            title
-            owner
-        }
-    }
-    `);
-  console.log(JSON.stringify(delReq, null, 4));
-  expect(delReq.data.deleteTestIdentity).toBeTruthy();
-  expect(delReq.data.deleteTestIdentity.title).toEqual('Test title update');
-  expect(delReq.data.deleteTestIdentity.owner.slice(0, 19)).toEqual('https://cognito-idp');
-});
-
-/**
- * Test 'operations' argument
- */
-test("Test get and list with 'read' operation set", async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createOwnerReadProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response);
-  expect(response.data.createOwnerReadProtected.id).toBeDefined();
-  expect(response.data.createOwnerReadProtected.content).toEqual('Hello, World!');
-  expect(response.data.createOwnerReadProtected.owner).toEqual(USERNAME1);
-
-  const response2 = await GRAPHQL_CLIENT_2.query(
-    `query {
-        getOwnerReadProtected(id: "${response.data.createOwnerReadProtected.id}") {
-            id content owner
-        }
-    }`,
-    {}
-  );
-  console.log(response2);
-  expect(response2.data.getOwnerReadProtected).toBeNull();
-  expect(response2.errors).toHaveLength(1);
-
-  const response3 = await GRAPHQL_CLIENT_1.query(
-    `query {
-        getOwnerReadProtected(id: "${response.data.createOwnerReadProtected.id}") {
-            id content owner
-        }
-    }`,
-    {}
-  );
-  console.log(response3);
-  expect(response3.data.getOwnerReadProtected.id).toBeDefined();
-  expect(response3.data.getOwnerReadProtected.content).toEqual('Hello, World!');
-  expect(response3.data.getOwnerReadProtected.owner).toEqual(USERNAME1);
-
-  const response4 = await GRAPHQL_CLIENT_1.query(
-    `query {
-        listOwnerReadProtecteds {
-            items {
-                id content owner
-            }
-        }
-    }`,
-    {}
-  );
-  console.log(response4);
-  expect(response4.data.listOwnerReadProtecteds.items.length).toBeGreaterThanOrEqual(1);
-
-  const response5 = await GRAPHQL_CLIENT_2.query(
-    `query {
-        listOwnerReadProtecteds {
-            items {
-                id content owner
-            }
-        }
-    }`,
-    {}
-  );
-  console.log(response5);
-  expect(response5.data.listOwnerReadProtecteds.items).toHaveLength(0);
-});
-
-test("Test createOwnerCreateUpdateDeleteProtected with 'create' operation set", async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response);
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
-
-  const response2 = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME2}" }) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response2);
-  expect(response2.data.createOwnerCreateUpdateDeleteProtected).toBeNull();
-  expect(response2.errors).toHaveLength(1);
-});
-
-test("Test updateOwnerCreateUpdateDeleteProtected with 'update' operation set", async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response);
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
-
-  const response2 = await GRAPHQL_CLIENT_2.query(
-    `mutation {
-        updateOwnerCreateUpdateDeleteProtected(
-            input: {
-                id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}",
-                content: "Bye, World!"
-            }
-        ) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response2);
-  expect(response2.data.updateOwnerCreateUpdateDeleteProtected).toBeNull();
-  expect(response2.errors).toHaveLength(1);
-
-  const response3 = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        updateOwnerCreateUpdateDeleteProtected(
-            input: {
-                id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}",
-                content: "Bye, World!"
-            }
-        ) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response3);
-  expect(response3.data.updateOwnerCreateUpdateDeleteProtected.id).toBeDefined();
-  expect(response3.data.updateOwnerCreateUpdateDeleteProtected.content).toEqual('Bye, World!');
-  expect(response3.data.updateOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
-});
-
-test("Test deleteOwnerCreateUpdateDeleteProtected with 'update' operation set", async () => {
-  const response = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        createOwnerCreateUpdateDeleteProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response);
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
-  expect(response.data.createOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
-
-  const response2 = await GRAPHQL_CLIENT_2.query(
-    `mutation {
-        deleteOwnerCreateUpdateDeleteProtected(
-            input: {
-                id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}"
-            }
-        ) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response2);
-  expect(response2.data.deleteOwnerCreateUpdateDeleteProtected).toBeNull();
-  expect(response2.errors).toHaveLength(1);
-
-  const response3 = await GRAPHQL_CLIENT_1.query(
-    `mutation {
-        deleteOwnerCreateUpdateDeleteProtected(
-            input: {
-                id: "${response.data.createOwnerCreateUpdateDeleteProtected.id}"
-            }
-        ) {
-            id
-            content
-            owner
-        }
-    }`,
-    {}
-  );
-  console.log(response3);
-  expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.id).toBeDefined();
-  expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.content).toEqual('Hello, World!');
-  expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.owner).toEqual(USERNAME1);
-});
-
-test('Test allow private combined with groups as Admin and non-admin users', async () => {
-  const create = `mutation {
-      p1: createPerformance(input: {
+          id
+        }
+      }
+      `;
+
+    // Create as non-admin user, should fail
+    const response1 = await GRAPHQL_CLIENT_3.query(create, {});
+    console.log(response1);
+
+    expect(response1.data.p1).toBeNull();
+    expect(response1.data.p2).toBeNull();
+    expect(response1.data.s1).toBeNull();
+    expect(response1.errors.length).toEqual(3);
+    expect((response1.errors[0] as any).errorType).toEqual('Unauthorized');
+    expect((response1.errors[1] as any).errorType).toEqual('Unauthorized');
+    expect((response1.errors[2] as any).errorType).toEqual('Unauthorized');
+
+    // Create as Admin, should succeed
+    const response2 = await GRAPHQL_CLIENT_1.query(create, {});
+    console.log(response2);
+
+    expect(response2.data.p1.id).toEqual('P1');
+    expect(response2.data.p2.id).toEqual('P2');
+    expect(response2.data.s1.id).toEqual('S1');
+
+    const update = `mutation {
+      updatePerformance(input: {
         id: "P1"
-        performer: "Perf #1"
-        description: "Description"
-        time: "2019-11-11T00:00:00Z"
-        performanceStageId: "S1"
+        performer: "Best Perf #1"
       }) {
         id
-      }
-
-      p2: createPerformance(input: {
-        id: "P2"
-        performer: "Perf #2"
-        description: "Description"
-        time: "2019-11-11T00:00:00Z"
-        performanceStageId: "S1"
-      }) {
-        id
-      }
-
-      s1: createStage(input: {
-        id: "S1"
-        name: "Stage #1"
-      }) {
-        id
+        performer
       }
     }
     `;
 
-  // Create as non-admin user, should fail
-  const response1 = await GRAPHQL_CLIENT_3.query(create, {});
-  console.log(response1);
+    // Update as non-admin user, should fail
+    const response3 = await GRAPHQL_CLIENT_3.query(update, {});
+    console.log(response3);
 
-  expect(response1.data.p1).toBeNull();
-  expect(response1.data.p2).toBeNull();
-  expect(response1.data.s1).toBeNull();
-  expect(response1.errors.length).toEqual(3);
-  expect((response1.errors[0] as any).errorType).toEqual('Unauthorized');
-  expect((response1.errors[1] as any).errorType).toEqual('Unauthorized');
-  expect((response1.errors[2] as any).errorType).toEqual('Unauthorized');
+    expect(response3.data.updatePerformance).toBeNull();
+    expect(response3.errors.length).toEqual(1);
+    expect((response3.errors[0] as any).errorType).toEqual('Unauthorized');
 
-  // Create as Admin, should succeed
-  const response2 = await GRAPHQL_CLIENT_1.query(create, {});
-  console.log(response2);
+    // Update as Admin, should succeed
+    const response4 = await GRAPHQL_CLIENT_1.query(update, {});
+    console.log(response4);
 
-  expect(response2.data.p1.id).toEqual('P1');
-  expect(response2.data.p2.id).toEqual('P2');
-  expect(response2.data.s1.id).toEqual('S1');
+    expect(response4.data.updatePerformance.id).toEqual('P1');
+    expect(response4.data.updatePerformance.performer).toEqual('Best Perf #1');
 
-  const update = `mutation {
-    updatePerformance(input: {
-      id: "P1"
-      performer: "Best Perf #1"
-    }) {
-      id
-      performer
+    // List as non-admin and Admin user as well, should succeed
+    const list = `query List {
+      listPerformances {
+        items {
+          id
+          performer
+          description
+          time
+          stage {
+            name
+          }
+        }
+      }
     }
-  }
-  `;
+    `;
 
-  // Update as non-admin user, should fail
-  const response3 = await GRAPHQL_CLIENT_3.query(update, {});
-  console.log(response3);
+    const response5 = await GRAPHQL_CLIENT_3.query(list, {});
+    console.log(response5);
 
-  expect(response3.data.updatePerformance).toBeNull();
-  expect(response3.errors.length).toEqual(1);
-  expect((response3.errors[0] as any).errorType).toEqual('Unauthorized');
+    expect(response5.data.listPerformances).toBeDefined();
+    expect(response5.data.listPerformances.items).toBeDefined();
+    expect(response5.data.listPerformances.items.length).toEqual(2);
+    expect(response5.data.listPerformances.items[0].id).toEqual('P2');
+    expect(response5.data.listPerformances.items[0].performer).toEqual('Perf #2');
+    expect(response5.data.listPerformances.items[0].stage).toBeDefined();
+    expect(response5.data.listPerformances.items[0].stage.name).toEqual('Stage #1');
+    expect(response5.data.listPerformances.items[1].id).toEqual('P1');
+    expect(response5.data.listPerformances.items[1].performer).toEqual('Best Perf #1');
+    expect(response5.data.listPerformances.items[1].stage).toBeDefined();
+    expect(response5.data.listPerformances.items[1].stage.name).toEqual('Stage #1');
 
-  // Update as Admin, should succeed
-  const response4 = await GRAPHQL_CLIENT_1.query(update, {});
-  console.log(response4);
+    const response6 = await GRAPHQL_CLIENT_1.query(list, {});
+    console.log(response6);
 
-  expect(response4.data.updatePerformance.id).toEqual('P1');
-  expect(response4.data.updatePerformance.performer).toEqual('Best Perf #1');
+    expect(response6.data.listPerformances).toBeDefined();
+    expect(response6.data.listPerformances.items).toBeDefined();
+    expect(response6.data.listPerformances.items.length).toEqual(2);
+    expect(response6.data.listPerformances.items[0].id).toEqual('P2');
+    expect(response6.data.listPerformances.items[0].performer).toEqual('Perf #2');
+    expect(response6.data.listPerformances.items[0].stage).toBeDefined();
+    expect(response6.data.listPerformances.items[0].stage.name).toEqual('Stage #1');
+    expect(response6.data.listPerformances.items[1].id).toEqual('P1');
+    expect(response6.data.listPerformances.items[1].performer).toEqual('Best Perf #1');
+    expect(response6.data.listPerformances.items[1].stage.name).toEqual('Stage #1');
+    expect(response6.data.listPerformances.items[1].stage).toBeDefined();
 
-  // List as non-admin and Admin user as well, should succeed
-  const list = `query List {
-    listPerformances {
-      items {
+    // Get as non-admin and Admin user as well, should succeed
+    const get = `query Get {
+      getPerformance(id: "P1") {
         id
         performer
         description
@@ -2845,92 +2891,48 @@ test('Test allow private combined with groups as Admin and non-admin users', asy
         }
       }
     }
-  }
-  `;
+    `;
 
-  const response5 = await GRAPHQL_CLIENT_3.query(list, {});
-  console.log(response5);
+    const response7 = await GRAPHQL_CLIENT_3.query(get, {});
+    console.log(response7);
 
-  expect(response5.data.listPerformances).toBeDefined();
-  expect(response5.data.listPerformances.items).toBeDefined();
-  expect(response5.data.listPerformances.items.length).toEqual(2);
-  expect(response5.data.listPerformances.items[0].id).toEqual('P2');
-  expect(response5.data.listPerformances.items[0].performer).toEqual('Perf #2');
-  expect(response5.data.listPerformances.items[0].stage).toBeDefined();
-  expect(response5.data.listPerformances.items[0].stage.name).toEqual('Stage #1');
-  expect(response5.data.listPerformances.items[1].id).toEqual('P1');
-  expect(response5.data.listPerformances.items[1].performer).toEqual('Best Perf #1');
-  expect(response5.data.listPerformances.items[1].stage).toBeDefined();
-  expect(response5.data.listPerformances.items[1].stage.name).toEqual('Stage #1');
+    expect(response7.data.getPerformance).toBeDefined();
+    expect(response7.data.getPerformance.id).toEqual('P1');
+    expect(response7.data.getPerformance.performer).toEqual('Best Perf #1');
+    expect(response7.data.getPerformance.stage).toBeDefined();
+    expect(response7.data.getPerformance.stage.name).toEqual('Stage #1');
 
-  const response6 = await GRAPHQL_CLIENT_1.query(list, {});
-  console.log(response6);
+    const response8 = await GRAPHQL_CLIENT_1.query(get, {});
+    console.log(response8);
 
-  expect(response6.data.listPerformances).toBeDefined();
-  expect(response6.data.listPerformances.items).toBeDefined();
-  expect(response6.data.listPerformances.items.length).toEqual(2);
-  expect(response6.data.listPerformances.items[0].id).toEqual('P2');
-  expect(response6.data.listPerformances.items[0].performer).toEqual('Perf #2');
-  expect(response6.data.listPerformances.items[0].stage).toBeDefined();
-  expect(response6.data.listPerformances.items[0].stage.name).toEqual('Stage #1');
-  expect(response6.data.listPerformances.items[1].id).toEqual('P1');
-  expect(response6.data.listPerformances.items[1].performer).toEqual('Best Perf #1');
-  expect(response6.data.listPerformances.items[1].stage.name).toEqual('Stage #1');
-  expect(response6.data.listPerformances.items[1].stage).toBeDefined();
+    expect(response8.data.getPerformance).toBeDefined();
+    expect(response8.data.getPerformance.id).toEqual('P1');
+    expect(response8.data.getPerformance.performer).toEqual('Best Perf #1');
+    expect(response8.data.getPerformance.stage).toBeDefined();
+    expect(response8.data.getPerformance.stage.name).toEqual('Stage #1');
 
-  // Get as non-admin and Admin user as well, should succeed
-  const get = `query Get {
-    getPerformance(id: "P1") {
-      id
-      performer
-      description
-      time
-      stage {
-        name
+    const deleteMutation = `mutation {
+      deletePerformance(input: {
+        id: "P1"
+      }) {
+        id
       }
     }
-  }
-  `;
+    `;
 
-  const response7 = await GRAPHQL_CLIENT_3.query(get, {});
-  console.log(response7);
+    // Delete as non-admin user, should fail
+    const response9 = await GRAPHQL_CLIENT_3.query(deleteMutation, {});
+    console.log(response9);
 
-  expect(response7.data.getPerformance).toBeDefined();
-  expect(response7.data.getPerformance.id).toEqual('P1');
-  expect(response7.data.getPerformance.performer).toEqual('Best Perf #1');
-  expect(response7.data.getPerformance.stage).toBeDefined();
-  expect(response7.data.getPerformance.stage.name).toEqual('Stage #1');
+    expect(response9.data.deletePerformance).toBeNull();
+    expect(response9.errors.length).toEqual(1);
+    expect((response9.errors[0] as any).errorType).toEqual('Unauthorized');
 
-  const response8 = await GRAPHQL_CLIENT_1.query(get, {});
-  console.log(response8);
+    // Delete as Admin, should succeed
+    const response10 = await GRAPHQL_CLIENT_1.query(deleteMutation, {});
+    console.log(response10);
 
-  expect(response8.data.getPerformance).toBeDefined();
-  expect(response8.data.getPerformance.id).toEqual('P1');
-  expect(response8.data.getPerformance.performer).toEqual('Best Perf #1');
-  expect(response8.data.getPerformance.stage).toBeDefined();
-  expect(response8.data.getPerformance.stage.name).toEqual('Stage #1');
-
-  const deleteMutation = `mutation {
-    deletePerformance(input: {
-      id: "P1"
-    }) {
-      id
-    }
-  }
-  `;
-
-  // Delete as non-admin user, should fail
-  const response9 = await GRAPHQL_CLIENT_3.query(deleteMutation, {});
-  console.log(response9);
-
-  expect(response9.data.deletePerformance).toBeNull();
-  expect(response9.errors.length).toEqual(1);
-  expect((response9.errors[0] as any).errorType).toEqual('Unauthorized');
-
-  // Delete as Admin, should succeed
-  const response10 = await GRAPHQL_CLIENT_1.query(deleteMutation, {});
-  console.log(response10);
-
-  expect(response10.data.deletePerformance).toBeDefined();
-  expect(response10.data.deletePerformance.id).toEqual('P1');
+    expect(response10.data.deletePerformance).toBeDefined();
+    expect(response10.data.deletePerformance.id).toEqual('P1');
+  });
 });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -180,6 +180,62 @@ beforeAll(async () => {
         type: String
         date: AWSDateTime
     }
+
+    # This type is for the managed policy slicing, only deployment test in this e2e
+    type TodoWithExtraLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName @model(subscriptions:null) @auth(rules:[{allow: private, provider: iam}])
+    {
+      id: ID!
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename001: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename002: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename003: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename004: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename005: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename006: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename007: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename008: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename009: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename010: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename011: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename012: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename013: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename014: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename015: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename016: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename017: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename018: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename019: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename020: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename021: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename022: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename023: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename024: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename025: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename026: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename027: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename028: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename029: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename030: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename031: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename032: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename033: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename034: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename035: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename036: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename037: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename038: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename039: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename040: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename041: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename042: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename043: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename044: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename045: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename046: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename047: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename048: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename049: String! @auth(rules:[{allow: private, provider: iam}])
+      description: String
+    }
     `;
 
   const transformer = new GraphQLTransform({


### PR DESCRIPTION
*Issue #, if available:*

fixed: #2703

*Description of changes:*

Use managed policies instead of policies for GraphQL API policy generation for auth and unauth roles. Also take into account the policy size and create multiple policies of needed. This means that 6144 bytes long can be 1 policy and 10 Managed Policies can be attached to a single role and that 10 can be raised to 20 by AWS Support, which raises the maximum policy size to ~120kb, which is 10 times the currently supported size.

This PR does not solve the policy size issue for API Gateway (#2084), but since sizes are adding up, perhaps customers can be unblocked by this change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.