### PR TITLE
chore(cli): improve error message in readJsonFile

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -68,11 +68,13 @@
     "lodash": "^4.17.15",
     "open": "^7.0.0",
     "ora": "^4.0.3",
+    "parse-json": "^5.0.0",
     "promise-sequential": "^1.1.1",
     "which": "^2.0.2"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13"
+    "@types/node": "^10.17.13",
+    "@types/parse-json": "^4.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/read-json-file.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/read-json-file.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra');
+const parseJson = require('parse-json');
 
 function stripBOM(content) {
   if (content.charCodeAt(0) === 0xfeff) {
@@ -8,7 +9,8 @@ function stripBOM(content) {
 }
 
 function readJsonFile(jsonFilePath, encoding = 'utf8') {
-  return JSON.parse(stripBOM(fs.readFileSync(jsonFilePath, encoding)));
+  const content = fs.readFileSync(jsonFilePath, encoding);
+  return parseJson(stripBOM(content), jsonFilePath);
 }
 
 module.exports = {

--- a/packages/amplify-cli/src/utils/readJsonFile.ts
+++ b/packages/amplify-cli/src/utils/readJsonFile.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
+import parseJson from 'parse-json';
 
 function stripBOM(content: string) {
-  // tslint:disable-next-line
   if (content.charCodeAt(0) === 0xfeff) {
     content = content.slice(1);
   }
@@ -9,10 +9,11 @@ function stripBOM(content: string) {
 }
 
 export function readJsonFileSync(jsonFilePath: string, encoding: string = 'utf8'): any {
-  return JSON.parse(stripBOM(fs.readFileSync(jsonFilePath, encoding)));
+  const content = fs.readFileSync(jsonFilePath, encoding);
+  return parseJson(stripBOM(content), jsonFilePath);
 }
 
 export async function readJsonFile(jsonFilePath: string, encoding: string = 'utf8'): Promise<any> {
-  const contents = await fs.readFile(jsonFilePath, encoding);
-  return JSON.parse(stripBOM(contents));
+  const content = await fs.readFile(jsonFilePath, encoding);
+  return parseJson(stripBOM(content), jsonFilePath);
 }


### PR DESCRIPTION
*Issue #, if available:*

I'm tired to see useless error messages like `SyntaxError: Unexpected token } in JSON at position 6`

This CL improves error messaage like following:

```
JSONParseError: some.json:3:2: Unexpected token } in JSON at position 6
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.