### PR TITLE
fix(amplify-codegen-appsync-model-plugin): support non-codeable types

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -4,7 +4,6 @@ import { SwiftDeclarationBlock } from '../languages/swift-declaration-block';
 import { AppSyncModelVisitor, CodeGenField, CodeGenGenerateEnum, CodeGenModel } from './appsync-visitor';
 import { CodeGenConnectionType } from '../utils/process-connections';
 import { schemaTypeMap } from '../configs/swift-config';
-import dedent from 'ts-dedent';
 export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
   protected modelExtensionImports: string[] = ['import Amplify', 'import Foundation'];
   protected imports: string[] = ['import Amplify', 'import Foundation'];
@@ -36,6 +35,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
           optional: !this.isFieldRequired(field),
           isList: field.isList,
           variable: isVariable,
+          isEnum: this.isEnumType(field),
         });
       });
       const initImpl: string = this.getInitBody(obj.fields);


### PR DESCRIPTION
fixed iOS model gen to handle non-codeable type arrays to use [] instead of List<> type

fix #3035

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.