### PR TITLE
fix(amplify-e2e-tests): fix addPinpointAnalytics to expect new prompt string

### DIFF
--- a/packages/amplify-e2e-tests/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-tests/src/utils/pinpoint.ts
@@ -93,7 +93,7 @@ export function initProject(cwd: string) {
 export function addPinpointAnalytics(cwd: string): Promise<string> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['add', 'analytics'], { cwd, stripColors: true })
-      .wait('Please select from one of the below mentioned services')
+      .wait('Select an Analytics provider')
       .sendCarriageReturn()
       .wait('Provide your pinpoint resource name:')
       .sendLine(settings.pinpointResourceName)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Delete pinpoint e2e test needs to expect the new analytics prompt [here](https://github.com/aws-amplify/amplify-cli/blob/b25cfd00b21416a82ecefda1f6498206ef71531b/packages/amplify-category-analytics/commands/analytics/add.js#L12)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.