### PR TITLE
fix(amplify-appsync-simulator): set max payload size for request

### DIFF
--- a/packages/amplify-appsync-simulator/src/server/operations.ts
+++ b/packages/amplify-appsync-simulator/src/server/operations.ts
@@ -15,6 +15,7 @@ import {
 import { exposeGraphQLErrors } from '../utils/expose-graphql-errors';
 import { SubscriptionServer } from './subscription';
 
+const MAX_BODY_SIZE = '10mb';
 const BASE_PORT = 8900;
 const MAX_PORT = 9999;
 
@@ -33,7 +34,7 @@ export class OperationServer {
   ) {
     this.port = config.port;
     this.app = express();
-    this.app.use(express.json());
+    this.app.use(express.json({ limit: MAX_BODY_SIZE }));
     this.app.use(cors());
     this.app.post('/graphql', this.handleRequest.bind(this));
     this.app.get('/api-config', this.handleAPIInfoRequest.bind(this));


### PR DESCRIPTION
set the body size limit to 10MB

fix #3086

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.