### PR TITLE
fix: remove extra curly brace in CLI output

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/amplify-service-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/amplify-service-manager.js
@@ -41,7 +41,7 @@ async function init(amplifyServiceParams) {
           appId: inputAmplifyAppId,
         })
         .promise();
-      context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}}`);
+      context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
       amplifyAppId = inputAmplifyAppId;
     } catch (e) {
       context.print.error(

--- a/packages/amplify-provider-awscloudformation/lib/amplify-service-migrate.js
+++ b/packages/amplify-provider-awscloudformation/lib/amplify-service-migrate.js
@@ -42,7 +42,7 @@ async function run(context) {
           appId: amplifyAppId,
         })
         .promise();
-      context.print.info(`Amplify AppID found: ${amplifyAppId}. Amplify App name is: ${getAppResult.app.name}}`);
+      context.print.info(`Amplify AppID found: ${amplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
     } catch (e) {
       context.print.error(
         `Amplify AppID: ${amplifyAppId} not found. Please ensure your local profile matches the AWS account or region in which the Amplify app exists.`

--- a/packages/amplify-provider-awscloudformation/lib/attach-backend.js
+++ b/packages/amplify-provider-awscloudformation/lib/attach-backend.js
@@ -95,7 +95,7 @@ async function getAmplifyApp(context, amplifyClient) {
           appId: inputAmplifyAppId,
         })
         .promise();
-      context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}}`);
+      context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
       return getAppResult.app;
     } catch (e) {
       context.print.error(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
CLI reads:
Amplify AppID found: xxx. Amplify App name is: name}

The brace was used in JS to interpolate the string, but one too many left one being
printed for no reason. Removing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.