### PR TITLE
fix(amplify-util-mock): fixes #3510 bucketname error

### DIFF
--- a/packages/amplify-util-mock/src/storage/storage.ts
+++ b/packages/amplify-util-mock/src/storage/storage.ts
@@ -141,7 +141,7 @@ export class StorageTest {
       endpoint: string;
       name: string;
       testMode: boolean;
-    }
+    },
   ) {
     const currentMeta = await getAmplifyMeta(context);
     const override = currentMeta.storage || {};
@@ -151,9 +151,9 @@ export class StorageTest {
         service: 'S3',
         ...storageMeta,
         output: {
+          ...storageMeta.output,
           BucketName: this.bucketName,
           Region: this.storageRegion,
-          ...storageMeta.output,
         },
         testMode: localStorageDetails.testMode,
         lastPushTimeStamp: new Date(),


### PR DESCRIPTION
*Issue #3510 

*Description of changes:*
* changed the code in storage.ts to avoid adding stackId to bucket name in mock storage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.