### PR TITLE
fix: fix amplify-app on windows

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -13,6 +13,7 @@ const stripAnsi = require('strip-ansi');
 const { engines } = require('../package.json');
 
 const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+const amplify = /^win/.test(process.platform) ? 'amplify.cmd' : 'amplify';
 const amplifyCliPackageName = '@aws-amplify/cli';
 
 function run() {
@@ -76,7 +77,7 @@ async function installAmplifyCLI() {
 
 // Check the amplify CLI version, install latest CLI if it does not exist or is too old
 async function amplifyCLIVersionCheck() {
-  const amplifyCLIVersionSpawn = spawnSync('amplify', ['-v']);
+  const amplifyCLIVersionSpawn = spawnSync(amplify, ['-v']);
   const minCLIVersion = engines['@aws-amplify/cli'];
   if (amplifyCLIVersionSpawn.stderr !== null) {
     const amplifyCLIVersion = semver.coerce(stripAnsi(amplifyCLIVersionSpawn.stdout.toString()));
@@ -104,7 +105,7 @@ async function createAmplifySkeletonProject() {
     console.log(`${emoji.get('guitar')} Creating base Amplify project`);
 
     return new Promise((resolve, reject) => {
-      const createSkeletonAmplifyProject = spawn('amplify', ['init', '--quickstart'], {
+      const createSkeletonAmplifyProject = spawn(amplify, ['init', '--quickstart'], {
         cwd: process.cwd(),
         env: process.env,
         stdio: 'inherit',

--- a/packages/amplify-app/src/scripts/amplify-modelgen.js
+++ b/packages/amplify-app/src/scripts/amplify-modelgen.js
@@ -7,7 +7,8 @@ console.log('Running codegen...');
 run();
 
 async function run() {
-  const modelGen = spawn('amplify', ['codegen', 'model'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+  const amplify = /^win/.test(process.platform) ? 'amplify.cmd' : 'amplify';
+  const modelGen = spawn(amplify, ['codegen', 'model'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
 
   modelGen.on('exit', code => {
     if (code === 0) {

--- a/packages/amplify-app/src/scripts/amplify-push.js
+++ b/packages/amplify-app/src/scripts/amplify-push.js
@@ -5,6 +5,7 @@ const ini = require('ini');
 const { spawn } = require('child_process');
 const inquirer = require('inquirer');
 
+const amplify = /^win/.test(process.platform) ? 'amplify.cmd' : 'amplify';
 const dotAWSDirPath = path.normalize(path.join(os.homedir(), '.aws'));
 const configFilePath = path.join(dotAWSDirPath, 'config');
 
@@ -50,7 +51,7 @@ async function getValidProfile(profileToUse) {
 }
 
 async function configureProfile() {
-  const amplifyConfigure = spawn('amplify', ['configure'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+  const amplifyConfigure = spawn(amplify, ['configure'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
 
   return new Promise((resolve, reject) => {
     amplifyConfigure.on('exit', code => {
@@ -120,7 +121,7 @@ async function run() {
   if (!fs.existsSync(`./amplify/.config/local-env-info.json`)) {
     // init and then push
 
-    cloudPush = spawn('amplify', ['init', '--amplify', PROJECT_CONFIG, '--providers', PROVIDER_CONFIG, '--yes'], {
+    cloudPush = spawn(amplify, ['init', '--amplify', PROJECT_CONFIG, '--providers', PROVIDER_CONFIG, '--yes'], {
       cwd: process.cwd(),
       env: process.env,
       stdio: 'inherit',
@@ -128,7 +129,7 @@ async function run() {
   } else {
     // just push
 
-    cloudPush = spawn('amplify', ['push', '--yes'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+    cloudPush = spawn(amplify, ['push', '--yes'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
   }
 
   cloudPush.on('exit', code => {


### PR DESCRIPTION
fix #3396

*Issue #, if available:*
#3396

*Description of changes:*
Use amplify.cmd on windows to avoid spawn error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.