### PR TITLE
fix(amplify-codegen): use Java Long for AWSTimestamp

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/scalars/index.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/scalars/index.ts
@@ -9,7 +9,7 @@ export const JAVA_SCALAR_MAP: NormalizedScalarsMap = {
   AWSDate: 'java.util.Date',
   AWSDateTime: 'java.util.Date',
   AWSTime: 'java.sql.Time',
-  AWSTimestamp: 'long',
+  AWSTimestamp: 'Long',
   AWSEmail: 'String',
   AWSJSON: 'String',
   AWSURL: 'String',


### PR DESCRIPTION
*Issue #, if available:*
 #3593

*Description of changes:*
Use Java object Long instead of primitive long so that it can be set to null.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.