### PR TITLE
refactor: simplify return statements, change i += 1 to ++i in for loops

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -26,11 +26,7 @@ async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPus
   const localDirHash = await getHashForResourceDir(localBackendDir);
   const cloudDirHash = await getHashForResourceDir(cloudBackendDir);
 
-  if (localDirHash !== cloudDirHash) {
-    return true;
-  }
-
-  return false;
+  return localDirHash !== cloudDirHash;
 }
 
 function getHashForResourceDir(dirPath) {
@@ -52,16 +48,13 @@ function filterResources(resources, filteredResources) {
 
   resources = resources.filter(resource => {
     let common = false;
-    for (let i = 0; i < filteredResources.length; i += 1) {
+    for (let i = 0; i < filteredResources.length; ++i) {
       if (filteredResources[i].category === resource.category && filteredResources[i].resourceName === resource.resourceName) {
         common = true;
         break;
       }
     }
-    if (common === true) {
-      return true;
-    }
-    return false;
+    return common;
   });
 
   return resources;
@@ -127,9 +120,9 @@ function getResourcesToBeCreated(amplifyMeta, currentamplifyMeta, category, reso
 
   // Check for dependencies and add them
 
-  for (let i = 0; i < resources.length; i += 1) {
+  for (let i = 0; i < resources.length; ++i) {
     if (resources[i].dependsOn && resources[i].dependsOn.length > 0) {
-      for (let j = 0; j < resources[i].dependsOn.length; j += 1) {
+      for (let j = 0; j < resources[i].dependsOn.length; ++j) {
         const dependsOnCategory = resources[i].dependsOn[j].category;
         const dependsOnResourcename = resources[i].dependsOn[j].resourceName;
         if (
@@ -187,7 +180,7 @@ async function getResourcesToBeUpdated(amplifyMeta, currentamplifyMeta, category
           const backendModified = await isBackendDirModifiedSinceLastPush(
             resource,
             categoryName,
-            currentamplifyMeta[categoryName][resource].lastPushTimeStamp
+            currentamplifyMeta[categoryName][resource].lastPushTimeStamp,
           );
 
           if (backendModified) {
@@ -214,7 +207,7 @@ async function getResourcesToBeUpdated(amplifyMeta, currentamplifyMeta, category
 }
 
 async function asyncForEach(array, callback) {
-  for (let index = 0; index < array.length; index += 1) {
+  for (let index = 0; index < array.length; ++index) {
     await callback(array[index], index, array);
   }
 }
@@ -233,7 +226,7 @@ async function getResourceStatus(category, resourceName, providerName, filteredR
     amplifyMeta = readJsonFile(backendConfigFilePath);
   } else {
     throw new Error(
-      "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify"
+      "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
     );
   }
 
@@ -273,7 +266,7 @@ async function showResourceTable(category, resourceName, filteredResources) {
     category,
     resourceName,
     undefined,
-    filteredResources
+    filteredResources,
   );
 
   let noChangeResources = _.differenceWith(allResources, resourcesToBeCreated.concat(resourcesToBeUpdated), _.isEqual);
@@ -284,7 +277,7 @@ async function showResourceTable(category, resourceName, filteredResources) {
   const deleteOperationLabel = 'Delete';
   const noOperationLabel = 'No Change';
   const tableOptions = [['Category', 'Resource name', 'Operation', 'Provider plugin']];
-  for (let i = 0; i < resourcesToBeCreated.length; i += 1) {
+  for (let i = 0; i < resourcesToBeCreated.length; ++i) {
     tableOptions.push([
       capitalize(resourcesToBeCreated[i].category),
       resourcesToBeCreated[i].resourceName,
@@ -292,7 +285,7 @@ async function showResourceTable(category, resourceName, filteredResources) {
       resourcesToBeCreated[i].providerPlugin,
     ]);
   }
-  for (let i = 0; i < resourcesToBeUpdated.length; i += 1) {
+  for (let i = 0; i < resourcesToBeUpdated.length; ++i) {
     tableOptions.push([
       capitalize(resourcesToBeUpdated[i].category),
       resourcesToBeUpdated[i].resourceName,
@@ -300,7 +293,7 @@ async function showResourceTable(category, resourceName, filteredResources) {
       resourcesToBeUpdated[i].providerPlugin,
     ]);
   }
-  for (let i = 0; i < resourcesToBeDeleted.length; i += 1) {
+  for (let i = 0; i < resourcesToBeDeleted.length; ++i) {
     tableOptions.push([
       capitalize(resourcesToBeDeleted[i].category),
       resourcesToBeDeleted[i].resourceName,
@@ -308,7 +301,7 @@ async function showResourceTable(category, resourceName, filteredResources) {
       resourcesToBeDeleted[i].providerPlugin,
     ]);
   }
-  for (let i = 0; i < noChangeResources.length; i += 1) {
+  for (let i = 0; i < noChangeResources.length; ++i) {
     tableOptions.push([
       capitalize(noChangeResources[i].category),
       noChangeResources[i].resourceName,


### PR DESCRIPTION
Simplify return statements, change `i += 1` to `++i` for more idiomatic code and slightly better perf

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.