### PR TITLE
fix (graphql-auth-transformer): non-model @auth propagation fails enums

### DIFF
--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -228,7 +228,7 @@ export class ModelAuthTransformer extends Transformer {
           update
           delete
         }
-      `
+      `,
     );
 
     if (config && config.authConfig) {
@@ -377,21 +377,21 @@ export class ModelAuthTransformer extends Transformer {
       ResolverResourceIDs.DynamoDBCreateResolverResourceID(def.name.value),
       operationRules.create,
       def,
-      modelConfiguration
+      modelConfiguration,
     );
     this.protectUpdateMutation(
       ctx,
       ResolverResourceIDs.DynamoDBUpdateResolverResourceID(def.name.value),
       operationRules.update,
       def,
-      modelConfiguration
+      modelConfiguration,
     );
     this.protectDeleteMutation(
       ctx,
       ResolverResourceIDs.DynamoDBDeleteResolverResourceID(def.name.value),
       operationRules.delete,
       def,
-      modelConfiguration
+      modelConfiguration,
     );
     this.protectGetQuery(ctx, ResolverResourceIDs.DynamoDBGetResolverResourceID(def.name.value), queryRules.get, def, modelConfiguration);
     this.protectListQuery(
@@ -399,7 +399,7 @@ export class ModelAuthTransformer extends Transformer {
       ResolverResourceIDs.DynamoDBListResolverResourceID(def.name.value),
       queryRules.list,
       def,
-      modelConfiguration
+      modelConfiguration,
     );
     this.protectConnections(ctx, def, operationRules.read, modelConfiguration);
     this.protectQueries(ctx, def, operationRules.read, modelConfiguration);
@@ -429,11 +429,11 @@ export class ModelAuthTransformer extends Transformer {
     parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
     definition: FieldDefinitionNode,
     directive: DirectiveNode,
-    ctx: TransformerContext
+    ctx: TransformerContext,
   ) => {
     if (parent.kind === Kind.INTERFACE_TYPE_DEFINITION) {
       throw new InvalidDirectiveError(
-        `The @auth directive cannot be placed on an interface's field. See ${parent.name.value}${definition.name.value}`
+        `The @auth directive cannot be placed on an interface's field. See ${parent.name.value}${definition.name.value}`,
       );
     }
     const modelDirective = parent.directives.find(dir => dir.name.value === 'model');
@@ -445,7 +445,7 @@ export class ModelAuthTransformer extends Transformer {
       console.warn(
         `Be careful when using @auth directives on a field in a root type. @auth directives on field definitions use the source \
 object to perform authorization logic and the source will be an empty object for fields on root types. \
-Static group authorization should perform as expected.`
+Static group authorization should perform as expected.`,
       );
     }
 
@@ -516,9 +516,14 @@ Static group authorization should perform as expected.`
   private propagateAuthDirectivesToNestedTypes(type: ObjectTypeDefinitionNode, rules: AuthRule[], ctx: TransformerContext) {
     const nonModelTypePredicate = (fieldType: TypeDefinitionNode): TypeDefinitionNode | undefined => {
       if (fieldType) {
+        if (fieldType.kind !== 'ObjectTypeDefinition') {
+          return undefined;
+        }
+
         const typeModel = fieldType.directives.find(dir => dir.name.value === 'model');
         return typeModel !== undefined ? undefined : fieldType;
       }
+
       return fieldType;
     };
 
@@ -545,7 +550,7 @@ Static group authorization should perform as expected.`
     ctx: TransformerContext,
     parent: ObjectTypeDefinitionNode,
     field: FieldDefinitionNode,
-    staticGroupRules: AuthRule[]
+    staticGroupRules: AuthRule[],
   ) {
     const typeName = parent.name.value;
     const fieldName = field.name.value;
@@ -578,7 +583,7 @@ Static group authorization should perform as expected.`
     parent: ObjectTypeDefinitionNode,
     field: FieldDefinitionNode,
     rules: AuthRule[],
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     if (rules && rules.length) {
       // Get the directives we need to add to the GraphQL nodes
@@ -637,7 +642,7 @@ Either make the field optional, set auth on the object and not the field, or dis
         }
         // operation check in the protected field
         resolver.Properties.ResponseMappingTemplate = print(
-          this.resources.operationCheckExpression(ctx.getMutationTypeName(), field.name.value)
+          this.resources.operationCheckExpression(ctx.getMutationTypeName(), field.name.value),
         );
       }
       // If a resolver exists, a @connection for example. Prepend it to the req.
@@ -652,7 +657,7 @@ Either make the field optional, set auth on the object and not the field, or dis
     parent: ObjectTypeDefinitionNode,
     field: FieldDefinitionNode,
     rules: AuthRule[],
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const resolverResourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(parent.name.value);
     const subscriptionOperation: ModelDirectiveOperationType = 'onUpdate';
@@ -664,7 +669,7 @@ Either make the field optional, set auth on the object and not the field, or dis
     parent: ObjectTypeDefinitionNode,
     field: FieldDefinitionNode,
     rules: AuthRule[],
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const resolverResourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(parent.name.value);
     const subscriptionOperation: ModelDirectiveOperationType = 'onDelete';
@@ -683,7 +688,7 @@ Either make the field optional, set auth on the object and not the field, or dis
     parent: ObjectTypeDefinitionNode,
     field: FieldDefinitionNode,
     rules: AuthRule[],
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const typeName = parent.name.value;
     const resolverResourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
@@ -731,7 +736,7 @@ Either make the field optional, set auth on the object and not the field, or dis
         // are done before calling PutItem.
         const dynamicGroupAuthorizationExpression = this.resources.dynamicGroupAuthorizationExpressionForCreateOperationsByField(
           dynamicGroupAuthorizationRules,
-          field.name.value
+          field.name.value,
         );
         const fieldIsList = (fieldName: string) => {
           const field = parent.fields.find(field => field.name.value === fieldName);
@@ -743,7 +748,7 @@ Either make the field optional, set auth on the object and not the field, or dis
         const ownerAuthorizationExpression = this.resources.ownerAuthorizationExpressionForCreateOperationsByField(
           ownerAuthorizationRules,
           field.name.value,
-          fieldIsList
+          fieldIsList,
         );
 
         const throwIfUnauthorizedExpression = this.resources.throwIfUnauthorized(field);
@@ -944,7 +949,7 @@ Either make the field optional, set auth on the object and not the field, or dis
       if (queries || mutations) {
         throw new InvalidDirectiveError(
           `@auth directives used on field definitions may not specify the 'queries' or 'mutations' arguments. \
-All @auth directives used on field definitions are performed when the field is resolved and can be thought of as 'read' operations.`
+All @auth directives used on field definitions are performed when the field is resolved and can be thought of as 'read' operations.`,
         );
       }
       this.commonRuleValidation(rule);
@@ -986,7 +991,7 @@ All @auth directives used on field definitions are performed when the field is r
     resolverResourceId: string,
     rules: AuthRule[],
     parent: ObjectTypeDefinitionNode | null,
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const resolver = ctx.getResource(resolverResourceId);
     if (!rules || rules.length === 0 || !resolver) {
@@ -1036,11 +1041,11 @@ All @auth directives used on field definitions are performed when the field is r
       const staticGroupAuthorizationExpression = this.resources.staticGroupAuthorizationExpression(staticGroupAuthorizationRules);
       const dynamicGroupAuthorizationExpression = this.resources.dynamicGroupAuthorizationExpressionForReadOperations(
         dynamicGroupAuthorizationRules,
-        objectPath
+        objectPath,
       );
       const ownerAuthorizationExpression = this.resources.ownerAuthorizationExpressionForReadOperations(
         ownerAuthorizationRules,
-        objectPath
+        objectPath,
       );
       const throwIfUnauthorizedExpression = this.resources.throwIfUnauthorized();
 
@@ -1105,7 +1110,7 @@ All @auth directives used on field definitions are performed when the field is r
     rules: AuthRule[],
     parent: ObjectTypeDefinitionNode | null,
     modelConfiguration: ModelDirectiveConfiguration,
-    explicitOperationName: string = undefined
+    explicitOperationName: string = undefined,
   ) {
     const resolver = ctx.getResource(resolverResourceId);
     if (!rules || rules.length === 0 || !resolver) {
@@ -1168,13 +1173,13 @@ All @auth directives used on field definitions are performed when the field is r
         dynamicGroupAuthorizationRules,
         'item',
         ResourceConstants.SNIPPETS.IsLocalDynamicGroupAuthorizedVariable,
-        raw(`false`)
+        raw(`false`),
       );
       const ownerAuthorizationExpression = this.resources.ownerAuthorizationExpressionForReadOperations(
         ownerAuthorizationRules,
         'item',
         ResourceConstants.SNIPPETS.IsLocalOwnerAuthorizedVariable,
-        raw(`false`)
+        raw(`false`),
       );
       const appendIfLocallyAuthorized = this.resources.appendItemIfLocallyAuthorized();
 
@@ -1190,7 +1195,7 @@ All @auth directives used on field definitions are performed when the field is r
             appendIfLocallyAuthorized,
           ]),
           set(ref(itemList), ref('items')),
-        ])
+        ]),
       );
 
       // If we've any modes to check, then add the authMode check code block
@@ -1251,7 +1256,7 @@ All @auth directives used on field definitions are performed when the field is r
     resolverResourceId: string,
     rules: AuthRule[],
     parent: ObjectTypeDefinitionNode,
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const resolver = ctx.getResource(resolverResourceId);
     if (!rules || rules.length === 0 || !resolver) {
@@ -1290,7 +1295,7 @@ All @auth directives used on field definitions are performed when the field is r
         // In create mutations, the dynamic group and ownership authorization checks
         // are done before calling PutItem.
         const dynamicGroupAuthorizationExpression = this.resources.dynamicGroupAuthorizationExpressionForCreateOperations(
-          dynamicGroupAuthorizationRules
+          dynamicGroupAuthorizationRules,
         );
         const fieldIsList = (fieldName: string) => {
           const field = parent.fields.find(field => field.name.value === fieldName);
@@ -1301,7 +1306,7 @@ All @auth directives used on field definitions are performed when the field is r
         };
         const ownerAuthorizationExpression = this.resources.ownerAuthorizationExpressionForCreateOperations(
           ownerAuthorizationRules,
-          fieldIsList
+          fieldIsList,
         );
 
         const throwIfUnauthorizedExpression = this.resources.throwIfUnauthorized();
@@ -1378,7 +1383,7 @@ All @auth directives used on field definitions are performed when the field is r
     isUpdate: boolean,
     field?: FieldDefinitionNode,
     ifCondition?: Expression,
-    subscriptionOperation?: ModelDirectiveOperationType
+    subscriptionOperation?: ModelDirectiveOperationType,
   ) {
     const resolver = ctx.getResource(resolverResourceId);
     if (!rules || rules.length === 0 || !resolver) {
@@ -1418,7 +1423,7 @@ All @auth directives used on field definitions are performed when the field is r
         // are done before calling PutItem.
         const dynamicGroupAuthorizationExpression = this.resources.dynamicGroupAuthorizationExpressionForUpdateOrDeleteOperations(
           dynamicGroupAuthorizationRules,
-          field ? field.name.value : undefined
+          field ? field.name.value : undefined,
         );
 
         const fieldIsList = (fieldName: string) => {
@@ -1431,7 +1436,7 @@ All @auth directives used on field definitions are performed when the field is r
         const ownerAuthorizationExpression = this.resources.ownerAuthorizationExpressionForUpdateOrDeleteOperations(
           ownerAuthorizationRules,
           fieldIsList,
-          field ? field.name.value : undefined
+          field ? field.name.value : undefined,
         );
 
         const collectAuthCondition = this.resources.collectAuthCondition();
@@ -1444,11 +1449,11 @@ All @auth directives used on field definitions are performed when the field is r
             ownerAuthorizationExpression,
             newline(),
             collectAuthCondition,
-          ])
+          ]),
         );
 
         const throwIfNotStaticGroupAuthorizedOrAuthConditionIsEmpty = this.resources.throwIfNotStaticGroupAuthorizedOrAuthConditionIsEmpty(
-          field
+          field,
         );
 
         // If we've any modes to check, then add the authMode check code block
@@ -1536,7 +1541,7 @@ All @auth directives used on field definitions are performed when the field is r
     parent: ObjectTypeDefinitionNode,
     modelConfiguration: ModelDirectiveConfiguration,
     field?: FieldDefinitionNode,
-    subscriptionOperation?: ModelDirectiveOperationType
+    subscriptionOperation?: ModelDirectiveOperationType,
   ) {
     return this.protectUpdateOrDeleteMutation(
       ctx,
@@ -1547,7 +1552,7 @@ All @auth directives used on field definitions are performed when the field is r
       true,
       field,
       field ? raw(`$ctx.args.input.containsKey("${field.name.value}")`) : undefined,
-      subscriptionOperation
+      subscriptionOperation,
     );
   }
 
@@ -1567,7 +1572,7 @@ All @auth directives used on field definitions are performed when the field is r
     parent: ObjectTypeDefinitionNode,
     modelConfiguration: ModelDirectiveConfiguration,
     field?: FieldDefinitionNode,
-    subscriptionOperation?: ModelDirectiveOperationType
+    subscriptionOperation?: ModelDirectiveOperationType,
   ) {
     return this.protectUpdateOrDeleteMutation(
       ctx,
@@ -1580,7 +1585,7 @@ All @auth directives used on field definitions are performed when the field is r
       field
         ? raw(`$ctx.args.input.containsKey("${field.name.value}") && $util.isNull($ctx.args.input.get("${field.name.value}"))`)
         : undefined,
-      subscriptionOperation
+      subscriptionOperation,
     );
   }
 
@@ -1592,7 +1597,7 @@ All @auth directives used on field definitions are performed when the field is r
     ctx: TransformerContext,
     def: ObjectTypeDefinitionNode,
     rules: AuthRule[],
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const thisModelName = def.name.value;
     for (const inputDef of ctx.inputDocument.definitions) {
@@ -1628,7 +1633,7 @@ All @auth directives used on field definitions are performed when the field is r
     ctx: TransformerContext,
     def: ObjectTypeDefinitionNode,
     rules: AuthRule[],
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const secondaryKeyDirectivesWithQueries = (def.directives || []).filter(d => {
       const isKey = d.name.value === 'key';
@@ -1697,7 +1702,7 @@ All @auth directives used on field definitions are performed when the field is r
     ctx: TransformerContext,
     rules: AuthRule[],
     parent: ObjectTypeDefinitionNode,
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const names = modelConfiguration.getNames('onCreate');
     const level = modelConfiguration.getName('level') as ModelSubscriptionLevel;
@@ -1713,7 +1718,7 @@ All @auth directives used on field definitions are performed when the field is r
     ctx: TransformerContext,
     rules: AuthRule[],
     parent: ObjectTypeDefinitionNode,
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const names = modelConfiguration.getNames('onUpdate');
     const level = modelConfiguration.getName('level') as ModelSubscriptionLevel;
@@ -1729,7 +1734,7 @@ All @auth directives used on field definitions are performed when the field is r
     ctx: TransformerContext,
     rules: AuthRule[],
     parent: ObjectTypeDefinitionNode,
-    modelConfiguration: ModelDirectiveConfiguration
+    modelConfiguration: ModelDirectiveConfiguration,
   ) {
     const names = modelConfiguration.getNames('onDelete');
     const level = modelConfiguration.getName('level') as ModelSubscriptionLevel;
@@ -1747,7 +1752,7 @@ All @auth directives used on field definitions are performed when the field is r
     parent: ObjectTypeDefinitionNode,
     level: ModelSubscriptionLevel,
     fieldName: string,
-    mutationOperation: ModelDirectiveOperationType
+    mutationOperation: ModelDirectiveOperationType,
   ) {
     const resolverResourceId = ResolverResourceIDs.ResolverResourceID('Subscription', fieldName);
     const resolver = this.resources.generateSubscriptionResolver(fieldName);
@@ -1845,7 +1850,7 @@ All @auth directives used on field definitions are performed when the field is r
   private addSubscriptionOwnerArgument(ctx: TransformerContext, resolver: Resolver, ownerRules: AuthRule[], makeNonNull: boolean = false) {
     let subscription = ctx.getSubscription();
     let createField: FieldDefinitionNode = subscription.fields.find(
-      field => field.name.value === resolver.Properties.FieldName
+      field => field.name.value === resolver.Properties.FieldName,
     ) as FieldDefinitionNode;
     const nameNode: any = makeNonNull ? makeNonNullType(makeNamedType('String')) : makeNamedType('String');
     // const createArguments = [makeInputValueDefinition(DEFAULT_OWNER_FIELD, nameNode)];
@@ -1991,7 +1996,7 @@ All @auth directives used on field definitions are performed when the field is r
       Boolean(rules.find(r => r.provider === this.configuredAuthProviders.default)) &&
       Boolean(
         rules.find(r => r.provider !== this.configuredAuthProviders.default) &&
-          !Boolean(directives.find(d => d.name.value === authProviderDirectiveMap.get(this.configuredAuthProviders.default)))
+          !Boolean(directives.find(d => d.name.value === authProviderDirectiveMap.get(this.configuredAuthProviders.default))),
       )
     ) {
       directives.push(makeDirective(authProviderDirectiveMap.get(this.configuredAuthProviders.default), []));
@@ -2030,7 +2035,7 @@ All @auth directives used on field definitions are performed when the field is r
 
     if (rule.allow === 'groups' && rule.provider !== 'userPools' && rule.provider !== 'oidc') {
       throw new InvalidDirectiveError(
-        `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found '${rule.provider}' assigned.`
+        `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found '${rule.provider}' assigned.`,
       );
     }
 
@@ -2042,7 +2047,7 @@ All @auth directives used on field definitions are performed when the field is r
       if (rule.provider !== null && rule.provider !== 'userPools' && rule.provider !== 'oidc') {
         throw new InvalidDirectiveError(
           `@auth directive with 'owner' strategy only supports 'userPools' (default) and 'oidc' providers, but \
-found '${rule.provider}' assigned.`
+found '${rule.provider}' assigned.`,
         );
       }
     }
@@ -2055,7 +2060,7 @@ found '${rule.provider}' assigned.`
       if (rule.provider !== null && rule.provider !== 'apiKey' && rule.provider !== 'iam') {
         throw new InvalidDirectiveError(
           `@auth directive with 'public' strategy only supports 'apiKey' (default) and 'iam' providers, but \
-found '${rule.provider}' assigned.`
+found '${rule.provider}' assigned.`,
         );
       }
     }
@@ -2068,7 +2073,7 @@ found '${rule.provider}' assigned.`
       if (rule.provider !== null && rule.provider !== 'userPools' && rule.provider !== 'iam') {
         throw new InvalidDirectiveError(
           `@auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, but \
-found '${rule.provider}' assigned.`
+found '${rule.provider}' assigned.`,
         );
       }
     }
