### PR TITLE
chore: fix amplify-app related e2e execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,14 @@ jobs:
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
-          name: 'Publish to verdaccio'
+          name: Publish to verdaccio
           command: |
             source .circleci/local_publish_helpers.sh
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
             loginToLocalRegistry
             yarn publish-to-verdaccio
+            unsetNpmRegistryUrl
       - save_cache:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -121,20 +122,21 @@ jobs:
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
             changeNpmGlobalPath
-            loginToLocalRegistry
             npm install -g @aws-amplify/cli
+            npm install -g amplify-app
             unsetNpmRegistryUrl
       - run:
+          name: Run Amplify end-to-end tests
           command: |
-            export PATH=~/.npm-global/bin:$PATH
-            amplify -v
             source .circleci/local_publish_helpers.sh
+            changeNpmGlobalPath
+            amplify -v
+            amplify-app --version
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
-            loginToLocalRegistry
             cd packages/amplify-e2e-tests
             yarn run e2e --maxWorkers=3
-          name: 'Run Amplify end-to-end tests'
+            unsetNpmRegistryUrl
           no_output_timeout: 90m
       - store_test_results:
           path: packages/amplify-e2e-tests/
@@ -163,7 +165,7 @@ jobs:
       - run: yarn setup-dev
       - run: amplify-dev
       - run:
-          name: 'Clone auth test package'
+          name: Clone auth test package
           command: |
             cd ..
             git clone $AUTH_CLONE_URL
@@ -178,7 +180,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: cd ../aws-amplify-cypress-auth/src && cat $(find . -type f -name 'aws-exports*')
       - run:
-          name: 'Start Auth test server in background'
+          name: Start Auth test server in background
           command: |
             cd ../aws-amplify-cypress-auth
             pwd
@@ -186,7 +188,7 @@ jobs:
           background: true
       - run: cat $(find ../repo -type f -name 'auth_spec*')
       - run:
-          name: 'Run cypress tests for auth'
+          name: Run cypress tests for auth
           command: |
             cd ../aws-amplify-cypress-auth
             yarn add cypress --save
@@ -197,7 +199,7 @@ jobs:
       - run: cd .circleci/ && chmod +x delete_auth.sh
       - run: expect .circleci/delete_auth.exp
       - run:
-          name: 'Clone API test package'
+          name: Clone API test package
           command: |
             cd ..
             git clone $API_CLONE_URL
@@ -210,14 +212,14 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: cd ../aws-amplify-cypress-api/src && cat $(find . -type f -name 'aws-exports*')
       - run:
-          name: 'Start API test server in background'
+          name: Start API test server in background
           command: |
             cd ../aws-amplify-cypress-api
             pwd
             yarn start
           background: true
       - run:
-          name: 'Run cypress tests for api'
+          name: Run cypress tests for api
           command: |
             cd ../aws-amplify-cypress-auth
             yarn add cypress --save
@@ -248,7 +250,7 @@ jobs:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run:
-          name: 'Publish Amplify CLI'
+          name: Publish Amplify CLI
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
               git config --global user.email $GITHUB_EMAIL
@@ -269,31 +271,31 @@ jobs:
           at: ./
       - checkout
       - run:
+          name: Install AWS CLI dependencies
           command: |
             apt-get install -y sudo
             sudo apt-get install -y lsof
             sudo apt-get install -y python
             sudo apt-get update && sudo apt-get install -y python-pip libpython-dev
-          name: 'Install AWS CLI dependencies'
       - run:
+          name: Install Cypress Binary
           command: |
             cd ..
             mkdir videos
             mkdir screenshots
             npm install cypress
-          name: 'Install Cypress Binary'
       - run:
-          name: 'Install AWS CLI'
+          name: Install AWS CLI
           command: pip install awscli
       - run:
-          name: 'Configure AWS CLI'
+          name: Configure AWS CLI
           command: |
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
             aws configure set region $CLI_REGION --profile default
       - run:
+          name: Run ui tests in JS SDK
           command: 'cd packages/amplify-ui-tests && npm run ui'
-          name: 'Run ui tests in JS SDK'
           no_output_timeout: 45m
       - store_artifacts:
           path: /root/videos
@@ -309,48 +311,48 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: 'Set up environment variables'
+          name: Set up environment variables
           command: |
             cd ..
             circleci_root_directory=$(pwd)
             echo "export circleci_root_directory=$circleci_root_directory" >> $BASH_ENV
       - run:
-          name: 'Checkout sample apps repository'
+          name: Checkout sample apps repository
           command: |
             cd ..
             git clone https://github.com/awslabs/aws-sdk-ios-samples.git -b e2e-testing
       - run:
-          name: 'Install AWS CLI'
+          name: Install AWS CLI
           command: pip install awscli
       - run:
-          name: 'Configure AWS CLI'
+          name: Configure AWS CLI
           command: |
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
             aws configure set region $CLI_REGION --profile default
       - run:
-          name: 'Set-Up configuration for UITests'
+          name: Set-Up configuration for UITests
           command: |
             cd ../aws-sdk-ios-samples/CircleciScripts
             python3 setup_uitest_config.py -s master -l uitest_logs
       - run:
