### PR TITLE
refactor(cli): update lambda custom resource nodejs runtime version

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
@@ -1,428 +1,368 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "Pinpoint resource stack creation using Amplify CLI",
-    "Parameters": {
-        "appName": {
-            "Type": "String"
-        },
-        "appId": {
-            "Type": "String",
-            "Default": "NONE"
-        },
-        "roleName": {
-            "Type": "String"
-        },
-        "cloudWatchPolicyName": {
-            "Type": "String"
-        },
-        "pinpointPolicyName": {
-            "Type": "String"
-        },
-        "authPolicyName": {
-            "Type": "String"
-        },
-        "unauthPolicyName": {
-            "Type": "String"
-        },
-        "authRoleName": {
-            "Type":  "String"
-        },
-        "unauthRoleName": {
-            "Type":  "String"
-        },
-        "authRoleArn": {
-            "Type":  "String"
-        },
-        "env": {
-            "Type":  "String"
-        }
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Pinpoint resource stack creation using Amplify CLI",
+  "Parameters": {
+    "appName": {
+      "Type": "String"
     },
-    "Metadata": {
-        "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [
-                {
-                    "Label": {
-                        "default": "Creating pinpoint app"
-                    },
-                    "Parameters": [
-                        "appName"
-                    ]
-                }
-            ]
-        }
+    "appId": {
+      "Type": "String",
+      "Default": "NONE"
     },
-    "Conditions": {
-        "ShouldCreatePinpointApp": {
-            "Fn::Equals": [
-                {
-                    "Ref": "appId"
-                },
-                "NONE"
-            ]
-        },
-        "ShouldNotCreateEnvResources": {
-            "Fn::Equals": [
-                {
-                    "Ref": "env"
-                },
-                "NONE"
-            ]
-        }
+    "roleName": {
+      "Type": "String"
     },
-    "Resources": {
-        "LambdaExecutionRole": {
-            "Condition": "ShouldCreatePinpointApp",
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "RoleName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        {
-                           "Ref": "roleName"
-                        }, 
-                        {
-
-                            "Fn::Join": [
-                                "",
-                                [
-                                  {
-                                    "Ref": "roleName"
-                                  },
-                                  "-",
-                                  {
-                                    "Ref": "env"
-                                  }
-                                ]
-                            ]
-                        }       
-                    ]
-                },
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": [
-                                    "lambda.amazonaws.com"
-                                ]
-                            },
-                            "Action": [
-                                "sts:AssumeRole"
-                            ]
-                        }
-                    ]
-                },
-                "Policies": [
-                    {
-                        "PolicyName": {
-                            "Ref": "cloudWatchPolicyName"
-                        },
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "logs:CreateLogGroup",
-                                        "logs:CreateLogStream",
-                                        "logs:PutLogEvents"
-                                    ],
-                                    "Resource": "arn:aws:logs:*:*:*"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": {
-                            "Ref": "pinpointPolicyName"
-                        },
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "mobileanalytics:*",
-                                        "mobiletargeting:*"
-                                    ],
-                                    "Resource": "*"
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "PinpointFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-                "Code": {
-                    "ZipFile": {
-                        "Fn::Join": [
-                            "\n",
-                            [
-                                "const response = require('cfn-response');",
-                                "const aws = require('aws-sdk');",
-                                "exports.handler = function(event, context) {",
-                                "    if (event.RequestType == 'Delete') {",
-                                "        response.send(event, context, response.SUCCESS);",
-                                "        return;",
-                                "    }",
-                                "    if (event.RequestType == 'Update') {",
-                                "        response.send(event, context, response.SUCCESS);",
-                                "        return;",
-                                "    }",
-                                "    if (event.RequestType == 'Create') {",
-                                "       const appName = event.ResourceProperties.appName;",
-                                "       let responseData = {};",
-                                "       const params = {",
-                                "           CreateApplicationRequest: {",
-                                "               Name: appName",
-                                "           }",
-                                "       };",
-                                "       const pinpoint = new aws.Pinpoint({ apiVersion: '2016-12-01', region: event.ResourceProperties.region });",
-                                "       pinpoint.createApp(params).promise()",
-                                "           .then((res) => {",
-                                "               responseData = res.ApplicationResponse;",
-                                "               response.send(event, context, response.SUCCESS, responseData);",
-                                "           }).catch((err) => {",
-                                "               console.log(err.stack);",
-                                "               responseData = {Error: err};",
-                                "               response.send(event, context, response.FAILED, responseData);",
-                                "               throw err;",
-                                "           });",
-                                "    }",
-                                "};"
-                            ]
-                        ]
-                    }
-                },
-                "Handler": "index.handler",
-                "Runtime": "nodejs8.10",
-                "Timeout": "300",
-                "Role": {
-                    "Fn::GetAtt": [
-                        "LambdaExecutionRole",
-                        "Arn"
-                    ]
-                }
-            }
-        },
-        "PinpointFunctionOutputs": {
-            "Type": "Custom::LambdaCallout",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-                "ServiceToken": {
-                    "Fn::GetAtt": [
-                        "PinpointFunction",
-                        "Arn"
-                    ]
-                },
-                "region": { 
-                    "Fn::FindInMap" : [ 
-                        "RegionMapping", 
-                        { "Ref" : "AWS::Region" }, 
-                        "pinpointRegion"
-                    ]
-                },
-                "appName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        {
-                           "Ref": "appName"
-                        }, 
-                        {
-
-                            "Fn::Join": [
-                                "",
-                                [
-                                  {
-                                    "Ref": "appName"
-                                  },
-                                  "-",
-                                  {
-                                    "Ref": "env"
-                                  }
-                                ]
-                            ]
-                        }       
-                    ]
-                }
-            }
-        },
-        "CognitoUnauthPolicy": {
-            "Type": "AWS::IAM::Policy",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-              "PolicyName": {"Ref": "unauthPolicyName" },
-              "Roles": [ 
-                {"Ref": "unauthRoleName" }
-              ],
-              "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Action": [
-                        "mobiletargeting:PutEvents",
-                        "mobiletargeting:UpdateEndpoint",
-                        "mobiletargeting:GetUserEndpoints"
-                    ],
-                    "Resource": [
-                        {
-
-                            "Fn::If": [
-                                "ShouldCreatePinpointApp",
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Fn::GetAtt": [
-                                                "PinpointFunctionOutputs",
-                                                "Id"
-                                            ]
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                },
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Ref": "appId"
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                }
-                            ]
-                        }
-                
-                    ]
-                  }
-                ]
-              }
-            }
-        },
-        "CognitoAuthPolicy": {
-            "Type": "AWS::IAM::Policy",
-            "Condition": "ShouldCreatePinpointApp",
-            "Properties": {
-              "PolicyName": {"Ref": "authPolicyName" },
-              "Roles": [ 
-                {"Ref": "authRoleName" }
-              ],
-              "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Action": [
-                        "mobiletargeting:PutEvents",
-                        "mobiletargeting:UpdateEndpoint",
-                        "mobiletargeting:GetUserEndpoints"
-                    ],
-                    "Resource": [
-                        {
-
-                            "Fn::If": [
-                                "ShouldCreatePinpointApp",
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Fn::GetAtt": [
-                                                "PinpointFunctionOutputs",
-                                                "Id"
-                                            ]
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                },
-                                {
-
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                          "arn:aws:mobiletargeting:*:",
-                                          { "Fn::Select" : [ "4", { "Fn::Split": [":", {"Ref": "authRoleArn"}]}]},
-                                          ":apps/",
-                                          {
-                                            "Ref": "appId"
-                                          },
-                                          "*"
-                                        ]
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                  }
-                ]
-              }
-            }
-        }
+    "cloudWatchPolicyName": {
+      "Type": "String"
     },
