### PR TITLE
feat(amplify-appsync-simulator): add support for IAM authorization

### DIFF
--- a/packages/amplify-appsync-simulator/src/server/operations.ts
+++ b/packages/amplify-appsync-simulator/src/server/operations.ts
@@ -158,7 +158,7 @@ export class OperationServer {
     const isApiKeyAllowed = allowedAuthTypes.includes(AmplifyAppSyncSimulatorAuthenticationType.API_KEY);
     const isIamAllowed = allowedAuthTypes.includes(AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM);
     const isCupAllowed = allowedAuthTypes.includes(AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS);
-    const isOicdAllowed = allowedAuthTypes.includes(AmplifyAppSyncSimulatorAuthenticationType.OPENID_CONNECT);
+    const isOidcAllowed = allowedAuthTypes.includes(AmplifyAppSyncSimulatorAuthenticationType.OPENID_CONNECT);
 
     if (isApiKeyAllowed) {
       if (apiKey) {
@@ -185,7 +185,7 @@ export class OperationServer {
         }
       }
 
-      if (isOicdAllowed) {
+      if (isOidcAllowed) {
         const isOidcToken = this.hasValidOidcIssuer(jwtToken);
         if (isOidcToken) {
           return AmplifyAppSyncSimulatorAuthenticationType.OPENID_CONNECT;


### PR DESCRIPTION
This commit adds support for IAM-based authorization (@aws_iam) of GraphQL operations.

*Description of changes:*
Previously, only API key, OpenID Connect and Cognito User Pools were supported by amplify mock. This PR adds IAM auth.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.