### PR TITLE
fix(amplify-category-api): edit auth workflow if cognito is not used

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -70,7 +70,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
 
   if (resourceName) {
     context.print.warning(
-      'You already have an AppSync API in your project. Use the "amplify update api" command to update your existing AppSync API.'
+      'You already have an AppSync API in your project. Use the "amplify update api" command to update your existing AppSync API.',
     );
     process.exit(0);
   }
@@ -220,11 +220,11 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
 
   // Guided creation of the transform schema
   const authTypes = getAuthTypes(authConfig);
-  const onlyApiKeyAuthEnabled = authTypes.includes('API_KEY') && authTypes.length === 1;
+  const cognitoNotEnabled = !authTypes.includes('AMAZON_COGNITO_USER_POOLS');
 
   let templateSchemaChoices = inputs[4].options;
 
-  if (onlyApiKeyAuthEnabled) {
+  if (cognitoNotEnabled) {
     templateSchemaChoices = templateSchemaChoices.filter(schema => schema.value !== 'single-object-auth-schema.graphql');
   }
 
@@ -363,7 +363,7 @@ async function updateWalkthrough(context) {
     if (resource.providerPlugin !== providerName) {
       // TODO: Move message string to seperate file
       throw new Error(
-        `The selected resource is not managed using AWS Cloudformation. Please use the AWS AppSync Console to make updates to your API - ${resource.resourceName}`
+        `The selected resource is not managed using AWS Cloudformation. Please use the AWS AppSync Console to make updates to your API - ${resource.resourceName}`,
       );
     }
     ({ resourceName } = resource);
@@ -538,7 +538,7 @@ async function askResolverConflictQuestion(context, parameters, modelTypes) {
           resolverConfig.models = {};
           for (let i = 0; i < selectedModelTypes.length; i += 1) {
             resolverConfig.models[selectedModelTypes[i]] = await askConflictResolutionStrategy(
-              `Select the resolution strategy for ${selectedModelTypes[i]} model`
+              `Select the resolution strategy for ${selectedModelTypes[i]} model`,
             );
           }
         }
@@ -634,7 +634,7 @@ async function askAdditionalAuthQuestions(context, parameters, authConfig, defau
 
 async function checkForCognitoUserPools(context, parameters, authConfig) {
   const additionalUserPoolProviders = authConfig.additionalAuthenticationProviders.filter(
-    provider => provider.authenticationType === 'AMAZON_COGNITO_USER_POOLS'
+    provider => provider.authenticationType === 'AMAZON_COGNITO_USER_POOLS',
   );
   const additionalUserPoolProvider = additionalUserPoolProviders.length > 0 ? additionalUserPoolProviders[0] : undefined;
 
@@ -801,7 +801,7 @@ function validateDays(input) {
 
 function validateIssuerUrl(input) {
   const isValid = /^(((?!http:\/\/(?!localhost))([a-zA-Z0-9.]{1,}):\/\/([a-zA-Z0-9-._~:?#@!$&'()*+,;=/]{1,})\/)|(?!http)(?!https)([a-zA-Z0-9.]{1,}):\/\/)$/.test(
-    input
+    input,
   );
 
   if (!isValid) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3011,7 +3011,7 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
   integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
-"@types/jest@^24.0.15", "@types/jest@^24.0.16", "@types/jest@^24.0.23", "@types/jest@^24.0.25":
+"@types/jest@^24.0.15", "@types/jest@^24.0.16", "@types/jest@^24.0.23":
   version "24.0.25"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.25.tgz#2aba377824ce040114aa906ad2cac2c85351360f"
   integrity sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==
@@ -10192,7 +10192,7 @@ husky@^3.0.3:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==


### PR DESCRIPTION
removes the fine grain auth schema option if aws cognito is not selected as an auth mode

re #2967

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.