### PR TITLE
Add team-provider-info.json to gitignore appending string

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-git-ignore-blob.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-git-ignore-blob.js
@@ -12,6 +12,7 @@ function getGitIgnoreBlob() {
     'aws-exports.js',
     'awsconfiguration.json',
     'amplifyconfiguration.json',
+    'team-provider-info.json',
   ];
 
   const toAppend = `${os.EOL + os.EOL}${ignoreList.join(os.EOL)}`;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.js
@@ -53,6 +53,7 @@ function getGitIgnoreAppendString() {
     'amplifyconfiguration.json',
     'amplify-gradle-config.json',
     'amplifyxc.config',
+    'team-provider-info.json',
   ];
 
   const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}`;


### PR DESCRIPTION
@dabit3 confirmed that `team-provider-info.json` should be included in `.gitignore` appending string followed by the [issue](https://github.com/dabit3/amplify-auth-demo/issues/1).
