### PR TITLE
test(amplify-e2e-tests): use waitFor on bucket deletion check

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/predictions.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/predictions.test.ts
@@ -21,7 +21,6 @@ describe('amplify add predictions', () => {
     await addInterpret(projRoot, {});
     await amplifyPushAuth(projRoot);
     const awsExports: any = getAWSExports(projRoot).default;
-    console.log(`AWS Exports \n${JSON.stringify(awsExports, null, 4)}`);
     const { sourceLanguage, targetLanguage } = awsExports.predictions.convert.translateText.defaults;
     const { type } = awsExports.predictions.interpret.interpretText.defaults;
     expect(sourceLanguage).toBeDefined();
@@ -35,14 +34,12 @@ describe('amplify add predictions', () => {
     await addIdentifyCollection(projRoot, {});
     await amplifyPushAuth(projRoot);
     const awsExports: any = getAWSExports(projRoot).default;
-    console.log(`AWS Exports \n${JSON.stringify(awsExports, null, 4)}`);
     const { collectionId: collectionID, maxEntities: maxFaces } = awsExports.predictions.identify.identifyEntities.defaults;
     const { region, celebrityDetectionEnabled } = awsExports.predictions.identify.identifyEntities;
     expect(collectionID).toBeDefined();
     expect(maxFaces).toEqual(50);
     expect(celebrityDetectionEnabled).toBeTruthy();
     const cID = await getCollection(collectionID, region);
-    console.log(`Rekog Collection Response ${JSON.stringify(cID, null, 4)}`);
     expect(cID.CollectionARN.split('/').pop()).toEqual(collectionID);
   });
 });


### PR DESCRIPTION
- use waitFor when checking that bucket is deleted
- removed unnecessary logging from predictions test

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.