### PR TITLE
fix(amplify-graphql-types-generator): fix passing typename on fields …

### DIFF
--- a/packages/amplify-graphql-types-generator/src/flow/codeGeneration.js
+++ b/packages/amplify-graphql-types-generator/src/flow/codeGeneration.js
@@ -89,7 +89,7 @@ function structDeclarationForInputObjectType(generator, type) {
     () => {
       const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
       propertyDeclarations(generator, properties, true);
-    }
+    },
   );
 }
 
@@ -111,7 +111,7 @@ function interfaceNameFromOperation({ operationName, operationType }) {
 
 export function interfaceVariablesDeclarationForOperation(
   generator,
-  { operationName, operationType, variables, fields, fragmentsReferenced, source }
+  { operationName, operationType, variables, fields, fragmentsReferenced, source },
 ) {
   if (!variables || variables.length < 1) {
     return null;
@@ -126,7 +126,7 @@ export function interfaceVariablesDeclarationForOperation(
     () => {
       const properties = propertiesFromFields(generator.context, variables);
       propertyDeclarations(generator, properties, true);
-    }
+    },
   );
 }
 
@@ -151,7 +151,7 @@ function getObjectTypeName(type) {
 
 export function typeDeclarationForOperation(
   generator,
-  { operationName, operationType, variables, fields, fragmentSpreads, fragmentsReferenced, source }
+  { operationName, operationType, variables, fields, fragmentSpreads, fragmentsReferenced, source },
 ) {
   const interfaceName = interfaceNameFromOperation({ operationName, operationType });
   fields = fields.map(rootField => {
@@ -181,7 +181,7 @@ export function typeDeclarationForOperation(
     },
     () => {
       propertyDeclarations(generator, properties);
-    }
+    },
   );
 }
 
@@ -253,7 +253,7 @@ export function typeDeclarationForFragment(generator, fragment) {
         const properties = propertiesFromFields(generator.context, fragmentFields);
         propertyDeclarations(generator, properties);
       }
-    }
+    },
   );
 }
 
