### PR TITLE
fix: use relative path for xcode and android studio helper files

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -352,7 +352,7 @@ async function createAndroidHelperFiles() {
     syncEnabled: true,
   };
   const configJsonStr = JSON.stringify(configJsonObj, null, 4);
-  const configFile = './amplify-gradle-config.json';
+  const configFile = path.join(process.cwd(), './amplify-gradle-config.json');
   if (!fs.existsSync(configFile)) {
     fs.writeFileSync(configFile, configJsonStr);
   }

--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -346,19 +346,23 @@ async function createJSHelperFiles() {
 }
 
 async function createAndroidHelperFiles() {
-  const configJsonObj = { profile: 'default', envName: 'amplify', syncEnabled: true };
-  const configJsonStr = JSON.stringify(configJsonObj);
-  const configFile = path.join(process.cwd(), './amplify-gradle-config.json');
+  const configJsonObj = {
+    profile: 'default',
+    envName: 'amplify',
+    syncEnabled: true,
+  };
+  const configJsonStr = JSON.stringify(configJsonObj, null, 4);
+  const configFile = './amplify-gradle-config.json';
   if (!fs.existsSync(configFile)) {
     fs.writeFileSync(configFile, configJsonStr);
   }
 }
 
 async function createIosHelperFiles() {
-  const configFile = path.join(process.cwd(), '/amplifyxc.config');
-  const awsConfigFile = path.join(process.cwd(), '/awsconfiguration.json');
-  const amplifyConfigFile = path.join(process.cwd(), '/amplifyconfiguration.json');
-  const amplifyDir = path.join(process.cwd(), '/amplify');
+  const configFile = './amplifyxc.config';
+  const awsConfigFile = './awsconfiguration.json';
+  const amplifyConfigFile = './amplifyconfiguration.json';
+  const amplifyDir = './amplify';
   const configJsonObj = {};
   const configJsonStr = JSON.stringify(configJsonObj);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use relative paths so there is not a conflict when using source control.

https://github.com/aws-amplify/amplify-ios/issues/247

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.