### PR TITLE
fix(cli): print correct message if no provider plugins are active

### DIFF
--- a/packages/amplify-cli/src/lib/attach-backend-steps/a10-queryProvider.js
+++ b/packages/amplify-cli/src/lib/attach-backend-steps/a10-queryProvider.js
@@ -17,6 +17,12 @@ async function getProvider(context, providerPlugins) {
   let result;
   const providers = [];
   const providerPluginList = Object.keys(providerPlugins);
+
+  if (providerPluginList.length === 0) {
+    const errorMessage = 'Found no provider plugins';
+    throw new Error(errorMessage);
+  }
+
   const { inputParams } = context.exeInfo;
   if (inputParams && inputParams.amplify && inputParams.amplify.providers) {
     inputParams.amplify.providers.forEach(provider => {

--- a/packages/amplify-cli/src/lib/init-steps/s2-initProviders.js
+++ b/packages/amplify-cli/src/lib/init-steps/s2-initProviders.js
@@ -22,6 +22,12 @@ async function run(context) {
 async function getProviders(context, providerPlugins) {
   let providers = [];
   const providerPluginList = Object.keys(providerPlugins);
+
+  if (providerPluginList.length === 0) {
+    const errorMessage = 'Found no provider plugins';
+    throw new Error(errorMessage);
+  }
+
   const { inputParams } = context.exeInfo;
   if (inputParams && inputParams.amplify && inputParams.amplify.providers) {
     inputParams.amplify.providers.forEach(provider => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current behavior of the CLI plugin platform: If there are not active provider plugins, in the `init` or the `pull` workflows, it prompts the customer to select from an empty list. 
This PR address this bug by printing more relevant error message when it occurs, and then throws an error to properly end the commands' executions. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.