### PR TITLE
fix(graphql-dynamodb-transformer): prevent double escape of nextToken

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -677,7 +677,7 @@ export class ResourceFactory {
               limit: ref('limit'),
             }),
           ),
-          iff(ref('context.args.nextToken'), set(ref(`${requestVariable}.nextToken`), ref('util.toJson($context.args.nextToken)'))),
+          iff(ref('context.args.nextToken'), set(ref(`${requestVariable}.nextToken`), ref('context.args.nextToken'))),
           iff(
             ref('context.args.filter'),
             set(ref(`${requestVariable}.filter`), ref('util.parseJson("$util.transform.toDynamoDBFilterExpression($ctx.args.filter)")')),


### PR DESCRIPTION
Updated the resolver code not to escape nextToken in list resolver since the response object as a whole gets sanitized

fix #3411

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.