### PR TITLE
ci: update amplify e2e tests to use packages from verdaccio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,25 @@ jobs:
       - run:
           name: Collect code coverage
           command: yarn coverage
+
+  publish_to_local_registry:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: 'Publish to verdaccio'
+          command: |
+            source .circleci/local_publish_helpers.sh
+            startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+            yarn publish-to-verdaccio
+      - save_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/verdaccio-cache/
+
   graphql_e2e_tests:
     <<: *defaults
     steps:
@@ -59,6 +78,7 @@ jobs:
           no_output_timeout: 90m
       - store_test_results:
           path: packages/graphql-transformers-e2e-tests/
+
   mock_e2e_tests:
     <<: *defaults
     steps:
@@ -84,9 +104,20 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: 'amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run:
-          command: 'cd packages/amplify-e2e-tests && yarn run e2e --maxWorkers=3'
+          name: Start verdaccio and Install Amplify CLI
+          command: |
+            source .circleci/local_publish_helpers.sh
+            startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+            changeNpmGlobalPath
+            npm install -g @aws-amplify/cli
+      - run:
+          command: |
+            export PATH=~/.npm-global/bin:$PATH
+            amplify -v
+            cd packages/amplify-e2e-tests
+            yarn run e2e --maxWorkers=3
           name: 'Run Amplify end-to-end tests'
           no_output_timeout: 90m
       - store_test_results:
@@ -452,14 +483,22 @@ workflows:
           requires:
             - build
             - mock_e2e_tests
+      - publish_to_local_registry:
+          filters:
+            branches:
+              only:
+                - master
+                - e2e-from-verdaccio
+          requires:
+            - build
       - amplify_e2e_tests:
           filters:
             branches:
               only:
                 - master
+                - e2e-from-verdaccio
           requires:
-            - build
-            - mock_e2e_tests
+            - publish_to_local_registry
       - deploy:
           requires:
             - build

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -1,0 +1,34 @@
+  #!/bin/bash
+
+custom_registry_url=http://localhost:4873
+original_npm_registry_url=`npm get registry`
+original_yarn_registry_url=`yarn config get registry`
+default_verdaccio_package=verdaccio@3.8.2
+
+function startLocalRegistry {
+  # Start local registry
+  tmp_registry_log=`mktemp`
+  echo "Registry output file: $tmp_registry_log"
+  (cd && nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &)
+  # Wait for Verdaccio to boot
+  grep -q 'http address' <(tail -f $tmp_registry_log)
+
+  # Set registry to local registry
+  npm set registry "$custom_registry_url"
+  yarn config set registry "$custom_registry_url"
+
+  # Login so we can publish packages
+  (cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
+}
+
+function stopLocalRegistry {
+  # Restore the original NPM and Yarn registry URLs and stop Verdaccio
+  npm set registry "https://registry.npmjs.org/"
+  yarn config set registry "https://registry.npmjs.org/"
+}
+
+function changeNpmGlobalPath {
+  mkdir ~/.npm-global
+  npm config set prefix '~/.npm-global'
+  export PATH=~/.npm-global/bin:$PATH
+}

--- a/.circleci/verdaccio.yaml
+++ b/.circleci/verdaccio.yaml
@@ -1,0 +1,62 @@
+#
+# This is based on verdaccio's default config file. It allows all users
+# to do anything, so don't use it on production systems.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+#
+
+# path to a directory with all packages
+storage: ../../verdaccio-cache/storage
+
+auth:
+  htpasswd:
+    file: ../../verdaccio-cache/htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    #max_users: 1000
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    max_fails: 40
+    maxage: 30m
+    timeout: 60s
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    publish: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# log settings
+logs:
+  - { type: stdout, format: pretty, level: warn }
+  #- {type: file, path: verdaccio.log, level: info}
+
+# See https://github.com/verdaccio/verdaccio/issues/301
+server:
+  keepAliveTimeout: 0
+
+max_body_size: 500mb

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "publish:beta": "lerna publish prerelease --exact --dist-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]' --yes",
     "publish:release": "lerna publish --conventional-commits --exact --yes --message 'chore(release): Publish [ci skip]'",
     "postpublish:release": "git fetch . release:master && git push origin master",
+    "publish-to-verdaccio":"lerna publish prerelease --yes --force-publish=* --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest",
     "commit": "git-cz",
     "coverage": "codecov || exit 0"
   },

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -75,7 +75,10 @@
       "<rootDir>/src/setup-tests.ts"
     ],
     "globals": {
-      "window": {}
+      "window": {},
+      "ts-jest": {
+        "diagnostics": false
+      }
     }
   },
   "jest-junit": {

--- a/packages/amplify-e2e-tests/src/utils/index.ts
+++ b/packages/amplify-e2e-tests/src/utils/index.ts
@@ -12,6 +12,9 @@ export * from './api';
 config();
 
 export function getCLIPath() {
+  if (isCI()) {
+    return 'amplify';
+  }
   return path.join(__dirname, '..', '..', '..', 'amplify-cli', 'bin', 'amplify');
 }
 


### PR DESCRIPTION
updated Amplify E2E tests to use package published to verdaccio instead of using the development
version of the packages

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.