### PR TITLE
fix(amplify-storage-simulator): fixes aws-amplify#3215 Invalid win chars

### DIFF
--- a/packages/amplify-storage-simulator/src/server/utils.ts
+++ b/packages/amplify-storage-simulator/src/server/utils.ts
@@ -17,6 +17,11 @@ export function parseUrl(request, route: String) {
     request.params.path = request.params.path.substring(1);
   }
 
+  // changing file path by removing invalid file path characters for windows
+  if (process.platform === 'win32') {
+    request.params.path = request.params.path.replace(/[<>:"|?*]/g, (match, capture) => '%' + Buffer.from(match, 'utf8').toString('hex'));
+  }
+
   if (request.method === 'GET') {
     if (request.query.prefix !== undefined || (temp[1] === '' && temp[0] === '')) {
       request.method = 'LIST';


### PR DESCRIPTION
*Issue #3215

*Description of changes:*
* Replacing the invalid win32 chars with "%" in the request parameters path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.