@@ -2079,19 +2084,19 @@ found '${rule.provider}' assigned.`
 
     if (rule.provider === 'apiKey' && this.configuredAuthProviders.hasApiKey === false) {
       throw new InvalidDirectiveError(
-        `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`
+        `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`,
       );
     } else if (rule.provider === 'oidc' && this.configuredAuthProviders.hasOIDC === false) {
       throw new InvalidDirectiveError(
-        `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`
+        `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`,
       );
     } else if (rule.provider === 'userPools' && this.configuredAuthProviders.hasUserPools === false) {
       throw new InvalidDirectiveError(
-        `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`
+        `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`,
       );
     } else if (rule.provider === 'iam' && this.configuredAuthProviders.hasIAM === false) {
       throw new InvalidDirectiveError(
-        `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`
+        `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`,
       );
     }
   }

--- a/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/MultiAuth.test.ts
@@ -117,12 +117,18 @@ const getSchemaWithNonModelField = (authDirective: string) => {
         id: ID!
         title: String!
         location: Location
+        status: Status
         createdAt: String
         updatedAt: String
     }
 
     type Location {
       name: String
+    }
+
+    enum Status {
+      PUBLISHED,
+      DRAFT
     }`;
 };
 
@@ -173,7 +179,7 @@ describe('Validation tests', () => {
       privateAuthDirective,
       apiKeyDefaultConfig,
       `@auth directive with 'userPools' provider found, but the project has no Cognito User \
-Pools authentication provider configured.`
+Pools authentication provider configured.`,
     );
   });
 
@@ -182,7 +188,7 @@ Pools authentication provider configured.`
       publicAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'apiKey' provider found, but the project has no API Key \
-authentication provider configured.`
+authentication provider configured.`,
     );
   });
 
