### PR TITLE
add Date Type for @searchable

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -168,6 +168,17 @@ input SearchableBooleanFilterInput {
   ne: Boolean
 }
 
+input SearchableDateFilterInput {
+  ne: String
+  gt: String
+  lt: String
+  gte: String
+  lte: String
+  eq: String
+  exists: Boolean
+  range: [String]
+}
+
 input SearchablePostFilterInput {
   id: SearchableIDFilterInput
   content: SearchableStringFilterInput

--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -1,5 +1,5 @@
 import { Transformer, TransformerContext, getDirectiveArguments, gql, InvalidDirectiveError } from 'graphql-transformer-core';
-import { DirectiveNode, ObjectTypeDefinitionNode } from 'graphql';
+import { DirectiveNode, ObjectTypeDefinitionNode, InputObjectTypeDefinitionNode } from 'graphql';
 import { Expression, str } from 'graphql-mapping-template';
 import { ResourceFactory } from './resources';
 import {
@@ -174,12 +174,10 @@ export class SearchableModelTransformer extends Transformer {
   private generateSearchableInputs(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {
     // Create the Scalar filter inputs
     const inputs: string[] = ['String', 'ID', 'Int', 'Float', 'Boolean', 'Date'];
-    inputs.forEach((input: string) => {
-      if (!this.typeExist(`Searchable${input}FilterInput`, ctx)) {
-        const searchableInputFilterInput = makeSearchableScalarInputObject(input);
-        ctx.addInput(searchableInputFilterInput);
-      }
-    });
+    inputs
+      .filter((input: string) => !this.typeExist(`Searchable${input}FilterInput`, ctx))
+      .map((input: string) => makeSearchableScalarInputObject(input))
+      .forEach((node: InputObjectTypeDefinitionNode) => ctx.addInput(node));
 
     const searchableXQueryFilterInput = makeSearchableXFilterInputObject(def);
     if (!this.typeExist(searchableXQueryFilterInput.name.value, ctx)) {

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
@@ -1,239 +1,230 @@
-// import {
-//     ObjectTypeDefinitionNode, parse, FieldDefinitionNode, DocumentNode,
-//     DefinitionNode, Kind, InputObjectTypeDefinitionNode
-// } from 'graphql'
-// import { GraphQLTransform } from 'graphql-transformer-core';
-// import { ResourceConstants } from 'graphql-transformer-common'
-// import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer'
-// import { SearchableModelTransformer } from '../SearchableModelTransformer'
-// import AppSyncTransformer from 'graphql-appsync-transformer'
+import {
+  parse,
+  ObjectTypeDefinitionNode,
+  Kind,
+  DefinitionNode,
+  DocumentNode,
+  FieldDefinitionNode,
+  InputObjectTypeDefinitionNode,
+} from 'graphql';
+import { GraphQLTransform, InvalidDirectiveError } from 'graphql-transformer-core';
+import { SearchableModelTransformer } from '../SearchableModelTransformer';
+import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 
-// test('Test SearchableModelTransformer validation happy case', () => {
-//     const validSchema = `
-//     type Post @model @searchable {
-//         id: ID!
-//         title: String!
-//         createdAt: String
-//         updatedAt: String
-//     }
-//     `
-//     const transformer = new GraphQLTransform({
-//         transformers: [
-//             new AppSyncTransformer(),
-//             new DynamoDBModelTransformer(),
-//             new SearchableModelTransformer()
-//         ]
-//     })
-//     const out = transformer.transform(validSchema);
-//     expect(out).toBeDefined()
-// });
+test('schema without @model', () => {
+  const invalidSchema = `
+  type Record @searchable {
+    id: ID!
+    createdAt: AWSDate
+    updatedAt: AWSDateTime
+    info: String
+    precision: Float
+    age: Int
+    active: Boolean
+    email: AWSEmail
+    json: AWSJSON
+    url: AWSURL
+    phone: AWSPhone
+    ip: AWSIPAddress
+    time: AWSTime
+  }`;
 
-// test('Test SearchableModelTransformer with query overrides', () => {
-//     const validSchema = `type Post @model @searchable(queries: { search: "customSearchPost" }) {
-//         id: ID!
-//         title: String!
-//         createdAt: String
-//         updatedAt: String
-//     }
-//     `
-//     const transformer = new GraphQLTransform({
-//         transformers: [
-//             new AppSyncTransformer(),
-//             new DynamoDBModelTransformer(),
-//             new SearchableModelTransformer()
-//         ]
-//     })
-//     const out = transformer.transform(validSchema)
-//     expect(out).toBeDefined()
-//     const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
-//     expect(schema).toBeDefined()
-//     const definition = schema.Properties.Definition
-//     expect(definition).toBeDefined()
-//     const parsed = parse(definition);
-//     const queryType = getObjectType(parsed, 'Query')
-//     expect(queryType).toBeDefined()
-//     expectFields(queryType, ['customSearchPost'])
-// });
+  const transformer = new GraphQLTransform({
+    transformers: [new SearchableModelTransformer()],
+  });
+  expect(() => transformer.transform(invalidSchema)).toThrowError(InvalidDirectiveError);
+});
 
-// test('Test SearchableModelTransformer with only create mutations', () => {
-//     const validSchema = `type Post @model(mutations: { create: "customCreatePost" }) @searchable {
-//         id: ID!
-//         title: String!
-//         createdAt: String
-//         updatedAt: String
-//     }
-//     `
-//     const transformer = new GraphQLTransform({
-//         transformers: [
-//             new AppSyncTransformer(),
-//             new DynamoDBModelTransformer(),
-//             new SearchableModelTransformer()
-//         ]
-//     })
-//     const out = transformer.transform(validSchema);
-//     expect(out).toBeDefined()
-//     const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
-//     expect(schema).toBeDefined()
-//     const definition = schema.Properties.Definition
-//     expect(definition).toBeDefined()
-//     const parsed = parse(definition);
-//     const mutationType = getObjectType(parsed, 'Mutation')
-//     expect(mutationType).toBeDefined()
-//     expectFields(mutationType, ['customCreatePost'])
-//     doNotExpectFields(mutationType, ['updatePost'])
-// });
+test('filter input types have the correct output', () => {
+  const validSchema = `
+  type Record @model @searchable {
+    id: ID!
+    createdAt: AWSDate
+    updatedAt: AWSDateTime
+    info: String
+    precision: Float
+    age: Int
+    active: Boolean
+    email: AWSEmail
+    json: AWSJSON
+    url: AWSURL
+    phone: AWSPhone
+    ip: AWSIPAddress
+    time: AWSTime
+  }`;
 
-// test('Test SearchableModelTransformer with multiple model searchable directives', () => {
-//     const validSchema = `
-//     type Post @model @searchable {
-//         id: ID!
-//         title: String!
-//         createdAt: String
-//         updatedAt: String
-//     }
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new SearchableModelTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('input SearchableDateFilterInput');
+  expect(out.schema).toMatchSnapshot();
+});
+test('Test SearchableModelTransformer with query overrides', () => {
+  const validSchema = `type Post @model @searchable(queries: { search: "customSearchPost" }) {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }`;
 
-//     type User @model @searchable {
-//         id: ID!
-//         name: String!
-//     }
-//     `
-//     const transformer = new GraphQLTransform({
-//         transformers: [
-//             new AppSyncTransformer(),
-//             new DynamoDBModelTransformer(),
-//             new SearchableModelTransformer()
-//         ]
-//     })
-//     const out = transformer.transform(validSchema);
-//     expect(out).toBeDefined()
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new SearchableModelTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toBeDefined();
+  const parsed = parse(out.schema);
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  expectFields(queryType, ['customSearchPost']);
+});
 
-//     const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
-//     expect(schema).toBeDefined()
-//     const definition = schema.Properties.Definition
-//     expect(definition).toBeDefined()
-//     const parsed = parse(definition);
-//     const queryType = getObjectType(parsed, 'Query')
-//     expect(queryType).toBeDefined()
-//     expectFields(queryType, ['searchPosts'])
-//     expectFields(queryType, ['searchUsers'])
+test('Test SearchableModelTransformer with only create mutations', () => {
+  const validSchema = `type Post @model(mutations: { create: "customCreatePost" }) @searchable {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new SearchableModelTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const parsed = parse(out.schema);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  expectFields(mutationType, ['customCreatePost']);
+  doNotExpectFields(mutationType, ['updatePost']);
+});
 
-//     const stringInputType = getInputType(parsed, 'SearchableStringFilterInput')
-//     expect(stringInputType).toBeDefined()
-//     const booleanInputType = getInputType(parsed, 'SearchableBooleanFilterInput')
-//     expect(booleanInputType).toBeDefined()
-//     const intInputType = getInputType(parsed, 'SearchableIntFilterInput')
-//     expect(intInputType).toBeDefined()
-//     const floatInputType = getInputType(parsed, 'SearchableFloatFilterInput')
-//     expect(floatInputType).toBeDefined()
-//     const idInputType = getInputType(parsed, 'SearchableIDFilterInput')
-//     expect(idInputType).toBeDefined()
-//     const postInputType = getInputType(parsed, 'SearchablePostFilterInput')
-//     expect(postInputType).toBeDefined()
-//     const userInputType = getInputType(parsed, 'SearchableUserFilterInput')
-//     expect(userInputType).toBeDefined()
+test('Test SearchableModelTransformer with multiple model searchable directives', () => {
+  const validSchema = `
+    type Post @model @searchable {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
 
-//     expect(verifyInputCount(parsed, 'ModelStringFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelBooleanFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelIntFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelUserFilterInput', 1)).toBeTruthy;
+    type User @model @searchable {
+        id: ID!
+        name: String!
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new SearchableModelTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toBeDefined();
+  const parsed = parse(out.schema);
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  expectFields(queryType, ['searchPosts']);
+  expectFields(queryType, ['searchUsers']);
 
-//     expect(verifyInputCount(parsed, 'SearchableStringFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableBooleanFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableIntFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableFloatFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchablePostFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableUserFilterInput', 1)).toBeTruthy;
-// });
+  const stringInputType = getInputType(parsed, 'SearchableStringFilterInput');
+  expect(stringInputType).toBeDefined();
+  const booleanInputType = getInputType(parsed, 'SearchableBooleanFilterInput');
+  expect(booleanInputType).toBeDefined();
+  const intInputType = getInputType(parsed, 'SearchableIntFilterInput');
+  expect(intInputType).toBeDefined();
+  const floatInputType = getInputType(parsed, 'SearchableFloatFilterInput');
+  expect(floatInputType).toBeDefined();
+  const dateInputType = getInputType(parsed, 'SearchableDateFilterInput');
+  expect(dateInputType).toBeDefined();
+  const idInputType = getInputType(parsed, 'SearchableIDFilterInput');
+  expect(idInputType).toBeDefined();
+  const postInputType = getInputType(parsed, 'SearchablePostFilterInput');
+  expect(postInputType).toBeDefined();
+  const userInputType = getInputType(parsed, 'SearchableUserFilterInput');
+  expect(userInputType).toBeDefined();
 
-// test('Test SearchableModelTransformer with sort fields', () => {
-//     const validSchema = `
-//     type Post @model @searchable {
-//         id: ID!
-//         title: String!
-//         createdAt: String
-//         updatedAt: String
-//     }
-//     `
-//     const transformer = new GraphQLTransform({
-//         transformers: [
-//             new AppSyncTransformer(),
-//             new DynamoDBModelTransformer(),
-//             new SearchableModelTransformer()
-//         ]
-//     })
-//     const out = transformer.transform(validSchema);
-//     expect(out).toBeDefined()
+  expect(verifyInputCount(parsed, 'SearchableStringFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableBooleanFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableIntFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableFloatFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableDateFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchablePostFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableUserFilterInput', 1)).toBeTruthy;
+});
 
-//     const schema = out.Resources[ResourceConstants.RESOURCES.GraphQLSchemaLogicalID]
-//     expect(schema).toBeDefined()
-//     const definition = schema.Properties.Definition
-//     expect(definition).toBeDefined()
-//     const parsed = parse(definition);
-//     const queryType = getObjectType(parsed, 'Query')
-//     expect(queryType).toBeDefined()
-//     expectFields(queryType, ['searchPosts'])
+test('Test SearchableModelTransformer with sort fields', () => {
+  const validSchema = `
+    type Post @model @searchable {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }`;
 
-//     const stringInputType = getInputType(parsed, 'SearchableStringFilterInput')
-//     expect(stringInputType).toBeDefined()
-//     const booleanInputType = getInputType(parsed, 'SearchableBooleanFilterInput')
-//     expect(booleanInputType).toBeDefined()
-//     const intInputType = getInputType(parsed, 'SearchableIntFilterInput')
-//     expect(intInputType).toBeDefined()
-//     const floatInputType = getInputType(parsed, 'SearchableFloatFilterInput')
-//     expect(floatInputType).toBeDefined()
-//     const idInputType = getInputType(parsed, 'SearchableIDFilterInput')
-//     expect(idInputType).toBeDefined()
-//     const postInputType = getInputType(parsed, 'SearchablePostFilterInput')
-//     expect(postInputType).toBeDefined()
-//     const sortInputType = getInputType(parsed, 'SearchablePostSortInput')
-//     expect(sortInputType).toBeDefined()
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new SearchableModelTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toBeDefined();
+  const parsed = parse(out.schema);
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  expectFields(queryType, ['searchPosts']);
 
-//     expect(verifyInputCount(parsed, 'ModelStringFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelBooleanFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelIntFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy;
+  const stringInputType = getInputType(parsed, 'SearchableStringFilterInput');
+  expect(stringInputType).toBeDefined();
+  const booleanInputType = getInputType(parsed, 'SearchableBooleanFilterInput');
+  expect(booleanInputType).toBeDefined();
+  const intInputType = getInputType(parsed, 'SearchableIntFilterInput');
+  expect(intInputType).toBeDefined();
+  const floatInputType = getInputType(parsed, 'SearchableFloatFilterInput');
+  expect(floatInputType).toBeDefined();
+  const dateInputType = getInputType(parsed, 'SearchableDateFilterInput');
+  expect(dateInputType).toBeDefined();
+  const idInputType = getInputType(parsed, 'SearchableIDFilterInput');
+  expect(idInputType).toBeDefined();
+  const postInputType = getInputType(parsed, 'SearchablePostFilterInput');
+  expect(postInputType).toBeDefined();
+  const sortInputType = getInputType(parsed, 'SearchablePostSortInput');
+  expect(sortInputType).toBeDefined();
 
-//     expect(verifyInputCount(parsed, 'SearchableStringFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableBooleanFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableIntFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchableFloatFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchablePostFilterInput', 1)).toBeTruthy;
-//     expect(verifyInputCount(parsed, 'SearchablePostSortInput', 1)).toBeTruthy;
-// });
+  expect(verifyInputCount(parsed, 'SearchableStringFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableBooleanFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableIntFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableFloatFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchableDateFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchablePostFilterInput', 1)).toBeTruthy;
+  expect(verifyInputCount(parsed, 'SearchablePostSortInput', 1)).toBeTruthy;
+});
 
-// function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
-//     for (const fieldName of fields) {
-//         const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
-//         expect(foundField).toBeDefined()
-//     }
-// }
+function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeDefined();
+  }
+}
 
-// function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
-//     for (const fieldName of fields) {
-//         expect(
-//             type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)
-//         ).toBeUndefined()
-//     }
-// }
+function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    expect(type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)).toBeUndefined();
+  }
+}
 
-// function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
-//     return doc.definitions.find(
-//         (def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type
-//     ) as ObjectTypeDefinitionNode | undefined
-// }
+function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | ObjectTypeDefinitionNode
+    | undefined;
+}
 
-// function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
-//     return doc.definitions.find(
-//         (def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type
-//     ) as InputObjectTypeDefinitionNode | undefined
-// }
+function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | InputObjectTypeDefinitionNode
+    | undefined;
+}
 
-// function verifyInputCount(doc: DocumentNode, type: string, count: number): boolean {
-//     return doc.definitions.filter(def => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type).length == count;
-// }
+function verifyInputCount(doc: DocumentNode, type: string, count: number): boolean {
+  return doc.definitions.filter(def => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type).length == count;
+}

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
@@ -1,0 +1,273 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`filter input types have the correct output 1`] = `
+"type Record {
+  id: ID!
+  createdAt: AWSDate
+  updatedAt: AWSDateTime
+  info: String
+  precision: Float
+  age: Int
+  active: Boolean
+  email: AWSEmail
+  json: AWSJSON
+  url: AWSURL
+  phone: AWSPhone
+  ip: AWSIPAddress
+  time: AWSTime
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelRecordConnection {
+  items: [Record]
+  nextToken: String
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelRecordFilterInput {
+  id: ModelIDFilterInput
+  createdAt: ModelStringFilterInput
+  updatedAt: ModelStringFilterInput
+  info: ModelStringFilterInput
+  precision: ModelFloatFilterInput
+  age: ModelIntFilterInput
+  active: ModelBooleanFilterInput
+  email: ModelStringFilterInput
+  json: ModelStringFilterInput
+  url: ModelStringFilterInput
+  phone: ModelStringFilterInput
+  ip: ModelStringFilterInput
+  time: ModelStringFilterInput
+  and: [ModelRecordFilterInput]
+  or: [ModelRecordFilterInput]
+  not: ModelRecordFilterInput
+}
+
+type Query {
+  getRecord(id: ID!): Record
+  listRecords(filter: ModelRecordFilterInput, limit: Int, nextToken: String): ModelRecordConnection
+  searchRecords(filter: SearchableRecordFilterInput, sort: SearchableRecordSortInput, limit: Int, nextToken: String): SearchableRecordConnection
+}
+
+input CreateRecordInput {
+  id: ID
+  createdAt: AWSDate
+  updatedAt: AWSDateTime
+  info: String
+  precision: Float
+  age: Int
+  active: Boolean
+  email: AWSEmail
+  json: AWSJSON
+  url: AWSURL
+  phone: AWSPhone
+  ip: AWSIPAddress
+  time: AWSTime
+}
+
+input UpdateRecordInput {
+  id: ID!
+  createdAt: AWSDate
+  updatedAt: AWSDateTime
+  info: String
+  precision: Float
+  age: Int
+  active: Boolean
+  email: AWSEmail
+  json: AWSJSON
+  url: AWSURL
+  phone: AWSPhone
+  ip: AWSIPAddress
+  time: AWSTime
+}
+
+input DeleteRecordInput {
+  id: ID
+}
+
+type Mutation {
+  createRecord(input: CreateRecordInput!): Record
+  updateRecord(input: UpdateRecordInput!): Record
+  deleteRecord(input: DeleteRecordInput!): Record
+}
+
+type Subscription {
+  onCreateRecord: Record @aws_subscribe(mutations: [\\"createRecord\\"])
+  onUpdateRecord: Record @aws_subscribe(mutations: [\\"updateRecord\\"])
+  onDeleteRecord: Record @aws_subscribe(mutations: [\\"deleteRecord\\"])
+}
+
+input SearchableStringFilterInput {
+  ne: String
+  gt: String
+  lt: String
+  gte: String
+  lte: String
+  eq: String
+  match: String
+  matchPhrase: String
+  matchPhrasePrefix: String
+  multiMatch: String
+  exists: Boolean
+  wildcard: String
+  regexp: String
+}
+
+input SearchableIDFilterInput {
+  ne: ID
+  gt: ID
+  lt: ID
+  gte: ID
+  lte: ID
+  eq: ID
+  match: ID
+  matchPhrase: ID
+  matchPhrasePrefix: ID
+  multiMatch: ID
+  exists: Boolean
+  wildcard: ID
+  regexp: ID
+}
+
+input SearchableIntFilterInput {
+  ne: Int
+  gt: Int
+  lt: Int
+  gte: Int
+  lte: Int
+  eq: Int
+  range: [Int]
+}
+
+input SearchableFloatFilterInput {
+  ne: Float
+  gt: Float
+  lt: Float
+  gte: Float
+  lte: Float
+  eq: Float
+  range: [Float]
+}
+
+input SearchableBooleanFilterInput {
+  eq: Boolean
+  ne: Boolean
+}
+
+input SearchableDateFilterInput {
+  ne: String
+  gt: String
+  lt: String
+  gte: String
+  lte: String
+  eq: String
+  exists: Boolean
+  range: [String]
+}
+
+input SearchableRecordFilterInput {
+  id: SearchableIDFilterInput
+  createdAt: SearchableDateFilterInput
+  updatedAt: SearchableDateFilterInput
+  info: SearchableStringFilterInput
+  precision: SearchableFloatFilterInput
+  age: SearchableIntFilterInput
+  active: SearchableBooleanFilterInput
+  email: SearchableStringFilterInput
+  json: SearchableStringFilterInput
+  url: SearchableStringFilterInput
+  phone: SearchableStringFilterInput
+  ip: SearchableStringFilterInput
+  time: SearchableStringFilterInput
+  and: [SearchableRecordFilterInput]
+  or: [SearchableRecordFilterInput]
+  not: SearchableRecordFilterInput
+}
+
+enum SearchableSortDirection {
+  asc
+  desc
+}
+
+enum SearchableRecordSortableFields {
+  id
+  createdAt
+  updatedAt
+  info
+  precision
+  age
+  active
+  email
+  json
+  url
+  phone
+  ip
+  time
+}
+
+input SearchableRecordSortInput {
+  field: SearchableRecordSortableFields
+  direction: SearchableSortDirection
+}
+
+type SearchableRecordConnection {
+  items: [Record]
+  nextToken: String
+  total: Int
+}
+"
+`;