-    "Outputs": {
-        "Region": {
-            "Value":{ 
-                "Fn::FindInMap" : [ 
-                    "RegionMapping", 
-                    { "Ref" : "AWS::Region" }, 
-                    "pinpointRegion"
-                ]
-            }
-        },
-        "Id": {
-            "Value": {
-                "Fn::If": [
-                    "ShouldCreatePinpointApp",
-                    {
-                        "Fn::GetAtt": [
-                            "PinpointFunctionOutputs",
-                            "Id"
-                        ]
-                    }, 
-                    {
-                        "Ref": "appId"
-                    }       
-                ]
-            }
-        },
-        "appName": {
-            "Value": {
-                "Fn::If": [
-                    "ShouldCreatePinpointApp",
-                    {
-                        "Fn::GetAtt": [
-                            "PinpointFunctionOutputs",
-                            "Name"
-                        ]
-                    }, 
-                    {
-                        "Ref": "appName"
-                    }       
-                ]
-            }
-        }
+    "pinpointPolicyName": {
+      "Type": "String"
+    },
+    "authPolicyName": {
+      "Type": "String"
+    },
+    "unauthPolicyName": {
+      "Type": "String"
+    },
+    "authRoleName": {
+      "Type": "String"
+    },
+    "unauthRoleName": {
+      "Type": "String"
+    },
+    "authRoleArn": {
+      "Type": "String"
+    },
+    "env": {
+      "Type": "String"
     }
+  },
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "Creating pinpoint app"
+          },
+          "Parameters": ["appName"]
+        }
+      ]
+    }
+  },
+  "Conditions": {
+    "ShouldCreatePinpointApp": {
+      "Fn::Equals": [
+        {
+          "Ref": "appId"
+        },
+        "NONE"
+      ]
+    },
+    "ShouldNotCreateEnvResources": {
+      "Fn::Equals": [
+        {
+          "Ref": "env"
+        },
+        "NONE"
+      ]
+    }
+  },
+  "Resources": {
+    "LambdaExecutionRole": {
+      "Condition": "ShouldCreatePinpointApp",
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            {
+              "Ref": "roleName"
+            },
+            {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "roleName"
+                  },
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["lambda.amazonaws.com"]
+              },
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": {
+              "Ref": "cloudWatchPolicyName"
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+                  "Resource": "arn:aws:logs:*:*:*"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": {
+              "Ref": "pinpointPolicyName"
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["mobileanalytics:*", "mobiletargeting:*"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "PinpointFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "\n",
+              [
+                "const response = require('cfn-response');",
+                "const aws = require('aws-sdk');",
+                "exports.handler = function(event, context) {",
+                "    if (event.RequestType == 'Delete') {",
+                "        response.send(event, context, response.SUCCESS);",
+                "        return;",
+                "    }",
+                "    if (event.RequestType == 'Update') {",
+                "        response.send(event, context, response.SUCCESS);",
+                "        return;",
+                "    }",
+                "    if (event.RequestType == 'Create') {",
+                "       const appName = event.ResourceProperties.appName;",
+                "       let responseData = {};",
+                "       const params = {",
+                "           CreateApplicationRequest: {",
+                "               Name: appName",
+                "           }",
+                "       };",
+                "       const pinpoint = new aws.Pinpoint({ apiVersion: '2016-12-01', region: event.ResourceProperties.region });",
+                "       pinpoint.createApp(params).promise()",
+                "           .then((res) => {",
+                "               responseData = res.ApplicationResponse;",
+                "               response.send(event, context, response.SUCCESS, responseData);",
+                "           }).catch((err) => {",
+                "               console.log(err.stack);",
+                "               responseData = {Error: err};",
+                "               response.send(event, context, response.FAILED, responseData);",
+                "               throw err;",
+                "           });",
+                "    }",
+                "};"
+              ]
+            ]
+          }
+        },
+        "Handler": "index.handler",
+        "Runtime": "nodejs10.x",
+        "Timeout": "300",
+        "Role": {
+          "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]
+        }
+      }
+    },
+    "PinpointFunctionOutputs": {
+      "Type": "Custom::LambdaCallout",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": ["PinpointFunction", "Arn"]
+        },
+        "region": {
+          "Fn::FindInMap": ["RegionMapping", { "Ref": "AWS::Region" }, "pinpointRegion"]
+        },
+        "appName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            {
+              "Ref": "appName"
+            },
+            {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "appName"
+                  },
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CognitoUnauthPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "PolicyName": { "Ref": "unauthPolicyName" },
+        "Roles": [{ "Ref": "unauthRoleName" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["mobiletargeting:PutEvents", "mobiletargeting:UpdateEndpoint", "mobiletargeting:GetUserEndpoints"],
+              "Resource": [
+                {
+                  "Fn::If": [
+                    "ShouldCreatePinpointApp",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Fn::GetAtt": ["PinpointFunctionOutputs", "Id"]
+                          },
+                          "*"
+                        ]
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Ref": "appId"
+                          },
+                          "*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CognitoAuthPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "ShouldCreatePinpointApp",
+      "Properties": {
+        "PolicyName": { "Ref": "authPolicyName" },
+        "Roles": [{ "Ref": "authRoleName" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["mobiletargeting:PutEvents", "mobiletargeting:UpdateEndpoint", "mobiletargeting:GetUserEndpoints"],
+              "Resource": [
+                {
+                  "Fn::If": [
+                    "ShouldCreatePinpointApp",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Fn::GetAtt": ["PinpointFunctionOutputs", "Id"]
+                          },
+                          "*"
+                        ]
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:mobiletargeting:*:",
+                          { "Fn::Select": ["4", { "Fn::Split": [":", { "Ref": "authRoleArn" }] }] },
+                          ":apps/",
+                          {
+                            "Ref": "appId"
+                          },
+                          "*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "Region": {
+      "Value": {
+        "Fn::FindInMap": ["RegionMapping", { "Ref": "AWS::Region" }, "pinpointRegion"]
+      }
+    },
+    "Id": {
+      "Value": {
+        "Fn::If": [
+          "ShouldCreatePinpointApp",
+          {
+            "Fn::GetAtt": ["PinpointFunctionOutputs", "Id"]
+          },
+          {
+            "Ref": "appId"
+          }
+        ]
+      }
+    },
+    "appName": {
+      "Value": {
+        "Fn::If": [
+          "ShouldCreatePinpointApp",
+          {
+            "Fn::GetAtt": ["PinpointFunctionOutputs", "Name"]
+          },
+          {
+            "Ref": "appName"
+          }
+        ]
+      }
+    }
+  }
 }

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/assets/adminAuth/admin-queries-function-template.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/assets/adminAuth/admin-queries-function-template.json.ejs
@@ -65,7 +65,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -367,7 +367,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -493,7 +493,7 @@ Resources:
 
 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -622,7 +622,7 @@ Resources:
             - '} '
 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -721,7 +721,7 @@ Resources:
             - '}'
 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -842,7 +842,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - MFALambdaRole
@@ -1002,7 +1002,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - OpenIdLambdaRole

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/user-pool-group-template.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/user-pool-group-template.json.ejs
@@ -235,7 +235,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs
@@ -104,7 +104,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs
@@ -121,7 +121,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs
@@ -97,7 +97,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs
@@ -97,7 +97,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs
@@ -104,7 +104,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs
@@ -97,7 +97,7 @@
               }
           },
           "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-          "Runtime": "nodejs8.10",
+          "Runtime": "nodejs10.x",
           "Timeout": "25"
         }
       },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs
