### PR TITLE
feat(amplify-util-mock): add mock config for JAVA_OPTS

### DIFF
--- a/packages/amplify-dynamodb-simulator/index.js
+++ b/packages/amplify-dynamodb-simulator/index.js
@@ -73,7 +73,13 @@ async function which(bin) {
 }
 
 function buildArgs(options) {
-  const args = ['-Djava.library.path=./DynamoDBLocal_lib', '-jar', 'DynamoDBLocal.jar', '-port', options.port];
+  const args = [];
+
+  if (options.javaOpts) {
+    args.push(...options.javaOpts.split(' '));
+  }
+
+  args.push(...['-Djava.library.path=./DynamoDBLocal_lib', '-jar', 'DynamoDBLocal.jar', '-port', options.port]);
   if (options.dbPath) {
     args.push('-dbPath');
     args.push(options.dbPath);
@@ -153,7 +159,7 @@ async function launch(givenOptions = {}, retry = 0, startTime = Date.now()) {
                 host: 'localhost',
                 port,
                 output: 'silent',
-              })
+              }),
             );
           }
         }

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -13,6 +13,7 @@ import { ConfigOverrideManager } from '../utils/config-override';
 import { configureDDBDataSource, ensureDynamoDBTables } from '../utils/ddb-utils';
 import { invoke } from '../utils/lambda/invoke';
 import { getAllLambdaFunctions } from '../utils/lambda/load';
+import { getMockConfig } from '../utils/mock-config-file';
 
 export class APITest {
   private apiName: string;
@@ -255,9 +256,11 @@ export class APITest {
     const { projectPath } = context.amplify.getEnvInfo();
     const dbPath = path.join(await getMockDataDirectory(context), 'dynamodb');
     fs.ensureDirSync(dbPath);
+    const mockConfig = await getMockConfig(context);
     this.ddbEmulator = await dynamoEmulator.launch({
       dbPath,
       port: null,
+      ...mockConfig,
     });
     return dynamoEmulator.getClient(this.ddbEmulator);
   }

--- a/packages/amplify-util-mock/src/utils/mock-config-file.ts
+++ b/packages/amplify-util-mock/src/utils/mock-config-file.ts
@@ -1,0 +1,11 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+export function getMockConfig(context) {
+  const { projectPath } = context.amplify.getEnvInfo();
+  const mockConfigPath = path.join(projectPath, 'amplify', 'mock.json');
+  if (fs.existsSync(mockConfigPath)) {
+    return JSON.parse(fs.readFileSync(mockConfigPath).toString('UTF-8'));
+  }
+  return {};
+}


### PR DESCRIPTION
Allows to configure JAVA_OPTS in a mock.json config file.

*Issue #, if available:*
Relates to https://github.com/aws-amplify/amplify-console/pull/453.

*Description of changes:*
- When the file `amplify/mock.json` exists, its contents will be passed to the DynamoDB emulator. Currently, the only supported parameter is `javaOpts`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.