### PR TITLE
updated path for amplify-category-function

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -263,7 +263,7 @@ async function initTriggerEnvs(context, resourceParams, providerPlugin, envParam
     const currentTrigger = resourceParams.resourceName.replace(parentResourceParams.resourceName, '');
     if (currentTrigger && currentTrigger !== resourceParams.resourceName) {
       const currentEnvVariables = context.amplify.loadEnvResourceParameters(context, 'function', resourceParams.resourceName);
-      const triggerPath = `${__dirname}/../../../amplify-category-${resourceParams.parentStack}/provider-utils/${srvcMetaData.provider}/triggers/${currentTrigger}`;
+      const triggerPath = `${__dirname}/../../../../amplify-category-${resourceParams.parentStack}/provider-utils/${srvcMetaData.provider}/triggers/${currentTrigger}`;
       if (context.commandName !== 'checkout') {
         envParams = await context.amplify.getTriggerEnvInputs(
           context,


### PR DESCRIPTION
when the provider-utils/awscloudformation/index.ts was refactored
the path for initTriggerEnvs was one directory traversal short.

Issue #3746

added an additional ../ to the function initTriggerEnvs amplify-category-function/provide-utils/awscloudformation/index.ts

In amplify 4.16.1 when initializing an existing amplify project and you answer No to creating a Lambda the project initializes successfully, when initializing an project with 4.17.1 it fails regardless of the answer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.