@@ -191,7 +197,7 @@ authentication provider configured.`
       publicIAMAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'iam' provider found, but the project has no IAM \
-authentication provider configured.`
+authentication provider configured.`,
     );
   });
 
@@ -200,7 +206,7 @@ authentication provider configured.`
       ownerOpenIdAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT \
-authentication provider configured.`
+authentication provider configured.`,
     );
   });
 
@@ -209,7 +215,7 @@ authentication provider configured.`
       groupsWithProviderAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found \
-'iam' assigned`
+'iam' assigned`,
     );
   });
 
@@ -218,7 +224,7 @@ authentication provider configured.`
       ownerWithIAMAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'owner' strategy only supports 'userPools' (default) and \
-'oidc' providers, but found 'iam' assigned.`
+'oidc' providers, but found 'iam' assigned.`,
     );
   });
 
@@ -227,7 +233,7 @@ authentication provider configured.`
       publicUserPoolsAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'public' strategy only supports 'apiKey' (default) and 'iam' providers, but \
-found 'userPools' assigned.`
+found 'userPools' assigned.`,
     );
   });
 
@@ -236,7 +242,7 @@ found 'userPools' assigned.`
       privateWithApiKeyAuthDirective,
       userPoolsDefaultConfig,
       `@auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, but \
-found 'apiKey' assigned.`
+found 'apiKey' assigned.`,
     );
   });
 });
@@ -465,7 +471,7 @@ describe('Type directive transformation tests', () => {
           r['Fn::Sub'].length &&
           r['Fn::Sub'].length === 2 &&
           r['Fn::Sub'][1].typeName &&
-          r['Fn::Sub'][1].typeName === 'Location'
+          r['Fn::Sub'][1].typeName === 'Location',
       );
       expect(locationPolicy).toBeDefined();
     }
@@ -504,7 +510,7 @@ describe('Type directive transformation tests', () => {
         r['Fn::Sub'].length &&
         r['Fn::Sub'].length === 2 &&
         r['Fn::Sub'][1].typeName &&
-        r['Fn::Sub'][1].typeName === 'Location'
+        r['Fn::Sub'][1].typeName === 'Location',
     );
     expect(locationPolicy).toBeDefined();
   });


### PR DESCRIPTION
*Description of changes:*

- fix: non-model @auth propagation fails enum fields

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.