### PR TITLE
fix(amplify-velocity-template): #Return directive called several times

### DIFF
--- a/packages/amplify-velocity-template/src/compile/compile.js
+++ b/packages/amplify-velocity-template/src/compile/compile.js
@@ -28,6 +28,7 @@ module.exports = function(Velocity, utils) {
      * @return str
      */
     render: function(context, macros, silence) {
+      this._state = { stop: false, break: false, return: false };
       this.silence = !!silence;
       this.context = context || {};
       this.jsmacros = utils.mixin(macros || {}, this.directive);

--- a/packages/amplify-velocity-template/tests/return.test.js
+++ b/packages/amplify-velocity-template/tests/return.test.js
@@ -32,4 +32,13 @@ describe('Return', function() {
     console.log(tpl);
     html.should.containEql('');
   });
+
+  it('return value several times', function() {
+    var tpl = `#return ("Foo")`;
+    var compile = new Compile(parse(tpl));
+    const result = compile.render(context);
+    const result2 = compile.render(context);
+    result.should.containEql('Foo');
+    result2.should.containEql('Foo');
+  });
 });


### PR DESCRIPTION
*Issue #, if available:*
No issue exists

*Description of changes:*
When the same resolver is called several times and a `#return` directive is in the template, it stops working the second time.
This is because the same [`Compiler`](https://github.com/aws-amplify/amplify-cli/blob/6795e783c104004a2b2576f6903b35c1c6d2ed03/packages/amplify-appsync-simulator/src/velocity/index.ts#L34) is being reused and `state.stop` is not being reset before the following `render()` is called.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.