--- a/packages/graphql-elasticsearch-transformer/src/definitions.ts
+++ b/packages/graphql-elasticsearch-transformer/src/definitions.ts
@@ -28,6 +28,7 @@ const ID_CONDITIONS = [
 const STRING_CONDITIONS = ID_CONDITIONS;
 const INT_CONDITIONS = ['ne', 'gt', 'lt', 'gte', 'lte', 'eq', 'range'];
 const FLOAT_CONDITIONS = ['ne', 'gt', 'lt', 'gte', 'lte', 'eq', 'range'];
+const DATE_CONDITIONS = ['ne', 'gt', 'lt', 'gte', 'lte', 'eq', 'exists', 'range'];
 const BOOLEAN_CONDITIONS = ['eq', 'ne'];
 
 export function makeSearchableScalarInputObject(type: string): InputObjectTypeDefinitionNode {
@@ -103,7 +104,7 @@ export function makeSearchableXFilterInputObject(obj: ObjectTypeDefinitionNode):
       // TODO: Service does not support new style descriptions so wait.
       // description: field.description,
       directives: [],
-    }
+    },
   );
   return {
     kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
@@ -203,6 +204,9 @@ export function makeSearchableXSortInputObject(obj: ObjectTypeDefinitionNode): I
 }
 
 function getScalarFilterInputType(condition: string, type: string, filterInputName: string): TypeNode {
+  if (type === 'Date') {
+    type = 'String';
+  }
   switch (condition) {
     case 'range':
       return makeListType(makeNamedType(type));
@@ -225,7 +229,9 @@ function getScalarConditions(type: string): string[] {
       return FLOAT_CONDITIONS;
     case 'Boolean':
       return BOOLEAN_CONDITIONS;
+    case 'Date':
+      return DATE_CONDITIONS;
     default:
-      throw 'Valid types are String, ID, Int, Float, Boolean';
+      throw 'Valid types are String, ID, Int, Float, Boolean, Date';
   }
 }

--- a/packages/graphql-transformer-common/src/SearchableResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/SearchableResourceIDs.ts
@@ -1,11 +1,11 @@
-import { DEFAULT_SCALARS } from './definition';
+import { ES_SCALARS } from './definition';
 
 export class SearchableResourceIDs {
   static SearchableEventSourceMappingID(typeName: string): string {
     return `Searchable${typeName}LambdaMapping`;
   }
   static SearchableFilterInputTypeName(name: string): string {
-    const nameOverride = DEFAULT_SCALARS[name];
+    const nameOverride = ES_SCALARS[name];
     if (nameOverride) {
       return `Searchable${nameOverride}FilterInput`;
     }

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -22,6 +22,7 @@ import {
 type ScalarMap = {
   [k: string]: 'String' | 'Int' | 'Float' | 'Boolean' | 'ID' | 'Date';
 };
+
 export const STANDARD_SCALARS: ScalarMap = {
   String: 'String',
   Int: 'Int',
@@ -61,7 +62,7 @@ export const DEFAULT_SCALARS: ScalarMap = {
   ...APPSYNC_DEFINED_SCALARS,
 };
 
-export const NUMERIC_SCALARS: { [k: string]: boolean } = {
+export const NUMERIC_SCALARS: Record<string, boolean> = {
   BigInt: true,
   Int: true,
   Float: true,
@@ -69,7 +70,7 @@ export const NUMERIC_SCALARS: { [k: string]: boolean } = {
   AWSTimestamp: true,
 };
 
-export const MAP_SCALARS: { [k: string]: boolean } = {
+export const MAP_SCALARS: Record<string, boolean> = {
   AWSJSON: true,
 };
 

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -16,13 +16,11 @@ import {
   DirectiveNode,
   EnumTypeDefinitionNode,
   ValueNode,
-  ListValueNode,
-  ObjectValueNode,
   InputObjectTypeDefinitionNode,
 } from 'graphql';
 
 type ScalarMap = {
-  [k: string]: 'String' | 'Int' | 'Float' | 'Boolean' | 'ID';
+  [k: string]: 'String' | 'Int' | 'Float' | 'Boolean' | 'ID' | 'Date';
 };
 export const STANDARD_SCALARS: ScalarMap = {
   String: 'String',
@@ -47,6 +45,14 @@ export const APPSYNC_DEFINED_SCALARS: ScalarMap = {
   AWSURL: 'String',
   AWSPhone: 'String',
   AWSIPAddress: 'String',
+};
+
+export const ES_SCALARS: ScalarMap = {
+  ...STANDARD_SCALARS,
+  ...OTHER_SCALARS,
+  ...APPSYNC_DEFINED_SCALARS,
+  AWSDate: 'Date',
+  AWSDateTime: 'Date',
 };
 
 export const DEFAULT_SCALARS: ScalarMap = {
@@ -280,7 +286,7 @@ export function makeField(
   name: string,
   args: InputValueDefinitionNode[],
   type: TypeNode,
-  directives: DirectiveNode[] = []
+  directives: DirectiveNode[] = [],
 ): FieldDefinitionNode {
   return {
     kind: Kind.FIELD_DEFINITION,
@@ -358,7 +364,6 @@ export function makeInputValueDefinition(name: string, type: TypeNode): InputVal
     directives: [],
   };
 }
-
 
 export function makeNamedType(name: string): NamedTypeNode {
   return {


### PR DESCRIPTION
*Issue #, if available:*
re #3340
docs pr https://github.com/aws-amplify/docs/pull/1150

*Description of changes:*
- add date input filter type for `@searchable`
- add unit `@searchable` unit tests
- create es scalar specific record under `@searchable` resources.
- updated `@auth` unit test related to `@searchable`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.