### PR TITLE
Fix for .gitignore duplicating amplify\mock-data

### DIFF
--- a/packages/amplify-util-mock/src/utils/git-ignore.ts
+++ b/packages/amplify-util-mock/src/utils/git-ignore.ts
@@ -6,7 +6,7 @@ export function addMockDataToGitIgnore(context) {
   const gitIgnoreFilePath = context.amplify.pathManager.getGitIgnoreFilePath();
   if (fs.existsSync(gitIgnoreFilePath)) {
     const gitRoot = path.dirname(gitIgnoreFilePath);
-    const mockDataDirectory = path.relative(gitRoot, getMockDataDirectory(context));
+    const mockDataDirectory = path.relative(gitRoot, getMockDataDirectory(context)).replace(/\\/g,"/");
     let gitIgnoreContent = fs.readFileSync(gitIgnoreFilePath).toString();
     if (gitIgnoreContent.search(RegExp(`^\s*${mockDataDirectory}\w*$`, 'gm')) === -1) {
       gitIgnoreContent += '\n' + mockDataDirectory;


### PR DESCRIPTION
Original bug: On Windows, path.relative returns a path with escaped backslashes. This entry is incompatible with .gitignore and results in new entries being added every time "amplify mock" is run.  

Fix: Convert escaped backslash to forward slash for detection and entry in .gitignore.

#2624 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.