### PR TITLE
feat(graphql-auth-transformer): add compound auth rules

### DIFF
--- a/packages/graphql-auth-transformer/src/AuthRule.ts
+++ b/packages/graphql-auth-transformer/src/AuthRule.ts
@@ -15,4 +15,5 @@ export interface AuthRule {
   operations?: ModelOperation[];
   queries?: ModelQuery[];
   mutations?: ModelMutation[];
+  and?: string;
 }

--- a/packages/graphql-auth-transformer/src/__tests__/AndArgument.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/AndArgument.test.ts
@@ -1,0 +1,144 @@
+import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
+import { ModelAuthTransformer } from '../ModelAuthTransformer';
+import { GraphQLTransform } from 'graphql-transformer-core';
+
+test('Test "and" parameter forces all rules to pass for read', () => {
+  const validSchema = `
+    type Comment @model @auth(rules: [
+        {allow: groups, groups: ["Dev"], operations: [read]},
+        {allow: groups, groups: ["Admin"], operations: [read], and: "testing"},
+        {allow: owner, operations: [read], and: "testing"},
+        {allow: groups, groupsField: "groupField", operations: [read], and: "testing"}
+    ]) {
+        id: ID!
+        owner: ID!
+        groupField: [String]!
+        text: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new DynamoDBModelTransformer(),
+      new ModelAuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [],
+        },
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.resolvers['Query.getComment.res.vtl']).toContain('#set( $isStaticGroupAuthorized = true )');
+  expect(out.resolvers['Query.getComment.res.vtl']).toContain('$util.defaultIfNull($compoundAuthRuleCounts.testing, 0) == 3');
+  expect(out.resolvers['Query.listComments.res.vtl']).toContain('$util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) == 3');
+  expect(out.resolvers['Query.getComment.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listComments.res.vtl']).toMatchSnapshot();
+});
+
+test('Test "create", "update", "delete" auth operations with "and" parameter forces all rules to pass', () => {
+  const validSchema = `
+    type Post @model @auth(rules: [
+        {allow: groups, groups: ["Admin"], operations: [read, create, update, delete], and: "testing"},
+        {allow: groups, groupsField: "groupField", operations: [read, create, update, delete], and: "testing"},
+        {allow: owner, operations: [create, update, delete], and: "testing2"},
+        {allow: groups, groups: ["Dev"], operations: [create, update, delete], and: "testing2"}
+    ]) {
+        id: ID!
+        title: String!
+        groupField: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new DynamoDBModelTransformer(),
+      new ModelAuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [],
+        },
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.resolvers['Query.getPost.res.vtl']).toContain('$util.defaultIfNull($compoundAuthRuleCounts.testing, 0) == 2');
+
+  expect(out.resolvers['Query.getPost.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listPosts.res.vtl']).toContain('$util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) == 2');
+  expect(out.resolvers['Query.listPosts.res.vtl']).toMatchSnapshot();
+
+  expect(out.resolvers['Mutation.createPost.req.vtl']).toContain('$util.defaultIfNull($compoundAuthRuleCounts.testing, 0) == 2');
+  expect(out.resolvers['Mutation.createPost.req.vtl']).toContain('$util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) == 2');
+
+  expect(out.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+
+  expect(out.resolvers['Mutation.updatePost.req.vtl']).toContain('#set( $innerCompoundAuth = "$innerCompoundAuth AND" )');
+  expect(out.resolvers['Mutation.updatePost.req.vtl'].replace(/ +?/g, '')).toContain(
+    '#if($compoundAuthRuleCounts.testing2==1)\n' + '$util.qr($compoundAuthExpressions.testing2.add("#owner0=:identity0"))\n' + '#end'
+  );
+  expect(out.resolvers['Mutation.updatePost.req.vtl'].replace(/ +?/g, '')).toContain(
+    '#if($compoundAuthRuleCounts.testing==1)\n' +
+      '$util.qr($groupCompoundAuthExpressionValues.add("contains(#groupsAttribute0,:group0$foreach.count)"))\n' +
+      '#end'
+  );
+
+  expect(out.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+
+  expect(out.resolvers['Mutation.deletePost.req.vtl'].replace(/ +?/g, '')).toContain(
+    '#if($compoundAuthRuleCounts.testing2==1)\n' + '$util.qr($compoundAuthExpressions.testing2.add("#owner0=:identity0"))\n' + '#end'
+  );
+  expect(out.resolvers['Mutation.deletePost.req.vtl'].replace(/ +?/g, '')).toContain(
+    '#if($compoundAuthRuleCounts.testing==1)\n' +
+      '$util.qr($groupCompoundAuthExpressionValues.add("contains(#groupsAttribute0,:group0$foreach.count)"))\n' +
+      '#end'
+  );
+
+  expect(out.resolvers['Mutation.deletePost.req.vtl']).toMatchSnapshot();
+});
+
+test('Test "update" auth operations with "and" parameter on fields prevents security bypass', () => {
+  const validSchema = `
+    type Post @model @auth(rules: [{allow: groups, groups: ["Admin"], operations: [create, read]}, {allow: groups, groups: ["Nobody"]}]) {
+        id: ID!
+        unprotected: String!
+        protectedByStaticGroup: String @auth(rules: [{allow: groups, groups: ["Admin"], operations: [read, update]}])
+        protectedByDynamocGroup: String @auth(rules: [{allow: groups, groupsField: "groupField", operations: [read, update]}])
+        protectedByOwner: String @auth(rules: [{allow: owner, ownerField: "id", operations: [read, update]}])
+        protectedByB: String @auth(rules: [{allow: owner, ownerField: "id", operations: [read, update], and: "bRule"}])
+        protectedByA: String @auth(rules: [{allow: owner, ownerField: "id", operations: [read, update], and: "aRule"}])
+        protectedByC: String @auth(rules: [{allow: groups, groups: ["Admin"], operations: [read, update], and: "cRule"}])
+        groupField: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new DynamoDBModelTransformer(),
+      new ModelAuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [],
+        },
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.getPost.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.listPosts.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createPost.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deletePost.res.vtl']).toMatchSnapshot();
+});

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/AndArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/AndArgument.test.ts.snap
@@ -1,0 +1,1980 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test "and" parameter forces all rules to pass for read 1`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Dev\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $isStaticGroupAuthorized = true )
+      #break
+    #end
+  #end
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  ## [Start] Dynamic Group Authorization Checks **
+  #set( $isDynamicGroupAuthorized = $util.defaultIfNull($isDynamicGroupAuthorized, false) )
+  ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $allowedGroups = $util.defaultIfNull($ctx.result.groupField, []) )
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #foreach( $userGroup in $userGroups )
+    #if( $util.isList($allowedGroups) )
+      #if( $allowedGroups.contains($userGroup) )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+    #if( $util.isString($allowedGroups) )
+      #if( $allowedGroups == $userGroup )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+  #end
+  ## [End] Dynamic Group Authorization Checks **
+
+
+  ## [Start] Owner Authorization Checks **
+  #set( $isOwnerAuthorized = $util.defaultIfNull($isOwnerAuthorized, false) )
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", and: \\"testing\\" } **
+  #set( $allowedOwners0 = $ctx.result.owner )
+  #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $util.isList($allowedOwners0) )
+    #foreach( $allowedOwner in $allowedOwners0 )
+      #if( $allowedOwner == $identityValue )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+  #end
+  #if( $util.isString($allowedOwners0) )
+    #if( $allowedOwners0 == $identityValue )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+    #end
+  #end
+  ## [End] Owner Authorization Checks **
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || $isDynamicGroupAuthorized == true || $isOwnerAuthorized == true || $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) == 3) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+$util.toJson($ctx.result)"
+`;
+
+exports[`Test "and" parameter forces all rules to pass for read 2`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Dev\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $isStaticGroupAuthorized = true )
+      #break
+    #end
+  #end
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  ## [Start] If not static group authorized, filter items **
+  #if( true )
+    #set( $items = [] )
+    #foreach( $item in $ctx.result.items )
+      #set( $staticCompoundAuthRuleCounts = $util.parseJson($util.toJson($compoundAuthRuleCounts)) )
+      ## [Start] Dynamic Group Authorization Checks **
+      #set( $isLocalDynamicGroupAuthorized = false )
+      ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+      #set( $allowedGroups = $util.defaultIfNull($item.groupField, []) )
+      #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+      #foreach( $userGroup in $userGroups )
+        #if( $util.isList($allowedGroups) )
+          #if( $allowedGroups.contains($userGroup) )
+            #set( $staticCompoundAuthRuleCounts.testing = $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) + 1 )
+          #end
+        #end
+        #if( $util.isString($allowedGroups) )
+          #if( $allowedGroups == $userGroup )
+            #set( $staticCompoundAuthRuleCounts.testing = $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) + 1 )
+          #end
+        #end
+      #end
+      ## [End] Dynamic Group Authorization Checks **
+
+
+      ## [Start] Owner Authorization Checks **
+      #set( $isLocalOwnerAuthorized = false )
+      ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", and: \\"testing\\" } **
+      #set( $allowedOwners0 = $item.owner )
+      #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+      #if( $util.isList($allowedOwners0) )
+        #foreach( $allowedOwner in $allowedOwners0 )
+          #if( $allowedOwner == $identityValue )
+            #set( $staticCompoundAuthRuleCounts.testing = $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) + 1 )
+          #end
+        #end
+      #end
+      #if( $util.isString($allowedOwners0) )
+        #if( $allowedOwners0 == $identityValue )
+          #set( $staticCompoundAuthRuleCounts.testing = $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) + 1 )
+        #end
+      #end
+      ## [End] Owner Authorization Checks **
+
+
+      #if( $isStaticGroupAuthorized == true || $isLocalDynamicGroupAuthorized == true || $isLocalOwnerAuthorized == true || $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) == 3 )
+        $util.qr($items.add($item))
+      #end
+    #end
+    #set( $ctx.result.items = $items )
+  #end
+  ## [End] If not static group authorized, filter items **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+$util.toJson($ctx.result)"
+`;
+
+exports[`Test "create", "update", "delete" auth operations with "and" parameter forces all rules to pass 1`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  ## [Start] Dynamic Group Authorization Checks **
+  #set( $isDynamicGroupAuthorized = $util.defaultIfNull($isDynamicGroupAuthorized, false) )
+  ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $allowedGroups = $util.defaultIfNull($ctx.result.groupField, []) )
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #foreach( $userGroup in $userGroups )
+    #if( $util.isList($allowedGroups) )
+      #if( $allowedGroups.contains($userGroup) )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+    #if( $util.isString($allowedGroups) )
+      #if( $allowedGroups == $userGroup )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+  #end
+  ## [End] Dynamic Group Authorization Checks **
+
+
+  ## No Owner Authorization Rules **
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || $isDynamicGroupAuthorized == true || $isOwnerAuthorized == true || $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) == 2) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+$util.toJson($ctx.result)"
+`;
+
+exports[`Test "create", "update", "delete" auth operations with "and" parameter forces all rules to pass 2`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  ## [Start] If not static group authorized, filter items **
+  #if( true )
+    #set( $items = [] )
+    #foreach( $item in $ctx.result.items )
+      #set( $staticCompoundAuthRuleCounts = $util.parseJson($util.toJson($compoundAuthRuleCounts)) )
+      ## [Start] Dynamic Group Authorization Checks **
+      #set( $isLocalDynamicGroupAuthorized = false )
+      ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+      #set( $allowedGroups = $util.defaultIfNull($item.groupField, []) )
+      #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+      #foreach( $userGroup in $userGroups )
+        #if( $util.isList($allowedGroups) )
+          #if( $allowedGroups.contains($userGroup) )
+            #set( $staticCompoundAuthRuleCounts.testing = $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) + 1 )
+          #end
+        #end
+        #if( $util.isString($allowedGroups) )
+          #if( $allowedGroups == $userGroup )
+            #set( $staticCompoundAuthRuleCounts.testing = $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) + 1 )
+          #end
+        #end
+      #end
+      ## [End] Dynamic Group Authorization Checks **
+
+
+      ## No Owner Authorization Rules **
+
+
+      #if( $isStaticGroupAuthorized == true || $isLocalDynamicGroupAuthorized == true || $isLocalOwnerAuthorized == true || $util.defaultIfNull($staticCompoundAuthRuleCounts.testing, 0) == 2 )
+        $util.qr($items.add($item))
+      #end
+    #end
+    #set( $ctx.result.items = $items )
+  #end
+  ## [End] If not static group authorized, filter items **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+$util.toJson($ctx.result)"
+`;
+
+exports[`Test "create", "update", "delete" auth operations with "and" parameter forces all rules to pass 3`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## Authorization rule: { allow: groups, groups: [\\"Dev\\"], groupClaim: \\"cognito:groups\\", and: \\"testing2\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Dev\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing2 = $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  ## [Start] Dynamic Group Authorization Checks **
+  ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\" **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $isDynamicGroupAuthorized = $util.defaultIfNull($isDynamicGroupAuthorized, false) )
+  #foreach( $userGroup in $userGroups )
+    #if( $util.isList($ctx.args.input.groupField) )
+      #if( $ctx.args.input.groupField.contains($userGroup) )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+    #if( $util.isString($ctx.args.input.groupField) )
+      #if( $ctx.args.input.groupField == $userGroup )
+        #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #end
+    #end
+  #end
+  ## [End] Dynamic Group Authorization Checks **
+
+
+  ## [Start] Owner Authorization Checks **
+  #set( $isOwnerAuthorized = false )
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", and: \\"testing2\\" } **
+  #set( $allowedOwners0 = $util.defaultIfNull($ctx.args.input.owner, null) )
+  #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $util.isList($allowedOwners0) )
+    #foreach( $allowedOwner in $allowedOwners0 )
+      #if( $allowedOwner == $identityValue )
+        #set( $compoundAuthRuleCounts.testing2 = $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) + 1 )
+      #end
+    #end
+  #end
+  #if( $util.isString($allowedOwners0) )
+    #if( $allowedOwners0 == $identityValue )
+      #set( $compoundAuthRuleCounts.testing2 = $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) + 1 )
+    #end
+  #end
+  #if( $util.isNull($allowedOwners0) && (! $ctx.args.input.containsKey(\\"owner\\")) )
+    $util.qr($ctx.args.input.put(\\"owner\\", $identityValue))
+    #set( $compoundAuthRuleCounts.testing2 = $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) + 1 )
+  #end
+  ## [End] Owner Authorization Checks **
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || $isDynamicGroupAuthorized == true || $isOwnerAuthorized == true || $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) == 2 || $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) == 2) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test "create", "update", "delete" auth operations with "and" parameter forces all rules to pass 4`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## Authorization rule: { allow: groups, groups: [\\"Dev\\"], groupClaim: \\"cognito:groups\\", and: \\"testing2\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Dev\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing2 = $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  #if( ! $isStaticGroupAuthorized )
+    ## [Start] Dynamic group authorization checks **
+    #if( !$compoundAuthExpressions )
+      #set( $compoundAuthExpressions = {} )
+    #end
+    #set( $compoundAuthExpressions.testing = $util.defaultIfNull($compoundAuthExpressions.testing, []) )
+    #set( $groupAuthExpressions = [] )
+    #set( $groupAuthExpressionValues = {} )
+    #set( $groupAuthExpressionNames = {} )
+    #set( $groupCompoundAuthExpressionValues = [] )
+    ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\"} **
+    #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+    #foreach( $userGroup in $userGroups )
+      #if( $compoundAuthRuleCounts.testing == 1 )
+        $util.qr($groupCompoundAuthExpressionValues.add(\\"contains(#groupsAttribute0, :group0$foreach.count)\\"))
+      #end
+      #if( $compoundAuthRuleCounts.testing == 1 )
+        $util.qr($groupAuthExpressionValues.put(\\":group0$foreach.count\\", { \\"S\\": $userGroup }))
+      #end
+    #end
+    #if( $userGroups.size() > 0 && $compoundAuthRuleCounts.testing == 1 )
+      $util.qr($groupAuthExpressionNames.put(\\"#groupsAttribute0\\", \\"groupField\\"))
+    #end
+    #if( $groupCompoundAuthExpressionValues.size() > 1 )
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"(\\" )
+    #else
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"\\" )
+    #end
+    #foreach( $groupCompoundAuthExpressionValue in $groupCompoundAuthExpressionValues )
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"$groupCompoundAuthExpressionValuesCombined $groupCompoundAuthExpressionValue\\" )
+      #if( $foreach.hasNext )
+        #set( $groupCompoundAuthExpressionValuesCombined = \\"$groupCompoundAuthExpressionValuesCombined OR\\" )
+      #end
+    #end
+    #if( $groupCompoundAuthExpressionValues.size() > 1 )
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"$groupCompoundAuthExpressionValuesCombined )\\" )
+    #end
+    #if( ($groupCompoundAuthExpressionValuesCombined != \\"\\") )
+      $util.qr($compoundAuthExpressions.testing.add($groupCompoundAuthExpressionValuesCombined))
+    #end
+    ## [End] Dynamic group authorization checks **
+
+
+    ## [Start] Owner Authorization Checks **
+    #set( $ownerAuthExpressions = [] )
+    #if( !$compoundAuthExpressions )
+      #set( $compoundAuthExpressions = {} )
+    #end
+    #set( $compoundAuthExpressions.testing2 = $util.defaultIfNull($compoundAuthExpressions.testing2, []) )
+    #set( $ownerAuthExpressionValues = {} )
+    #set( $ownerAuthExpressionNames = {} )
+    ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", and: \\"testing2\\" } **
+    #if( $compoundAuthRuleCounts.testing2 == 1 )
+      $util.qr($compoundAuthExpressions.testing2.add(\\"#owner0 = :identity0\\"))
+    #end
+    #if( $compoundAuthRuleCounts.testing2 == 1 )
+      $util.qr($ownerAuthExpressionNames.put(\\"#owner0\\", \\"owner\\"))
+      $util.qr($ownerAuthExpressionValues.put(\\":identity0\\", $util.dynamodb.toDynamoDB($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")))))
+    #end
+    ## [End] Owner Authorization Checks **
+
+
+    ## [Start] Collect Auth Condition **
+    #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+    #set( $totalAuthExpression = \\"\\" )
+    ## Add dynamic group auth conditions if they exist **
+    #if( $groupAuthExpressions )
+      #foreach( $authExpr in $groupAuthExpressions )
+        #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+      #end
+    #end
+    #if( $groupAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+    #end
+    #if( $groupAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+    #end
+    ## Add owner auth conditions if they exist **
+    #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+    #end
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #foreach( $authExpr in $ownerAuthExpressions )
+        #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+      #end
+    #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
+    #if( $ownerAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+    #end
+    #if( $ownerAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+    #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
+    ## Set final expression if it has changed. **
+    #if( $totalAuthExpression != \\"\\" )
+      #if( $util.isNullOrEmpty($authCondition.expression) )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+      #else
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+      #end
+    #end
+    ## [End] Collect Auth Condition **
+  #end
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": \\"$context.args.input.id\\"
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test "create", "update", "delete" auth operations with "and" parameter forces all rules to pass 5`] = `
+"## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"testing\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Admin\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing = $util.defaultIfNull($compoundAuthRuleCounts.testing, 0) + 1 )
+      #break
+    #end
+  #end
+  ## Authorization rule: { allow: groups, groups: [\\"Dev\\"], groupClaim: \\"cognito:groups\\", and: \\"testing2\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Dev\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $compoundAuthRuleCounts.testing2 = $util.defaultIfNull($compoundAuthRuleCounts.testing2, 0) + 1 )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  #if( ! $isStaticGroupAuthorized )
+    ## [Start] Dynamic group authorization checks **
+    #if( !$compoundAuthExpressions )
+      #set( $compoundAuthExpressions = {} )
+    #end
+    #set( $compoundAuthExpressions.testing = $util.defaultIfNull($compoundAuthExpressions.testing, []) )
+    #set( $groupAuthExpressions = [] )
+    #set( $groupAuthExpressionValues = {} )
+    #set( $groupAuthExpressionNames = {} )
+    #set( $groupCompoundAuthExpressionValues = [] )
+    ## Authorization rule: { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\", and: \\"testing\\"} **
+    #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+    #foreach( $userGroup in $userGroups )
+      #if( $compoundAuthRuleCounts.testing == 1 )
+        $util.qr($groupCompoundAuthExpressionValues.add(\\"contains(#groupsAttribute0, :group0$foreach.count)\\"))
+      #end
+      #if( $compoundAuthRuleCounts.testing == 1 )
+        $util.qr($groupAuthExpressionValues.put(\\":group0$foreach.count\\", { \\"S\\": $userGroup }))
+      #end
+    #end
+    #if( $userGroups.size() > 0 && $compoundAuthRuleCounts.testing == 1 )
+      $util.qr($groupAuthExpressionNames.put(\\"#groupsAttribute0\\", \\"groupField\\"))
+    #end
+    #if( $groupCompoundAuthExpressionValues.size() > 1 )
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"(\\" )
+    #else
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"\\" )
+    #end
+    #foreach( $groupCompoundAuthExpressionValue in $groupCompoundAuthExpressionValues )
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"$groupCompoundAuthExpressionValuesCombined $groupCompoundAuthExpressionValue\\" )
+      #if( $foreach.hasNext )
+        #set( $groupCompoundAuthExpressionValuesCombined = \\"$groupCompoundAuthExpressionValuesCombined OR\\" )
+      #end
+    #end
+    #if( $groupCompoundAuthExpressionValues.size() > 1 )
+      #set( $groupCompoundAuthExpressionValuesCombined = \\"$groupCompoundAuthExpressionValuesCombined )\\" )
+    #end
+    #if( ($groupCompoundAuthExpressionValuesCombined != \\"\\") )
+      $util.qr($compoundAuthExpressions.testing.add($groupCompoundAuthExpressionValuesCombined))
+    #end
+    ## [End] Dynamic group authorization checks **
+
+
+    ## [Start] Owner Authorization Checks **
+    #set( $ownerAuthExpressions = [] )
+    #if( !$compoundAuthExpressions )
+      #set( $compoundAuthExpressions = {} )
+    #end
+    #set( $compoundAuthExpressions.testing2 = $util.defaultIfNull($compoundAuthExpressions.testing2, []) )
+    #set( $ownerAuthExpressionValues = {} )
+    #set( $ownerAuthExpressionNames = {} )
+    ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", and: \\"testing2\\" } **
+    #if( $compoundAuthRuleCounts.testing2 == 1 )
+      $util.qr($compoundAuthExpressions.testing2.add(\\"#owner0 = :identity0\\"))
+    #end
+    #if( $compoundAuthRuleCounts.testing2 == 1 )
+      $util.qr($ownerAuthExpressionNames.put(\\"#owner0\\", \\"owner\\"))
+      $util.qr($ownerAuthExpressionValues.put(\\":identity0\\", $util.dynamodb.toDynamoDB($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")))))
+    #end
+    ## [End] Owner Authorization Checks **
+
+
+    ## [Start] Collect Auth Condition **
+    #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+    #set( $totalAuthExpression = \\"\\" )
+    ## Add dynamic group auth conditions if they exist **
+    #if( $groupAuthExpressions )
+      #foreach( $authExpr in $groupAuthExpressions )
+        #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+      #end
+    #end
+    #if( $groupAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+    #end
+    #if( $groupAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+    #end
+    ## Add owner auth conditions if they exist **
+    #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+    #end
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #foreach( $authExpr in $ownerAuthExpressions )
+        #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+      #end
+    #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
+    #if( $ownerAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+    #end
+    #if( $ownerAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+    #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
+    ## Set final expression if it has changed. **
+    #if( $totalAuthExpression != \\"\\" )
+      #if( $util.isNullOrEmpty($authCondition.expression) )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+      #else
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+      #end
+    #end
+    ## [End] Collect Auth Condition **
+  #end
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+#if( $authCondition )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+  #end
+#end
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  #set( $expressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
+  $util.qr($expressionValues.putAll($versionedCondition.expressionValues))
+  #set( $condition.expressionValues = $expressionValues )
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  #set( $conditionExpressionValues = $util.defaultIfNull($condition.expressionValues, {}) )
+  $util.qr($conditionExpressionValues.putAll($conditionFilterExpressions.expressionValues))
+  #set( $condition.expressionValues = $conditionExpressionValues )
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"DeleteItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test "update" auth operations with "and" parameter on fields prevents security bypass 1`] = `
+"#if( $ctx.args.input.containsKey(\\"protectedByC\\") )
+  ## [Start] Determine request authentication mode **
+  #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+    #set( $authMode = \\"userPools\\" )
+  #end
+  ## [End] Determine request authentication mode **
+  ## [Start] Check authMode and execute owner/group checks **
+  #if( $authMode == \\"userPools\\" )
+    #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+    ## [Start] Static Group Authorization Checks **
+    #set($protectedByC_isStaticGroupAuthorized = $util.defaultIfNull(
+        $protectedByC_isStaticGroupAuthorized, false))
+    ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\", and: \\"cRule\\" } **
+    #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+    #set( $allowedGroups = [\\"Admin\\"] )
+    #foreach( $userGroup in $userGroups )
+      #if( $allowedGroups.contains($userGroup) )
+        #set( $compoundAuthRuleCounts.cRule = $util.defaultIfNull($compoundAuthRuleCounts.cRule, 0) + 1 )
+        #break
+      #end
+    #end
+    ## [End] Static Group Authorization Checks **
+
+
+    #if( ! $protectedByC_isStaticGroupAuthorized )
+      ## No dynamic group authorization rules for field \\"protectedByC\\" **
+
+
+      ## No owner authorization rules for field \\"protectedByC\\" **
+
+
+      ## [Start] Collect Auth Condition **
+      #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+      #set( $totalAuthExpression = \\"\\" )
+      ## Add dynamic group auth conditions if they exist **
+      #if( $groupAuthExpressions )
+        #foreach( $authExpr in $groupAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $groupAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+      #end
+      #if( $groupAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+      #end
+      ## Add owner auth conditions if they exist **
+      #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+      #end
+      #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #foreach( $authExpr in $ownerAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $totalAuthExpression != \\"\\" )
+        #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+      #end
+      #if( $ownerAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+      #end
+      #if( $ownerAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+      #end
+      ## Add compound auth conditions if they exist **
+      #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+        #foreach( $entry in $compoundAuthExpressions.entrySet() )
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"(\\" )
+          #else
+            #set( $innerCompoundAuth = \\"\\" )
+          #end
+          #foreach( $authExpr in $entry.value )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+            #if( $foreach.hasNext )
+              #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+            #end
+          #end
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+          #end
+        #end
+      #end
+      ## Set final expression if it has changed. **
+      #if( $totalAuthExpression != \\"\\" )
+        #if( $util.isNullOrEmpty($authCondition.expression) )
+          #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+        #else
+          #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+        #end
+      #end
+      ## [End] Collect Auth Condition **
+    #end
+
+
+    ## [Start] Throw if unauthorized **
+    #if( !($protectedByC_isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+      $util.unauthorized()
+    #end
+    ## [End] Throw if unauthorized **
+  #end
+  ## [End] Check authMode and execute owner/group checks **
+#end
+
+#if( $ctx.args.input.containsKey(\\"protectedByA\\") )
+  ## [Start] Determine request authentication mode **
+  #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+    #set( $authMode = \\"userPools\\" )
+  #end
+  ## [End] Determine request authentication mode **
+  ## [Start] Check authMode and execute owner/group checks **
+  #if( $authMode == \\"userPools\\" )
+    #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+    ## No Static Group Authorization Rules **
+
+
+    #if( ! $protectedByA_isStaticGroupAuthorized )
+      ## No dynamic group authorization rules for field \\"protectedByA\\" **
+
+
+      ## [Start] Owner Authorization Checks **
+      #set( $ownerAuthExpressions = [] )
+      #if( !$compoundAuthExpressions )
+        #set( $compoundAuthExpressions = {} )
+      #end
+      #set( $compoundAuthExpressions.aRule = $util.defaultIfNull($compoundAuthExpressions.aRule, []) )
+      #set( $ownerAuthExpressionValues = {} )
+      #set( $ownerAuthExpressionNames = {} )
+      ## Authorization rule for field \\"protectedByA\\": { allow: owner, ownerField: \\"id\\", identityClaim: \\"cognito:username\\", and: \\"aRule\\" } **
+      #if( true )
+        $util.qr($compoundAuthExpressions.aRule.add(\\"#protectedByA_owner0 = :protectedByA_identity0\\"))
+      #end
+      #if( true )
+        $util.qr($ownerAuthExpressionNames.put(\\"#protectedByA_owner0\\", \\"id\\"))
+        $util.qr($ownerAuthExpressionValues.put(\\":protectedByA_identity0\\", $util.dynamodb.toDynamoDB($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")))))
+      #end
+      ## [End] Owner Authorization Checks **
+
+
+      ## [Start] Collect Auth Condition **
+      #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+      #set( $totalAuthExpression = \\"\\" )
+      ## Add dynamic group auth conditions if they exist **
+      #if( $groupAuthExpressions )
+        #foreach( $authExpr in $groupAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $groupAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+      #end
+      #if( $groupAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+      #end
+      ## Add owner auth conditions if they exist **
+      #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+      #end
+      #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #foreach( $authExpr in $ownerAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $totalAuthExpression != \\"\\" )
+        #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+      #end
+      #if( $ownerAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+      #end
+      #if( $ownerAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+      #end
+      ## Add compound auth conditions if they exist **
+      #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+        #foreach( $entry in $compoundAuthExpressions.entrySet() )
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"(\\" )
+          #else
+            #set( $innerCompoundAuth = \\"\\" )
+          #end
+          #foreach( $authExpr in $entry.value )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+            #if( $foreach.hasNext )
+              #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+            #end
+          #end
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+          #end
+        #end
+      #end
+      ## Set final expression if it has changed. **
+      #if( $totalAuthExpression != \\"\\" )
+        #if( $util.isNullOrEmpty($authCondition.expression) )
+          #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+        #else
+          #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+        #end
+      #end
+      ## [End] Collect Auth Condition **
+    #end
+
+
+    ## [Start] Throw if unauthorized **
+    #if( !($protectedByA_isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+      $util.unauthorized()
+    #end
+    ## [End] Throw if unauthorized **
+  #end
+  ## [End] Check authMode and execute owner/group checks **
+#end
+
+#if( $ctx.args.input.containsKey(\\"protectedByB\\") )
+  ## [Start] Determine request authentication mode **
+  #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+    #set( $authMode = \\"userPools\\" )
+  #end
+  ## [End] Determine request authentication mode **
+  ## [Start] Check authMode and execute owner/group checks **
+  #if( $authMode == \\"userPools\\" )
+    #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+    ## No Static Group Authorization Rules **
+
+
+    #if( ! $protectedByB_isStaticGroupAuthorized )
+      ## No dynamic group authorization rules for field \\"protectedByB\\" **
+
+
+      ## [Start] Owner Authorization Checks **
+      #set( $ownerAuthExpressions = [] )
+      #if( !$compoundAuthExpressions )
+        #set( $compoundAuthExpressions = {} )
+      #end
+      #set( $compoundAuthExpressions.bRule = $util.defaultIfNull($compoundAuthExpressions.bRule, []) )
+      #set( $ownerAuthExpressionValues = {} )
+      #set( $ownerAuthExpressionNames = {} )
+      ## Authorization rule for field \\"protectedByB\\": { allow: owner, ownerField: \\"id\\", identityClaim: \\"cognito:username\\", and: \\"bRule\\" } **
+      #if( true )
+        $util.qr($compoundAuthExpressions.bRule.add(\\"#protectedByB_owner0 = :protectedByB_identity0\\"))
+      #end
+      #if( true )
+        $util.qr($ownerAuthExpressionNames.put(\\"#protectedByB_owner0\\", \\"id\\"))
+        $util.qr($ownerAuthExpressionValues.put(\\":protectedByB_identity0\\", $util.dynamodb.toDynamoDB($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")))))
+      #end
+      ## [End] Owner Authorization Checks **
+
+
+      ## [Start] Collect Auth Condition **
+      #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+      #set( $totalAuthExpression = \\"\\" )
+      ## Add dynamic group auth conditions if they exist **
+      #if( $groupAuthExpressions )
+        #foreach( $authExpr in $groupAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $groupAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+      #end
+      #if( $groupAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+      #end
+      ## Add owner auth conditions if they exist **
+      #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+      #end
+      #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #foreach( $authExpr in $ownerAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $totalAuthExpression != \\"\\" )
+        #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+      #end
+      #if( $ownerAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+      #end
+      #if( $ownerAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+      #end
+      ## Add compound auth conditions if they exist **
+      #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+        #foreach( $entry in $compoundAuthExpressions.entrySet() )
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"(\\" )
+          #else
+            #set( $innerCompoundAuth = \\"\\" )
+          #end
+          #foreach( $authExpr in $entry.value )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+            #if( $foreach.hasNext )
+              #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+            #end
+          #end
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+          #end
+        #end
+      #end
+      ## Set final expression if it has changed. **
+      #if( $totalAuthExpression != \\"\\" )
+        #if( $util.isNullOrEmpty($authCondition.expression) )
+          #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+        #else
+          #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+        #end
+      #end
+      ## [End] Collect Auth Condition **
+    #end
+
+
+    ## [Start] Throw if unauthorized **
+    #if( !($protectedByB_isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+      $util.unauthorized()
+    #end
+    ## [End] Throw if unauthorized **
+  #end
+  ## [End] Check authMode and execute owner/group checks **
+#end
+
+#if( $ctx.args.input.containsKey(\\"protectedByOwner\\") )
+  ## [Start] Determine request authentication mode **
+  #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+    #set( $authMode = \\"userPools\\" )
+  #end
+  ## [End] Determine request authentication mode **
+  ## [Start] Check authMode and execute owner/group checks **
+  #if( $authMode == \\"userPools\\" )
+    #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+    ## No Static Group Authorization Rules **
+
+
+    #if( ! $protectedByOwner_isStaticGroupAuthorized )
+      ## No dynamic group authorization rules for field \\"protectedByOwner\\" **
+
+
+      ## [Start] Owner Authorization Checks **
+      #set( $ownerAuthExpressions = [] )
+      #if( !$compoundAuthExpressions )
+        #set( $compoundAuthExpressions = {} )
+      #end
+      #set( $ownerAuthExpressionValues = {} )
+      #set( $ownerAuthExpressionNames = {} )
+      ## Authorization rule for field \\"protectedByOwner\\": { allow: owner, ownerField: \\"id\\", identityClaim: \\"cognito:username\\" } **
+      $util.qr($ownerAuthExpressions.add(\\"#protectedByOwner_owner0 = :protectedByOwner_identity0\\"))
+      #if( true )
+        $util.qr($ownerAuthExpressionNames.put(\\"#protectedByOwner_owner0\\", \\"id\\"))
+        $util.qr($ownerAuthExpressionValues.put(\\":protectedByOwner_identity0\\", $util.dynamodb.toDynamoDB($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")))))
+      #end
+      ## [End] Owner Authorization Checks **
+
+
+      ## [Start] Collect Auth Condition **
+      #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+      #set( $totalAuthExpression = \\"\\" )
+      ## Add dynamic group auth conditions if they exist **
+      #if( $groupAuthExpressions )
+        #foreach( $authExpr in $groupAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $groupAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+      #end
+      #if( $groupAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+      #end
+      ## Add owner auth conditions if they exist **
+      #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+      #end
+      #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #foreach( $authExpr in $ownerAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $totalAuthExpression != \\"\\" )
+        #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+      #end
+      #if( $ownerAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+      #end
+      #if( $ownerAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+      #end
+      ## Add compound auth conditions if they exist **
+      #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+        #foreach( $entry in $compoundAuthExpressions.entrySet() )
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"(\\" )
+          #else
+            #set( $innerCompoundAuth = \\"\\" )
+          #end
+          #foreach( $authExpr in $entry.value )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+            #if( $foreach.hasNext )
+              #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+            #end
+          #end
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+          #end
+        #end
+      #end
+      ## Set final expression if it has changed. **
+      #if( $totalAuthExpression != \\"\\" )
+        #if( $util.isNullOrEmpty($authCondition.expression) )
+          #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+        #else
+          #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+        #end
+      #end
+      ## [End] Collect Auth Condition **
+    #end
+
+
+    ## [Start] Throw if unauthorized **
+    #if( !($protectedByOwner_isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+      $util.unauthorized()
+    #end
+    ## [End] Throw if unauthorized **
+  #end
+  ## [End] Check authMode and execute owner/group checks **
+#end
+
+#if( $ctx.args.input.containsKey(\\"protectedByDynamocGroup\\") )
+  ## [Start] Determine request authentication mode **
+  #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+    #set( $authMode = \\"userPools\\" )
+  #end
+  ## [End] Determine request authentication mode **
+  ## [Start] Check authMode and execute owner/group checks **
+  #if( $authMode == \\"userPools\\" )
+    #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+    ## No Static Group Authorization Rules **
+
+
+    #if( ! $protectedByDynamocGroup_isStaticGroupAuthorized )
+      ## [Start] Dynamic group authorization checks **
+      #if( !$compoundAuthExpressions )
+        #set( $compoundAuthExpressions = {} )
+      #end
+      #set( $groupAuthExpressions = [] )
+      #set( $groupAuthExpressionValues = {} )
+      #set( $groupAuthExpressionNames = {} )
+      ## Authorization rule for field \\"protectedByDynamocGroup\\": { allow: groups, groupsField: \\"groupField\\", groupClaim: \\"cognito:groups\\"} **
+      #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+      #foreach( $userGroup in $userGroups )
+        $util.qr($groupAuthExpressions.add(\\"contains(#protectedByDynamocGroup_groupsAttribute0, :protectedByDynamocGroup_group0$foreach.count)\\"))
+        #if( true )
+          $util.qr($groupAuthExpressionValues.put(\\":protectedByDynamocGroup_group0$foreach.count\\", { \\"S\\": $userGroup }))
+        #end
+      #end
+      #if( $userGroups.size() > 0 && true )
+        $util.qr($groupAuthExpressionNames.put(\\"#protectedByDynamocGroup_groupsAttribute0\\", \\"groupField\\"))
+      #end
+      ## [End] Dynamic group authorization checks **
+
+
+      ## No owner authorization rules for field \\"protectedByDynamocGroup\\" **
+
+
+      ## [Start] Collect Auth Condition **
+      #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+      #set( $totalAuthExpression = \\"\\" )
+      ## Add dynamic group auth conditions if they exist **
+      #if( $groupAuthExpressions )
+        #foreach( $authExpr in $groupAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $groupAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+      #end
+      #if( $groupAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+      #end
+      ## Add owner auth conditions if they exist **
+      #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+      #end
+      #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #foreach( $authExpr in $ownerAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $totalAuthExpression != \\"\\" )
+        #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+      #end
+      #if( $ownerAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+      #end
+      #if( $ownerAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+      #end
+      ## Add compound auth conditions if they exist **
+      #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+        #foreach( $entry in $compoundAuthExpressions.entrySet() )
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"(\\" )
+          #else
+            #set( $innerCompoundAuth = \\"\\" )
+          #end
+          #foreach( $authExpr in $entry.value )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+            #if( $foreach.hasNext )
+              #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+            #end
+          #end
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+          #end
+        #end
+      #end
+      ## Set final expression if it has changed. **
+      #if( $totalAuthExpression != \\"\\" )
+        #if( $util.isNullOrEmpty($authCondition.expression) )
+          #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+        #else
+          #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+        #end
+      #end
+      ## [End] Collect Auth Condition **
+    #end
+
+
+    ## [Start] Throw if unauthorized **
+    #if( !($protectedByDynamocGroup_isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+      $util.unauthorized()
+    #end
+    ## [End] Throw if unauthorized **
+  #end
+  ## [End] Check authMode and execute owner/group checks **
+#end
+
+#if( $ctx.args.input.containsKey(\\"protectedByStaticGroup\\") )
+  ## [Start] Determine request authentication mode **
+  #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+    #set( $authMode = \\"userPools\\" )
+  #end
+  ## [End] Determine request authentication mode **
+  ## [Start] Check authMode and execute owner/group checks **
+  #if( $authMode == \\"userPools\\" )
+    #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+    ## [Start] Static Group Authorization Checks **
+    #set($protectedByStaticGroup_isStaticGroupAuthorized = $util.defaultIfNull(
+        $protectedByStaticGroup_isStaticGroupAuthorized, false))
+    ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\" } **
+    #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+    #set( $allowedGroups = [\\"Admin\\"] )
+    #foreach( $userGroup in $userGroups )
+      #if( $allowedGroups.contains($userGroup) )
+        #set( $protectedByStaticGroup_isStaticGroupAuthorized = true )
+        #break
+      #end
+    #end
+    ## [End] Static Group Authorization Checks **
+
+
+    #if( ! $protectedByStaticGroup_isStaticGroupAuthorized )
+      ## No dynamic group authorization rules for field \\"protectedByStaticGroup\\" **
+
+
+      ## No owner authorization rules for field \\"protectedByStaticGroup\\" **
+
+
+      ## [Start] Collect Auth Condition **
+      #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+      #set( $totalAuthExpression = \\"\\" )
+      ## Add dynamic group auth conditions if they exist **
+      #if( $groupAuthExpressions )
+        #foreach( $authExpr in $groupAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $groupAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+      #end
+      #if( $groupAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+      #end
+      ## Add owner auth conditions if they exist **
+      #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+      #end
+      #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+        #foreach( $authExpr in $ownerAuthExpressions )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+        #end
+      #end
+      #if( $totalAuthExpression != \\"\\" )
+        #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+      #end
+      #if( $ownerAuthExpressionNames )
+        $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+      #end
+      #if( $ownerAuthExpressionValues )
+        $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+      #end
+      ## Add compound auth conditions if they exist **
+      #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+        #foreach( $entry in $compoundAuthExpressions.entrySet() )
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"(\\" )
+          #else
+            #set( $innerCompoundAuth = \\"\\" )
+          #end
+          #foreach( $authExpr in $entry.value )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+            #if( $foreach.hasNext )
+              #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+            #end
+          #end
+          #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+          #end
+          #if( $innerCompoundAuth != \\"\\" )
+            #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+          #end
+        #end
+      #end
+      ## Set final expression if it has changed. **
+      #if( $totalAuthExpression != \\"\\" )
+        #if( $util.isNullOrEmpty($authCondition.expression) )
+          #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+        #else
+          #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+        #end
+      #end
+      ## [End] Collect Auth Condition **
+    #end
+
+
+    ## [Start] Throw if unauthorized **
+    #if( !($protectedByStaticGroup_isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+      $util.unauthorized()
+    #end
+    ## [End] Throw if unauthorized **
+  #end
+  ## [End] Check authMode and execute owner/group checks **
+#end
+
+## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = \\"userPools\\" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+        $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: [\\"Nobody\\"], groupClaim: \\"cognito:groups\\" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
+  #set( $allowedGroups = [\\"Nobody\\"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $isStaticGroupAuthorized = true )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  #if( ! $isStaticGroupAuthorized )
+    ## No dynamic group authorization rules **
+
+
+    ## No owner authorization rules **
+
+
+    ## [Start] Collect Auth Condition **
+    #set( $authCondition = $util.defaultIfNull($authCondition, {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+}) )
+    #set( $totalAuthExpression = \\"\\" )
+    ## Add dynamic group auth conditions if they exist **
+    #if( $groupAuthExpressions )
+      #foreach( $authExpr in $groupAuthExpressions )
+        #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+      #end
+    #end
+    #if( $groupAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+    #end
+    #if( $groupAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+    #end
+    ## Add owner auth conditions if they exist **
+    #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+    #end
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #foreach( $authExpr in $ownerAuthExpressions )
+        #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+      #end
+    #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
+    #if( $ownerAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+    #end
+    #if( $ownerAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+    #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
+    ## Set final expression if it has changed. **
+    #if( $totalAuthExpression != \\"\\" )
+      #if( $util.isNullOrEmpty($authCondition.expression) )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
+      #else
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
+      #end
+    #end
+    ## [End] Collect Auth Condition **
+  #end
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || ($totalAuthExpression != \\"\\")) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": \\"$context.args.input.id\\"
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test "update" auth operations with "and" parameter on fields prevents security bypass 2`] = `undefined`;
+
+exports[`Test "update" auth operations with "and" parameter on fields prevents security bypass 3`] = `undefined`;
+
+exports[`Test "update" auth operations with "and" parameter on fields prevents security bypass 4`] = `"$util.toJson($ctx.result)"`;
+
+exports[`Test "update" auth operations with "and" parameter on fields prevents security bypass 5`] = `"$util.toJson($ctx.result)"`;

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -12,9 +12,10 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 ## [End] Determine request authentication mode **
 ## [Start] Check authMode and execute owner/group checks **
 #if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\",\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\", \\"Dev\\"] )
