### PR TITLE
fix: update import

### DIFF
--- a/packages/amplify-e2e-tests/src/categories/codegen.ts
+++ b/packages/amplify-e2e-tests/src/categories/codegen.ts
@@ -1,5 +1,5 @@
 import { getCLIPath } from '../utils';
-import { nspawn as spawn } from '../utils/nexpect';
+import { nspawn as spawn } from 'amplify-e2e-core';
 
 export function generateModels(cwd: string) {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-e2e-tests/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-tests/src/utils/pinpoint.ts
@@ -1,6 +1,6 @@
 import { Pinpoint } from 'aws-sdk';
 import { getCLIPath } from '../utils';
-import { nspawn as spawn } from '../utils/nexpect';
+import { nspawn as spawn } from 'amplify-e2e-core';
 
 const settings = {
   name: '\r',


### PR DESCRIPTION
Update import of nexpect to use new amplify-e2e-core package

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.