### PR TITLE
fix: add graphql dependency

### DIFF
--- a/packages/amplify-app/package.json
+++ b/packages/amplify-app/package.json
@@ -33,6 +33,7 @@
     "amplify-frontend-javascript": "2.13.2",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
+    "graphql": "^14.5.8",
     "ini": "^1.3.5",
     "inquirer": "^7.0.3",
     "node-emoji": "^1.10.0",


### PR DESCRIPTION
fix #3465

*Issue #, if available:*
#3465

*Description of changes:*
Add graphql as a dependency to support amplify-frontend-javascript

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.