### PR TITLE
fix(graphql-connection-transformer): support non string type in sort key

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
@@ -608,7 +608,6 @@ test('Test @key directive to support Int as sort key', async () => {
     `,
     mutationData,
   );
-  debugger;
   expect(result).toBeDefined();
   expect(result.data).toBeDefined();
   expect(result.data.createConfigWithParent).toBeDefined();


### PR DESCRIPTION
Connection transformer did not support sort key that were of non string type. Fixing

fix #3403

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.