### PR TITLE
feat(amplify-graphql-types-generator): generate model types

### DIFF
--- a/packages/amplify-graphql-types-generator/src/angular/index.ts
+++ b/packages/amplify-graphql-types-generator/src/angular/index.ts
@@ -8,7 +8,7 @@ import {
   interfaceDeclarationForFragment,
   propertiesFromFields,
   updateTypeNameField,
-  propertyDeclarations,
+  pickedPropertyDeclarations,
   interfaceNameFromOperation,
 } from '../typescript/codeGeneration';
 import { typeNameFromGraphQLType } from '../typescript/types';
@@ -83,7 +83,7 @@ function interfaceDeclarationForOperation(generator: CodeGenerator, { operationN
         interfaceName,
       },
       () => {
-        propertyDeclarations(generator, properties);
+        pickedPropertyDeclarations(generator, properties);
       },
     );
   }

--- a/packages/amplify-graphql-types-generator/src/flow/codeGeneration.js
+++ b/packages/amplify-graphql-types-generator/src/flow/codeGeneration.js
@@ -308,7 +308,7 @@ export function propertyFromField(context, field) {
   }
 }
 
-export function propertyDeclarations(generator, properties, isInput) {
+export function propertyDeclarations(generator, properties, isOptional) {
   if (!properties) return;
   properties.forEach(property => {
     if (isAbstractType(getNamedType(property.type || property.fieldType))) {
@@ -367,11 +367,11 @@ export function propertyDeclarations(generator, properties, isInput) {
           }
         });
         propertyDeclaration(generator, property, () => {
-          const properties = propertiesFromFields(generator.context, fields);
-          propertyDeclarations(generator, properties, isInput);
+          const properties = propertiesFromFields(generator.context, property.fields);
+          propertyDeclarations(generator, properties, isOptional);
         });
       } else {
-        propertyDeclaration(generator, { ...property, isInput });
+        propertyDeclaration(generator, { ...property, isOptional });
       }
     }
   });

--- a/packages/amplify-graphql-types-generator/src/flow/codeGeneration.js
+++ b/packages/amplify-graphql-types-generator/src/flow/codeGeneration.js
@@ -355,17 +355,6 @@ export function propertyDeclarations(generator, properties, isOptional) {
         (property.inlineFragments && property.inlineFragments.length > 0) ||
         (property.fragmentSpreads && property.fragmentSpreads.length > 0)
       ) {
-        const fields = property.fields.map(field => {
-          if (field.fieldName === '__typename') {
-            return {
-              ...field,
-              typeName: `"${property.typeName}"`,
-              type: { name: `"${property.typeName}"` },
-            };
-          } else {
-            return field;
-          }
-        });
         propertyDeclaration(generator, property, () => {
           const properties = propertiesFromFields(generator.context, property.fields);
           propertyDeclarations(generator, properties, isOptional);

--- a/packages/amplify-graphql-types-generator/src/flow/language.js
+++ b/packages/amplify-graphql-types-generator/src/flow/language.js
@@ -21,10 +21,10 @@ export function typeDeclaration(generator, { interfaceName, noBrackets }, closur
 
 export function propertyDeclaration(
   generator,
-  { fieldName, type, propertyName, typeName, description, isArray, isNullable, isArrayElementNullable, fragmentSpreads, isInput },
+  { fieldName, type, propertyName, typeName, description, isArray, isNullable, isArrayElementNullable, fragmentSpreads, isOptional },
   closure,
   open = ' {|',
-  close = '|}'
+  close = '|}',
 ) {
   const name = fieldName || propertyName;
 
@@ -36,7 +36,7 @@ export function propertyDeclaration(
 
   if (closure) {
     generator.printOnNewline(name);
-    if (isInput && isNullable) {
+    if (isOptional && isNullable) {
       generator.print('?');
     }
     generator.print(':');
@@ -64,7 +64,7 @@ export function propertyDeclaration(
     }
   } else {
     generator.printOnNewline(name);
-    if (isInput && isNullable) {
+    if (isOptional && isNullable) {
       generator.print('?');
     }
     generator.print(`: ${typeName || typeNameFromGraphQLType(generator.context, type)}`);
@@ -110,7 +110,7 @@ export function propertySetsDeclaration(generator, property, propertySets, stand
       });
     },
     '(',
-    ')'
+    ')',
   );
 
   generator.popScope();

--- a/packages/amplify-graphql-types-generator/src/serializeToJSON.ts
+++ b/packages/amplify-graphql-types-generator/src/serializeToJSON.ts
@@ -1,4 +1,19 @@
-import { isType, GraphQLType, GraphQLScalarType, GraphQLEnumType, GraphQLInputObjectType } from 'graphql';
+import {
+  isType,
+  isEnumType,
+  isUnionType,
+  isInputObjectType,
+  isObjectType,
+  isInterfaceType,
+  isScalarType,
+  GraphQLType,
+  GraphQLScalarType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+} from 'graphql';
 
 import { LegacyCompilerContext } from './compiler/legacyIR';
 
@@ -9,7 +24,7 @@ export default function serializeToJSON(context: LegacyCompilerContext) {
       fragments: Object.values(context.fragments),
       typesUsed: context.typesUsed.map(serializeType),
     },
-    '\t'
+    '\t',
   );
 }
 
@@ -23,16 +38,22 @@ export function serializeAST(ast: any, space?: string) {
         return value;
       }
     },
-    space
+    space,
   );
 }
 
 function serializeType(type: GraphQLType) {
-  if (type instanceof GraphQLEnumType) {
+  if (isEnumType(type)) {
     return serializeEnumType(type);
-  } else if (type instanceof GraphQLInputObjectType) {
+  } else if (isUnionType(type)) {
+    return serializeUnionType(type);
+  } else if (isInputObjectType(type)) {
     return serializeInputObjectType(type);
-  } else if (type instanceof GraphQLScalarType) {
+  } else if (isObjectType(type)) {
+    return serializeObjectType(type);
+  } else if (isInterfaceType(type)) {
+    return serializeInterfaceType(type);
+  } else if (isScalarType(type)) {
     return serializeScalarType(type);
   } else {
     throw new Error(`Unexpected GraphQL type: ${type}`);
@@ -56,6 +77,21 @@ function serializeEnumType(type: GraphQLEnumType) {
   };
 }
 
+function serializeUnionType(type: GraphQLUnionType) {
+  const { name, description } = type;
+  const types = type.getTypes();
+
+  return {
+    kind: 'UnionType',
+    name,
+    description,
+    types: types.map(type => ({
+      name: type.name,
+      description: type.description,
+    })),
+  };
+}
+
 function serializeInputObjectType(type: GraphQLInputObjectType) {
   const { name, description } = type;
   const fields = Object.values(type.getFields());
@@ -69,6 +105,43 @@ function serializeInputObjectType(type: GraphQLInputObjectType) {
       type: String(field.type),
       description: field.description,
       defaultValue: field.defaultValue,
+    })),
+  };
+}
+
+function serializeObjectType(type: GraphQLObjectType) {
+  const { name, description } = type;
+  const ifaces = Object.values(type.getInterfaces());
+  const fields = Object.values(type.getFields());
+
+  return {
+    kind: 'ObjectType',
+    name,
+    description,
+    ifaces: ifaces.map(iface => ({
+      name: iface.name,
+      description: iface.description,
+    })),
+    fields: fields.map(field => ({
+      name: field.name,
+      type: String(field.type),
+      description: field.description,
+    })),
+  };
+}
+
+function serializeInterfaceType(type: GraphQLInterfaceType) {
+  const { name, description } = type;
+  const fields = Object.values(type.getFields());
+
+  return {
+    kind: 'InterfaceType',
+    name,
+    description,
+    fields: fields.map(field => ({
+      name: field.name,
+      type: String(field.type),
+      description: field.description,
     })),
   };
 }

--- a/packages/amplify-graphql-types-generator/src/typescript/codeGeneration.ts
+++ b/packages/amplify-graphql-types-generator/src/typescript/codeGeneration.ts
@@ -114,7 +114,7 @@ function structDeclarationForInputObjectType(generator: CodeGenerator, type: Gra
     },
     () => {
       const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
-      properties.forEach(property => propertyDeclaration(generator, { ...property, isOptional: true }));
+      properties.forEach(property => propertyDeclaration(generator, { ...property }));
     },
   );
 }

--- a/packages/amplify-graphql-types-generator/src/typescript/codeGeneration.ts
+++ b/packages/amplify-graphql-types-generator/src/typescript/codeGeneration.ts
@@ -5,12 +5,16 @@ import {
   isCompositeType,
   isAbstractType,
   GraphQLEnumType,
-  GraphQLNonNull,
-  GraphQLInputObjectType,
-  GraphQLType,
-  GraphQLUnionType,
-  GraphQLInterfaceType,
   GraphQLObjectType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLType,
+  isEnumType,
+  isUnionType,
+  isInterfaceType,
+  isObjectType,
+  isInputObjectType,
   isListType,
   isNonNullType,
 } from 'graphql';
@@ -19,7 +23,7 @@ import { wrap } from '../utilities/printing';
 
 import { CodeGenerator } from '../utilities/CodeGenerator';
 
