### PR TITLE
feat(amplify-appsync-simulator): implement missing string methods (#3389)

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/value-mapper/string.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/value-mapper/string.test.ts
@@ -8,4 +8,121 @@ describe('JavaString', () => {
     expect(replacedStr.toIdString()).toEqual('baz bar baz bar baz bar Foo');
     expect(replacedStr.toJSON()).toEqual('baz bar baz bar baz bar Foo');
   });
+
+  it('length', () => {
+    const str1 = new JavaString('foo');
+    expect(str1.length()).toEqual(3);
+  });
+
+  it('concat', () => {
+    const str1 = new JavaString('foo');
+    expect(str1.concat(new JavaString('bar')).toString()).toEqual('foobar');
+  });
+
+  it('contains', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.contains(new JavaString('ipsum'))).toEqual(true);
+    expect(str.contains(new JavaString('DOLOR'))).toEqual(false);
+  });
+
+  it('endsWith', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.endsWith(new JavaString('ipsum'))).toEqual(false);
+    expect(str.endsWith(new JavaString('elit'))).toEqual(true);
+  });
+
+  it('indexOf', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.indexOf(new JavaString('ipsum'))).toEqual(6);
+    expect(str.indexOf(new JavaString('ipsum'), 10)).toEqual(-1);
+  });
+
+  it('isEmpty', () => {
+    const emptyStr = new JavaString('');
+    expect(emptyStr.isEmpty()).toEqual(true);
+
+    const str = new JavaString('foo bar');
+    expect(str.isEmpty()).toEqual(false);
+  });
+
+  it('lastIndexOf', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem');
+    expect(str.lastIndexOf(new JavaString('Lorem'))).toEqual(57);
+    expect(str.lastIndexOf(new JavaString('Lorem'), 10)).toEqual(0);
+
+    expect(str.lastIndexOf(new JavaString('foo'))).toEqual(-1);
+  });
+
+  it('matches', () => {
+    const str = new JavaString('foo bar');
+
+    expect(str.matches('foo')).toEqual(true);
+    expect(str.matches('lorem')).toEqual(false);
+    expect(str.matches('(foo|test)')).toEqual(true);
+  });
+
+  it('replace', () => {
+    const str = new JavaString('foo foo bar');
+
+    expect(str.replace('foo', 'bar').toString()).toEqual('bar bar bar');
+    expect(str.replace('test', 'bar').toString()).toEqual('foo foo bar');
+  });
+
+  it('replaceFirst', () => {
+    const str = new JavaString('foo foo bar');
+
+    expect(str.replaceFirst('foo', 'bar').toString()).toEqual('bar foo bar');
+    expect(str.replaceFirst('test', 'bar').toString()).toEqual('foo foo bar');
+  });
+
+  it('split', () => {
+    const str = new JavaString('foo bar foo bar foo bar Foo');
+
+    const splitStr = str.split(new JavaString(' '));
+    expect(splitStr.length).toEqual(7);
+    expect(splitStr.toJSON()).toEqual(['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'Foo']);
+
+    const splitStr2 = str.split(new JavaString('(foo)'));
+    expect(splitStr2.length).toEqual(4);
+    expect(splitStr2.toJSON()).toEqual(['', ' bar ', ' bar ', ' bar Foo']);
+  });
+
+  it('startsWith', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.startsWith(new JavaString('ipsum'))).toEqual(false);
+    expect(str.startsWith(new JavaString('Lorem'))).toEqual(true);
+
+    expect(str.startsWith(new JavaString('Lorem'), 10)).toEqual(false);
+  });
+
+  it('substring', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.substring(0).toString()).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.substring(0, 1).toString()).toEqual('L');
+    expect(str.substring(6, 11).toString()).toEqual('ipsum');
+  });
+
+  it('toLowerCase', () => {
+    const str = new JavaString('Foo BaR');
+    expect(str.toLowerCase().toString()).toEqual('foo bar');
+  });
+
+  it('toUpperCase', () => {
+    const str = new JavaString('Foo BaR');
+    expect(str.toUpperCase().toString()).toEqual('FOO BAR');
+  });
+
+  it('trim', () => {
+    const str = new JavaString('foo bar');
+    expect(str.trim().toString()).toEqual('foo bar');
+
+    const str2 = new JavaString('   foo bar');
+    expect(str2.trim().toString()).toEqual('foo bar');
+
+    const str3 = new JavaString('   foo bar      ');
+    expect(str3.trim().toString()).toEqual('foo bar');
+
+    const str4 = new JavaString('foo bar      ');
+    expect(str4.trim().toString()).toEqual('foo bar');
+  });
 });

