### PR TITLE
fix(amplify-provider-awscloudformation): hand general config

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js
@@ -44,10 +44,15 @@ async function getConfiguredAmplifyClient(context, options = {}) {
 
   const config = { ...cred, ...defaultOptions, ...options };
 
-  if (config.region && amplifyServiceRegions.includes(config.region)) {
-    return new aws.Amplify(config);
+  if (cred) {
+    // this is the "project" config level case, creds and region are explicitly set or retrieved from a profile
+    if (config.region && amplifyServiceRegions.includes(config.region)) {
+      return new aws.Amplify(config);
+    }
+    return undefined;
   }
-  return undefined;
+  // this is the "general" config level case, aws sdk will resolve creds and region from env variables etc.
+  return new aws.Amplify(config);
 }
 
 function printAuthErrorMessage(context) {


### PR DESCRIPTION
general config level is not correctly handled for the amplify service client. This PR fixes it.

*Issue #, if available:*

*Description of changes:*
If the project is set to have 'general' config level for credentials and region, the configurationManger.loadConfiguration will return undefined, to allow the aws sdk to resolve the configuration. 
The getConfiguredAmplifyClient method checks for region and if the region is not covered by the Amplify Service, it will return undefined. But this does not work for general config level, because at that point region is unknown (configurationManger.loadConfiguration returned undefined), so for general config level the getConfiguredAmplifyClient method will always return undefined, nullify the Amplify Service related logic in the Amplify CLI workflows. 
This PR fixes the issue by confine the region checking logic only in situation when configurationManger.loadConfiguration returns an object (project config level). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.