### PR TITLE
fix(amplify-appsync-simulator): make resolver result parsing strict

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -35,7 +35,6 @@
     "graphql-type-json": "^0.3.0",
     "ip": "^1.1.5",
     "js-string-escape": "^1.0.1",
-    "json5": "^2.1.0",
     "jwt-decode": "^2.2.0",
     "libphonenumber-js": "^1.7.18",
     "lodash": "^4.17.15",

--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -1,5 +1,4 @@
 import { Compile, parse } from 'amplify-velocity-template';
-import JSON5 from 'json5';
 import { AmplifyAppSyncSimulator } from '..';
 import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncVTLTemplate } from '../type-definition';
 import { create as createUtil, TemplateSentError } from './util';
@@ -55,7 +54,7 @@ export class VelocityTemplate {
     const templateResult = this.compiler.render(context);
     const stash = context.ctx.stash.toJSON();
     try {
-      const result = JSON5.parse(templateResult);
+      const result = JSON.parse(templateResult);
       return { result, stash, errors: context.util.errors };
     } catch (e) {
       const errorMessage = `Unable to convert ${templateResult} to class com.amazonaws.deepdish.transform.model.lambda.LambdaVersionedConfig.`;


### PR DESCRIPTION
updated the appsync resolver parsing to use plain JSON parse instead of using JSON5 which is a
looser spec

fix #3180

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.