--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/string.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/string.ts
@@ -1,7 +1,37 @@
+import { JavaArray } from './array';
+
 export class JavaString {
   value: string;
   constructor(str) {
     this.value = str;
+  }
+
+  concat(str) {
+    return new JavaString(this.value.concat(str.toString()));
+  }
+
+  contains(str) {
+    return this.value.indexOf(str.toString()) !== -1;
+  }
+
+  endsWith(suffix) {
+    return this.value.endsWith(suffix.toString());
+  }
+
+  indexOf(val, fromIndex = 0) {
+    return this.value.indexOf(val.toString(), fromIndex);
+  }
+
+  isEmpty() {
+    return this.value.length === 0;
+  }
+
+  lastIndexOf(val, fromIndex = Infinity) {
+    return this.value.lastIndexOf(val.toString(), fromIndex);
+  }
+
+  replace(find, replace) {
+    return this.replaceAll(find, replace);
   }
 
   replaceAll(find, replace) {
@@ -9,8 +39,52 @@ export class JavaString {
     return new JavaString(rep);
   }
 
+  replaceFirst(find, replace) {
+    const rep = this.value.replace(new RegExp(find), replace);
+    return new JavaString(rep);
+  }
+
+  matches(regexString) {
+    const re = new RegExp(regexString.toString());
+
+    return this.value.match(re) !== null;
+  }
+
+  split(regexString, limit = undefined) {
+    // WARNING: this assumes Java and JavaScript regular expressions are identical, according to
+    // https://en.wikipedia.org/wiki/Comparison_of_regular_expression_engines#Language_features
+    // this should be the case except for look-behind which is not implemented in JavaScript
+
+    // java.util.String.split does not to include the separator in the result. JS does splice any capturing group
+    // in the regex into the result. To remove the groups from the result we need the count of capturing groups in
+    // the provided regex, the only way in JS seems to be via a match to an empty string
+    const testRe = new RegExp(`${regexString.toString()}|`);
+    const ngroups = ''.match(testRe).length; // actually num of groups plus one, ie "" and the (empty) groups
+
+    const re = new RegExp(regexString.toString());
+
+    const result = this.value.split(re, limit).filter((v, ii) => !(ii % ngroups));
+    return new JavaArray(result, e => new JavaString(e.toString()));
+  }
+
+  startsWith(prefix, toffset = 0) {
+    return this.value.startsWith(prefix.toString(), toffset);
+  }
+
+  substring(beginIndex, endIndex = Infinity) {
+    return this.value.substring(beginIndex, endIndex);
+  }
+
   toJSON() {
     return this.toString();
+  }
+
+  toLowerCase() {
+    return new JavaString(this.value.toLowerCase());
+  }
+
+  toUpperCase() {
+    return new JavaString(this.value.toUpperCase());
   }
 
   toString() {
@@ -19,6 +93,10 @@ export class JavaString {
 
   toIdString() {
     return this.value;
+  }
+
+  trim() {
+    return new JavaString(this.value.trim());
   }
 
   length() {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3389 

*Description of changes:*
Add the following methods for JavaString:
- concat
- contains
- endsWith
- indexOf
- isEmpty
- lastIndexOf
- replace
- replaceFirst
- matches
- split
- startsWith
- substring
- toLowerCase
- toUpperCase
- trim

split() implementation has been adapted from ConduitVC/aws-utils repository (which AFAIU was the starting point for the amplify mock).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.