### PR TITLE
use reduce instead of flatmap for node compatibility

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -86,7 +86,8 @@ async function getSelectionFromContributors<T>(context: any, selectionOptions: P
       return meta;
     })
     .map(meta => meta.manifest[selectionOptions.pluginType])
-    .flatMap(contributes => contributes[selectionOptions.listOptionsField]);
+    .map(contributes => contributes[selectionOptions.listOptionsField])
+    .reduce((acc, it) => acc.concat(it), []);
 
 
   // sanity checks


### PR DESCRIPTION
*Issue #, if available:*
Previous function refactor used flatMap but we support node 10 which does not support flatmap so changing to use reduce and concat instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.