### PR TITLE
fix: scoping down user pool group IAM roles and adding --force to amplify push command

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/user-pool-group-template.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/user-pool-group-template.json.ejs
@@ -78,7 +78,11 @@
                             "Principal": {
                                 "Federated": "cognito-identity.amazonaws.com"
                             },
-                            "Action": "sts:AssumeRoleWithWebIdentity"
+                            "Action": "sts:AssumeRoleWithWebIdentity",
+                            "Condition": {
+                              "StringEquals": {"cognito-identity.amazonaws.com:aud": "auth<%= props.cognitoResourceName %>IdentityPoolId"},
+                              "ForAnyValue:StringLike": {"cognito-identity.amazonaws.com:amr": "authenticated"}
+                            }
                         }
                     ]
                 }<% if(props.groups[i].customPolicies && props.groups[i].customPolicies.length > 0) { %>,

--- a/packages/amplify-cli/src/commands/push.js
+++ b/packages/amplify-cli/src/commands/push.js
@@ -11,6 +11,9 @@ module.exports = {
   run: async context => {
     try {
       context.amplify.constructExeInfo(context);
+      if (context.parameters.options.force) {
+        context.exeInfo.forcePush = true;
+      }
       await syncCurrentCloudBackend(context);
       return await context.amplify.pushResources(context);
     } catch (e) {

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -24,8 +24,12 @@ const optionalBuildDirectoryName = 'build';
 async function run(context, resourceDefinition) {
   try {
     const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = resourceDefinition;
-
-    const resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
+    let resources;
+    if (context.exeInfo.forcePush) {
+      resources = allResources;
+    } else {
+      resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
+    }
     let projectDetails = context.amplify.getProjectDetails();
 
     validateCfnTemplates(context, resources);


### PR DESCRIPTION

*Description of changes:*
1) Scope down the IAM roles assigned to user pool groups by the following condition:
'Condition': {
	'StringEquals': {'cognito-identity.amazonaws.com:aud': <idpId>},
	'ForAnyValue:StringLike': {'cognito-identity.amazonaws.com:amr': 'authenticated'
}

2) Implement `amplify push --force` with force as an optional parameter to trigger Cloud-formation deployments without any changes to the CFN files or going through any update flows.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.