### PR TITLE
test(amplify-e2e-tests): assert exit code in migration tests

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth.test.ts
@@ -59,9 +59,13 @@ describe('amplify add auth...', () => {
     await addAuthWithDefaultSocial(projRoot, {});
     await amplifyPushAuth(projRoot);
     const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+
+    const authMeta = Object.keys(meta.auth).map(key => meta.auth[key])[0];
+    const id = authMeta.output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
+    const clientIds = [authMeta.output.AppClientIDWeb, authMeta.output.AppClientID];
+    const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
+
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
     expect(clients[0].UserPoolClient.CallbackURLs[0]).toEqual('https://www.google.com/');
@@ -74,11 +78,15 @@ describe('amplify add auth...', () => {
     await addAuthWithGroupTrigger(projRoot, {});
     await amplifyPushAuth(projRoot);
     const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+
     const functionName = `${Object.keys(meta.auth)[0]}PostConfirmation-integtest`;
 
+    const authMeta = Object.keys(meta.auth).map(key => meta.auth[key])[0];
+    const id = authMeta.output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
+    const clientIds = [authMeta.output.AppClientIDWeb, authMeta.output.AppClientID];
+    const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
+
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
@@ -91,11 +99,14 @@ describe('amplify add auth...', () => {
     await addAuthViaAPIWithTrigger(projRoot, {});
     await amplifyPush(projRoot);
     const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
-    const functionName = `${Object.keys(meta.auth)[0]}PostConfirmation-integtest`;
 
+    const functionName = `${Object.keys(meta.auth)[0]}PostConfirmation-integtest`;
+    const authMeta = Object.keys(meta.auth).map(key => meta.auth[key])[0];
+    const id = authMeta.output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
+    const clientIds = [authMeta.output.AppClientIDWeb, authMeta.output.AppClientID];
+    const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
+
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
@@ -108,12 +119,17 @@ describe('amplify add auth...', () => {
     await addAuthWithRecaptchaTrigger(projRoot, {});
     await amplifyPushAuth(projRoot);
     const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+
     const createFunctionName = `${Object.keys(meta.auth)[0]}CreateAuthChallenge-integtest`;
     const defineFunctionName = `${Object.keys(meta.auth)[0]}DefineAuthChallenge-integtest`;
     const verifyFunctionName = `${Object.keys(meta.auth)[0]}VerifyAuthChallengeResponse-integtest`;
+
+    const authMeta = Object.keys(meta.auth).map(key => meta.auth[key])[0];
+    const id = authMeta.output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
+    const clientIds = [authMeta.output.AppClientIDWeb, authMeta.output.AppClientID];
+    const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
+
     const createFunction = await getLambdaFunction(createFunctionName, meta.providers.awscloudformation.Region);
     const defineFunction = await getLambdaFunction(defineFunctionName, meta.providers.awscloudformation.Region);
     const verifyFunction = await getLambdaFunction(verifyFunctionName, meta.providers.awscloudformation.Region);
@@ -131,11 +147,16 @@ describe('amplify add auth...', () => {
     await addAuthWithMaxOptions(projRoot, {});
     await amplifyPushAuth(projRoot);
     const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[1].output.UserPoolId;
+
     const createFunctionName = `${Object.keys(meta.auth)[1]}CreateAuthChallenge-integtest`;
     const defineFunctionName = `${Object.keys(meta.auth)[1]}DefineAuthChallenge-integtest`;
+
+    const authMeta = Object.keys(meta.auth).map(key => meta.auth[key])[0];
+    const id = authMeta.output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
+    const clientIds = [authMeta.output.AppClientIDWeb, authMeta.output.AppClientID];
+    const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
+
     const createFunction = await getLambdaFunction(createFunctionName, meta.providers.awscloudformation.Region);
     const defineFunction = await getLambdaFunction(defineFunctionName, meta.providers.awscloudformation.Region);
 
@@ -165,10 +186,15 @@ describe('amplify updating auth...', () => {
     await addAuthWithCustomTrigger(projRoot, {});
     await amplifyPushAuth(projRoot);
     const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+
     const functionName = `${Object.keys(meta.auth)[0]}PreSignup-integtest`;
+
+    const authMeta = Object.keys(meta.auth).map(key => meta.auth[key])[0];
+    const id = authMeta.output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const clients = await getUserPoolClients(id, meta.providers.awscloudformation.Region);
+    const clientIds = [authMeta.output.AppClientIDWeb, authMeta.output.AppClientID];
+    const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
+
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     const dirContents = fs.readdirSync(`${projRoot}/amplify/backend/function/${Object.keys(meta.auth)[0]}PreSignup/src`);
     expect(dirContents.includes('custom.js')).toBeTruthy();

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
@@ -21,10 +21,12 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(
-      projRoot,
-      /Attempting to edit the global secondary index gsi-PostComments on the CommentTable table in the Comment stack.*/,
-    );
+    await expect(
+      amplifyPushUpdate(
+        projRoot,
+        /Attempting to edit the global secondary index gsi-PostComments on the CommentTable table in the Comment stack.*/,
+      ),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run invalid migration trying to change add and remove connection at same time, and check for error', async () => {
@@ -35,10 +37,12 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(
-      projRoot,
-      /Attempting to add and remove a global secondary index at the same time on the CommentTable table in the Comment stack.*/,
-    );
+    await expect(
+      amplifyPushUpdate(
+        projRoot,
+        /Attempting to add and remove a global secondary index at the same time on the CommentTable table in the Comment stack.*/,
+      ),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run invalid migration trying to change a @connection field name, and check for error', async () => {
@@ -49,10 +53,12 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(
-      projRoot,
-      /Attempting to edit the global secondary index gsi-PostComments on the CommentTable table in the Comment stack.*/,
-    );
+    await expect(
+      amplifyPushUpdate(
+        projRoot,
+        /Attempting to edit the global secondary index gsi-PostComments on the CommentTable table in the Comment stack.*/,
+      ),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run valid migration to remove a connection, then run another migration that adds a slightly different GSI.', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration.test.ts
@@ -21,10 +21,12 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(
-      projRoot,
-      /Attempting to add a local secondary index to the TodoTable table in the Todo stack. Local secondary indexes must be created when the table is created.*/,
-    );
+    await expect(
+      amplifyPushUpdate(
+        projRoot,
+        /Attempting to add a local secondary index to the TodoTable table in the Todo stack. Local secondary indexes must be created when the table is created.*/,
+      ),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run invalid migration trying to change a gsi, and check for error', async () => {
@@ -35,7 +37,9 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(projRoot, /Attempting to edit the global secondary index SomeGSI on the TodoTable table in the Todo stack.*/);
+    await expect(
+      amplifyPushUpdate(projRoot, /Attempting to edit the global secondary index SomeGSI on the TodoTable table in the Todo stack.*/),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run invalid migration trying to change the key schema, and check for error', async () => {
@@ -46,7 +50,9 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(projRoot, /Attempting to edit the key schema of the TodoTable table in the Todo stack.*/);
+    await expect(
+      amplifyPushUpdate(projRoot, /Attempting to edit the key schema of the TodoTable table in the Todo stack.*/),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run invalid migration trying to change an lsi, and check for error', async () => {
@@ -57,7 +63,9 @@ describe('amplify add api', () => {
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
-    await amplifyPushUpdate(projRoot, /Attempting to edit the local secondary index SomeLSI on the TodoTable table in the Todo stack.*/);
+    await expect(
+      amplifyPushUpdate(projRoot, /Attempting to edit the local secondary index SomeLSI on the TodoTable table in the Todo stack.*/),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init project, run valid migration adding a GSI', async () => {

--- a/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
@@ -44,17 +44,15 @@ const getLambdaFunction = async (functionName, region) => {
   return res;
 };
 
-const getUserPoolClients = async (userpoolId, region) => {
-  config.update({ region });
-  const provider = new CognitoIdentityServiceProvider();
+const getUserPoolClients = async (userPoolId: string, clientIds: string[], region: string) => {
+  const provider = new CognitoIdentityServiceProvider({ region });
   const res = [];
   try {
-    const clients = await provider.listUserPoolClients({ UserPoolId: userpoolId }).promise();
-    for (let i = 0; i < clients.UserPoolClients.length; i++) {
+    for (let i = 0; i < clientIds.length; i++) {
       const clientData = await provider
         .describeUserPoolClient({
-          UserPoolId: userpoolId,
-          ClientId: clients.UserPoolClients[i].ClientId,
+          UserPoolId: userPoolId,
+          ClientId: clientIds[i],
         })
         .promise();
       res.push(clientData);


### PR DESCRIPTION
test(amplify-e2e-tests): update SDK call to use congito application ids from meta file
test(amplify-e2e-tests): assert exit code in migration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.