@@ -84,9 +85,10 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 ## [End] Determine request authentication mode **
 ## [Start] Check authMode and execute owner/group checks **
 #if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\",\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\", \\"Dev\\"] )
@@ -132,7 +134,7 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
     #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
     #end
-    #if( $ownerAuthExpressions )
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #foreach( $authExpr in $ownerAuthExpressions )
         #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
         #if( $foreach.hasNext )
@@ -140,18 +142,46 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
         #end
       #end
     #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
     #if( $ownerAuthExpressionNames )
       $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
     #end
     #if( $ownerAuthExpressionValues )
       $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
     #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
     ## Set final expression if it has changed. **
     #if( $totalAuthExpression != \\"\\" )
       #if( $util.isNullOrEmpty($authCondition.expression) )
-        #set( $authCondition.expression = \\"($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
       #else
-        #set( $authCondition.expression = \\"$authCondition.expression AND ($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
       #end
     #end
     ## [End] Collect Auth Condition **
@@ -308,9 +338,10 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
 ## [End] Determine request authentication mode **
 ## [Start] Check authMode and execute owner/group checks **
 #if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\",\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\", \\"Dev\\"] )
@@ -356,7 +387,7 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
     #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
     #end
-    #if( $ownerAuthExpressions )
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #foreach( $authExpr in $ownerAuthExpressions )
         #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
         #if( $foreach.hasNext )
