### PR TITLE
Fix string literal to be a `Ref` in the cloud formation template

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/user-pool-group-template.json.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/user-pool-group-template.json.ejs
@@ -80,7 +80,7 @@
                             },
                             "Action": "sts:AssumeRoleWithWebIdentity",
                             "Condition": {
-                              "StringEquals": {"cognito-identity.amazonaws.com:aud": "auth<%= props.cognitoResourceName %>IdentityPoolId"},
+                              "StringEquals": {"cognito-identity.amazonaws.com:aud": {"Ref":"auth<%= props.cognitoResourceName %>IdentityPoolId"}},
                               "ForAnyValue:StringLike": {"cognito-identity.amazonaws.com:amr": "authenticated"}
                             }
                         }


### PR DESCRIPTION
A bug was recently introduced into the CLI in this commit https://github.com/aws-amplify/amplify-cli/commit/e8e9322e910259e04d063883d5acbfe46a96d191

It added a condition to the Trust policy in the CloudFormation template, but unfortunately was using a literal string reference to the `IdentityPoolId` parameter instead of using a `Ref`.

This resulted in a pretty significant bug where all calls to a REST API would fail if you were using Cognito Roles.

The cloud formation template ended up looking like this: 

`"StringEquals": {"cognito-identity.amazonaws.com:aud": "somelabel123IdentityPoolId"}`

Whereas it should be:

`"StringEquals": {"cognito-identity.amazonaws.com:aud": {"Ref":"somelabel123IdentityPoolId"}}`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.