### PR TITLE
feat(amplify-function-plugin-interface): update contribute params

### DIFF
--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -23,15 +23,23 @@ export type FunctionTemplateParameters = Pick<FunctionParameters, 'dependsOn' | 
 export type ContributorFactory<T extends Partial<FunctionParameters>> = (context: any) => Contributor<T>;
 
 export interface Contributor<T extends Partial<FunctionParameters>> {
-  contribute(selection: string): Promise<T>;
+  contribute(request: ContributionRequest): Promise<T>;
 }
 
 export interface FunctionRuntimeLifecycleManager {
-  checkDependencies(selection: string): Promise<CheckDependenciesResult>;
+  checkDependencies(runtimeValue: string): Promise<CheckDependenciesResult>;
   package(request: PackageRequest): Promise<PackageResult>;
   build(request: BuildRequest): Promise<BuildResult>;
   invoke(request: InvocationRequest): Promise<any>;
 }
+
+export type ContributionRequest = {
+  selection: string;
+  contributionContext: {
+    functionName: string;
+    resourceName: string;
+  };
+};
 
 // Request sent to invoke a function
 export type InvocationRequest = {

--- a/packages/amplify-nodejs-runtime-provider/src/index.ts
+++ b/packages/amplify-nodejs-runtime-provider/src/index.ts
@@ -2,9 +2,9 @@ import { FunctionRuntimeContributorFactory } from 'amplify-function-plugin-inter
 import { buildResource } from './utils/legacyBuild';
 import { packageResource } from './utils/legacyPackage';
 export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactory = context => {
-  context.amplify;
   return {
-    contribute: selection => {
+    contribute: request => {
+      const selection = request.selection;
       if (selection !== 'nodejs') {
         return Promise.reject(new Error(`Unknown selection ${selection}`));
       }

--- a/packages/amplify-nodejs-template-provider/src/index.ts
+++ b/packages/amplify-nodejs-template-provider/src/index.ts
@@ -1,14 +1,14 @@
 import { FunctionTemplateContributorFactory } from 'amplify-function-plugin-interface';
 
-import { provideHelloWorld } from './providers/helloWorldProvider'
-import { provideCrud } from './providers/crudProvider'
-import { provideServerless } from './providers/serverlessProvider'
+import { provideHelloWorld } from './providers/helloWorldProvider';
+import { provideCrud } from './providers/crudProvider';
+import { provideServerless } from './providers/serverlessProvider';
 import { provideTrigger } from './providers/triggerProvider';
 
 export const functionTemplateContributorFactory: FunctionTemplateContributorFactory = context => {
   return {
-    contribute: selection => {
-      switch (selection) {
+    contribute: request => {
+      switch (request.selection) {
         case 'helloworld': {
           return provideHelloWorld();
         }
@@ -22,9 +22,9 @@ export const functionTemplateContributorFactory: FunctionTemplateContributorFact
           return provideTrigger(context);
         }
         default: {
-          throw new Error(`Unknown template selection [${selection}]`)
+          throw new Error(`Unknown template selection [${request.selection}]`);
         }
       }
-    }
-  }
-}
+    },
+  };
+};


### PR DESCRIPTION
Some function plugins need access to the functionName and resourceName to properly construct templates and runtimes. This exposes a ContributionRequest object that has these parameters instead of just the raw selection string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.