### PR TITLE
test: remove npx from amplify-app testing

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
@@ -5,6 +5,7 @@ import {
   amplifyAppReact,
   amplifyModelgen,
   amplifyPush,
+  addIntegAccountInConfig,
 } from '../amplify-app-helpers/amplify-app-setup';
 import { createNewProjectDir, deleteProjectDir } from '../utils';
 import { deleteProject } from '../init';
@@ -60,6 +61,7 @@ describe('amplify-app platform tests', () => {
     validateProjectConfig(projRoot, 'javascript', 'react');
     validateApi(projRoot);
     validateBackendConfig(projRoot);
+    await addIntegAccountInConfig(projRoot);
     await amplifyModelgen(projRoot);
     validateModelgen(projRoot);
     await amplifyPush(projRoot);

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
@@ -3,15 +3,13 @@ import * as path from 'path';
 import { isCI } from '../utils';
 
 const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
-const npx = /^win/.test(process.platform) ? 'npx.cmd' : 'npx';
 const amplifyAppBinPath = path.join(__dirname, '..', '..', '..', 'amplify-app', 'bin', 'amplify-app');
+const spawnCommand = isCI() ? 'amplify-app' : amplifyAppBinPath;
 
 function amplifyAppAndroid(projRoot: string, verbose: Boolean = isCI() ? false : true) {
-  const spawnCommand = isCI() ? npx : amplifyAppBinPath;
-  const spawnArgs = isCI() ? ['amplify-app', '--platform', 'android'] : ['--platform', 'android'];
   return new Promise((resolve, reject) => {
     nexpect
-      .spawn(spawnCommand, spawnArgs, { cwd: projRoot, stripColors: true, verbose })
+      .spawn(spawnCommand, ['--platform', 'android'], { cwd: projRoot, stripColors: true, verbose })
       .wait('Successfully created base Amplify Project')
       .wait('Amplify setup completed successfully')
       .run(function(err) {
@@ -25,11 +23,9 @@ function amplifyAppAndroid(projRoot: string, verbose: Boolean = isCI() ? false :
 }
 
 function amplifyAppIos(projRoot: string, verbose: Boolean = isCI() ? false : true) {
-  const spawnCommand = isCI() ? npx : amplifyAppBinPath;
-  const spawnArgs = isCI() ? ['amplify-app', '--platform', 'ios'] : ['--platform', 'ios'];
   return new Promise((resolve, reject) => {
     nexpect
-      .spawn(spawnCommand, spawnArgs, { cwd: projRoot, stripColors: true, verbose })
+      .spawn(spawnCommand, ['--platform', 'ios'], { cwd: projRoot, stripColors: true, verbose })
       .wait('Successfully created base Amplify Project')
       .wait('Amplify setup completed successfully')
       .run(function(err) {
@@ -43,11 +39,9 @@ function amplifyAppIos(projRoot: string, verbose: Boolean = isCI() ? false : tru
 }
 
 function amplifyAppAngular(projRoot: string, verbose: Boolean = isCI() ? false : true) {
-  const spawnCommand = isCI() ? npx : amplifyAppBinPath;
-  const spawnArgs = isCI() ? ['amplify-app'] : [];
   return new Promise((resolve, reject) => {
     nexpect
-      .spawn(spawnCommand, spawnArgs, { cwd: projRoot, stripColors: true, verbose })
+      .spawn(spawnCommand, { cwd: projRoot, stripColors: true, verbose })
       .wait('What type of app are you building')
       .sendline('\r')
       .wait('What javascript framework are you using')
@@ -63,11 +57,9 @@ function amplifyAppAngular(projRoot: string, verbose: Boolean = isCI() ? false :
 }
 
 function amplifyAppReact(projRoot: string, verbose: Boolean = isCI() ? false : true) {
-  const spawnCommand = isCI() ? npx : amplifyAppBinPath;
-  const spawnArgs = isCI() ? ['amplify-app'] : [];
   return new Promise((resolve, reject) => {
     nexpect
-      .spawn(spawnCommand, spawnArgs, { cwd: projRoot, stripColors: true, verbose })
+      .spawn(spawnCommand, { cwd: projRoot, stripColors: true, verbose })
       .wait('What type of app are you building')
       .sendline('\r')
       .wait('What javascript framework are you using')

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
@@ -1,5 +1,6 @@
 import * as nexpect from '../utils/nexpect-modified';
 import * as path from 'path';
+import * as fs from 'fs-extra';
 import { isCI } from '../utils';
 
 const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
@@ -98,4 +99,15 @@ function amplifyPush(projRoot: string, verbose: Boolean = isCI() ? false : true)
   });
 }
 
-export { amplifyAppAndroid, amplifyAppIos, amplifyAppAngular, amplifyAppReact, amplifyModelgen, amplifyPush };
+function addIntegAccountInConfig(projRoot: string) {
+  // add test account to config since no default account in circle ci
+  if (isCI()) {
+    const buildConfigPath = path.join(projRoot, 'amplify-build-config.json');
+    const buildConfigFile = fs.readFileSync(buildConfigPath);
+    let buildConfig = JSON.parse(buildConfigFile.toString());
+    buildConfig.profile = 'amplify-integ-test-user';
+    fs.writeFileSync(buildConfigPath, JSON.stringify(buildConfig));
+  }
+}
+
+export { amplifyAppAndroid, amplifyAppIos, amplifyAppAngular, amplifyAppReact, amplifyModelgen, amplifyPush, addIntegAccountInConfig };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use amplify-app instead of npx to pull the version published to verdaccio
add integtest profile to config since default profile doesn't exist in circleCI
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.