@@ -364,18 +395,46 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
         #end
       #end
     #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
     #if( $ownerAuthExpressionNames )
       $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
     #end
     #if( $ownerAuthExpressionValues )
       $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
     #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
     ## Set final expression if it has changed. **
     #if( $totalAuthExpression != \\"\\" )
       #if( $util.isNullOrEmpty($authCondition.expression) )
-        #set( $authCondition.expression = \\"($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
       #else
-        #set( $authCondition.expression = \\"$authCondition.expression AND ($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
       #end
     #end
     ## [End] Collect Auth Condition **
@@ -472,7 +531,7 @@ exports[`Test that checks subscription resolvers are generated with auth logic 1
 #if( $authMode == \\"userPools\\" )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\"] )
@@ -487,7 +546,7 @@ exports[`Test that checks subscription resolvers are generated with auth logic 1
 
   ## [Start] Owner Authorization Checks **
   #set( $isOwnerAuthorized = false )
-  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\" } **
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\"} **
   #set( $allowedOwners0 = $util.defaultIfNull($ctx.args.owner, null) )
   #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"),
                         $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
@@ -527,7 +586,7 @@ exports[`Test that checks subscription resolvers are generated with auth logic 2
 #if( $authMode == \\"userPools\\" )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\"] )
@@ -542,7 +601,7 @@ exports[`Test that checks subscription resolvers are generated with auth logic 2
 
   ## [Start] Owner Authorization Checks **
   #set( $isOwnerAuthorized = false )
-  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\" } **
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\"} **
   #set( $allowedOwners0 = $util.defaultIfNull($ctx.args.owner, null) )
   #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"),
                         $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
@@ -582,7 +641,7 @@ exports[`Test that checks subscription resolvers are generated with auth logic 3
 #if( $authMode == \\"userPools\\" )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\"] )
@@ -597,7 +656,7 @@ exports[`Test that checks subscription resolvers are generated with auth logic 3
 
   ## [Start] Owner Authorization Checks **
   #set( $isOwnerAuthorized = false )
-  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\" } **
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\"} **
   #set( $allowedOwners0 = $util.defaultIfNull($ctx.args.owner, null) )
   #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"),
                         $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
@@ -639,9 +698,10 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 ## [End] Determine request authentication mode **
 ## [Start] Check authMode and execute owner/group checks **
 #if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = {} )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\",\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\", \\"Dev\\"] )
@@ -711,9 +771,10 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 ## [End] Determine request authentication mode **
 ## [Start] Check authMode and execute owner/group checks **
 #if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\",\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\", \\"Dev\\"] )
@@ -759,7 +820,7 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
     #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
     #end
-    #if( $ownerAuthExpressions )
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #foreach( $authExpr in $ownerAuthExpressions )
         #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
         #if( $foreach.hasNext )
@@ -767,18 +828,46 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
         #end
       #end
     #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
     #if( $ownerAuthExpressionNames )
       $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
     #end
     #if( $ownerAuthExpressionValues )
       $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
     #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
     ## Set final expression if it has changed. **
     #if( $totalAuthExpression != \\"\\" )
       #if( $util.isNullOrEmpty($authCondition.expression) )
-        #set( $authCondition.expression = \\"($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
       #else
-        #set( $authCondition.expression = \\"$authCondition.expression AND ($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
       #end
     #end
     ## [End] Collect Auth Condition **
@@ -935,9 +1024,10 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
 ## [End] Determine request authentication mode **
 ## [Start] Check authMode and execute owner/group checks **
 #if( $authMode == \\"userPools\\" )
+  #set( $compoundAuthRuleCounts = $util.defaultIfNull($compoundAuthRuleCounts, {}) )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Admin\\",\\"Dev\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Admin\\", \\"Dev\\"] )
@@ -983,7 +1073,7 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
     #if( $totalAuthExpression != \\"\\" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
     #end
-    #if( $ownerAuthExpressions )
+    #if( $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
       #foreach( $authExpr in $ownerAuthExpressions )
         #set( $totalAuthExpression = \\"$totalAuthExpression $authExpr\\" )
         #if( $foreach.hasNext )
@@ -991,18 +1081,46 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
         #end
       #end
     #end
+    #if( $totalAuthExpression != \\"\\" )
+      #set( $totalAuthExpression = \\"($totalAuthExpression)\\" )
+    #end
     #if( $ownerAuthExpressionNames )
       $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
     #end
     #if( $ownerAuthExpressionValues )
       $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
     #end
+    ## Add compound auth conditions if they exist **
+    #if( $compoundAuthExpressions && $compoundAuthExpressions.entrySet().size() > 0 )
+      #foreach( $entry in $compoundAuthExpressions.entrySet() )
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"(\\" )
+        #else
+          #set( $innerCompoundAuth = \\"\\" )
+        #end
+        #foreach( $authExpr in $entry.value )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth $authExpr\\" )
+          #if( $foreach.hasNext )
+            #set( $innerCompoundAuth = \\"$innerCompoundAuth AND\\" )
+          #end
+        #end
+        #if( $entry.value && $entry.value.size() > 1 && $compoundAuthExpressions.entrySet().size() > 1 )
+          #set( $innerCompoundAuth = \\"$innerCompoundAuth )\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" && $totalAuthExpression != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression OR\\" )
+        #end
+        #if( $innerCompoundAuth != \\"\\" )
+          #set( $totalAuthExpression = \\"$totalAuthExpression $innerCompoundAuth\\" )
+        #end
+      #end
+    #end
     ## Set final expression if it has changed. **
     #if( $totalAuthExpression != \\"\\" )
       #if( $util.isNullOrEmpty($authCondition.expression) )
-        #set( $authCondition.expression = \\"($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$totalAuthExpression\\" )
       #else
-        #set( $authCondition.expression = \\"$authCondition.expression AND ($totalAuthExpression)\\" )
+        #set( $authCondition.expression = \\"$authCondition.expression AND $totalAuthExpression\\" )
       #end
     #end
     ## [End] Collect Auth Condition **
@@ -1093,7 +1211,7 @@ exports[`Test that subscriptions are only generated if the respective mutation o
 #if( $authMode == \\"userPools\\" )
   ## [Start] Static Group Authorization Checks **
   #set($isStaticGroupAuthorized = $util.defaultIfNull(
-            $isStaticGroupAuthorized, false))
+        $isStaticGroupAuthorized, false))
   ## Authorization rule: { allow: groups, groups: [\\"Moderator\\"], groupClaim: \\"cognito:groups\\" } **
   #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
   #set( $allowedGroups = [\\"Moderator\\"] )
@@ -1108,7 +1226,7 @@ exports[`Test that subscriptions are only generated if the respective mutation o
 
   ## [Start] Owner Authorization Checks **
   #set( $isOwnerAuthorized = false )
-  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\" } **
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\"} **
   #set( $allowedOwners0 = $util.defaultIfNull($ctx.args.owner, null) )
   #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"),
                         $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
@@ -1151,7 +1269,7 @@ exports[`Test that subscriptions are only generated if the respective mutation o
 
   ## [Start] Owner Authorization Checks **
   #set( $isOwnerAuthorized = false )
-  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\" } **
+  ## Authorization rule: { allow: owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\"} **
   #set( $allowedOwners0 = $util.defaultIfNull($ctx.args.owner, null) )
   #set( $identityValue = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"),
                         $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Test per-field @auth without model 1`] = `
 "## [Start] Static Group Authorization Checks **
 #set($listContext_isStaticGroupAuthorized = $util.defaultIfNull(
-            $listContext_isStaticGroupAuthorized, false))
+        $listContext_isStaticGroupAuthorized, false))
 ## Authorization rule: { allow: groups, groups: [\\"Allowed\\"], groupClaim: \\"cognito:groups\\" } **
 #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
 #set( $allowedGroups = [\\"Allowed\\"] )

--- a/packages/graphql-auth-transformer/tsconfig.json
+++ b/packages/graphql-auth-transformer/tsconfig.json
@@ -1,18 +1,11 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
-        "sourceMap": true,
-        "outDir": "lib",
-        "lib": [
-            "es2016.array.include",
-            "esnext.asynciterable",
-            "dom"
-        ],
-        "declaration": true
-    },
-    "exclude": [
-        "node_modules",
-        "lib"
-    ]
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "sourceMap": true,
+    "outDir": "lib",
+    "lib": ["es2017", "esnext.asynciterable", "dom"],
+    "declaration": true
+  },
+  "exclude": ["node_modules", "lib"]
 }

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -105,5 +105,7 @@ export class ResourceConstants {
     IsStaticGroupAuthorizedVariable: 'isStaticGroupAuthorized',
     IsOwnerAuthorizedVariable: 'isOwnerAuthorized',
     IsLocalOwnerAuthorizedVariable: 'isLocalOwnerAuthorized',
+    CompoundAuthRuleCounts: 'compoundAuthRuleCounts',
+    StaticCompoundAuthRuleCounts: 'staticCompoundAuthRuleCounts',
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6780,7 +6780,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -6898,11 +6898,6 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -7051,11 +7046,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -9947,7 +9937,7 @@ husky@^3.0.3:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -10138,7 +10128,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -13439,15 +13429,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -13612,22 +13593,6 @@ node-notifier@^5.2.1, node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.40, node-releases@^1.1.46:
   version "1.1.47"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
@@ -13752,7 +13717,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -13791,7 +13756,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -15789,16 +15754,6 @@ raw-body@^2.2.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-app-polyfill@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.5.tgz#59c7377a0b9ed25692eeaca7ad9b12ef2d064709"
@@ -17660,7 +17615,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -17831,7 +17786,7 @@ tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
adds 'and' property on auth rules to force each auth rule with the same 'and' property to all match before allowing operations. Allows combining owner, group, and dynamic group authentication rules. Works on objects and fields for user pools.

*Issue #, if available:* #1043 #317 #1578

*Description of changes:*
The RFC for @auth directive improvements describes in option 5 the ability to join auth rules together using 'AND' and 'OR', with an arbitrary level of nesting. This PR takes a slightly different approach in only implementing AND, and not allowing nesting. This feels reasonable as @auth rules are OR'd by default and any nesting can be decomposed into a flat structure.

To implement this a new property on an auth rule is created, "and". And is assigned a string, and all rules with the same assigned and string are considered part of a group whose rules must all pass to allow the operation.

Compound rules are tracked by counting how many of the rules have passed, rejecting the operation if no compound rule sets have all their rules pass.

List operations require a deep clone of the object holding the counts via json stringify and json parse operations so that their count tracking is independent of each other.

Update and Delete operations are somewhat more challenging as their dynamic group and owner rules are evaluated on the server, while the static auth is evaluated on the client. This requires nesting condition expressions, and only executing DynamoDB calls if the static group rules have been satisfied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.