### PR TITLE
fix(graphql-elasticsearch-transformer): allow range on searches

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/definitions.ts
+++ b/packages/graphql-elasticsearch-transformer/src/definitions.ts
@@ -10,15 +10,29 @@ import {
 } from 'graphql';
 import { graphqlName, makeNamedType, isScalar, makeListType, getBaseType, SearchableResourceIDs } from 'graphql-transformer-common';
 
-const STRING_CONDITIONS = ['ne', 'eq', 'match', 'matchPhrase', 'matchPhrasePrefix', 'multiMatch', 'exists', 'wildcard', 'regexp'];
-const ID_CONDITIONS = ['ne', 'eq', 'match', 'matchPhrase', 'matchPhrasePrefix', 'multiMatch', 'exists', 'wildcard', 'regexp'];
+const ID_CONDITIONS = [
+  'ne',
+  'gt',
+  'lt',
+  'gte',
+  'lte',
+  'eq',
+  'match',
+  'matchPhrase',
+  'matchPhrasePrefix',
+  'multiMatch',
+  'exists',
+  'wildcard',
+  'regexp',
+];
+const STRING_CONDITIONS = ID_CONDITIONS;
 const INT_CONDITIONS = ['ne', 'gt', 'lt', 'gte', 'lte', 'eq', 'range'];
 const FLOAT_CONDITIONS = ['ne', 'gt', 'lt', 'gte', 'lte', 'eq', 'range'];
 const BOOLEAN_CONDITIONS = ['eq', 'ne'];
 
 export function makeSearchableScalarInputObject(type: string): InputObjectTypeDefinitionNode {
   const name = SearchableResourceIDs.SearchableFilterInputTypeName(type);
-  let conditions = getScalarConditions(type);
+  const conditions = getScalarConditions(type);
   const fields: InputValueDefinitionNode[] = conditions.map((condition: string) => ({
     kind: Kind.INPUT_VALUE_DEFINITION,
     name: { kind: 'Name' as 'Name', value: condition },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
@@ -740,8 +740,8 @@ test('query using date range for createdAt', async () => {
     `query {
       searchUsers(filter: {
         createdAt: {
-          lt: "2019-07-04"
-          gt: "2016-07-20"
+          lte: "2017-08-22"
+          gte: "2017-06-10"
         }
       }) {
         items {


### PR DESCRIPTION
allows the use of lt lte gt gte on `@searchable`

re #2775

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.