### PR TITLE
fix(cli): alter tsconfig to produce valid souremap locations

### DIFF
--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -3,12 +3,10 @@
     "target": "es6",
     "module": "commonjs",
     "sourceMap": true,
-    "mapRoot": "lib",
     "lib": ["es6", "es2015", "dom"],
     "declaration": false,
     "allowJs": true,
     "outDir": "lib",
-    // "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

tsconfig.json file for amplify-cli contained a property `compilerOptions.mapRoot` = “lib”
that would cause `tsc` (version 3.7.5, latest) command to produce

{"version":3,"file":"index.js","sourceRoot":"","sources":["../index.ts"],"names":[],"mappings”:”…”}

Sources *should* read: “../src/index.ts”.

I’m not exactly sure how/why its set up this way, but all other tsconfig files in this project do not specify
a mapRoot, so this change brings this in line with all the other packages, and now I can debug the cli
package again :)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.