-          name: 'Set-Up Mobile SDK Dependencies'
+          name: Set-Up Mobile SDK Dependencies
           command: |
             cd ../aws-sdk-ios-samples/CircleciScripts
             python3 run_setup_mobile_sdk_dependencies.py -n PhotoAlbum -a ${circleci_root_directory}/aws-sdk-ios-samples
       - run:
-          name: 'Configure AWS Resources'
+          name: Configure AWS Resources
           command: |
             cd packages/amplify-ui-tests
             cp ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum/simple_model.graphql ./schemas/simple_model.graphql
             npm run config ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum ios auth storage api
       - run:
-          name: 'Build and UITest'
+          name: Build and UITest
           command: |
             cd ../aws-sdk-ios-samples/CircleciScripts
             python3 run_build_and_uitest.py -n PhotoAlbum -a ${circleci_root_directory}/aws-sdk-ios-samples -c ${circleci_root_directory}
       - run:
-          name: 'Clean-Up UITest'
+          name: Clean-Up UITest
           command: |
             cd packages/amplify-ui-tests
             npm run delete ${circleci_root_directory}/aws-sdk-ios-samples/PhotoAlbum
@@ -382,7 +384,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install maven
       - run:
-          name: 'Checkout PhotoAlbum Sample App Repo'
+          name: Checkout PhotoAlbum Sample App Repo
           command: |
             cd ..
             git clone https://github.com/awslabs/aws-sdk-android-samples.git -b e2e-tests-sample-app sample_app_repo
@@ -409,10 +411,10 @@ jobs:
           command: |
             sudo apt-get -y install python3-pip
       - run:
-          name: 'Install AWS CLI'
+          name: Install AWS CLI
           command: sudo pip3 install awscli
       - run:
-          name: 'Configure AWS CLI'
+          name: Configure AWS CLI
           command: |
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
@@ -430,13 +432,13 @@ jobs:
             bash gradlew app:dependencies
             sudo npm install -g apollo-codegen@0.19.1
       - run:
-          name: 'Configure AWS Resources'
+          name: Configure AWS Resources
           command: |
             cd packages/amplify-ui-tests
             cp ${circleci_root_directory}/sample_app_repo/PhotoAlbumSample/simple_model.graphql schemas/simple_model.graphql
             npm run config ${app_root} android auth storage api
       - run:
-          name: 'Set-Up Mobile SDK Dependencies'
+          name: Set-Up Mobile SDK Dependencies
           command: |
             cd ${circleci_root_directory}/sample_app_repo/CircleciScripts
             python3 run_setup_mobile_sdk_dependencies.py -n PhotoAlbumSample -a ${circleci_root_directory}/sample_app_repo
@@ -462,12 +464,12 @@ jobs:
             circle-android wait-for-boot
             python3 ${circleci_root_directory}/sample_app_repo/CircleciScripts/unlock_emulatorscreen.py
       - run:
-          name: 'Build and UITest'
+          name: Build and UITest
           command: |
             cd ${circleci_root_directory}/sample_app_repo/CircleciScripts
             python3 run_build_and_uitest.py -n PhotoAlbumSample -a ${circleci_root_directory}/sample_app_repo -c ${circleci_root_directory}
       - run:
-          name: 'Clean-Up UITest'
+          name: Clean-Up UITest
           command: |
             cd packages/amplify-ui-tests
             npm run delete ${app_root}
@@ -509,7 +511,6 @@ workflows:
             branches:
               only:
                 - master
-                - e2e-from-verdaccio
           requires:
             - build
       - amplify_e2e_tests:
@@ -517,7 +518,6 @@ workflows:
             branches:
               only:
                 - master
-                - e2e-from-verdaccio
           requires:
             - publish_to_local_registry
       - deploy:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -1,8 +1,6 @@
   #!/bin/bash
 
 custom_registry_url=http://localhost:4873
-original_npm_registry_url=`npm get registry`
-original_yarn_registry_url=`yarn config get registry`
 default_verdaccio_package=verdaccio@4.4.3
 
 function startLocalRegistry {
@@ -26,7 +24,7 @@ function unsetNpmRegistryUrl {
 }
 
 function changeNpmGlobalPath {
-  mkdir ~/.npm-global
+  mkdir -p ~/.npm-global
   npm config set prefix '~/.npm-global'
   export PATH=~/.npm-global/bin:$PATH
 }

--- a/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
@@ -19,15 +19,16 @@ import {
 
 describe('amplify-app platform tests', () => {
   let projRoot: string;
+
   beforeEach(() => {
     projRoot = createNewProjectDir();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     deleteProjectDir(projRoot);
   });
 
-  jest.setTimeout(600000);
+  jest.setTimeout(1000 * 60 * 30); // 30 minutes is suffice as push operations are taking time
 
   it('should set up an android project', async () => {
     await amplifyAppAndroid(projRoot);


### PR DESCRIPTION
*Description of changes:*

- Fix ```amplify-app``` related e2e setup in circle ci to fix the previous file permission issues
- Increase timeout and remove extra async statement from ```amplify-app``` e2e test
- Standardize task names in circle ci

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.