### PR TITLE
fix(amplify-codegen-appsync-model-plugin): update QueryField name (java)

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -572,7 +572,7 @@ public final class task implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField TITLE = field(\\"title\\");
   public static final QueryField DONE = field(\\"done\\");
-  public static final QueryField TODO = field(\\"todo\\");
+  public static final QueryField TODO = field(\\"taskTodoId\\");
   public static final QueryField TIME = field(\\"time\\");
   public static final QueryField CREATED_ON = field(\\"createdOn\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) ID id;
@@ -854,7 +854,7 @@ public final class Todo implements Model {
   private final @ModelField(targetType=\\"String\\") String due_date;
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Int version;
   private final @ModelField(targetType=\\"Float\\") Float value;
-  private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks;
+  private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
   public ID getId() {
       return id;
   }


### PR DESCRIPTION
Updated the QueryField name for Computed fields. The field used for input used for BelongsTo field
is an id field and the field itself is computed based on the value of input. Updated codegen to
generate the right input varaible in QueryField

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.