### PR TITLE
test(amplify-e2e-tests): increase cloudwatch timeout to 100 seconds

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -66,7 +66,7 @@ describe('amplify add function', () => {
     expect(resp.data.createTodo.id).toBeDefined();
 
     // sleep a bit to make sure lambda logs appear in cloudwatch
-    await sleep(50 * 1000);
+    await sleep(100 * 1000);
 
     const logs = await getCloudWatchLogs(meta.providers.awscloudformation.Region, `/aws/lambda/${functionName}`);
     // NOTE: this expects default Lambda DynamoDB trigger template to log dynamoDB json records


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase timeout to make sure lambda logs appear in cloudwatch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.