### PR TITLE
Filter graphql error.data based on query selection set

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -1,0 +1,57 @@
+import { create } from '../../../velocity/util/index';
+import { JavaMap } from '../../../velocity/value-mapper/map';
+import { GraphQLResolveInfo } from 'graphql';
+import { TemplateSentError } from '../../../velocity/util/errors';
+
+// jest.mock('../../../velocity/util/errors');
+
+const stubInfo = {
+  fieldName: 'testFieldName',
+  path: {
+    prev: null,
+    key: 'pathKey',
+  },
+  fieldNodes: [],
+  operation: {
+    selectionSet: {
+      selections: [
+        {
+          name: {
+            value: 'someOtherField',
+          },
+        },
+        {
+          name: {
+            value: 'testFieldName',
+          },
+          selectionSet: {
+            selections: [
+              {
+                name: {
+                  value: 'field1',
+                },
+              },
+              {
+                name: {
+                  value: 'field2',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+} as unknown;
+const mockInfo = stubInfo as GraphQLResolveInfo;
+
+const util = create(undefined, undefined, mockInfo);
+
+it('error_filterDataJavaMap', () => {
+  // setup
+  const stubJavaMap: JavaMap = new JavaMap({ field1: 'field1Value', field2: 'field2Value', field3: 'field3Value' }, x => x);
+
+  expect(() => util.error('test message', 'ERROR_TYPE', stubJavaMap)).toThrow();
+  expect(util.errors.length).toBe(1);
+  expect(util.errors[0].data).toStrictEqual({ field1: 'field1Value', field2: 'field2Value' });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -42,14 +42,21 @@ const stubInfo = {
   },
 } as unknown;
 const mockInfo = stubInfo as GraphQLResolveInfo;
+const stubJavaMap: JavaMap = new JavaMap({ field1: 'field1Value', field2: 'field2Value', field3: 'field3Value' }, x => x);
+var util;
 
-const util = create(undefined, undefined, mockInfo);
+beforeEach(() => {
+  util = create(undefined, undefined, mockInfo);
+});
 
 it('error_filterDataJavaMap', () => {
-  // setup
-  const stubJavaMap: JavaMap = new JavaMap({ field1: 'field1Value', field2: 'field2Value', field3: 'field3Value' }, x => x);
-
   expect(() => util.error('test message', 'ERROR_TYPE', stubJavaMap)).toThrow();
+  expect(util.errors.length).toBe(1);
+  expect(util.errors[0].data).toStrictEqual({ field1: 'field1Value', field2: 'field2Value' });
+});
+
+it('appendError_filterDataJavaMap', () => {
+  util.appendError('test message', 'ERROR_TYPE', stubJavaMap);
   expect(util.errors.length).toBe(1);
   expect(util.errors[0].data).toStrictEqual({ field1: 'field1Value', field2: 'field2Value' });
 });

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -3,8 +3,6 @@ import { JavaMap } from '../../../velocity/value-mapper/map';
 import { GraphQLResolveInfo } from 'graphql';
 import { TemplateSentError } from '../../../velocity/util/errors';
 
-// jest.mock('../../../velocity/util/errors');
-
 const stubInfo = {
   fieldName: 'testFieldName',
   path: {

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -4,6 +4,7 @@ import { JavaString } from '../value-mapper/string';
 import { JavaArray } from '../value-mapper/array';
 import { JavaMap } from '../value-mapper/map';
 import jsStringEscape from 'js-string-escape';
+import { GraphQLResolveInfo, FieldNode } from 'graphql';
 export const generalUtils = {
   errors: [],
   quiet: () => '',
@@ -40,20 +41,13 @@ export const generalUtils = {
     throw err;
   },
   error(message, type = null, data = null, errorInfo = null) {
-    if (data instanceof JavaMap) {
-      var filteredData = {};
-      // filter fields in data based on the query selection set
-      this.info.operation.selectionSet.selections
-        .find(selection => selection.name.value === this.info.fieldName)
-        .selectionSet.selections.map(fieldNode => fieldNode.name.value)
-        .forEach(field => (filteredData[field] = data.get(field)));
-      data = filteredData;
-    }
+    data = filterData(this.info, data);
     const err = new TemplateSentError(message, type, data, errorInfo, this.info);
     this.errors.push(err);
     throw err;
   },
   appendError(message, type = null, data = null, errorInfo = null) {
+    data = filterData(this.info, data);
     this.errors.push(new TemplateSentError(message, type, data, errorInfo, this.info));
     return '';
   },
@@ -129,3 +123,17 @@ export const generalUtils = {
     return new RegExp(pattern).test(value);
   },
 };
+
+function filterData(info: GraphQLResolveInfo, data = null): any {
+  if (data instanceof JavaMap) {
+    var filteredData = {};
+    // filter fields in data based on the query selection set
+    info.operation.selectionSet.selections
+      .map(selection => selection as FieldNode)
+      .find(selection => selection.name.value === info.fieldName)
+      .selectionSet.selections.map(fieldNode => (fieldNode as FieldNode).name.value)
+      .forEach(field => (filteredData[field] = data.get(field)));
+    data = filteredData;
+  }
+  return data;
+}

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -40,6 +40,15 @@ export const generalUtils = {
     throw err;
   },
   error(message, type = null, data = null, errorInfo = null) {
+    if (data instanceof JavaMap) {
+      var filteredData = {};
+      // filter fields in data based on the query selection set
+      this.info.operation.selectionSet.selections
+        .find(selection => selection.name.value === this.info.fieldName)
+        .selectionSet.selections.map(fieldNode => fieldNode.name.value)
+        .forEach(field => (filteredData[field] = data.get(field)));
+      data = filteredData;
+    }
     const err = new TemplateSentError(message, type, data, errorInfo, this.info);
     this.errors.push(err);
     throw err;


### PR DESCRIPTION
Fixes #3202

Based on the [AppSync docs](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-util-reference.html) $util.error(string, string, data) and $util.appendError(string, string, data) should filter the fields of data based on the query selection set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.