### PR TITLE
fix(amplify-appsync-simulator): forward stash to responseMappingTemplate

### DIFF
--- a/packages/amplify-appsync-simulator/src/resolvers/function.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/function.ts
@@ -48,7 +48,7 @@ export class AmplifySimulatorFunction {
     }
 
     const responseMappingResult = await responseMappingTemplate.render(
-      { source, arguments: args, result, stash, prevResult, error },
+      { source, arguments: args, result, stash: requestTemplateResult.stash, prevResult, error },
       context,
       info,
     );


### PR DESCRIPTION
*Description of changes:*
According to docs, stash should live across functions inside a pipeline resolver. Currently, the stash returned from the requestMappingTemplate is not forwarded to the responseMappingTemplate, therefore parameters set during request are not passed through. 

Ref: https://docs.aws.amazon.com/appsync/latest/devguide/pipeline-resolvers.html#ctx-stash

This PR fixes this by forwarding the requestTemplateResult stash to the responseMappingTemplate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.