### PR TITLE
feat(amplify-category-auth): export lambda trigger roles in template

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
@@ -191,6 +191,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
@@ -192,7 +192,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
@@ -209,7 +209,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
@@ -208,6 +208,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
@@ -184,6 +184,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
@@ -185,7 +185,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
@@ -184,6 +184,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
@@ -185,7 +185,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
@@ -191,6 +191,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
@@ -192,7 +192,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
@@ -184,6 +184,11 @@
       "Arn": {
           "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
       },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
       "Region": {
           "Value": {
               "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
@@ -185,7 +185,7 @@
           "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
       },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
@@ -199,7 +199,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
@@ -198,6 +198,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
@@ -184,6 +184,11 @@
       "Arn": {
           "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
       },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
       "Region": {
           "Value": {
               "Ref": "AWS::Region"

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
@@ -185,7 +185,7 @@
           "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
       },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
@@ -193,7 +193,7 @@
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
         "LambdaExecutionRole": {
-            "Value: {
+            "Value": {
                 "Ref": "LambdaExecutionRole"
             }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
@@ -192,6 +192,11 @@
         "Arn": {
             "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
         },
+        "LambdaExecutionRole": {
+            "Value: {
+                "Ref": "LambdaExecutionRole"
+            }
+        },
         "Region": {
             "Value": {
                 "Ref": "AWS::Region"


### PR DESCRIPTION
Export execution role so that policies can be associated later. This brings them in line with
function category provider.

re #2303

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.