-import { interfaceDeclaration, propertyDeclaration, propertySetsDeclaration, Property } from './language';
+import { interfaceDeclaration, propertyDeclaration, pickedPropertySetsDeclaration, Property } from './language';
 
 import { typeNameFromGraphQLType } from './types';
 import Maybe from 'graphql/tsutils/Maybe';
@@ -44,10 +48,16 @@ export function generateSource(context: LegacyCompilerContext) {
 }
 
 export function typeDeclarationForGraphQLType(generator: CodeGenerator, type: GraphQLType) {
-  if (type instanceof GraphQLEnumType) {
+  if (isEnumType(type)) {
     enumerationDeclaration(generator, type);
-  } else if (type instanceof GraphQLInputObjectType) {
+  } else if (isUnionType(type)) {
+    unionDeclaration(generator, type);
+  } else if (isInputObjectType(type)) {
     structDeclarationForInputObjectType(generator, type);
+  } else if (isObjectType(type)) {
+    structDeclarationForObjectType(generator, type);
+  } else if (isInterfaceType(type)) {
+    structDeclarationForInterfaceType(generator, type);
   }
 }
 
@@ -78,6 +88,23 @@ function enumerationDeclaration(generator: CodeGenerator, type: GraphQLEnumType)
   generator.printNewline();
 }
 
+function unionDeclaration(generator: CodeGenerator, type: GraphQLUnionType) {
+  const { name, description } = type;
+  const value = type
+    .getTypes()
+    .map(type => type.name)
+    .join(' | ');
+
+  generator.printNewlineIfNeeded();
+  if (description) {
+    description.split('\n').forEach(line => {
+      generator.printOnNewline(`// ${line.trim()}`);
+    });
+  }
+  generator.printOnNewline(`export type ${name} = ${value}`);
+  generator.printNewline();
+}
+
 function structDeclarationForInputObjectType(generator: CodeGenerator, type: GraphQLInputObjectType) {
   const interfaceName = type.name;
   interfaceDeclaration(
@@ -87,7 +114,37 @@ function structDeclarationForInputObjectType(generator: CodeGenerator, type: Gra
     },
     () => {
       const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
-      propertyDeclarations(generator, properties, true);
+      properties.forEach(property => propertyDeclaration(generator, { ...property, isOptional: true }));
+    },
+  );
+}
+
+function structDeclarationForObjectType(generator: CodeGenerator, type: GraphQLObjectType) {
+  const interfaceName = type.name;
+  interfaceDeclaration(
+    generator,
+    {
+      interfaceName,
+    },
+    () => {
+      const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
+      propertyDeclaration(generator, { fieldName: '__typename', typeName: `"${interfaceName}"` });
+      properties.forEach(property => propertyDeclaration(generator, { ...property, isOptional: true }));
+    },
+  );
+}
+
+function structDeclarationForInterfaceType(generator: CodeGenerator, type: GraphQLInterfaceType) {
+  const interfaceName = type.name;
+  interfaceDeclaration(
+    generator,
+    {
+      interfaceName,
+    },
+    () => {
+      const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
+      propertyDeclaration(generator, { fieldName: '__typename', typeName: `"${interfaceName}"` });
+      properties.forEach(property => propertyDeclaration(generator, { ...property, isOptional: true }));
     },
   );
 }
@@ -124,7 +181,7 @@ export function interfaceVariablesDeclarationForOperation(
     },
     () => {
       const properties = propertiesFromFields(generator.context, variables);
-      propertyDeclarations(generator, properties, true);
+      pickedPropertyDeclarations(generator, properties, true);
     },
   );
 }
@@ -136,10 +193,10 @@ function getObjectTypeName(type: GraphQLType): string {
   if (isNonNullType(type)) {
     return getObjectTypeName(type.ofType);
   }
-  if (type instanceof GraphQLObjectType) {
+  if (isObjectType(type)) {
     return `"${type.name}"`;
   }
-  if (type instanceof GraphQLUnionType) {
+  if (isUnionType(type)) {
     return type
       .getTypes()
       .map(type => getObjectTypeName(type))
@@ -183,7 +240,7 @@ export function interfaceDeclarationForOperation(generator: CodeGenerator, { ope
       interfaceName,
     },
     () => {
-      propertyDeclarations(generator, properties);
+      pickedPropertyDeclarations(generator, properties);
     },
   );
 }
@@ -240,7 +297,7 @@ export function interfaceDeclarationForFragment(generator: CodeGenerator, fragme
           }
         });
 
-        propertySetsDeclaration(generator, fragment, propertySets, true);
+        pickedPropertySetsDeclaration(generator, fragment, propertySets, true);
       } else {
         const fragmentFields = fields.map(field => {
           if (field.fieldName === '__typename') {
@@ -255,7 +312,7 @@ export function interfaceDeclarationForFragment(generator: CodeGenerator, fragme
         });
 
         const properties = propertiesFromFields(generator.context, fragmentFields);
-        propertyDeclarations(generator, properties);
+        pickedPropertyDeclarations(generator, properties);
       }
     },
   );
