### PR TITLE
fix(amplify-codegen-appsync-model-plugin): make id field the first field

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -100,6 +100,24 @@ describe('AppSyncModelVisitor', () => {
     const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
     expect(() => visit(ast, { leave: visitor })).toThrowError();
   });
+  it('should have id as the first field to ensure arity of constructors', () => {
+    const schema = /* GraphQL */ `
+      type Post @model {
+        title: String!
+        content: String!
+        id: ID!
+      }
+    `;
+    const ast = parse(schema);
+    const builtSchema = buildSchemaWithDirectives(schema);
+    const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
+    visit(ast, { leave: visitor });
+    const postFields = visitor.types.Post.fields;
+    expect(postFields[0].name).toEqual('id');
+    expect(postFields[0].type).toEqual('ID');
+    expect(postFields[0].isNullable).toEqual(false);
+    expect(postFields[0].isList).toEqual(false);
+  });
 
   describe(' 2 Way Connection', () => {
     const schema = /* GraphQL */ `

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -196,6 +196,7 @@ export class AppSyncModelVisitor<
         fields,
       };
       this.ensureIdField(model);
+      this.sortFields(model);
       this.typeMap[node.name.value] = model;
     }
   }
@@ -362,6 +363,22 @@ export class AppSyncModelVisitor<
       .update(JSON.stringify(typeArr))
       .digest()
       .toString('hex');
+  }
+
+  /**
+   * Sort the fields to ensure id is always the first field
+   * @param model
+   */
+  protected sortFields(model: CodeGenModel) {
+    // sort has different behavior in node 10 and 11. Using reduce instead
+    model.fields = model.fields.reduce((acc, field) => {
+      if (field.name === 'id') {
+        acc.unshift(field);
+      } else {
+        acc.push(field);
+      }
+      return acc;
+    }, [] as CodeGenField[]);
   }
 
   protected ensureIdField(model: CodeGenModel) {

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -8,7 +8,7 @@ import {
 } from '@graphql-codegen/visitor-plugin-common';
 import { constantCase, pascalCase } from 'change-case';
 import { plural } from 'pluralize';
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import {
   DefinitionNode,
   DirectiveNode,


### PR DESCRIPTION
Make the id field the first field so arity of the constructor is maintained

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.