### PR TITLE
feat(amplify-python-runtime-provider): implement python runtime provider

### DIFF
--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -55,7 +55,7 @@ export type BuildRequest = {
   env: string;
   srcRoot: string;
   runtime: string;
-  legacyBuildHookParams: {
+  legacyBuildHookParams?: {
     projectRoot: string;
     resourceName: string;
   };

--- a/packages/amplify-nodejs-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-runtime-provider/src/utils/legacyBuild.ts
@@ -10,7 +10,9 @@ export async function buildResource(request: BuildRequest): Promise<BuildResult>
 
   if (!request.lastBuildTimestamp || isBuildStale(request.srcRoot, request.lastBuildTimestamp)) {
     installDependencies(resourceDir);
-    runBuildScriptHook(request.legacyBuildHookParams.resourceName, request.legacyBuildHookParams.projectRoot);
+    if (request.legacyBuildHookParams) {
+      runBuildScriptHook(request.legacyBuildHookParams.resourceName, request.legacyBuildHookParams.projectRoot);
+    }
     return Promise.resolve({ rebuilt: true });
   }
   return Promise.resolve({ rebuilt: false });

--- a/packages/amplify-nodejs-template-provider/amplify-plugin.json
+++ b/packages/amplify-nodejs-template-provider/amplify-plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "functionTemplate",
-  "id": "f579f2fa-35c1-49c4-950f-b588e779b4dd",
   "type": "util",
   "commands": [],
   "eventHandlers": [],
@@ -13,7 +12,7 @@
     "templates": [
       {
         "name": "Hello World",
-        "value": "helloworld"
+        "value": "hello-world"
       },
       {
         "name": "CRUD function for DynamoDB (Integration with API Gateway)",

--- a/packages/amplify-nodejs-template-provider/src/index.ts
+++ b/packages/amplify-nodejs-template-provider/src/index.ts
@@ -9,7 +9,7 @@ export const functionTemplateContributorFactory: FunctionTemplateContributorFact
   return {
     contribute: request => {
       switch (request.selection) {
-        case 'helloworld': {
+        case 'hello-world': {
           return provideHelloWorld();
         }
         case 'crud': {

--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -29,7 +29,13 @@ async function buildResource(context, resource) {
 
   let zipFilename = resource.distZipFilename;
 
+  // load plugin and perform dependency pre-check
   const runtimePlugin = await loadRuntimePlugin(context, breadcrumbs.pluginId);
+  const depCheck = await runtimePlugin.checkDependencies();
+  if (!depCheck.hasRequiredDependencies) {
+    context.print.error(depCheck.errorMessage || `You are missing dependencies required to package ${resourceName}`);
+    throw new Error(`Missing required dependencies to package ${resourceName}`);
+  }
 
   // build the function
   let rebuilt = false;

--- a/packages/amplify-python-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-python-runtime-provider/amplify-plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "functionRuntime",
+  "type": "util",
+  "commands": [],
+  "eventHandlers": [],
+  "functionRuntime": {
+    "pluginId": "amplify-python-function-runtime-provider",
+    "conditions": {
+      "provider": "awscloudformation",
+      "service": "Lambda"
+    },
+    "runtimes": [
+      {
+        "name": "Python",
+        "value": "python"
+      }
+    ]
+  }
+}

--- a/packages/amplify-python-runtime-provider/package.json
+++ b/packages/amplify-python-runtime-provider/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "amplify-python-runtime-provider",
+  "version": "1.0.0",
+  "description": "Provides functionality related to functions in Python on AWS",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf ./lib"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "amplify-function-plugin-interface": "1.0.0",
+    "archiver": "^3.1.1"
+  },
+  "devDependencies": {
+    "@types/archiver": "^3.1.0"
+  },
+  "jest": {
+    "testURL": "http://localhost",
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(.*/__tests__/.*.test.(j|t)s)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true,
+    "coverageReporters": [
+      "json",
+      "html"
+    ]
+  }
+}

--- a/packages/amplify-python-runtime-provider/src/index.ts
+++ b/packages/amplify-python-runtime-provider/src/index.ts
@@ -1,24 +1,35 @@
-import { FunctionRuntimeContributorFactory, PackageRequest, BuildRequest } from 'amplify-function-plugin-interface';
+import {
+  FunctionRuntimeContributorFactory,
+  PackageRequest,
+  BuildRequest,
+  PackageResult,
+  BuildResult,
+  CheckDependenciesResult,
+} from 'amplify-function-plugin-interface';
 import { execAsStringPromise, getPipenvDir } from './util/buildUtils';
 import archiver from 'archiver';
 import fs from 'fs-extra';
-import path from 'path';
+import glob from 'glob';
+import { majMinPyVersion } from './util/buildUtils';
 
 export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactory = context => {
   return {
-    contribute: selection => {
+    contribute: request => {
+      const selection = request.selection;
       if (selection !== 'python') {
         return Promise.reject(new Error(`Unknown selection ${selection}`));
       }
       return Promise.resolve({
         runtime: {
-          name: 'python',
-          value: 'python3.8',
+          name: 'Python',
+          value: 'python',
+          cloudTemplateValue: 'python3.8',
           defaultHandler: 'index.handler',
         },
       });
     },
-    package: pythonPackage,
+    checkDependencies: checkDeps,
+    package: params => pythonPackage(params, context),
     build: pythonBuild,
     invoke: params => {
       throw new Error('not yet implemented');
@@ -26,23 +37,69 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
   };
 };
 
-// packages python lambda functions and writes the archive to params.dstStream
-async function pythonPackage(params: PackageRequest): Promise<void> {
-  // do fresh build
-  await pythonBuild(params);
-
-  // zip source and dependencies and write to specified file
-  const zip = archiver.create('zip', {});
-  const file = fs.createWriteStream(params.dstFilename);
-  zip.pipe(file);
-  zip.directory(params.srcRoot, false);
-  zip.directory(await getPipenvDir(params.srcRoot), false);
-  await zip.finalize();
+async function checkDeps(): Promise<CheckDependenciesResult> {
+  return new Promise((resolve, reject) => {
+    Promise.all([execAsStringPromise('python3 --version'), execAsStringPromise('pipenv --version')]).then(versions => {
+      let hasDeps = true;
+      let errorMessage = '';
+      if (!versions[0] || parseFloat(majMinPyVersion(versions[0])) < 3.8) {
+        hasDeps = false;
+        errorMessage =
+          'You must have python >= 3.8 installed and available on your PATH as "python3". It can be installed at https://www.python.org/downloads';
+      }
+      if (!versions[1]) {
+        hasDeps = false;
+        let message =
+          'You must have pipenv installed and available on your PATH as "pipenv". It can be installed by running "pip install pipenv".';
+        errorMessage = errorMessage.concat(errorMessage ? '\n' : '', message);
+      }
+      resolve({
+        hasRequiredDependencies: hasDeps,
+        errorMessage,
+      });
+    });
+  });
 }
 
-async function pythonBuild(params: BuildRequest): Promise<void> {
-  if (fs.existsSync(path.join(params.srcRoot, buildScript))) {
-    await execAsStringPromise(`./${buildScript}`, { cwd: params.srcRoot });
+// packages python lambda functions and writes the archive to the specified file
+async function pythonPackage(params: PackageRequest, context: any): Promise<PackageResult> {
+  if (!params.lastPackageTimestamp || params.lastBuildTimestamp > params.lastPackageTimestamp) {
+    // zip source and dependencies and write to specified file
+    const file = fs.createWriteStream(params.dstFilename);
+    const packageHash = await context.amplify.hashDir(params.srcRoot, ['dist']);
+    return new Promise(async (resolve, reject) => {
+      file.on('close', () => {
+        resolve({ packageHash });
+      });
+      file.on('error', err => {
+        reject(new Error(`Failed to zip with error: [${err}]`));
+      });
+      const zip = archiver.create('zip', {});
+      zip.pipe(file);
+      zip.glob('**/*', {
+        cwd: params.srcRoot,
+        ignore: ['dist/**'],
+      });
+      zip.directory(await getPipenvDir(params.srcRoot), false);
+      zip.finalize();
+    });
   }
-  await execAsStringPromise('pipenv install', { cwd: params.srcRoot });
+  return Promise.resolve({});
+}
+
+async function pythonBuild(params: BuildRequest): Promise<BuildResult> {
+  if (!params.lastBuildTimestamp || isBuildStale(params.srcRoot, params.lastBuildTimestamp)) {
+    await execAsStringPromise('pipenv install', { cwd: params.srcRoot }, undefined, true);
+    return Promise.resolve({ rebuilt: true });
+  }
+  return Promise.resolve({ rebuilt: false });
+}
+
+function isBuildStale(resourceDir: string, lastBuildTimestamp: Date) {
+  const dirTime = new Date(fs.statSync(resourceDir).mtime);
+  if (dirTime > lastBuildTimestamp) {
+    return true;
+  }
+  const fileUpdatedAfterLastBuild = glob.sync(`${resourceDir}/**`).find(file => new Date(fs.statSync(file).mtime) > lastBuildTimestamp);
+  return !!fileUpdatedAfterLastBuild;
 }

--- a/packages/amplify-python-runtime-provider/src/util/buildUtils.ts
+++ b/packages/amplify-python-runtime-provider/src/util/buildUtils.ts
@@ -1,0 +1,46 @@
+import { exec, ExecOptions } from 'child_process';
+import path from 'path';
+import fs from 'fs-extra';
+import { promisify } from 'util';
+
+// Gets the pipenv dir where this function's dependencies are located
+export async function getPipenvDir(srcRoot: string): Promise<string> {
+  const pipEnvDir = await execAsStringPromise('pipenv --venv', { cwd: srcRoot });
+  const pyVersion = await execAsStringPromise('python3 --version');
+  let pipEnvPath = path.join(pipEnvDir, 'lib', 'python' + majMinPyVersion(pyVersion), 'site-packages');
+  if (fs.existsSync(pipEnvPath)) {
+    return pipEnvPath;
+  }
+  throw new Error('Could not find a pipenv site-packages directory');
+}
+
+export function majMinPyVersion(pyVersion: string): string {
+  if (!/^Python \d+\.\d+\.\d+$/.test(pyVersion)) {
+    throw new Error(`Cannot interpret Python version "${pyVersion}"`);
+  }
+  const versionNum = pyVersion.split(' ')[1];
+  return versionNum
+    .split('.')
+    .slice(0, 2)
+    .join('.');
+}
+
+// wrapper for executing a shell command and returning the result as a string promise
+// opts are passed directly to the exec command
+// errorMessage is an optional error message to throw if the command fails
+// outputOnStderr is a flag if the 'success' output of the command will be on stderr (for some ungodly reason, this is how python --version works)
+export async function execAsStringPromise(
+  command: string,
+  opts?: ExecOptions,
+  errorMessage?: string,
+  outputOnStderr: boolean = false,
+): Promise<string> {
+  const { stdout, stderr } = await promisify(exec)(command, opts);
+  if (outputOnStderr) {
+    return stderr.toString('utf8').trim();
+  }
+  if (stderr) {
+    throw new Error(errorMessage || `Received error [${stderr.toString('utf8').trim()}] running command [${command}]`);
+  }
+  return stdout.toString('utf8').trim();
+}

--- a/packages/amplify-python-runtime-provider/tsconfig.json
+++ b/packages/amplify-python-runtime-provider/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "strict": true,
+  },
+  "references": [
+    {"path": "../amplify-function-plugin-interface"}
+  ]
+}

--- a/packages/amplify-python-template-provider/amplify-plugin.json
+++ b/packages/amplify-python-template-provider/amplify-plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "functionTemplate",
+  "type": "util",
+  "commands": [],
+  "eventHandlers": [],
+  "functionTemplate": {
+    "conditions": {
+      "provider": "awscloudformation",
+      "service": "Lambda",
+      "runtime": "python"
+    },
+    "templates": [
+      {
+        "name": "Hello World",
+        "value": "hello-world"
+      }
+    ]
+  }
+}

--- a/packages/amplify-python-template-provider/package.json
+++ b/packages/amplify-python-template-provider/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "amplify-python-template-provider",
+  "version": "1.0.0",
+  "description": "Python templates supplied by the Amplify Team",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf ./lib"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "amplify-function-plugin-interface": "1.0.0"
+  }
+}

--- a/packages/amplify-python-template-provider/resources/hello-world/Pipfile
+++ b/packages/amplify-python-template-provider/resources/hello-world/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.8"

--- a/packages/amplify-python-template-provider/resources/hello-world/index.py
+++ b/packages/amplify-python-template-provider/resources/hello-world/index.py
@@ -1,0 +1,6 @@
+import json
+
+def handler(event, context):
+  return {
+    'message': 'received event: ' + json.dumps(event)
+  }

--- a/packages/amplify-python-template-provider/src/index.ts
+++ b/packages/amplify-python-template-provider/src/index.ts
@@ -1,0 +1,27 @@
+import { FunctionTemplateContributorFactory, FunctionTemplateParameters } from 'amplify-function-plugin-interface';
+import fs from 'fs-extra';
+
+const pathToTemplateFiles = `${__dirname}/../resources/hello-world`;
+
+export const functionTemplateContributorFactory: FunctionTemplateContributorFactory = context => {
+  return {
+    contribute: request => {
+      const selection = request.selection;
+      if (selection !== 'hello-world') {
+        throw new Error(`Unknown python template selection ${selection}`);
+      }
+      return helloWorld();
+    },
+  };
+};
+
+export function helloWorld(): Promise<FunctionTemplateParameters> {
+  const files = fs.readdirSync(pathToTemplateFiles);
+  return Promise.resolve({
+    functionTemplate: {
+      sourceRoot: pathToTemplateFiles,
+      sourceFiles: files,
+      defaultEditorFile: 'index.py',
+    },
+  });
+}

--- a/packages/amplify-python-template-provider/tsconfig.json
+++ b/packages/amplify-python-template-provider/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "strict": true
+  }
+}


### PR DESCRIPTION
Implements python runtime function plugin and hello world template.

Note that E2E tests will fail until they are updated with the new runtime question in the function creation flow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.