### PR TITLE
feat(amplify-category-api): allow minified CF stack templates

### DIFF
--- a/packages/amplify-category-api/commands/api/gql-compile.js
+++ b/packages/amplify-category-api/commands/api/gql-compile.js
@@ -4,7 +4,13 @@ module.exports = {
   name: subcommand,
   run: async context => {
     try {
-      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', { forceCompile: true });
+      const {
+        parameters: { options },
+      } = context;
+      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+        forceCompile: true,
+        minify: options['minify'],
+      });
     } catch (err) {
       context.print.error(err.toString());
     }

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -24,6 +24,9 @@ const optionalBuildDirectoryName = 'build';
 async function run(context, resourceDefinition) {
   try {
     const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = resourceDefinition;
+    const {
+      parameters: { options },
+    } = context;
     let resources;
     if (context.exeInfo && context.exeInfo.forcePush) {
       resources = allResources;
@@ -38,6 +41,7 @@ async function run(context, resourceDefinition) {
 
     await transformGraphQLSchema(context, {
       handleMigration: opts => updateStackForAPIMigration(context, 'api', undefined, opts),
+      minify: options['minify'],
     });
 
     await uploadAppSyncFiles(context, resources, allResources);

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -453,6 +453,7 @@ async function transformGraphQLSchema(context, options) {
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
     disableResolverOverrides: options.disableResolverOverrides,
+    minify: options.minify,
   };
   const transformerOutput = await TransformPackage.buildAPIProject(buildConfig);
 


### PR DESCRIPTION
*Issue #, if available:*
#2914 #162 #185 #151

*Description of changes:*

This adds an optional cli flag `--minify-stack-templates` to `amplify push` and `amplify gql-compile` commands to generate minified CloudFront templates to circumvent the 460800 bytes size limit of CloudFront templates.

This significantly reduces the size of the templates which solves issues encountered with schemas with a large number of connections, functions etc. 

```
amplify api gql-compile --minify-stack-templates
amplify push --minify-stack-templates
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.