### PR TITLE
chore: e2e test failure for trigger tests, update verdaccio to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             changeNpmGlobalPath
             npm install -g @aws-amplify/cli
+            stopLocalRegistry
       - run:
           command: |
             export PATH=~/.npm-global/bin:$PATH

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -3,7 +3,7 @@
 custom_registry_url=http://localhost:4873
 original_npm_registry_url=`npm get registry`
 original_yarn_registry_url=`yarn config get registry`
-default_verdaccio_package=verdaccio@3.8.2
+default_verdaccio_package=verdaccio@4.4.3
 
 function startLocalRegistry {
   # Start local registry


### PR DESCRIPTION
*Description of changes:*

E2E tests were failing in circleci because after spawning Verdaccio the package registry values were not reset, so when a function was deployed and invoked ```npm install``` it failed to connect to the previously set Verdaccio repository url. This fix resets the urls after Amplify CLI install, so function deployment happens as normal.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.