### PR TITLE
test(amplify-e2e-tests): fixed add auth with max options

### DIFF
--- a/packages/amplify-e2e-tests/src/categories/auth.ts
+++ b/packages/amplify-e2e-tests/src/categories/auth.ts
@@ -545,7 +545,6 @@ export function addAuthWithMaxOptions(cwd: string, settings: any, verbose: boole
       .send('\r')
       .wait('Do you want to edit your custom function now')
       .send('n')
-      .send('\r')
       .sendEof()
       .run((err: Error) => {
         if (!err) {


### PR DESCRIPTION
removed additional send which caused expect next line issues

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.