### PR TITLE
fix(amplify-codegen-appsync-model-plugin): support self referncing conn

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-connections.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-connections.ts
@@ -73,7 +73,7 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
   } else if (connectionName) {
     // when the connection is named
     const connectedField = connectedModel.fields.find(f =>
-      f.directives.find(d => d.name === 'connection' && d.arguments.name === connectionName)
+      f.directives.find(d => d.name === 'connection' && d.arguments.name === connectionName && f !== field)
     );
     if (!connectedField) {
       throw new Error(`Can not find key field with connection name ${connectionName} in ${connectedModel}`);


### PR DESCRIPTION
Model gen did not handle a connection if it was referencing itself

partial fix to #3040

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.