### PR TITLE
fix(amplify-provider-awscloudformation): fix template not found

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -93,7 +93,7 @@ async function updateStackForAPIMigration(context, category, resourceName, optio
   const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = await context.amplify.getResourceStatus(
     category,
     resourceName,
-    providerName
+    providerName,
   );
 
   const { isReverting, isCLIMigration } = options;
@@ -118,7 +118,7 @@ async function updateStackForAPIMigration(context, category, resourceName, optio
             Ref: 'UnauthRoleName',
           },
         },
-      })
+      }),
     )
     .then(() => updateS3Templates(context, resources, projectDetails.amplifyMeta))
     .then(() => {
@@ -326,10 +326,13 @@ function getCfnFiles(context, category, resourceName) {
   if (fs.existsSync(resourceBuildDir) && fs.lstatSync(resourceBuildDir).isDirectory()) {
     const files = fs.readdirSync(resourceBuildDir);
     const cfnFiles = files.filter(file => file.indexOf('.') !== 0).filter(file => file.indexOf('template') !== -1);
-    return {
-      resourceDir: resourceBuildDir,
-      cfnFiles,
-    };
+
+    if (cfnFiles.length > 0) {
+      return {
+        resourceDir: resourceBuildDir,
+        cfnFiles,
+      };
+    }
   }
   const files = fs.readdirSync(resourceDir);
   const cfnFiles = files.filter(file => file.indexOf('.') !== 0).filter(file => file.indexOf('template') !== -1);


### PR DESCRIPTION
When pushing resources, previously the code would search for cloudformation templates in the build/ folder, if the build folder exists.
This was intended for use by the API resource, but has the unintended effect of causing templates to not be found in other resource folders,
which may contain build folders but still hold their template file in the root resource directory.

To reproduce this issue, create a function and inside the function resource directory create a build/ folder.
When pushing, the cloudformation file will not be found and not uploaded to S3.

*Issue #, if available:*

*Description of changes:*

The resolve the issue, if a cloudformation file is not found inside the build folder, continue to search for templates in the root directory.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.