### PR TITLE
fix: #2703 - policy size calculation

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
@@ -502,11 +502,11 @@ describe(`Policy slicing tests`, () => {
     const out = transformer.transform(schema);
 
     expect(out.rootStack.Resources.AuthRolePolicy01).toBeTruthy();
-    expect(out.rootStack.Resources.AuthRolePolicy01.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(27);
+    expect(out.rootStack.Resources.AuthRolePolicy01.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(26);
     expect(out.rootStack.Resources.AuthRolePolicy02).toBeTruthy();
-    expect(out.rootStack.Resources.AuthRolePolicy02.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(27);
+    expect(out.rootStack.Resources.AuthRolePolicy02.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(26);
     expect(out.rootStack.Resources.AuthRolePolicy03).toBeTruthy();
-    expect(out.rootStack.Resources.AuthRolePolicy03.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(2);
+    expect(out.rootStack.Resources.AuthRolePolicy03.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(4);
     expect(out.rootStack.Resources.UnauthRolePolicy01).toBeFalsy();
   });
 });

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -982,7 +982,10 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
     // 6144 bytes is the maximum policy payload size, but there is structural overhead, hence the 6000 bytes
     const MAX_BUILT_SIZE_BYTES = 6000;
     // The overhead is the amount of static policy arn contents like region, accountid, etc.
-    const RESOURCE_OVERHEAD = 90;
+    // arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:apis/${apiId}/types/${typeName}/fields/${fieldName}
+    // 16              15             13                5    27       6     X+1         7      Y
+    // 89 + 11 extra = 100
+    const RESOURCE_OVERHEAD = 100;
 
     const createPolicy = newPolicyResources =>
       new IAM.ManagedPolicy({


### PR DESCRIPTION
*Issue #, if available:*

fix: #2703 - Policy size calculation used a smaller value for region name and certain regions could cause a miscalculation, so policy was larger than possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.