@@ -299,7 +356,7 @@ export function propertyFromField(
   const namedType = getNamedType(fieldType);
 
   let isNullable = true;
-  if (fieldType instanceof GraphQLNonNull) {
+  if (isNonNullType(fieldType)) {
     isNullable = false;
   }
 
@@ -309,10 +366,10 @@ export function propertyFromField(
     let isArrayElementNullable = null;
     if (isListType(fieldType)) {
       isArray = true;
-      isArrayElementNullable = !(fieldType.ofType instanceof GraphQLNonNull);
+      isArrayElementNullable = !isNonNullType(fieldType.ofType);
     } else if (isNonNullType(fieldType) && isListType(fieldType.ofType)) {
       isArray = true;
-      isArrayElementNullable = !(fieldType.ofType.ofType instanceof GraphQLNonNull);
+      isArrayElementNullable = !isNonNullType(fieldType.ofType.ofType);
     }
 
     return {
@@ -338,7 +395,8 @@ export function propertyFromField(
   }
 }
 
-export function propertyDeclarations(generator: CodeGenerator, properties: Property[], isInput = false) {
+// pickedPropertyDeclarations declares specific properties selected by execution schemas or fragment schemas.
+export function pickedPropertyDeclarations(generator: CodeGenerator, properties: Property[], isOptional = false) {
   if (!properties) return;
   properties.forEach(property => {
     if (isAbstractType(getNamedType(property.type || property.fieldType!))) {
@@ -380,30 +438,19 @@ export function propertyDeclarations(generator: CodeGenerator, properties: Prope
         }
       });
 
-      propertySetsDeclaration(generator, property, propertySets);
+      pickedPropertySetsDeclaration(generator, property, propertySets);
     } else {
       if (
         (property.fields && property.fields.length > 0) ||
         (property.inlineFragments && property.inlineFragments.length > 0) ||
         (property.fragmentSpreads && property.fragmentSpreads.length > 0)
       ) {
-        const fields = property.fields!.map(field => {
-          if (field.fieldName === '__typename') {
-            return {
-              ...field,
-              typeName: `"${property.typeName}"`,
-              type: { name: `"${property.typeName}"` } as GraphQLType,
-            };
-          } else {
-            return field;
-          }
-        });
         propertyDeclaration(generator, property, () => {
-          const properties = propertiesFromFields(generator.context, fields!);
-          propertyDeclarations(generator, properties, isInput);
+          const properties = propertiesFromFields(generator.context, property.fields!);
+          pickedPropertyDeclarations(generator, properties, isOptional);
         });
       } else {
-        propertyDeclaration(generator, { ...property, isInput });
+        propertyDeclaration(generator, { ...property, isOptional });
       }
     }
   });
@@ -417,7 +464,7 @@ export function propertyDeclarations(generator: CodeGenerator, properties: Prope
 function getPossibleTypeNames(generator: CodeGenerator<LegacyCompilerContext>, property: Property) {
   const type = getNamedType(property.fieldType || property.type!);
 
-  if (type instanceof GraphQLUnionType || type instanceof GraphQLInterfaceType) {
+  if (isUnionType(type) || isInterfaceType(type)) {
     return generator.context.schema.getPossibleTypes(type).map(type => type.name);
   }
 

--- a/packages/amplify-graphql-types-generator/src/typescript/language.ts
+++ b/packages/amplify-graphql-types-generator/src/typescript/language.ts
@@ -1,6 +1,6 @@
 import { LegacyInlineFragment } from '../compiler/legacyIR';
 
-import { propertyDeclarations } from './codeGeneration';
+import { pickedPropertyDeclarations } from './codeGeneration';
 import { typeNameFromGraphQLType } from './types';
 
 import { CodeGenerator } from '../utilities/CodeGenerator';
@@ -19,7 +19,7 @@ export interface Property {
   fields?: any[];
   inlineFragments?: LegacyInlineFragment[];
   fragmentSpreads?: any;
-  isInput?: boolean;
+  isOptional?: boolean;
   isArray?: boolean;
   isArrayElementNullable?: boolean | null;
 }
@@ -27,7 +27,7 @@ export interface Property {
 export function interfaceDeclaration(
   generator: CodeGenerator,
   { interfaceName, noBrackets }: { interfaceName: string; noBrackets?: boolean },
-  closure: () => void
+  closure: () => void,
 ) {
   generator.printNewlineIfNeeded();
   generator.printNewline();
@@ -44,8 +44,8 @@ export function interfaceDeclaration(
 
 export function propertyDeclaration(
   generator: CodeGenerator,
-  { fieldName, type, propertyName, typeName, description, isInput, isArray, isNullable, isArrayElementNullable }: Property,
-  closure?: () => void
+  { fieldName, type, propertyName, typeName, description, isOptional, isArray, isNullable, isArrayElementNullable }: Property,
+  closure?: () => void,
 ) {
   const name = fieldName || propertyName;
 
@@ -58,7 +58,7 @@ export function propertyDeclaration(
   if (closure) {
     generator.printOnNewline(name);
 
-    if (isNullable && isInput) {
+    if (isNullable && isOptional) {
       generator.print('?');
     }
     generator.print(': ');
@@ -84,7 +84,7 @@ export function propertyDeclaration(
     }
   } else {
     generator.printOnNewline(name);
-    if (isInput && isNullable) {
+    if (isOptional && isNullable) {
       generator.print('?');
     }
     generator.print(`: ${typeName || (type && typeNameFromGraphQLType(generator.context, type))}`);
@@ -92,7 +92,12 @@ export function propertyDeclaration(
   generator.print(',');
 }
 
-export function propertySetsDeclaration(generator: CodeGenerator, property: Property, propertySets: Property[][], standalone = false) {
+export function pickedPropertySetsDeclaration(
+  generator: CodeGenerator,
+  property: Property,
+  propertySets: Property[][],
+  standalone = false,
+) {
   const { description, fieldName, propertyName, isNullable, isArray, isArrayElementNullable } = property;
   const name = fieldName || propertyName;
 
@@ -116,7 +121,7 @@ export function propertySetsDeclaration(generator: CodeGenerator, property: Prop
     () => {
       propertySets.forEach((propertySet, index, propertySets) => {
         generator.withinBlock(() => {
-          propertyDeclarations(generator, propertySet);
+          pickedPropertyDeclarations(generator, propertySet);
         });
         if (index !== propertySets.length - 1) {
           generator.print(' |');
@@ -124,7 +129,7 @@ export function propertySetsDeclaration(generator: CodeGenerator, property: Prop
       });
     },
     '(',
-    ')'
+    ')',
   );
 
   generator.popScope();
@@ -158,7 +163,7 @@ export function methodDeclaration(
     async: boolean;
     args: Array<string>;
   },
-  closure: () => void
+  closure: () => void,
 ) {
   generator.printNewline();
   if (async) generator.print('async ');

--- a/packages/amplify-graphql-types-generator/src/typescript/language.ts
+++ b/packages/amplify-graphql-types-generator/src/typescript/language.ts
@@ -58,7 +58,7 @@ export function propertyDeclaration(
   if (closure) {
     generator.printOnNewline(name);
 
-    if (isNullable && isOptional) {
+    if (isNullable || isOptional) {
       generator.print('?');
     }
     generator.print(': ');
@@ -84,10 +84,26 @@ export function propertyDeclaration(
     }
   } else {
     generator.printOnNewline(name);
-    if (isOptional && isNullable) {
+    if (isOptional || isNullable) {
       generator.print('?');
     }
-    generator.print(`: ${typeName || (type && typeNameFromGraphQLType(generator.context, type))}`);
+    generator.print(': ');
+
+    if (isArray) {
+      generator.print(' Array<');
+    }
+    generator.print(`${typeName || (type && typeNameFromGraphQLType(generator.context, type))}`);
+    if (isArray) {
+      if (isArrayElementNullable) {
+        generator.print(' | null');
+      }
+      generator.print(' >');
+    }
+
+    // When typeName is passed as string it includes <typename> | null for nullable types.
+    if (isNullable && (!typeName || isArray)) {
+      generator.print(' | null');
+    }
   }
   generator.print(',');
 }

--- a/packages/amplify-graphql-types-generator/test/__snapshots__/jsonOutput.ts.snap
+++ b/packages/amplify-graphql-types-generator/test/__snapshots__/jsonOutput.ts.snap
@@ -149,6 +149,24 @@ exports[`JSON output should generate JSON output for a mutation with an enum and
 					\\"description\\": \\"\\"
 				}
 			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Review\\",
+			\\"description\\": \\"Represents a review for a movie\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"stars\\",
+					\\"type\\": \\"Int!\\",
+					\\"description\\": \\"The number of stars this review gave, 1-5\\"
+				},
+				{
+					\\"name\\": \\"commentary\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"Comment about the movie\\"
+				}
+			]
 		}
 	]
 }"
@@ -295,7 +313,263 @@ exports[`JSON output should generate JSON output for a query with a fragment spr
 			]
 		}
 	],
-	\\"typesUsed\\": []
+	\\"typesUsed\\": [
+		{
+			\\"kind\\": \\"InterfaceType\\",
+			\\"name\\": \\"Character\\",
+			\\"description\\": \\"A character from the Star Wars universe\\",
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the character\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"The name of the character\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"The friends of the character, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the character exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this character appears in\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Human\\",
+			\\"description\\": \\"A humanoid creature from the Star Wars universe\\",
+			\\"ifaces\\": [
+				{
+					\\"name\\": \\"Character\\",
+					\\"description\\": \\"A character from the Star Wars universe\\"
+				}
+			],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the human\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"What this human calls themselves\\"
+				},
+				{
+					\\"name\\": \\"homePlanet\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"The home planet of the human, or null if unknown\\"
+				},
+				{
+					\\"name\\": \\"height\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Height in the preferred unit, default is meters\\"
+				},
+				{
+					\\"name\\": \\"mass\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Mass in kilograms, or null if unknown\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"This human's friends, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the human exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this human appears in\\"
+				},
+				{
+					\\"name\\": \\"starships\\",
+					\\"type\\": \\"[Starship]\\",
+					\\"description\\": \\"A list of starships this person has piloted, or an empty list if none\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"FriendsConnection\\",
+			\\"description\\": \\"A connection object for a character's friends\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"totalCount\\",
+					\\"type\\": \\"Int\\",
+					\\"description\\": \\"The total number of friends\\"
+				},
+				{
+					\\"name\\": \\"edges\\",
+					\\"type\\": \\"[FriendsEdge]\\",
+					\\"description\\": \\"The edges for each of the character's friends.\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"A list of the friends, as a convenience when edges are not needed.\\"
+				},
+				{
+					\\"name\\": \\"pageInfo\\",
+					\\"type\\": \\"PageInfo!\\",
+					\\"description\\": \\"Information for paginating this connection\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"FriendsEdge\\",
+			\\"description\\": \\"An edge object for a character's friends\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"cursor\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"A cursor used for pagination\\"
+				},
+				{
+					\\"name\\": \\"node\\",
+					\\"type\\": \\"Character\\",
+					\\"description\\": \\"The character represented by this friendship edge\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"PageInfo\\",
+			\\"description\\": \\"Information for paginating this connection\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"startCursor\\",
+					\\"type\\": \\"ID\\",
+					\\"description\\": \\"\\"
+				},
+				{
+					\\"name\\": \\"endCursor\\",
+					\\"type\\": \\"ID\\",
+					\\"description\\": \\"\\"
+				},
+				{
+					\\"name\\": \\"hasNextPage\\",
+					\\"type\\": \\"Boolean!\\",
+					\\"description\\": \\"\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"EnumType\\",
+			\\"name\\": \\"Episode\\",
+			\\"description\\": \\"The episodes in the Star Wars trilogy\\",
+			\\"values\\": [
+				{
+					\\"name\\": \\"NEWHOPE\\",
+					\\"description\\": \\"Star Wars Episode IV: A New Hope, released in 1977.\\",
+					\\"isDeprecated\\": false,
+					\\"deprecationReason\\": null
+				},
+				{
+					\\"name\\": \\"EMPIRE\\",
+					\\"description\\": \\"Star Wars Episode V: The Empire Strikes Back, released in 1980.\\",
+					\\"isDeprecated\\": false,
+					\\"deprecationReason\\": null
+				},
+				{
+					\\"name\\": \\"JEDI\\",
+					\\"description\\": \\"Star Wars Episode VI: Return of the Jedi, released in 1983.\\",
+					\\"isDeprecated\\": false,
+					\\"deprecationReason\\": null
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Starship\\",
+			\\"description\\": \\"\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the starship\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"The name of the starship\\"
+				},
+				{
+					\\"name\\": \\"length\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Length of the starship, along the longest axis\\"
+				},
+				{
+					\\"name\\": \\"coordinates\\",
+					\\"type\\": \\"[[Float!]!]\\",
+					\\"description\\": \\"\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Droid\\",
+			\\"description\\": \\"An autonomous mechanical character in the Star Wars universe\\",
+			\\"ifaces\\": [
+				{
+					\\"name\\": \\"Character\\",
+					\\"description\\": \\"A character from the Star Wars universe\\"
+				}
+			],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the droid\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"What others call this droid\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"This droid's friends, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the droid exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this droid appears in\\"
+				},
+				{
+					\\"name\\": \\"primaryFunction\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"This droid's primary function\\"
+				}
+			]
+		}
+	]
 }"
 `;
 
@@ -370,7 +644,263 @@ exports[`JSON output should generate JSON output for a query with a nested selec
 		}
 	],
 	\\"fragments\\": [],
-	\\"typesUsed\\": []
+	\\"typesUsed\\": [
+		{
+			\\"kind\\": \\"InterfaceType\\",
+			\\"name\\": \\"Character\\",
+			\\"description\\": \\"A character from the Star Wars universe\\",
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the character\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"The name of the character\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"The friends of the character, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the character exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this character appears in\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Human\\",
+			\\"description\\": \\"A humanoid creature from the Star Wars universe\\",
+			\\"ifaces\\": [
+				{
+					\\"name\\": \\"Character\\",
+					\\"description\\": \\"A character from the Star Wars universe\\"
+				}
+			],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the human\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"What this human calls themselves\\"
+				},
+				{
+					\\"name\\": \\"homePlanet\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"The home planet of the human, or null if unknown\\"
+				},
+				{
+					\\"name\\": \\"height\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Height in the preferred unit, default is meters\\"
+				},
+				{
+					\\"name\\": \\"mass\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Mass in kilograms, or null if unknown\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"This human's friends, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the human exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this human appears in\\"
+				},
+				{
+					\\"name\\": \\"starships\\",
+					\\"type\\": \\"[Starship]\\",
+					\\"description\\": \\"A list of starships this person has piloted, or an empty list if none\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"FriendsConnection\\",
+			\\"description\\": \\"A connection object for a character's friends\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"totalCount\\",
+					\\"type\\": \\"Int\\",
+					\\"description\\": \\"The total number of friends\\"
+				},
+				{
+					\\"name\\": \\"edges\\",
+					\\"type\\": \\"[FriendsEdge]\\",
+					\\"description\\": \\"The edges for each of the character's friends.\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"A list of the friends, as a convenience when edges are not needed.\\"
+				},
+				{
+					\\"name\\": \\"pageInfo\\",
+					\\"type\\": \\"PageInfo!\\",
+					\\"description\\": \\"Information for paginating this connection\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"FriendsEdge\\",
+			\\"description\\": \\"An edge object for a character's friends\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"cursor\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"A cursor used for pagination\\"
+				},
+				{
+					\\"name\\": \\"node\\",
+					\\"type\\": \\"Character\\",
+					\\"description\\": \\"The character represented by this friendship edge\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"PageInfo\\",
+			\\"description\\": \\"Information for paginating this connection\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"startCursor\\",
+					\\"type\\": \\"ID\\",
+					\\"description\\": \\"\\"
+				},
+				{
+					\\"name\\": \\"endCursor\\",
+					\\"type\\": \\"ID\\",
+					\\"description\\": \\"\\"
+				},
+				{
+					\\"name\\": \\"hasNextPage\\",
+					\\"type\\": \\"Boolean!\\",
+					\\"description\\": \\"\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"EnumType\\",
+			\\"name\\": \\"Episode\\",
+			\\"description\\": \\"The episodes in the Star Wars trilogy\\",
+			\\"values\\": [
+				{
+					\\"name\\": \\"NEWHOPE\\",
+					\\"description\\": \\"Star Wars Episode IV: A New Hope, released in 1977.\\",
+					\\"isDeprecated\\": false,
+					\\"deprecationReason\\": null
+				},
+				{
+					\\"name\\": \\"EMPIRE\\",
+					\\"description\\": \\"Star Wars Episode V: The Empire Strikes Back, released in 1980.\\",
+					\\"isDeprecated\\": false,
+					\\"deprecationReason\\": null
+				},
+				{
+					\\"name\\": \\"JEDI\\",
+					\\"description\\": \\"Star Wars Episode VI: Return of the Jedi, released in 1983.\\",
+					\\"isDeprecated\\": false,
+					\\"deprecationReason\\": null
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Starship\\",
+			\\"description\\": \\"\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the starship\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"The name of the starship\\"
+				},
+				{
+					\\"name\\": \\"length\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Length of the starship, along the longest axis\\"
+				},
+				{
+					\\"name\\": \\"coordinates\\",
+					\\"type\\": \\"[[Float!]!]\\",
+					\\"description\\": \\"\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Droid\\",
+			\\"description\\": \\"An autonomous mechanical character in the Star Wars universe\\",
+			\\"ifaces\\": [
+				{
+					\\"name\\": \\"Character\\",
+					\\"description\\": \\"A character from the Star Wars universe\\"
+				}
+			],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the droid\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"What others call this droid\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"This droid's friends, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the droid exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this droid appears in\\"
+				},
+				{
+					\\"name\\": \\"primaryFunction\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"This droid's primary function\\"
+				}
+			]
+		}
+	]
 }"
 `;
 
@@ -457,6 +987,236 @@ exports[`JSON output should generate JSON output for a query with an enum variab
 					\\"description\\": \\"Star Wars Episode VI: Return of the Jedi, released in 1983.\\",
 					\\"isDeprecated\\": false,
 					\\"deprecationReason\\": null
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"InterfaceType\\",
+			\\"name\\": \\"Character\\",
+			\\"description\\": \\"A character from the Star Wars universe\\",
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the character\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"The name of the character\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"The friends of the character, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the character exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this character appears in\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Human\\",
+			\\"description\\": \\"A humanoid creature from the Star Wars universe\\",
+			\\"ifaces\\": [
+				{
+					\\"name\\": \\"Character\\",
+					\\"description\\": \\"A character from the Star Wars universe\\"
+				}
+			],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the human\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"What this human calls themselves\\"
+				},
+				{
+					\\"name\\": \\"homePlanet\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"The home planet of the human, or null if unknown\\"
+				},
+				{
+					\\"name\\": \\"height\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Height in the preferred unit, default is meters\\"
+				},
+				{
+					\\"name\\": \\"mass\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Mass in kilograms, or null if unknown\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"This human's friends, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the human exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this human appears in\\"
+				},
+				{
+					\\"name\\": \\"starships\\",
+					\\"type\\": \\"[Starship]\\",
+					\\"description\\": \\"A list of starships this person has piloted, or an empty list if none\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"FriendsConnection\\",
+			\\"description\\": \\"A connection object for a character's friends\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"totalCount\\",
+					\\"type\\": \\"Int\\",
+					\\"description\\": \\"The total number of friends\\"
+				},
+				{
+					\\"name\\": \\"edges\\",
+					\\"type\\": \\"[FriendsEdge]\\",
+					\\"description\\": \\"The edges for each of the character's friends.\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"A list of the friends, as a convenience when edges are not needed.\\"
+				},
+				{
+					\\"name\\": \\"pageInfo\\",
+					\\"type\\": \\"PageInfo!\\",
+					\\"description\\": \\"Information for paginating this connection\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"FriendsEdge\\",
+			\\"description\\": \\"An edge object for a character's friends\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"cursor\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"A cursor used for pagination\\"
+				},
+				{
+					\\"name\\": \\"node\\",
+					\\"type\\": \\"Character\\",
+					\\"description\\": \\"The character represented by this friendship edge\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"PageInfo\\",
+			\\"description\\": \\"Information for paginating this connection\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"startCursor\\",
+					\\"type\\": \\"ID\\",
+					\\"description\\": \\"\\"
+				},
+				{
+					\\"name\\": \\"endCursor\\",
+					\\"type\\": \\"ID\\",
+					\\"description\\": \\"\\"
+				},
+				{
+					\\"name\\": \\"hasNextPage\\",
+					\\"type\\": \\"Boolean!\\",
+					\\"description\\": \\"\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Starship\\",
+			\\"description\\": \\"\\",
+			\\"ifaces\\": [],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the starship\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"The name of the starship\\"
+				},
+				{
+					\\"name\\": \\"length\\",
+					\\"type\\": \\"Float\\",
+					\\"description\\": \\"Length of the starship, along the longest axis\\"
+				},
+				{
+					\\"name\\": \\"coordinates\\",
+					\\"type\\": \\"[[Float!]!]\\",
+					\\"description\\": \\"\\"
+				}
+			]
+		},
+		{
+			\\"kind\\": \\"ObjectType\\",
+			\\"name\\": \\"Droid\\",
+			\\"description\\": \\"An autonomous mechanical character in the Star Wars universe\\",
+			\\"ifaces\\": [
+				{
+					\\"name\\": \\"Character\\",
+					\\"description\\": \\"A character from the Star Wars universe\\"
+				}
+			],
+			\\"fields\\": [
+				{
+					\\"name\\": \\"id\\",
+					\\"type\\": \\"ID!\\",
+					\\"description\\": \\"The ID of the droid\\"
+				},
+				{
+					\\"name\\": \\"name\\",
+					\\"type\\": \\"String!\\",
+					\\"description\\": \\"What others call this droid\\"
+				},
+				{
+					\\"name\\": \\"friends\\",
+					\\"type\\": \\"[Character]\\",
+					\\"description\\": \\"This droid's friends, or an empty list if they have none\\"
+				},
+				{
+					\\"name\\": \\"friendsConnection\\",
+					\\"type\\": \\"FriendsConnection!\\",
+					\\"description\\": \\"The friends of the droid exposed as a connection with edges\\"
+				},
+				{
+					\\"name\\": \\"appearsIn\\",
+					\\"type\\": \\"[Episode]!\\",
+					\\"description\\": \\"The movies this droid appears in\\"
+				},
+				{
+					\\"name\\": \\"primaryFunction\\",
+					\\"type\\": \\"String\\",
+					\\"description\\": \\"This droid's primary function\\"
 				}
 			]
 		}

--- a/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -15,6 +15,96 @@ export enum Episode {
   JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
 }
 
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
+
 export type HeroAndFriendsNamesQuery = {
   __typename: \\"Character\\";
   // The name of the character
@@ -86,6 +176,103 @@ exports[`Angular code generation #generateSource() should generate fragmented qu
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
 
 export type HeroAndFriendsNamesQuery = {
   __typename: \\"Character\\";
@@ -198,6 +385,14 @@ export type ColorInput = {
   blue: number;
 };
 
+export type Review = {
+  __typename: \\"Review\\";
+  // The number of stars this review gave, 1-5
+  stars: number;
+  // Comment about the movie
+  commentary?: string | null;
+};
+
 export type ReviewMovieMutation = {
   __typename: \\"Review\\";
   // The number of stars this review gave, 1-5
@@ -245,6 +440,11 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type QueryObject = {
+  __typename: \\"QueryObject\\";
+  test?: string | null;
+};
+
 export type CustomScalarQuery = {
   __typename: \\"QueryObject\\";
   test: string | null;
@@ -275,6 +475,103 @@ exports[`Angular code generation #generateSource() should generate query operati
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
 
 export type HeroAndDetailsQuery = {
   __typename: \\"Character\\";
@@ -327,6 +624,96 @@ export enum Episode {
   EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
   JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
 }
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
 
 export type HeroAndFriendsNamesQuery = {
   __typename: \\"Character\\";
@@ -388,6 +775,17 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
 export type StarshipCoordsQuery = {
   __typename: \\"Starship\\";
   coordinates: Array<Array<number>> | null;
@@ -448,6 +846,103 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
+
 export type HeroNameQuery = {
   __typename: \\"Character\\";
   // The name of the character
@@ -486,6 +981,96 @@ export enum Episode {
   EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
   JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
 }
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
 
 export type HeroNameQuery = {
   __typename: \\"Character\\";
@@ -529,6 +1114,14 @@ export interface SubscriptionResponse<T> {
   value: GraphQLResult<T>;
 }
 
+export type Restaurant = {
+  __typename: \\"Restaurant\\";
+  id: string;
+  name: string;
+  description: string;
+  city: string;
+};
+
 export type OnCreateRestaurantSubscription = {
   __typename: \\"Restaurant\\";
   id: string;
@@ -568,6 +1161,16 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type CommentTest = {
+  __typename: \\"CommentTest\\";
+  // This is a single-line comment
+  singleLine?: string | null;
+  // This is a multi-line
+  // comment.
+  multiLine?: string | null;
+  enumCommentTest?: EnumCommentTestCase | null;
+};
+
 export enum EnumCommentTestCase {
   first = \\"first\\", // This is a single-line comment
   // This is a multi-line
@@ -606,6 +1209,23 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type InterfaceTestCase = {
+  __typename: \\"InterfaceTestCase\\";
+  prop: string;
+};
+
+export type ImplA = {
+  __typename: \\"ImplA\\";
+  prop: string;
+  propA: string;
+};
+
+export type ImplB = {
+  __typename: \\"ImplB\\";
+  prop: string;
+  propB?: number | null;
+};
+
 export type CustomScalarQuery = {
   __typename: \\"InterfaceTestCase\\";
   prop: string;
@@ -643,6 +1263,23 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type CommentTest = {
+  __typename: \\"CommentTest\\";
+  // This is a single-line comment
+  singleLine?: string | null;
+  // This is a multi-line
+  // comment.
+  multiLine?: string | null;
+  enumCommentTest?: EnumCommentTestCase | null;
+};
+
+export enum EnumCommentTestCase {
+  first = \\"first\\", // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  second = \\"second\\"
+}
+
 export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
   // This is a multi-line
@@ -676,6 +1313,23 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type CommentTest = {
+  __typename: \\"CommentTest\\";
+  // This is a single-line comment
+  singleLine?: string | null;
+  // This is a multi-line
+  // comment.
+  multiLine?: string | null;
+  enumCommentTest?: EnumCommentTestCase | null;
+};
+
+export enum EnumCommentTestCase {
+  first = \\"first\\", // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  second = \\"second\\"
+}
+
 export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
   // This is a single-line comment
@@ -707,6 +1361,18 @@ exports[`Angular code generation #generateSource() should handle unions at root 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
+
+export type UnionTestCase = PartialA | PartialB;
+
+export type PartialA = {
+  __typename: \\"PartialA\\";
+  prop: string;
+};
+
+export type PartialB = {
+  __typename: \\"PartialB\\";
+  prop: string;
+};
 
 export type CustomScalarQuery = {
   __typename: \\"PartialA\\" | \\"PartialB\\";
@@ -742,6 +1408,103 @@ exports[`Angular code generation #generateSource() should have __typename value 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
 
 export type HeroNameQuery = {
   __typename: \\"Character\\";
@@ -787,6 +1550,103 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
 export type DroidNameQuery = {
   __typename: \\"Droid\\";
   // What others call this droid
@@ -825,6 +1685,103 @@ import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
 import { Observable } from \\"zen-observable-ts\\";
 
+export type Human = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null;
+  // Height in the preferred unit, default is meters
+  height?: number | null;
+  // Mass in kilograms, or null if unknown
+  mass?: number | null;
+  // This human's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this human appears in
+  appearsIn: Array<Episode | null>;
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship;
+};
+
+export type Character = {
+  __typename: \\"Character\\";
+  // The ID of the character
+  id: string;
+  // The name of the character
+  name: string;
+  // The friends of the character, or an empty list if they have none
+  friends?: Character;
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this character appears in
+  appearsIn: Array<Episode | null>;
+};
+
+export type Droid = {
+  __typename: \\"Droid\\";
+  // The ID of the droid
+  id: string;
+  // What others call this droid
+  name: string;
+  // This droid's friends, or an empty list if they have none
+  friends?: Character;
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection;
+  // The movies this droid appears in
+  appearsIn: Array<Episode | null>;
+  // This droid's primary function
+  primaryFunction?: string | null;
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\";
+  // The total number of friends
+  totalCount?: number | null;
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge;
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character;
+  // Information for paginating this connection
+  pageInfo: PageInfo;
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\";
+  // A cursor used for pagination
+  cursor: string;
+  // The character represented by this friendship edge
+  node?: Character;
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\";
+  startCursor?: string | null;
+  endCursor?: string | null;
+  hasNextPage: boolean;
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\" // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+export type Starship = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+  // Length of the starship, along the longest axis
+  length?: number | null;
+  coordinates?: Array<Array<number>> | null;
+};
+
 export type FindHumanQuery = {
   __typename: \\"Human\\";
   // The ID of the human
@@ -849,7 +1806,7 @@ export type humanDetailsFragment = {
   name: string;
   // A list of starships this person has piloted, or an empty list if none
   starships: Array<{
-    __typename: \\"Starship\\";
+    __typename: string;
     // The ID of the starship
     id: string;
     // The name of the starship

--- a/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -18,23 +18,23 @@ export enum Episode {
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -42,13 +42,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -56,17 +56,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -75,15 +75,15 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -92,15 +92,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -180,23 +180,23 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -204,13 +204,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -218,17 +218,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -237,7 +237,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 // The episodes in the Star Wars trilogy
@@ -250,9 +250,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -261,15 +261,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -388,7 +388,7 @@ export type ColorInput = {
 export type Review = {
   __typename: \\"Review\\";
   // The number of stars this review gave, 1-5
-  stars: number;
+  stars?: number;
   // Comment about the movie
   commentary?: string | null;
 };
@@ -398,7 +398,7 @@ export type ReviewMovieMutation = {
   // The number of stars this review gave, 1-5
   stars: number;
   // Comment about the movie
-  commentary: string | null;
+  commentary?: string | null;
 };
 
 @Injectable({
@@ -447,7 +447,7 @@ export type QueryObject = {
 
 export type CustomScalarQuery = {
   __typename: \\"QueryObject\\";
-  test: string | null;
+  test?: string | null;
 };
 
 @Injectable({
@@ -479,23 +479,23 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -503,13 +503,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -517,17 +517,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -536,7 +536,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 // The episodes in the Star Wars trilogy
@@ -549,9 +549,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -560,15 +560,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -583,12 +583,12 @@ export type HeroDetailsFragment =
   | {
       __typename: \\"Human\\";
       // Height in the preferred unit, default is meters
-      height: number | null;
+      height?: number | null;
     }
   | {
       __typename: \\"Droid\\";
       // This droid's primary function
-      primaryFunction: string | null;
+      primaryFunction?: string | null;
     };
 
 @Injectable({
@@ -628,23 +628,23 @@ export enum Episode {
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -652,13 +652,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -666,17 +666,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -685,15 +685,15 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -702,15 +702,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -778,9 +778,9 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -788,7 +788,7 @@ export type Starship = {
 
 export type StarshipCoordsQuery = {
   __typename: \\"Starship\\";
-  coordinates: Array<Array<number>> | null;
+  coordinates?: Array<Array<number>> | null;
 };
 
 @Injectable({
@@ -849,23 +849,23 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -873,13 +873,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -887,17 +887,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -906,7 +906,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 // The episodes in the Star Wars trilogy
@@ -919,9 +919,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -930,15 +930,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -985,23 +985,23 @@ export enum Episode {
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -1009,13 +1009,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -1023,17 +1023,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -1042,15 +1042,15 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -1059,15 +1059,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -1116,10 +1116,10 @@ export interface SubscriptionResponse<T> {
 
 export type Restaurant = {
   __typename: \\"Restaurant\\";
-  id: string;
-  name: string;
-  description: string;
-  city: string;
+  id?: string;
+  name?: string;
+  description?: string;
+  city?: string;
 };
 
 export type OnCreateRestaurantSubscription = {
@@ -1180,7 +1180,7 @@ export enum EnumCommentTestCase {
 
 export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
-  enumCommentTest: EnumCommentTestCase | null;
+  enumCommentTest?: EnumCommentTestCase | null;
 };
 
 @Injectable({
@@ -1211,18 +1211,18 @@ import { Observable } from \\"zen-observable-ts\\";
 
 export type InterfaceTestCase = {
   __typename: \\"InterfaceTestCase\\";
-  prop: string;
+  prop?: string;
 };
 
 export type ImplA = {
   __typename: \\"ImplA\\";
-  prop: string;
-  propA: string;
+  prop?: string;
+  propA?: string;
 };
 
 export type ImplB = {
   __typename: \\"ImplB\\";
-  prop: string;
+  prop?: string;
   propB?: number | null;
 };
 
@@ -1284,7 +1284,7 @@ export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
   // This is a multi-line
   // comment.
-  multiLine: string | null;
+  multiLine?: string | null;
 };
 
 @Injectable({
@@ -1333,7 +1333,7 @@ export enum EnumCommentTestCase {
 export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
   // This is a single-line comment
-  singleLine: string | null;
+  singleLine?: string | null;
 };
 
 @Injectable({
@@ -1366,12 +1366,12 @@ export type UnionTestCase = PartialA | PartialB;
 
 export type PartialA = {
   __typename: \\"PartialA\\";
-  prop: string;
+  prop?: string;
 };
 
 export type PartialB = {
   __typename: \\"PartialB\\";
-  prop: string;
+  prop?: string;
 };
 
 export type CustomScalarQuery = {
@@ -1412,23 +1412,23 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -1436,13 +1436,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -1450,17 +1450,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -1469,7 +1469,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 // The episodes in the Star Wars trilogy
@@ -1482,9 +1482,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -1493,15 +1493,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -1553,15 +1553,15 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -1569,23 +1569,23 @@ export type Droid = {
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -1593,13 +1593,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type FriendsConnection = {
@@ -1607,17 +1607,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -1626,7 +1626,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 // The episodes in the Star Wars trilogy
@@ -1639,9 +1639,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -1688,9 +1688,9 @@ import { Observable } from \\"zen-observable-ts\\";
 export type Human = {
   __typename: \\"Human\\";
   // The ID of the human
-  id: string;
+  id?: string;
   // What this human calls themselves
-  name: string;
+  name?: string;
   // The home planet of the human, or null if unknown
   homePlanet?: string | null;
   // Height in the preferred unit, default is meters
@@ -1698,41 +1698,41 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null;
   // This human's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this human appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship;
+  starships?: Array<Starship | null> | null;
 };
 
 export type Character = {
   __typename: \\"Character\\";
   // The ID of the character
-  id: string;
+  id?: string;
   // The name of the character
-  name: string;
+  name?: string;
   // The friends of the character, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this character appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
 };
 
 export type Droid = {
   __typename: \\"Droid\\";
   // The ID of the droid
-  id: string;
+  id?: string;
   // What others call this droid
-  name: string;
+  name?: string;
   // This droid's friends, or an empty list if they have none
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection;
+  friendsConnection?: FriendsConnection;
   // The movies this droid appears in
-  appearsIn: Array<Episode | null>;
+  appearsIn?: Array<Episode | null>;
   // This droid's primary function
   primaryFunction?: string | null;
 };
@@ -1742,17 +1742,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null;
   // The edges for each of the character's friends.
-  edges?: FriendsEdge;
+  edges?: Array<FriendsEdge | null> | null;
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character;
+  friends?: Array<Character | null> | null;
   // Information for paginating this connection
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\";
   // A cursor used for pagination
-  cursor: string;
+  cursor?: string;
   // The character represented by this friendship edge
   node?: Character;
 };
@@ -1761,7 +1761,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\";
   startCursor?: string | null;
   endCursor?: string | null;
-  hasNextPage: boolean;
+  hasNextPage?: boolean;
 };
 
 // The episodes in the Star Wars trilogy
@@ -1774,9 +1774,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\";
   // The ID of the starship
-  id: string;
+  id?: string;
   // The name of the starship
-  name: string;
+  name?: string;
   // Length of the starship, along the longest axis
   length?: number | null;
   coordinates?: Array<Array<number>> | null;
@@ -1789,7 +1789,7 @@ export type FindHumanQuery = {
   // What this human calls themselves
   name: string;
   // A list of starships this person has piloted, or an empty list if none
-  starships: Array<{
+  starships?: Array<{
     __typename: \\"Starship\\";
     // The ID of the starship
     id: string;
@@ -1805,7 +1805,7 @@ export type humanDetailsFragment = {
   // What this human calls themselves
   name: string;
   // A list of starships this person has piloted, or an empty list if none
-  starships: Array<{
+  starships?: Array<{
     __typename: string;
     // The ID of the starship
     id: string;

--- a/packages/amplify-graphql-types-generator/test/compiler/legacyIR.js
+++ b/packages/amplify-graphql-types-generator/test/compiler/legacyIR.js
@@ -76,7 +76,20 @@ describe('Compiling query documents to the legacy IR', () => {
 
     const { typesUsed } = withStringifiedTypes(compileToLegacyIR(schema, document));
 
-    expect(typesUsed).toEqual(['Episode', 'ReviewInput', 'ColorInput']);
+    expect(typesUsed).toEqual([
+      'Episode',
+      'Character',
+      'Human',
+      'FriendsConnection',
+      'FriendsEdge',
+      'PageInfo',
+      'Starship',
+      'Droid',
+      'SearchResult',
+      'ReviewInput',
+      'ColorInput',
+      'Review',
+    ]);
   });
 
   it(`should keep track of enums used in fields`, () => {
@@ -95,7 +108,7 @@ describe('Compiling query documents to the legacy IR', () => {
 
     const { typesUsed } = withStringifiedTypes(compileToLegacyIR(schema, document));
 
-    expect(typesUsed).toEqual(['Episode']);
+    expect(typesUsed).toEqual(['Character', 'Human', 'FriendsConnection', 'FriendsEdge', 'PageInfo', 'Episode', 'Starship', 'Droid']);
   });
 
   it(`should keep track of types used in fields of input objects`, () => {

--- a/packages/amplify-graphql-types-generator/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/packages/amplify-graphql-types-generator/test/flow/__snapshots__/codeGeneration.js.snap
@@ -169,6 +169,13 @@ exports[`Flow code generation #generateSource() should generate fragmented query
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
 export type HeroAndFriendsNamesQuery = {|
   hero: ?( {
       __typename: \\"Human\\",
@@ -282,6 +289,13 @@ exports[`Flow code generation #generateSource() should generate query operations
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
 export type HeroAndDetailsQuery = {|
   hero: ?( {
       __typename: \\"Human\\",
@@ -381,6 +395,13 @@ exports[`Flow code generation #generateSource() should generate simple query ope
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
 export type HeroNameQuery = {|
   hero: ?( {
       __typename: \\"Human\\",
@@ -469,6 +490,13 @@ exports[`Flow code generation #generateSource() should handle multi-line comment
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type EnumCommentTestCase =
+  \\"first\\" | // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  \\"second\\";
+
+
 export type CustomScalarQuery = {|
   commentTest: ? {|
     __typename: \\"CommentTest\\",
@@ -493,6 +521,13 @@ exports[`Flow code generation #generateSource() should handle single line commen
 "/* @flow */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type EnumCommentTestCase =
+  \\"first\\" | // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  \\"second\\";
+
 
 export type CustomScalarQuery = {|
   commentTest: ? {|
@@ -525,6 +560,13 @@ exports[`Flow code generation #generateSource() should have __typename value mat
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
 export type HeroNameQuery = {|
   hero: ?( {
       __typename: \\"Human\\",
@@ -555,6 +597,13 @@ exports[`Flow code generation #generateSource() should have __typename value mat
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
 export type DroidNameQuery = {|
   droid: ? {|
     __typename: \\"Droid\\",
@@ -574,6 +623,13 @@ exports[`Flow code generation #generateSource() should have __typename value mat
 "/* @flow */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
 
 export type DroidNameQuery = {|
   droid: ? {|

--- a/packages/amplify-graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/packages/amplify-graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -13,6 +13,96 @@ export enum Episode {
 }
 
 
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
+
 export type HeroAndFriendsNamesQueryVariables = {
   episode?: Episode | null,
 };
@@ -69,6 +159,104 @@ exports[`TypeScript code generation #generateSource() should generate fragmented
 "/* tslint:disable */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
 
 export type HeroAndFriendsNamesQuery = {
   hero: ( {
@@ -164,6 +352,14 @@ export type ColorInput = {
   blue: number,
 };
 
+export type Review = {
+  __typename: \\"Review\\",
+  // The number of stars this review gave, 1-5
+  stars: number,
+  // Comment about the movie
+  commentary?: string | null,
+};
+
 export type ReviewMovieMutationVariables = {
   episode?: Episode | null,
   review?: ReviewInput | null,
@@ -185,6 +381,104 @@ exports[`TypeScript code generation #generateSource() should generate query oper
 "/* tslint:disable */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
 
 export type HeroAndDetailsQuery = {
   hero: ( {
@@ -228,6 +522,96 @@ export enum Episode {
   JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
 }
 
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
 
 export type HeroAndFriendsNamesQueryVariables = {
   episode?: Episode | null,
@@ -275,6 +659,17 @@ exports[`TypeScript code generation #generateSource() should generate simple nes
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
 export type StarshipCoordsQuery = {
   starship:  {
     __typename: \\"Starship\\",
@@ -288,6 +683,104 @@ exports[`TypeScript code generation #generateSource() should generate simple que
 "/* tslint:disable */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
 
 export type HeroNameQuery = {
   hero: ( {
@@ -317,6 +810,96 @@ export enum Episode {
 }
 
 
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
+
 export type HeroNameQueryVariables = {
   episode?: Episode | null,
 };
@@ -341,6 +924,16 @@ exports[`TypeScript code generation #generateSource() should handle comments in 
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type CommentTest = {
+  __typename: \\"CommentTest\\",
+  // This is a single-line comment
+  singleLine?: string | null,
+  // This is a multi-line
+  // comment.
+  multiLine?: string | null,
+  enumCommentTest?: EnumCommentTestCase | null,
+};
+
 export enum EnumCommentTestCase {
   first = \\"first\\", // This is a single-line comment
   // This is a multi-line
@@ -363,6 +956,23 @@ exports[`TypeScript code generation #generateSource() should handle interfaces a
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type InterfaceTestCase = {
+  __typename: \\"InterfaceTestCase\\",
+  prop: string,
+};
+
+export type ImplA = {
+  __typename: \\"ImplA\\",
+  prop: string,
+  propA: string,
+};
+
+export type ImplB = {
+  __typename: \\"ImplB\\",
+  prop: string,
+  propB?: number | null,
+};
+
 export type CustomScalarQuery = {
   interfaceTest: ( {
       __typename: \\"ImplA\\",
@@ -383,6 +993,24 @@ exports[`TypeScript code generation #generateSource() should handle multi-line c
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type CommentTest = {
+  __typename: \\"CommentTest\\",
+  // This is a single-line comment
+  singleLine?: string | null,
+  // This is a multi-line
+  // comment.
+  multiLine?: string | null,
+  enumCommentTest?: EnumCommentTestCase | null,
+};
+
+export enum EnumCommentTestCase {
+  first = \\"first\\", // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  second = \\"second\\",
+}
+
+
 export type CustomScalarQuery = {
   commentTest:  {
     __typename: \\"CommentTest\\",
@@ -399,6 +1027,24 @@ exports[`TypeScript code generation #generateSource() should handle single line 
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type CommentTest = {
+  __typename: \\"CommentTest\\",
+  // This is a single-line comment
+  singleLine?: string | null,
+  // This is a multi-line
+  // comment.
+  multiLine?: string | null,
+  enumCommentTest?: EnumCommentTestCase | null,
+};
+
+export enum EnumCommentTestCase {
+  first = \\"first\\", // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  second = \\"second\\",
+}
+
+
 export type CustomScalarQuery = {
   commentTest:  {
     __typename: \\"CommentTest\\",
@@ -413,6 +1059,19 @@ exports[`TypeScript code generation #generateSource() should handle unions at ro
 "/* tslint:disable */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type UnionTestCase = PartialA | PartialB
+
+
+export type PartialA = {
+  __typename: \\"PartialA\\",
+  prop: string,
+};
+
+export type PartialB = {
+  __typename: \\"PartialB\\",
+  prop: string,
+};
 
 export type CustomScalarQuery = {
   unionTest: ( {
@@ -431,6 +1090,104 @@ exports[`TypeScript code generation #generateSource() should have __typename val
 "/* tslint:disable */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
 
 export type HeroNameQuery = {
   hero: ( {
@@ -463,6 +1220,104 @@ exports[`TypeScript code generation #generateSource() should have __typename val
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
 
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
+
 export type DroidNameQuery = {
   droid:  {
     __typename: \\"Droid\\",
@@ -483,6 +1338,104 @@ exports[`TypeScript code generation #generateSource() should have the correct __
 "/* tslint:disable */
 /* eslint-disable */
 //  This file was automatically generated and should not be edited.
+
+export type Human = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // The home planet of the human, or null if unknown
+  homePlanet?: string | null,
+  // Height in the preferred unit, default is meters
+  height?: number | null,
+  // Mass in kilograms, or null if unknown
+  mass?: number | null,
+  // This human's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the human exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this human appears in
+  appearsIn: Array< Episode | null >,
+  // A list of starships this person has piloted, or an empty list if none
+  starships?: Starship,
+};
+
+export type Character = {
+  __typename: \\"Character\\",
+  // The ID of the character
+  id: string,
+  // The name of the character
+  name: string,
+  // The friends of the character, or an empty list if they have none
+  friends?: Character,
+  // The friends of the character exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this character appears in
+  appearsIn: Array< Episode | null >,
+};
+
+export type Droid = {
+  __typename: \\"Droid\\",
+  // The ID of the droid
+  id: string,
+  // What others call this droid
+  name: string,
+  // This droid's friends, or an empty list if they have none
+  friends?: Character,
+  // The friends of the droid exposed as a connection with edges
+  friendsConnection: FriendsConnection,
+  // The movies this droid appears in
+  appearsIn: Array< Episode | null >,
+  // This droid's primary function
+  primaryFunction?: string | null,
+};
+
+export type FriendsConnection = {
+  __typename: \\"FriendsConnection\\",
+  // The total number of friends
+  totalCount?: number | null,
+  // The edges for each of the character's friends.
+  edges?: FriendsEdge,
+  // A list of the friends, as a convenience when edges are not needed.
+  friends?: Character,
+  // Information for paginating this connection
+  pageInfo: PageInfo,
+};
+
+export type FriendsEdge = {
+  __typename: \\"FriendsEdge\\",
+  // A cursor used for pagination
+  cursor: string,
+  // The character represented by this friendship edge
+  node?: Character,
+};
+
+export type PageInfo = {
+  __typename: \\"PageInfo\\",
+  startCursor?: string | null,
+  endCursor?: string | null,
+  hasNextPage: boolean,
+};
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\", // Star Wars Episode IV: A New Hope, released in 1977.
+  EMPIRE = \\"EMPIRE\\", // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  JEDI = \\"JEDI\\", // Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+
+export type Starship = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+  // Length of the starship, along the longest axis
+  length?: number | null,
+  coordinates?: Array< Array< number > > | null,
+};
 
 export type FindHumanQueryVariables = {
   id: string,
@@ -514,7 +1467,7 @@ export type humanDetailsFragment = {
   name: string,
   // A list of starships this person has piloted, or an empty list if none
   starships:  Array< {
-    __typename: \\"Starship\\",
+    __typename: string,
     // The ID of the starship
     id: string,
     // The name of the starship

--- a/packages/amplify-graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/packages/amplify-graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -16,23 +16,23 @@ export enum Episode {
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -40,13 +40,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -54,17 +54,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -73,15 +73,15 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -90,15 +90,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -163,23 +163,23 @@ exports[`TypeScript code generation #generateSource() should generate fragmented
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -187,13 +187,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -201,17 +201,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -220,7 +220,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 // The episodes in the Star Wars trilogy
@@ -234,9 +234,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -245,15 +245,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -355,7 +355,7 @@ export type ColorInput = {
 export type Review = {
   __typename: \\"Review\\",
   // The number of stars this review gave, 1-5
-  stars: number,
+  stars?: number,
   // Comment about the movie
   commentary?: string | null,
 };
@@ -366,12 +366,12 @@ export type ReviewMovieMutationVariables = {
 };
 
 export type ReviewMovieMutation = {
-  createReview:  {
+  createReview?:  {
     __typename: \\"Review\\",
     // The number of stars this review gave, 1-5
     stars: number,
     // Comment about the movie
-    commentary: string | null,
+    commentary?: string | null,
   } | null,
 };
 "
@@ -385,23 +385,23 @@ exports[`TypeScript code generation #generateSource() should generate query oper
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -409,13 +409,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -423,17 +423,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -442,7 +442,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 // The episodes in the Star Wars trilogy
@@ -456,9 +456,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -467,15 +467,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -486,13 +486,13 @@ export type HeroAndDetailsQuery = {
       // What this human calls themselves
       name: string,
       // Height in the preferred unit, default is meters
-      height: number | null,
+      height?: number | null,
     } | {
       __typename: \\"Droid\\",
       // What others call this droid
       name: string,
       // This droid's primary function
-      primaryFunction: string | null,
+      primaryFunction?: string | null,
     }
   ) | null,
 };
@@ -500,11 +500,11 @@ export type HeroAndDetailsQuery = {
 export type HeroDetailsFragment = ( {
       __typename: \\"Human\\",
       // Height in the preferred unit, default is meters
-      height: number | null,
+      height?: number | null,
     } | {
       __typename: \\"Droid\\",
       // This droid's primary function
-      primaryFunction: string | null,
+      primaryFunction?: string | null,
     }
   );
 "
@@ -526,23 +526,23 @@ export enum Episode {
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -550,13 +550,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -564,17 +564,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -583,15 +583,15 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -600,15 +600,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -662,18 +662,18 @@ exports[`TypeScript code generation #generateSource() should generate simple nes
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
 };
 
 export type StarshipCoordsQuery = {
-  starship:  {
+  starship?:  {
     __typename: \\"Starship\\",
-    coordinates: Array< Array< number > > | null,
+    coordinates?: Array< Array< number > > | null,
   } | null,
 };
 "
@@ -687,23 +687,23 @@ exports[`TypeScript code generation #generateSource() should generate simple que
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -711,13 +711,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -725,17 +725,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -744,7 +744,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 // The episodes in the Star Wars trilogy
@@ -758,9 +758,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -769,15 +769,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -813,23 +813,23 @@ export enum Episode {
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -837,13 +837,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -851,17 +851,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -870,15 +870,15 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -887,15 +887,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -943,9 +943,9 @@ export enum EnumCommentTestCase {
 
 
 export type CustomScalarQuery = {
-  commentTest:  {
+  commentTest?:  {
     __typename: \\"CommentTest\\",
-    enumCommentTest: EnumCommentTestCase | null,
+    enumCommentTest?: EnumCommentTestCase | null,
   } | null,
 };
 "
@@ -958,18 +958,18 @@ exports[`TypeScript code generation #generateSource() should handle interfaces a
 
 export type InterfaceTestCase = {
   __typename: \\"InterfaceTestCase\\",
-  prop: string,
+  prop?: string,
 };
 
 export type ImplA = {
   __typename: \\"ImplA\\",
-  prop: string,
-  propA: string,
+  prop?: string,
+  propA?: string,
 };
 
 export type ImplB = {
   __typename: \\"ImplB\\",
-  prop: string,
+  prop?: string,
   propB?: number | null,
 };
 
@@ -981,7 +981,7 @@ export type CustomScalarQuery = {
     } | {
       __typename: \\"ImplB\\",
       prop: string,
-      propB: number | null,
+      propB?: number | null,
     }
   ) | null,
 };
@@ -1012,11 +1012,11 @@ export enum EnumCommentTestCase {
 
 
 export type CustomScalarQuery = {
-  commentTest:  {
+  commentTest?:  {
     __typename: \\"CommentTest\\",
     // This is a multi-line
     // comment.
-    multiLine: string | null,
+    multiLine?: string | null,
   } | null,
 };
 "
@@ -1046,10 +1046,10 @@ export enum EnumCommentTestCase {
 
 
 export type CustomScalarQuery = {
-  commentTest:  {
+  commentTest?:  {
     __typename: \\"CommentTest\\",
     // This is a single-line comment
-    singleLine: string | null,
+    singleLine?: string | null,
   } | null,
 };
 "
@@ -1065,12 +1065,12 @@ export type UnionTestCase = PartialA | PartialB
 
 export type PartialA = {
   __typename: \\"PartialA\\",
-  prop: string,
+  prop?: string,
 };
 
 export type PartialB = {
   __typename: \\"PartialB\\",
-  prop: string,
+  prop?: string,
 };
 
 export type CustomScalarQuery = {
@@ -1094,23 +1094,23 @@ exports[`TypeScript code generation #generateSource() should have __typename val
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -1118,13 +1118,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -1132,17 +1132,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -1151,7 +1151,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 // The episodes in the Star Wars trilogy
@@ -1165,9 +1165,9 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
@@ -1176,15 +1176,15 @@ export type Starship = {
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -1223,15 +1223,15 @@ exports[`TypeScript code generation #generateSource() should have __typename val
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -1239,23 +1239,23 @@ export type Droid = {
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -1263,13 +1263,13 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type FriendsConnection = {
@@ -1277,17 +1277,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -1296,7 +1296,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 // The episodes in the Star Wars trilogy
@@ -1310,16 +1310,16 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
 };
 
 export type DroidNameQuery = {
-  droid:  {
+  droid?:  {
     __typename: \\"Droid\\",
     // What others call this droid
     name: string,
@@ -1342,9 +1342,9 @@ exports[`TypeScript code generation #generateSource() should have the correct __
 export type Human = {
   __typename: \\"Human\\",
   // The ID of the human
-  id: string,
+  id?: string,
   // What this human calls themselves
-  name: string,
+  name?: string,
   // The home planet of the human, or null if unknown
   homePlanet?: string | null,
   // Height in the preferred unit, default is meters
@@ -1352,41 +1352,41 @@ export type Human = {
   // Mass in kilograms, or null if unknown
   mass?: number | null,
   // This human's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the human exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this human appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // A list of starships this person has piloted, or an empty list if none
-  starships?: Starship,
+  starships?:  Array<Starship | null > | null,
 };
 
 export type Character = {
   __typename: \\"Character\\",
   // The ID of the character
-  id: string,
+  id?: string,
   // The name of the character
-  name: string,
+  name?: string,
   // The friends of the character, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the character exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this character appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
 };
 
 export type Droid = {
   __typename: \\"Droid\\",
   // The ID of the droid
-  id: string,
+  id?: string,
   // What others call this droid
-  name: string,
+  name?: string,
   // This droid's friends, or an empty list if they have none
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // The friends of the droid exposed as a connection with edges
-  friendsConnection: FriendsConnection,
+  friendsConnection?: FriendsConnection,
   // The movies this droid appears in
-  appearsIn: Array< Episode | null >,
+  appearsIn?: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
 };
@@ -1396,17 +1396,17 @@ export type FriendsConnection = {
   // The total number of friends
   totalCount?: number | null,
   // The edges for each of the character's friends.
-  edges?: FriendsEdge,
+  edges?:  Array<FriendsEdge | null > | null,
   // A list of the friends, as a convenience when edges are not needed.
-  friends?: Character,
+  friends?:  Array<Character | null > | null,
   // Information for paginating this connection
-  pageInfo: PageInfo,
+  pageInfo?: PageInfo,
 };
 
 export type FriendsEdge = {
   __typename: \\"FriendsEdge\\",
   // A cursor used for pagination
-  cursor: string,
+  cursor?: string,
   // The character represented by this friendship edge
   node?: Character,
 };
@@ -1415,7 +1415,7 @@ export type PageInfo = {
   __typename: \\"PageInfo\\",
   startCursor?: string | null,
   endCursor?: string | null,
-  hasNextPage: boolean,
+  hasNextPage?: boolean,
 };
 
 // The episodes in the Star Wars trilogy
@@ -1429,27 +1429,27 @@ export enum Episode {
 export type Starship = {
   __typename: \\"Starship\\",
   // The ID of the starship
-  id: string,
+  id?: string,
   // The name of the starship
-  name: string,
+  name?: string,
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
 };
 
 export type FindHumanQueryVariables = {
-  id: string,
+  id?: string,
 };
 
 export type FindHumanQuery = {
-  human:  {
+  human?:  {
     __typename: \\"Human\\",
     // The ID of the human
     id: string,
     // What this human calls themselves
     name: string,
     // A list of starships this person has piloted, or an empty list if none
-    starships:  Array< {
+    starships?:  Array< {
       __typename: \\"Starship\\",
       // The ID of the starship
       id: string,
@@ -1466,7 +1466,7 @@ export type humanDetailsFragment = {
   // What this human calls themselves
   name: string,
   // A list of starships this person has piloted, or an empty list if none
-  starships:  Array< {
+  starships?:  Array< {
     __typename: string,
     // The ID of the starship
     id: string,


### PR DESCRIPTION
Fixes #3323

* accumulate return type of operation
* accumulate object types, interface types and union types
* generate object types, interface types and union types (for TypeScript)

This PR mainly handles TypeScript. Other frontends may have similary issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.