### PR TITLE
test(amplify-e2e-tests): randomize ddb and fnnames

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -172,8 +172,9 @@ describe('amplify add function with additional permissions', () => {
   it('lambda with dynamoDB permissions should be able to scan ddb', async () => {
     await initJSProjectWithProfile(projRoot, {});
 
-    const fnName = 'integtestfn';
-    const ddbName = 'integtestddb';
+    const random = Math.floor(Math.random() * 10000);
+    const fnName = `integtestfn${random}`;
+    const ddbName = `integtestddb${random}`;
 
     // test ability to scan both appsync @model-backed and regular ddb tables
     await addApiWithSchema(projRoot, 'simple_model.graphql');
@@ -241,7 +242,8 @@ describe('amplify add function with additional permissions', () => {
   it('existing lambda updated with additional permissions should be able to scan ddb', async () => {
     await initJSProjectWithProfile(projRoot, {});
 
-    const fnName = 'integtestfn';
+    const random = Math.floor(Math.random() * 10000);
+    const fnName = `integtestfn${random}`;
     await addFunction(projRoot, {
       name: fnName,
       functionTemplate: 'helloWorld',
@@ -298,7 +300,9 @@ describe('amplify add function with additional permissions', () => {
     await initJSProjectWithProfile(projRoot, {});
     await addApiWithSchema(projRoot, 'simple_model.graphql');
 
-    let fnName = 'integtestfn';
+    const random = Math.floor(Math.random() * 10000);
+    const fnName = `integtestfn${random}`;
+
     await addFunction(projRoot, {
       name: fnName,
       functionTemplate: 'helloWorld',


### PR DESCRIPTION
Randomize the function and ddb names to support parallel test runs

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.