### PR TITLE
fix: add configuration.json placeholders

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -356,8 +356,21 @@ async function createAndroidHelperFiles() {
   };
   const configJsonStr = JSON.stringify(configJsonObj, null, 4);
   const configFile = path.join(process.cwd(), './amplify-gradle-config.json');
+  const emptyJsonStr = JSON.stringify({});
+  const rawPath = path.join(process.cwd(), './app/src/main/res/raw');
+  const awsConfigFile = path.join(rawPath, './awsconfiguration.json');
+  const amplifyConfigFile = path.join(rawPath, './amplifyconfiguration.json');
   if (!fs.existsSync(configFile)) {
     fs.writeFileSync(configFile, configJsonStr);
+  }
+
+  fs.ensureDirSync(rawPath);
+
+  if (!fs.existsSync(awsConfigFile)) {
+    fs.writeFileSync(awsConfigFile, emptyJsonStr);
+  }
+  if (!fs.existsSync(amplifyConfigFile)) {
+    fs.writeFileSync(amplifyConfigFile, emptyJsonStr);
   }
 }
 

--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -355,11 +355,11 @@ async function createAndroidHelperFiles() {
     syncEnabled: true,
   };
   const configJsonStr = JSON.stringify(configJsonObj, null, 4);
-  const configFile = path.join(process.cwd(), './amplify-gradle-config.json');
+  const configFile = path.join(process.cwd(), 'amplify-gradle-config.json');
   const emptyJsonStr = JSON.stringify({});
-  const rawPath = path.join(process.cwd(), './app/src/main/res/raw');
-  const awsConfigFile = path.join(rawPath, './awsconfiguration.json');
-  const amplifyConfigFile = path.join(rawPath, './amplifyconfiguration.json');
+  const rawPath = path.join(process.cwd(), 'app', 'src', 'main', 'res', 'raw');
+  const awsConfigFile = path.join(rawPath, 'awsconfiguration.json');
+  const amplifyConfigFile = path.join(rawPath, 'amplifyconfiguration.json');
   if (!fs.existsSync(configFile)) {
     fs.writeFileSync(configFile, configJsonStr);
   }

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
@@ -6,6 +6,8 @@ function validateProject(projRoot: string, platform: string) {
   switch (platform) {
     case 'android':
       expect(fs.existsSync(path.join(projRoot, 'amplify-gradle-config.json'))).toBeTruthy();
+      expect(fs.existsSync(path.join(projRoot, 'app/src/main/res/raw/awsconfiguration.json'))).toBeTruthy();
+      expect(fs.existsSync(path.join(projRoot, 'app/src/main/res/raw/amplifyconfiguration.json'))).toBeTruthy();
       break;
     case 'ios':
       expect(fs.existsSync(path.join(projRoot, 'amplifyxc.config'))).toBeTruthy();

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
@@ -6,8 +6,8 @@ function validateProject(projRoot: string, platform: string) {
   switch (platform) {
     case 'android':
       expect(fs.existsSync(path.join(projRoot, 'amplify-gradle-config.json'))).toBeTruthy();
-      expect(fs.existsSync(path.join(projRoot, 'app/src/main/res/raw/awsconfiguration.json'))).toBeTruthy();
-      expect(fs.existsSync(path.join(projRoot, 'app/src/main/res/raw/amplifyconfiguration.json'))).toBeTruthy();
+      expect(fs.existsSync(path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'awsconfiguration.json'))).toBeTruthy();
+      expect(fs.existsSync(path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'amplifyconfiguration.json'))).toBeTruthy();
       break;
     case 'ios':
       expect(fs.existsSync(path.join(projRoot, 'amplifyxc.config'))).toBeTruthy();


### PR DESCRIPTION
Will create amplifyconfiguration.json and awsconfiguration.json at build time in amplify-tools android plugin

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.