### PR TITLE
Android Code Gen: Update import for Immutable utility

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/configs/java-config.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/configs/java-config.ts
@@ -28,7 +28,7 @@ export const ENUM_IMPORT_PACKAGES = ['com.amplifyframework.core.model.ModelEnum;
 
 // packages to be imported in loader class
 export const LOADER_IMPORT_PACKAGES = [
-  'com.amplifyframework.core.Immutable',
+  'com.amplifyframework.util.Immutable',
   'com.amplifyframework.core.model.Model',
   'com.amplifyframework.core.model.ModelProvider',
   '',


### PR DESCRIPTION
In the pre-release version of amplify-android, `com.amplifyframework.core.Immutable` has moved to `com.amplifyframework.util.Immutable`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.