### PR TITLE
fix(graphql-relational-schema-transformer): fix add datasource update

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/RelationalDBSchemaTransformerUtils.ts
+++ b/packages/graphql-relational-schema-transformer/src/RelationalDBSchemaTransformerUtils.ts
@@ -14,6 +14,7 @@ import {
   SchemaDefinitionNode,
   ArgumentNode,
   ListValueNode,
+  ListTypeNode,
   StringValueNode,
   InputObjectTypeDefinitionNode,
   DocumentNode,
@@ -66,6 +67,7 @@ export function getInputValueDefinition(typeNode: NamedTypeNode | NonNullTypeNod
       value: name,
     },
     type: typeNode,
+    directives: [],
   };
 }
 
@@ -81,8 +83,8 @@ export function getInputValueDefinition(typeNode: NamedTypeNode | NonNullTypeNod
 export function getOperationFieldDefinition(
   name: string,
   args: InputValueDefinitionNode[],
-  type: NamedTypeNode,
-  directives: ReadonlyArray<DirectiveNode>
+  type: NamedTypeNode | ListTypeNode,
+  directives: ReadonlyArray<DirectiveNode>,
 ): FieldDefinitionNode {
   return {
     kind: Kind.FIELD_DEFINITION,
@@ -92,7 +94,7 @@ export function getOperationFieldDefinition(
     },
     arguments: args,
     type: type,
-    directives: directives,
+    directives: directives || [],
   };
 }
 
@@ -111,6 +113,7 @@ export function getFieldDefinition(fieldName: string, type: NonNullTypeNode | Na
       value: fieldName,
     },
     type,
+    directives: [],
   };
 }
 
@@ -129,6 +132,8 @@ export function getTypeDefinition(fields: ReadonlyArray<FieldDefinitionNode>, ty
       value: typeName,
     },
     fields: fields,
+    directives: [],
+    interfaces: [],
   };
 }
 
@@ -147,6 +152,7 @@ export function getInputTypeDefinition(fields: ReadonlyArray<InputValueDefinitio
       value: typeName,
     },
     fields: fields,
+    directives: [],
   };
 }
 
@@ -160,6 +166,18 @@ export function getNameNode(name: string): NameNode {
   return {
     kind: Kind.NAME,
     value: name,
+  };
+}
+/**
+ * Create a singleton list type node for queries
+ *
+ * @param name the singleton named type for the list
+ * @return singleton ListTypeNode
+ */
+export function getSingletonListTypeNode(name: string): ListTypeNode {
+  return {
+    kind: Kind.LIST_TYPE,
+    type: getNamedType(name),
   };
 }
 

--- a/packages/graphql-relational-schema-transformer/src/__tests__/RelationalDBSchemaTransformerUtils.test.ts
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/RelationalDBSchemaTransformerUtils.test.ts
@@ -14,6 +14,7 @@ import {
   getInputTypeDefinition,
   getArgumentNode,
   getGraphQLTypeFromMySQLType,
+  getSingletonListTypeNode,
 } from '../RelationalDBSchemaTransformerUtils';
 
 test('Test operation type node creation', () => {
@@ -45,6 +46,7 @@ test('Test input value definition node creation', () => {
   const inputDefinitionNode = getInputValueDefinition(nameNode, name);
   expect(inputDefinitionNode.kind).toEqual(Kind.INPUT_VALUE_DEFINITION);
   expect(inputDefinitionNode.type).toEqual(nameNode);
+  expect(inputDefinitionNode.directives).toEqual([]);
   expect(inputDefinitionNode.name.value).toEqual(name);
 });
 
@@ -56,6 +58,7 @@ test('Test operation field definition node creation', () => {
   expect(operationFieldDefinitionNode.kind).toEqual(Kind.FIELD_DEFINITION);
   expect(operationFieldDefinitionNode.type).toEqual(namedNode);
   expect(operationFieldDefinitionNode.arguments).toEqual(args);
+  expect(operationFieldDefinitionNode.directives).toEqual([]);
 });
 
 test('Test field definition node creation', () => {
@@ -64,6 +67,7 @@ test('Test field definition node creation', () => {
   const fieldDefinitionNode = getFieldDefinition(fieldName, namedNode);
   expect(fieldDefinitionNode.kind).toEqual(Kind.FIELD_DEFINITION);
   expect(fieldDefinitionNode.type).toEqual(namedNode);
+  expect(fieldDefinitionNode.directives).toEqual([]);
   expect(fieldDefinitionNode.name.value).toEqual(fieldName);
 });
 
@@ -72,6 +76,8 @@ test('Test type definition node creation', () => {
   const typeName = 'type name';
   const typeDefinitionNode = getTypeDefinition(fieldList, typeName);
   expect(typeDefinitionNode.kind).toEqual(Kind.OBJECT_TYPE_DEFINITION);
+  expect(typeDefinitionNode.directives).toEqual([]);
+  expect(typeDefinitionNode.interfaces).toEqual([]);
   expect(typeDefinitionNode.name.value).toEqual(typeName);
   expect(typeDefinitionNode.fields).toEqual(fieldList);
 });
@@ -88,6 +94,13 @@ test('Test list value node creation', () => {
   const listValueNode = getListValueNode(valueList);
   expect(listValueNode.kind).toEqual(Kind.LIST);
   expect(listValueNode.values).toEqual(valueList);
+});
+
+test('Test singleton list type node creation', () => {
+  const value = 'singleton';
+  const listTypeNode = getSingletonListTypeNode(value);
+  expect(listTypeNode.kind).toEqual(Kind.LIST_TYPE);
+  expect(listTypeNode.type).toEqual(getNamedType('singleton'));
 });
 
 test('Test object type node creation', () => {


### PR DESCRIPTION
Modify RDS schema transformer to match the AST generated by graphql.parse, resolving mergeTypes conflicts

fix #2510

*Issue #, if available:*
#2510

*Description of changes:*
Prevent conflicts when updating datasource by matching schema generated from RDS tables to the AST generated by parsing the current schema
-Create placeholders for empty directives/interfaces (if the current schema has directives, they won't be overwritten)
-Modify list query to use list type instead of named type

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.