### PR TITLE
fix(cli): added logic for use of dir separator in generate()

### DIFF
--- a/packages/amplify-cli/src/context-extensions.ts
+++ b/packages/amplify-cli/src/context-extensions.ts
@@ -316,8 +316,10 @@ function attachTemplate(context: Context) {
       const data = {
         props,
       };
-      const directory = opts.directory;
-      const pathToTemplate = `${directory}/${template}`;
+      // If a directory was supplied, append a directory seprator.
+      // Otherwise, the template path will be use as-is.
+      const directory = opts.directory ? opts.directory + '/' : '';
+      const pathToTemplate = `${directory}${template}`;
 
       if (!contextFileSystem.isFile(pathToTemplate)) {
         throw new Error(`template not found ${pathToTemplate}`);

--- a/packages/amplify-cli/src/context-extensions.ts
+++ b/packages/amplify-cli/src/context-extensions.ts
@@ -318,8 +318,7 @@ function attachTemplate(context: Context) {
       };
       // If a directory was supplied, append a directory seprator.
       // Otherwise, the template path will be use as-is.
-      const directory = opts.directory ? opts.directory + '/' : '';
-      const pathToTemplate = `${directory}${template}`;
+      const pathToTemplate = opts.directory ? path.join(opts.directory, template) : template;
 
       if (!contextFileSystem.isFile(pathToTemplate)) {
         throw new Error(`template not found ${pathToTemplate}`);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The new function plugin infrastructure does not function properly on Windows; it supplies an empty directory, and the cli's context extensions assume that A) there will be a directory defined for the ejs copy job and B) it's OK to prepend the path with a "/" even when there is not a directory. On Windows, this results in paths like "/C:\Users\foo\repos...." which is invalid. This fix has the generate method check for an empty directory and only append a directory separator between the directory nd the file to be templatized when one has been supplied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.