@@ -275,7 +275,7 @@ export function propertyFromField(context, field) {
   }
   const namedType = getNamedType(fieldType);
   if (isCompositeType(namedType)) {
-    const typeName = typeNameFromGraphQLType(context, fieldType);
+    const typeName = namedType.toString();
     let isArray = false;
     let isArrayElementNullable = null;
     if (fieldType instanceof GraphQLList) {
@@ -355,8 +355,19 @@ export function propertyDeclarations(generator, properties, isInput) {
         (property.inlineFragments && property.inlineFragments.length > 0) ||
         (property.fragmentSpreads && property.fragmentSpreads.length > 0)
       ) {
+        const fields = property.fields.map(field => {
+          if (field.fieldName === '__typename') {
+            return {
+              ...field,
+              typeName: `"${property.typeName}"`,
+              type: { name: `"${property.typeName}"` },
+            };
+          } else {
+            return field;
+          }
+        });
         propertyDeclaration(generator, property, () => {
-          const properties = propertiesFromFields(generator.context, property.fields);
+          const properties = propertiesFromFields(generator.context, fields);
           propertyDeclarations(generator, properties, isInput);
         });
       } else {

--- a/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -760,3 +760,75 @@ export class APIService {
 }
 "
 `;
+
+exports[`Angular code generation #generateSource() should have the correct __typename(s) for nested fragments 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+import { Injectable } from \\"@angular/core\\";
+import API, { graphqlOperation } from \\"@aws-amplify/api\\";
+import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
+import * as Observable from \\"zen-observable\\";
+
+export type FindHumanQuery = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // A list of starships this person has piloted, or an empty list if none
+  starships: Array<{
+    __typename: \\"Starship\\";
+    // The ID of the starship
+    id: string;
+    // The name of the starship
+    name: string;
+  } | null> | null;
+};
+
+export type humanDetailsFragment = {
+  __typename: \\"Human\\";
+  // The ID of the human
+  id: string;
+  // What this human calls themselves
+  name: string;
+  // A list of starships this person has piloted, or an empty list if none
+  starships: Array<{
+    __typename: \\"Starship\\";
+    // The ID of the starship
+    id: string;
+    // The name of the starship
+    name: string;
+  } | null> | null;
+};
+
+export type starshipDetailsFragment = {
+  __typename: \\"Starship\\";
+  // The ID of the starship
+  id: string;
+  // The name of the starship
+  name: string;
+};
+
+@Injectable({
+  providedIn: \\"root\\"
+})
+export class APIService {
+  async FindHuman(id: string): Promise<FindHumanQuery> {
+    const statement = \`query FindHuman($id: ID!) {
+        human {
+          __typename
+          ...humanDetails
+        }
+      }\`;
+    const gqlAPIServiceArguments: any = {
+      id
+    };
+    const response = (await API.graphql(
+      graphqlOperation(statement, gqlAPIServiceArguments)
+    )) as any;
+    return <FindHumanQuery>response.data.human;
+  }
+}
+"
+`;

--- a/packages/amplify-graphql-types-generator/test/angular/index.js
+++ b/packages/amplify-graphql-types-generator/test/angular/index.js
@@ -317,5 +317,29 @@ describe('Angular code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test('should have the correct __typename(s) for nested fragments', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query FindHuman($id: ID!) {
+          human {
+            ...humanDetails
+          }
+        }
+        fragment humanDetails on Human {
+          id
+          name
+          starships {
+            ...starshipDetails
+          }
+        }
+        fragment starshipDetails on Starship {
+          id
+          name
+        }
+      `);
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });

--- a/packages/amplify-graphql-types-generator/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/packages/amplify-graphql-types-generator/test/flow/__snapshots__/codeGeneration.js.snap
@@ -569,3 +569,23 @@ export type DroidWithNameFragment = {|
   name: string,
 |};"
 `;
+
+exports[`Flow code generation #generateSource() should have __typename value matching fragment type on specific type 2`] = `
+"/* @flow */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+
+export type DroidNameQuery = {|
+  droid: ? {|
+    __typename: \\"Droid\\",
+    // What others call this droid
+    name: string,
+  |},
+|};
+
+export type DroidWithNameFragment = {|
+  __typename: \\"Droid\\",
+  // What others call this droid
+  name: string,
+|};"
+`;

--- a/packages/amplify-graphql-types-generator/test/flow/codeGeneration.js
+++ b/packages/amplify-graphql-types-generator/test/flow/codeGeneration.js
@@ -360,5 +360,24 @@ describe('Flow code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test('should have __typename value matching fragment type on specific type', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query DroidName {
+          droid {
+            ...DroidWithName
+          }
+        }
+
+        fragment DroidWithName on Droid {
+          __typename
+          name
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });

--- a/packages/amplify-graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/packages/amplify-graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -478,3 +478,56 @@ export type DroidWithNameFragment = {
 };
 "
 `;
+
+exports[`TypeScript code generation #generateSource() should have the correct __typename(s) for nested fragments 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+
+export type FindHumanQueryVariables = {
+  id: string,
+};
+
+export type FindHumanQuery = {
+  human:  {
+    __typename: \\"Human\\",
+    // The ID of the human
+    id: string,
+    // What this human calls themselves
+    name: string,
+    // A list of starships this person has piloted, or an empty list if none
+    starships:  Array< {
+      __typename: \\"Starship\\",
+      // The ID of the starship
+      id: string,
+      // The name of the starship
+      name: string,
+    } | null > | null,
+  } | null,
+};
+
+export type humanDetailsFragment = {
+  __typename: \\"Human\\",
+  // The ID of the human
+  id: string,
+  // What this human calls themselves
+  name: string,
+  // A list of starships this person has piloted, or an empty list if none
+  starships:  Array< {
+    __typename: \\"Starship\\",
+    // The ID of the starship
+    id: string,
+    // The name of the starship
+    name: string,
+  } | null > | null,
+};
+
+export type starshipDetailsFragment = {
+  __typename: \\"Starship\\",
+  // The ID of the starship
+  id: string,
+  // The name of the starship
+  name: string,
+};
+"
+`;

--- a/packages/amplify-graphql-types-generator/test/typescript/codeGeneration.js
+++ b/packages/amplify-graphql-types-generator/test/typescript/codeGeneration.js
@@ -303,5 +303,29 @@ describe('TypeScript code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test('should have the correct __typename(s) for nested fragments', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query FindHuman($id: ID!) {
+          human {
+            ...humanDetails
+          }
+        }
+        fragment humanDetails on Human {
+          id
+          name
+          starships {
+            ...starshipDetails
+          }
+        }
+        fragment starshipDetails on Starship {
+          id
+          name
+        }
+      `);
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
fix #1325
*Description of changes:*
- fix passing typenames when evaluating fields and their selection sets
- typename should exist on nested fragments


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.