### PR TITLE
fix(graphql-dynamodb-transformer): fixed KeyError for unset DEBUG

### DIFF
--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -18,7 +18,7 @@ from boto3.dynamodb.types import TypeDeserializer
 # The following parameters are required to configure the ES cluster
 ES_ENDPOINT = os.environ['ES_ENDPOINT']
 ES_REGION = os.environ['ES_REGION']
-DEBUG = True if os.environ.get('DEBUG') not in ['0', 'False', 'false', None] else False
+DEBUG = True if os.environ.get('DEBUG') == 1 else False
 
 # ElasticSearch 6 deprecated having multiple mapping types in an index. Default to doc.
 DOC_TYPE = 'doc'

--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -18,7 +18,7 @@ from boto3.dynamodb.types import TypeDeserializer
 # The following parameters are required to configure the ES cluster
 ES_ENDPOINT = os.environ['ES_ENDPOINT']
 ES_REGION = os.environ['ES_REGION']
-DEBUG = True if os.environ.get('DEBUG') is not None else False
+DEBUG = True if os.environ.get('DEBUG') not in ['0', 'False', 'false', None] else False
 
 # ElasticSearch 6 deprecated having multiple mapping types in an index. Default to doc.
 DOC_TYPE = 'doc'

--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -18,16 +18,15 @@ from boto3.dynamodb.types import TypeDeserializer
 # The following parameters are required to configure the ES cluster
 ES_ENDPOINT = os.environ['ES_ENDPOINT']
 ES_REGION = os.environ['ES_REGION']
-DEBUG = True if os.environ['DEBUG'] is not None else False
+DEBUG = True if os.environ.get('DEBUG') is not None else False
 
 # ElasticSearch 6 deprecated having multiple mapping types in an index. Default to doc.
 DOC_TYPE = 'doc'
 ES_MAX_RETRIES = 3              # Max number of retries for exponential backoff
 
-print("Streaming to ElasticSearch")
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG if DEBUG else logging.INFO)
-
+logger.info("Streaming to ElasticSearch")
 
 # Subclass of boto's TypeDeserializer for DynamoDB to adjust for DynamoDB Stream format.
 class StreamTypeDeserializer(TypeDeserializer):
@@ -186,7 +185,7 @@ def _lambda_handler(event, context):
         # Deserialize DynamoDB type to Python types
         doc_fields = ddb_deserializer.deserialize({'M': ddb[image_name]})
 
-        print(doc_fields)
+        logger.debug('Deserialized doc_fields: ' + doc_fields)
 
         doc_id = doc_fields['id'] if 'id' in doc_fields else compute_doc_index(
             ddb['Keys'], ddb_deserializer)


### PR DESCRIPTION
#2938 

Replaced print with logger.debug in python_streaming_function.py to avoid unneeded logging.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.