@@ -111,7 +111,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs
@@ -97,7 +97,7 @@
               }
           },
           "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-          "Runtime": "nodejs8.10",
+          "Runtime": "nodejs10.x",
           "Timeout": "25"
         }
       },

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs
@@ -105,7 +105,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/cloudformation-templates/lex-cloudformation-template.json.ejs
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/cloudformation-templates/lex-cloudformation-template.json.ejs
@@ -65,7 +65,7 @@
                 },
                 "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
                 "Environment": {"Variables" : { "ENV": {"Ref": "env"}}},
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "300"
             }
         },

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/assets/identifyCFNGenerate.js
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/assets/identifyCFNGenerate.js
@@ -521,7 +521,7 @@ function generateLambdaAccessForRekognition(identifyCFNFile, functionName, s3Res
         },
       },
       Handler: 'index.handler',
-      Runtime: 'nodejs8.10',
+      Runtime: 'nodejs10.x',
       Timeout: '300',
       Role: {
         'Fn::GetAtt': ['CollectionsLambdaExecutionRole', 'Arn'],

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/identify-template.json.ejs
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/identify-template.json.ejs
@@ -353,7 +353,7 @@
                         }
                     },
                     "Handler": "index.handler",
-                    "Runtime": "nodejs8.10",
+                    "Runtime": "nodejs10.x",
                     "Timeout": "300",
                     "Role": {
                         "Fn::GetAtt": [

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
@@ -69,7 +69,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "900"
           }
         },

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
@@ -52,7 +52,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/triggers/s3/lambda-cloudformation-template.json.ejs
@@ -52,7 +52,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs8.10",
+            "Runtime": "nodejs10.x",
             "Timeout": "25"
           }
         },

