### PR TITLE
test(amplify-e2e-tests): randomize kenisis stream name

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/analytics.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/analytics.test.ts
@@ -27,7 +27,8 @@ describe('amplify add analytics', () => {
 
   it('add kinesis', async () => {
     await initJSProjectWithProfile(projRoot, {});
-    const rightName = 'myapp';
+    const random = Math.floor(Math.random() * 10000);
+    const rightName = `myapp-${random}`;
     await addKinesis(projRoot, { rightName, wrongName: '$' });
     await amplifyPushUpdate(projRoot);
     expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'analytics', rightName))).toBe(true);

--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -79,7 +79,8 @@ describe('amplify add function', () => {
 
   it('records put into kinesis stream should result in trigger called in minimal kinesis + trigger infra', async () => {
     await initJSProjectWithProfile(projRoot, {});
-    await addKinesis(projRoot, { rightName: 'kinesisintegtest', wrongName: '$' });
+    const random = Math.floor(Math.random() * 10000);
+    await addKinesis(projRoot, { rightName: `kinesisintegtest-${random}`, wrongName: '$' });
     await addFunction(projRoot, { functionTemplate: 'lambdaTrigger', triggerType: 'Kinesis' });
 
     await functionBuild(projRoot, {});


### PR DESCRIPTION
Randomize Kenisis stream name to enable concurrent execution of tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.