### PR TITLE
fix: point to correct file to delete for amplify config

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -1,9 +1,20 @@
 import { S3 } from 'aws-sdk';
 import { initJSProjectWithProfile, initIosProjectWithProfile, initAndroidProjectWithProfile, deleteProject } from '../init';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../utils';
+import {
+  createNewProjectDir,
+  deleteProjectDir,
+  getProjectMeta,
+  getAWSExportsPath,
+  getAWSConfigIOSPath,
+  getAmplifyConfigIOSPath,
+  getAWSConfigAndroidPath,
+  getAmplifyConfigAndroidPath,
+} from '../utils';
 import { addEnvironment } from '../environment/add-env';
 import { addApiWithoutSchema } from '../categories/api';
 import { addCodegen } from '../codegen/add';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 
 describe('amplify delete', () => {
   let projRoot: string;
@@ -48,6 +59,16 @@ async function testDeletion(projRoot: string, settings: { ios?: Boolean; android
   await expect(await bucketExists(deploymentBucketName2)).toBe(false);
   await expect(AuthRoleName).not.toBeIAMRoleWithArn(AuthRoleName);
   await expect(UnauthRoleName).not.toBeIAMRoleWithArn(UnauthRoleName);
+  // check that config/exports file was deleted
+  if (settings.ios) {
+    expect(fs.existsSync(getAWSConfigIOSPath(projRoot))).toBe(false);
+    expect(fs.existsSync(getAmplifyConfigIOSPath(projRoot))).toBe(false);
+  } else if (settings.android) {
+    expect(fs.existsSync(getAWSConfigAndroidPath(projRoot))).toBe(false);
+    expect(fs.existsSync(getAmplifyConfigAndroidPath(projRoot))).toBe(false);
+  } else {
+    expect(fs.existsSync(getAWSExportsPath(projRoot))).toBe(false);
+  }
 }
 
 async function bucketExists(bucket: string) {

--- a/packages/amplify-e2e-tests/src/utils/awsExports.ts
+++ b/packages/amplify-e2e-tests/src/utils/awsExports.ts
@@ -1,7 +1,11 @@
 require = require('esm')(module);
 import * as path from 'path';
 
+export function getAWSExportsPath(projRoot: string): string {
+  return path.join(projRoot, 'aws-exports.js');
+}
+
 export function getAWSExports(projectRoot: string) {
-  const metaFilePath = path.join(projectRoot, 'src', 'aws-exports.js');
+  const metaFilePath = getAWSExportsPath(projectRoot);
   return require(metaFilePath);
 }

--- a/packages/amplify-e2e-tests/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-tests/src/utils/projectMeta.ts
@@ -1,19 +1,43 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 
+function getAWSConfigAndroidPath(projRoot: string): string {
+  return path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'awsconfiguration.json');
+}
+
+function getAmplifyConfigAndroidPath(projRoot: string): string {
+  return path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'amplifyconfiguration.json');
+}
+
+function getAmplifyConfigIOSPath(projRoot: string): string {
+  return path.join(projRoot, 'amplifyconfiguration.json');
+}
+
+function getAWSConfigIOSPath(projRoot: string): string {
+  return path.join(projRoot, 'awsconfiguration.json');
+}
+
 function getProjectMeta(projectRoot: string) {
   const metaFilePath = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
   return JSON.parse(fs.readFileSync(metaFilePath, 'utf8'));
 }
 
 function getAwsAndroidConfig(projectRoot: string) {
-  const configPath = path.join(projectRoot, 'app', 'src', 'main', 'res', 'raw', 'awsconfiguration.json');
+  const configPath = getAWSConfigAndroidPath(projectRoot);
   return JSON.parse(fs.readFileSync(configPath, 'utf8'));
 }
 
 function getAwsIOSConfig(projectRoot: string) {
-  const configPath = path.join(projectRoot, 'awsconfiguration.json');
+  const configPath = getAWSConfigIOSPath(projectRoot);
   return JSON.parse(fs.readFileSync(configPath, 'utf8'));
 }
 
-export { getProjectMeta, getAwsAndroidConfig, getAwsIOSConfig };
+export {
+  getProjectMeta,
+  getAwsAndroidConfig,
+  getAwsIOSConfig,
+  getAWSConfigAndroidPath,
+  getAmplifyConfigAndroidPath,
+  getAmplifyConfigIOSPath,
+  getAWSConfigIOSPath,
+};

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -16,9 +16,15 @@ const fileNames = ['queries', 'mutations', 'subscriptions'];
 
 function deleteAmplifyConfig(context) {
   const { srcDirPath, projectPath } = getSrcDir(context);
-  const targetFilePath = path.join(srcDirPath, constants.amplifyConfigFilename);
-  if (fs.existsSync(targetFilePath)) {
-    fs.removeSync(targetFilePath);
+  // delete amplify config
+  const awsConfigFilePath = path.join(srcDirPath, constants.awsConfigFilename);
+  if (fs.existsSync(awsConfigFilePath)) {
+    fs.removeSync(awsConfigFilePath);
+  }
+  // delete amplify configuration
+  const amplifyConfigFilePath = path.join(srcDirPath, constants.amplifyConfigFilename);
+  if (fs.existsSync(amplifyConfigFilePath)) {
+    fs.removeSync(amplifyConfigFilePath);
   }
 
   if (!fs.existsSync(path.join(projectPath, '.graphqlconfig.yml'))) return;

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -17,9 +17,12 @@ const fileNames = ['queries', 'mutations', 'subscriptions'];
 
 function deleteAmplifyConfig(context) {
   const srcDirPath = getSrcDir(context);
+  // delete aws configuration and amplify configuration
   if (fs.existsSync(srcDirPath)) {
-    const targetFilePath = path.join(srcDirPath, constants.amplifyConfigFilename);
-    fs.removeSync(targetFilePath);
+    const amplifyConfigFilePath = path.join(srcDirPath, constants.amplifyConfigFilename);
+    const awsConfigFilePath = path.join(srcDirPath, constants.awsConfigFilename);
+    fs.removeSync(amplifyConfigFilePath);
+    fs.removeSync(awsConfigFilePath);
   }
 
   if (!fs.existsSync(path.join(srcDirPath, '.graphqlconfig.yml'))) return;

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -20,8 +20,9 @@ const fileNames = ['queries', 'mutations', 'subscriptions'];
 
 function deleteAmplifyConfig(context) {
   const { srcDirPath, projectPath } = getSrcDir(context);
+  // delete aws-exports
   if (fs.existsSync(srcDirPath)) {
-    const targetFilePath = path.join(srcDirPath, constants.configFilename);
+    const targetFilePath = path.join(srcDirPath, constants.exportsFilename);
     fs.removeSync(targetFilePath);
   }
   if (!fs.existsSync(path.join(projectPath, '.graphqlconfig.yml'))) return;


### PR DESCRIPTION
point to aws exporsts in js deleteConfig and include amplify configuration in the delete for android
and ios

re #2997

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.