--- a/packages/amplify-cli/src/extensions/amplify-helpers/constants.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/constants.js
@@ -17,5 +17,5 @@ module.exports = {
   LocalEnvFileName: 'local-env-info.json',
   ProviderInfoFileName: 'team-provider-info.json',
   BackendConfigFileName: 'backend-config.json',
-  PROJECT_CONFIG_VERSION: '2.0',
+  PROJECT_CONFIG_VERSION: '3.0',
 };

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -7,6 +7,7 @@ import { print } from './context-extensions';
 import { executeCommand } from './execution-manager';
 import { Context } from './domain/context';
 import { constants } from './domain/constants';
+import { checkProjectConfigVersion } from './project-config-version-check';
 
 // entry from commandline
 export async function run(): Promise<number> {
@@ -35,6 +36,7 @@ export async function run(): Promise<number> {
     }
 
     const context = constructContext(pluginPlatform, input);
+    await checkProjectConfigVersion(context);
     await executeCommand(context);
     persistContext(context);
     return 0;

--- a/packages/amplify-cli/src/project-config-version-check.ts
+++ b/packages/amplify-cli/src/project-config-version-check.ts
@@ -86,12 +86,14 @@ async function checkLambdaCustomResourceNodeVersion(context: Context, projectPat
 
 function checkFileContent(fileString: string): boolean {
     let result = false;
-    prevLambdaRuntimeVersions.forEach((prevVersion) => {
-        if (fileString.includes(prevVersion)) {
+
+    for (let i = 0; i < prevLambdaRuntimeVersions.length; i++) {
+        if (fileString.includes(prevLambdaRuntimeVersions[i])) {
             result = true;
-            return false;
+            break;
         }
-    });
+    }
+
     return result;
 }
 

--- a/packages/amplify-cli/src/project-config-version-check.ts
+++ b/packages/amplify-cli/src/project-config-version-check.ts
@@ -1,0 +1,114 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { Context } from './domain/context';
+import inquirer from './domain/inquirer-helper';
+
+const prevLambdaRuntimeVersion = 'nodejs8.10';
+const lambdaRuntimeVersion = 'nodejs10.x';
+const jsonIndentation = 4;
+
+export async function checkProjectConfigVersion(context: Context): Promise<void> {
+  const { pathManager, readJsonFile, constants } = context.amplify;
+  const projectPath = pathManager.searchProjectRootPath();
+  if (projectPath) {
+    const projectConfigFilePath = pathManager.getProjectConfigFilePath(projectPath);
+    if (fs.existsSync(projectConfigFilePath)) {
+      const projectConfig = readJsonFile(projectConfigFilePath);
+      if (projectConfig.version !== constants.PROJECT_CONFIG_VERSION) {
+        await checkLambdaCustomResourceNodeVersion(context, projectPath);
+
+        projectConfig.version = constants.PROJECT_CONFIG_VERSION;
+        const jsonString = JSON.stringify(projectConfig, null, jsonIndentation);
+        fs.writeFileSync(projectConfigFilePath, jsonString, 'utf8');
+      }
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////
+////// check lambda custom resources nodejs runtime version ///////
+///////////////////////////////////////////////////////////////////
+async function checkLambdaCustomResourceNodeVersion(context: Context, projectPath: string): Promise<void> {
+  const { pathManager, readJsonFile, constants } = context.amplify;
+  const backendDirPath = pathManager.getBackendDirPath(projectPath);
+
+  const filesToUpdate: string[] = [];
+
+  if (fs.existsSync(backendDirPath)) {
+    const categoryDirNames = fs.readdirSync(backendDirPath);
+    categoryDirNames.forEach(categoryDirName => {
+      const categoryDirPath = path.join(backendDirPath, categoryDirName);
+      if (!fs.statSync(categoryDirPath).isDirectory()) {
+        return;
+      }
+
+      const resourceDirNames = fs.readdirSync(categoryDirPath);
+      resourceDirNames.forEach(resourceDirName => {
+        const resourceDirPath = path.join(categoryDirPath, resourceDirName);
+        if (!fs.statSync(resourceDirPath).isDirectory()) {
+          return;
+        }
+
+        const fileNames = fs.readdirSync(resourceDirPath);
+        fileNames.forEach(fileName => {
+          const filePath = path.join(resourceDirPath, fileName);
+          if (!fs.statSync(filePath).isFile()) {
+            return;
+          }
+          const templateFileNamePattern = new RegExp('cloudformation-template');
+          if (templateFileNamePattern.test(fileName)) {
+            const fileString = fs.readFileSync(filePath, 'utf8');
+            if (fileString.includes(prevLambdaRuntimeVersion)) {
+              filesToUpdate.push(filePath);
+            }
+          }
+        });
+      });
+    });
+  }
+
+  if (filesToUpdate.length > 0) {
+    const confirmed = await promptForConfirmation(context, filesToUpdate);
+    if (confirmed) {
+      filesToUpdate.forEach(filePath => {
+        let fileString = fs.readFileSync(filePath, 'utf8');
+        fileString = fileString.replace(prevLambdaRuntimeVersion, lambdaRuntimeVersion);
+        fs.writeFileSync(filePath, fileString, 'utf8');
+      });
+      context.print.info('');
+      context.print.success('The nodejs runtime are updated successfully in the CloudFormation templates.');
+      context.print.warning('Make sure the template changes are pushed to the cloud by "amplify push"');
+    }
+  }
+}
+
+async function promptForConfirmation(context: Context, filesToUpdate: string[]): Promise<boolean> {
+  context.print.info('');
+  context.print.info('Amplify CLI uses Lambda backed custom resources with CloudFormation to manage part of your backend resources.');
+  context.print.info('In response to the Lambda Runtime support deprecation schedule');
+  context.print.green('https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html');
+  context.print.warning(
+    `Nodejs runtime need to be updated from ${prevLambdaRuntimeVersion}  to ${lambdaRuntimeVersion} in the following template files:`
+  );
+  filesToUpdate.forEach(filePath => {
+    context.print.info(filePath);
+  });
+
+  const question = {
+    type: 'confirm',
+    name: 'confirmUpdateNodeVersion',
+    message: 'Confirm to update the nodejs runtime version.',
+    default: true,
+  };
+  const answer = await inquirer.prompt(question);
+  if (!answer.confirmUpdateNodeVersion) {
+    const warningMessage = `After a runtime is deprecated, \
+Lambda might retire it completely at any time by disabling invocation. \
+Deprecated runtimes aren't eligible for security updates or technical support. \
+Before retiring a runtime, Lambda sends additional notifications to affected customers.`;
+    context.print.warning(warningMessage);
+    context.print.info('You will need to manually update the nodejs runtime in the template files and push the udpates to the cloud.');
+  }
+
+  return answer.confirmUpdateNodeVersion;
+}

--- a/packages/amplify-provider-awscloudformation/lib/update-idp-roles-cfn.json
+++ b/packages/amplify-provider-awscloudformation/lib/update-idp-roles-cfn.json
@@ -1,172 +1,145 @@
 {
-
-    "UpdateRolesWithIDPFunction": {
-        "DependsOn": [
-            "AuthRole",
-            "UnauthRole"
-        ],
-        "Type": "AWS::Lambda::Function",
-        "Properties": {
-            "Code": {
-                "ZipFile": {
-                    "Fn::Join": [
-                        "\n",
-                        [
-                            "const response = require('cfn-response');",
-                            "const aws = require('aws-sdk');",
-                            "let responseData = {};",
-                            "exports.handler = function(event, context) {",
-                            "  try {",
-                            "    let authRoleName = event.ResourceProperties.authRoleName;",
-                            "    let unauthRoleName = event.ResourceProperties.unauthRoleName;",
-                            "    let idpId = event.ResourceProperties.idpId;",
-                            "    let promises = [];",
-                            "    let authParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'authenticated'}}}]};",
-                            "    let unauthParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'unauthenticated'}}}]};",
-                            "    if (event.RequestType == 'Delete') {",
-                            "        delete authParamsJson.Statement.Condition;",
-                            "        delete unauthParamsJson.Statement.Condition;",
-                            "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
-                            "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
-                            "        const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
-                            "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
-                            "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
-                            "        Promise.all(promises)",
-                            "         .then((res) => {",
-                            "            console.log(\"delete response data\" + JSON.stringify(res));",
-                            "            response.send(event, context, response.SUCCESS, {});",
-                            "         });",
-                            "    }",
-                            "    if (event.RequestType == 'Update' || event.RequestType == 'Create') {",
-                            "       const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
-                            "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
-                            "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
-                            "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
-                            "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
-                            "        Promise.all(promises)",
-                            "         .then((res) => {",
-                            "            console.log(\"createORupdate\" + res);",
-                            "            console.log(\"response data\" + JSON.stringify(res));",
-                            "            response.send(event, context, response.SUCCESS, {});",
-                            "         });",
-                            "    }",
-                            "  } catch(err) {",
-                            "       console.log(err.stack);",
-                            "       responseData = {Error: err};",
-                            "       response.send(event, context, response.FAILED, responseData);",
-                            "       throw err;",
-                            "  }",
-                            "};"
-                        ]
-                    ]
-                }
-            },
-            "Handler": "index.handler",
-            "Runtime": "nodejs8.10",
-            "Timeout": "300",
-            "Role": {
-                "Fn::GetAtt": [
-                    "UpdateRolesWithIDPFunctionRole",
-                    "Arn"
-                ]
-            }
-        }
-    },
-    "UpdateRolesWithIDPFunctionOutputs": {
-        "Type": "Custom::LambdaCallout",
-        "Properties": {
-            "ServiceToken": {
-                "Fn::GetAtt": [
-                    "UpdateRolesWithIDPFunction",
-                    "Arn"
-                ]
-            },
-            "region": {
-                "Ref": "AWS::Region"
-            },
-            "idpId": {
-                "Fn::GetAtt": [
-
-                    "Outputs.IdentityPoolId"
-                ]
-            },
-            "authRoleName": {
-                "Ref": "AuthRoleName"
-            },
-            "unauthRoleName": {
-                "Ref": "UnauthRoleName"
-            }
-        }
-    },
-    "UpdateRolesWithIDPFunctionRole": {
-        "Type": "AWS::IAM::Role",
-        "Properties": {
-            "RoleName": {
-                "Fn::Join": [
-                    "",
-                    [
-                        {
-                            "Ref": "AuthRoleName"
-                        },
-                        "-idp"
-                    ]
-                ]
-            },
-            "AssumeRolePolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": [
-                                "lambda.amazonaws.com"
-                            ]
-                        },
-                        "Action": [
-                            "sts:AssumeRole"
-                        ]
-                    }
-                ]
-            },
-            "Policies": [
-                {
-                    "PolicyName": "UpdateRolesWithIDPFunctionPolicy",
-                    "PolicyDocument": {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    "logs:CreateLogGroup",
-                                    "logs:CreateLogStream",
-                                    "logs:PutLogEvents"
-                                ],
-                                "Resource": "arn:aws:logs:*:*:*"
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": "iam:UpdateAssumeRolePolicy",
-                                "Resource": {
-                                    "Fn::GetAtt": [
-                                        "AuthRole",
-                                        "Arn"
-                                    ]
-                                }
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": "iam:UpdateAssumeRolePolicy",
-                                "Resource": {
-                                    "Fn::GetAtt": [
-                                        "UnauthRole",
-                                        "Arn"
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
+  "UpdateRolesWithIDPFunction": {
+    "DependsOn": ["AuthRole", "UnauthRole"],
+    "Type": "AWS::Lambda::Function",
+    "Properties": {
+      "Code": {
+        "ZipFile": {
+          "Fn::Join": [
+            "\n",
+            [
+              "const response = require('cfn-response');",
+              "const aws = require('aws-sdk');",
+              "let responseData = {};",
+              "exports.handler = function(event, context) {",
+              "  try {",
+              "    let authRoleName = event.ResourceProperties.authRoleName;",
+              "    let unauthRoleName = event.ResourceProperties.unauthRoleName;",
+              "    let idpId = event.ResourceProperties.idpId;",
+              "    let promises = [];",
+              "    let authParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'authenticated'}}}]};",
+              "    let unauthParamsJson = { 'Version': '2012-10-17','Statement': [{'Effect': 'Allow','Principal': {'Federated': 'cognito-identity.amazonaws.com'},'Action': 'sts:AssumeRoleWithWebIdentity','Condition': {'StringEquals': {'cognito-identity.amazonaws.com:aud': idpId},'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'unauthenticated'}}}]};",
+              "    if (event.RequestType == 'Delete') {",
+              "        delete authParamsJson.Statement.Condition;",
+              "        delete unauthParamsJson.Statement.Condition;",
+              "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
+              "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
+              "        const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
+              "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
+              "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
+              "        Promise.all(promises)",
+              "         .then((res) => {",
+              "            console.log(\"delete response data\" + JSON.stringify(res));",
+              "            response.send(event, context, response.SUCCESS, {});",
+              "         });",
+              "    }",
+              "    if (event.RequestType == 'Update' || event.RequestType == 'Create') {",
+              "       const iam = new aws.IAM({ apiVersion: '2010-05-08', region: event.ResourceProperties.region});",
+              "        let authParams = { PolicyDocument: JSON.stringify(authParamsJson),RoleName: authRoleName};",
+              "        let unauthParams = {PolicyDocument: JSON.stringify(unauthParamsJson),RoleName: unauthRoleName};",
+              "        promises.push(iam.updateAssumeRolePolicy(authParams).promise());",
+              "        promises.push(iam.updateAssumeRolePolicy(unauthParams).promise());",
+              "        Promise.all(promises)",
+              "         .then((res) => {",
+              "            console.log(\"createORupdate\" + res);",
+              "            console.log(\"response data\" + JSON.stringify(res));",
+              "            response.send(event, context, response.SUCCESS, {});",
+              "         });",
+              "    }",
+              "  } catch(err) {",
+              "       console.log(err.stack);",
+              "       responseData = {Error: err};",
+              "       response.send(event, context, response.FAILED, responseData);",
+              "       throw err;",
+              "  }",
+              "};"
             ]
+          ]
         }
+      },
+      "Handler": "index.handler",
+      "Runtime": "nodejs10.x",
+      "Timeout": "300",
+      "Role": {
+        "Fn::GetAtt": ["UpdateRolesWithIDPFunctionRole", "Arn"]
+      }
     }
+  },
+  "UpdateRolesWithIDPFunctionOutputs": {
+    "Type": "Custom::LambdaCallout",
+    "Properties": {
+      "ServiceToken": {
+        "Fn::GetAtt": ["UpdateRolesWithIDPFunction", "Arn"]
+      },
+      "region": {
+        "Ref": "AWS::Region"
+      },
+      "idpId": {
+        "Fn::GetAtt": ["Outputs.IdentityPoolId"]
+      },
+      "authRoleName": {
+        "Ref": "AuthRoleName"
+      },
+      "unauthRoleName": {
+        "Ref": "UnauthRoleName"
+      }
+    }
+  },
+  "UpdateRolesWithIDPFunctionRole": {
+    "Type": "AWS::IAM::Role",
+    "Properties": {
+      "RoleName": {
+        "Fn::Join": [
+          "",
+          [
+            {
+              "Ref": "AuthRoleName"
+            },
+            "-idp"
+          ]
+        ]
+      },
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": ["lambda.amazonaws.com"]
+            },
+            "Action": ["sts:AssumeRole"]
+          }
+        ]
+      },
+      "Policies": [
+        {
+          "PolicyName": "UpdateRolesWithIDPFunctionPolicy",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+                "Resource": "arn:aws:logs:*:*:*"
+              },
+              {
+                "Effect": "Allow",
+                "Action": "iam:UpdateAssumeRolePolicy",
+                "Resource": {
+                  "Fn::GetAtt": ["AuthRole", "Arn"]
+                }
+              },
+              {
+                "Effect": "Allow",
+                "Action": "iam:UpdateAssumeRolePolicy",
+                "Resource": {
+                  "Fn::GetAtt": ["UnauthRole", "Arn"]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
 }

--- a/packages/graphql-transformers-e2e-tests/src/LambdaHelper.ts
+++ b/packages/graphql-transformers-e2e-tests/src/LambdaHelper.ts
@@ -20,7 +20,7 @@ export class LambdaHelper {
         Code: {
           ZipFile: zipContents,
         },
-        Runtime: 'nodejs8.10',
+        Runtime: 'nodejs10.x',
         Handler: `${filePrefix}.handler`,
         Role: roleArn,
       })


### PR DESCRIPTION
re #2999
re #2617 

*Issue #, if available:*

*Description of changes:*
This PR updates the nodejs runtime version, from nodejs8.10 to nodejs10.x,  for all the Lambda backed custom resources in the Cloudformation templates used by the Amplify CLI. 
This is done according to the Lambda runtime support's [deprecation schdule](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html)

There's also logic to automatically check and update the nodejs versions for projects initialized by Amplify CLI prior to this PR update. So the customers do not need to manually update the versions. 





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.