### PR TITLE
feat: uplevel enabling of datastore and update of auth configs to top

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -107,11 +107,9 @@ async function serviceWalkthrough(context, defaultValuesFilename, serviceMetadat
 
   // Ask additonal questions
 
-  /* eslint-disable */
   ({ authConfig, defaultAuthType } = await askDefaultAuthQuestion(context, parameters));
   ({ authConfig, resolverConfig } = await askAdditionalQuestions(context, parameters, authConfig, defaultAuthType));
   await checkForCognitoUserPools(context, parameters, authConfig);
-  /* eslint-disable */
 
   // Ask schema file question
 
@@ -355,7 +353,9 @@ async function updateWalkthrough(context) {
   const { allResources } = await context.amplify.getResourceStatus();
   let resourceDir;
   let resourceName;
-  let authConfig, defaultAuthType, resolverConfig;
+  let authConfig;
+  let defaultAuthType;
+  let resolverConfig;
   const resources = allResources.filter(resource => resource.service === 'AppSync');
 
   // There can only be one appsync resource
@@ -429,17 +429,13 @@ async function updateWalkthrough(context) {
       project: { ConflictHandler: 'AUTOMERGE', ConflictDetection: 'VERSION' },
     };
   } else if (updateOption === 'authUpdate') {
-    /* eslint-disable */
     ({ authConfig, defaultAuthType } = await askDefaultAuthQuestion(context, parameters));
     authConfig = await askAdditionalAuthQuestions(context, parameters, authConfig, defaultAuthType);
     await checkForCognitoUserPools(context, parameters, authConfig);
-    /* eslint-disable */
   } else if (updateOption === 'all') {
-    /* eslint-disable */
     ({ authConfig, defaultAuthType } = await askDefaultAuthQuestion(context, parameters));
     ({ authConfig, resolverConfig } = await askAdditionalQuestions(context, parameters, authConfig, defaultAuthType, modelTypes));
     await checkForCognitoUserPools(context, parameters, authConfig);
-    /* eslint-disable */
   }
 
   if (authConfig) {
@@ -451,7 +447,7 @@ async function updateWalkthrough(context) {
     }
 
     amplifyMeta[category][resourceName].output.authConfig = authConfig;
-    let jsonString = JSON.stringify(amplifyMeta, null, '\t');
+    let jsonString = JSON.stringify(amplifyMeta, null, 4);
     fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
 
     const backendConfigFilePath = context.amplify.pathManager.getBackendConfigFilePath();
@@ -462,7 +458,7 @@ async function updateWalkthrough(context) {
     }
 
     backendConfig[category][resourceName].output.authConfig = authConfig;
-    jsonString = JSON.stringify(backendConfig, null, '\t');
+    jsonString = JSON.stringify(backendConfig, null, 4);
     fs.writeFileSync(backendConfigFilePath, jsonString, 'utf8');
   }
 

--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -424,8 +424,6 @@ async function updateWalkthrough(context) {
 
   let { updateOption } = await inquirer.prompt([updateOptionQuestion]);
 
-  console.log(updateOption);
-
   if (updateOption === 'enableDatastore') {
     resolverConfig = {
       project: { ConflictHandler: 'AUTOMERGE', ConflictDetection: 'VERSION' },
@@ -586,8 +584,6 @@ async function askResolverConflictQuestion(context, parameters, modelTypes) {
       }
     }
   }
-
-  console.log(resolverConfig);
 
   return resolverConfig;
 }


### PR DESCRIPTION
*Description of changes:*
New amplify update api flow:

f45c89966b0d:datstore kaustavg$ amplify-dev update api
? Please select from one of the below mentioned services: GraphQL
? Select from the options below (Use arrow keys)
❯ Walkthrough all configurations 
  Update auth settings 
  Enable DataStore for entire API 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.