### PR TITLE
fix(amplify-category-function): fix ddb table name env var

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -197,16 +197,13 @@ export async function askExecRolePermissionsQuestions(context, allDefaultValues,
      */
     if (resource.needsAdditionalDynamoDBResourceProps) {
       const modelEnvPrefix = `${category.toUpperCase()}_${resourceName.toUpperCase()}_${resource._modelName.toUpperCase()}`;
-      let modelNameResourcePropValue = {
-        'Fn::Join': ['-', resource._cfJoinComponentTableName],
-      };
       let modelArnResourcePropValue = {
         'Fn::Join': ['', resource._cfJoinComponentTableArn],
       };
 
-      resourceProperties.push(`"${modelEnvPrefix}_NAME": ${JSON.stringify(modelNameResourcePropValue)}`);
+      resourceProperties.push(`"${modelEnvPrefix}_NAME": ${JSON.stringify(resource._cfJoinComponentTableName)}`);
       resourceProperties.push(`"${modelEnvPrefix}_ARN": ${JSON.stringify(modelArnResourcePropValue)}`);
-      resourcePropertiesJSON[`${modelEnvPrefix}_NAME`] = modelNameResourcePropValue;
+      resourcePropertiesJSON[`${modelEnvPrefix}_NAME`] = resource._cfJoinComponentTableName;
       resourcePropertiesJSON[`${modelEnvPrefix}_ARN`] = modelArnResourcePropValue;
 
       const categoryMappingPrefix = `${category}${capitalizeFirstLetter(resourceName)}${capitalizeFirstLetter(resource._modelName)}`;
@@ -250,7 +247,7 @@ export async function askExecRolePermissionsQuestions(context, allDefaultValues,
     }
   });
 
-  allDefaultValues.resourceProperties = resourceProperties.join(',');
+  allDefaultValues.resourceProperties = resourceProperties.join(',\n');
   allDefaultValues.resourcePropertiesJSON = resourcePropertiesJSON;
 
   context.print.info('');

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
@@ -153,15 +153,15 @@ export function constructCFModelTableArnComponent(appsyncResourceName, resourceN
     ':',
     { Ref: 'AWS::AccountId' },
     ':table/',
-    {
-      'Fn::ImportValue': {
-        'Fn::Sub': `\${api${appsyncResourceName}GraphQLAPIIdOutput}:GetAtt:${resourceName.replace(`:${appsyncTableSuffix}`, 'Table')}:Name`,
-      },
-    },
+    constructCFModelTableNameComponent(appsyncResourceName, resourceName, appsyncTableSuffix),
   ];
 }
 
 /** CF template component of join function { "Fn::Join": ["-": THIS_PART ] } */
 export function constructCFModelTableNameComponent(appsyncResourceName, resourceName, appsyncTableSuffix) {
-  return [resourceName.replace(`:${appsyncTableSuffix}`, 'Table'), { Ref: `api${appsyncResourceName}GraphQLAPIIdOutput` }];
+  return {
+    'Fn::ImportValue': {
+      'Fn::Sub': `\${api${appsyncResourceName}GraphQLAPIIdOutput}:GetAtt:${resourceName.replace(`:${appsyncTableSuffix}`, 'Table')}:Name`,
+    },
+  };
 }


### PR DESCRIPTION
*Issue #, if available:*
fixes #3748 fixes #3737

*Description of changes:*
Correct the DynamoDB table name in lambdas that access model dynamo tables.
Before we were attempting to construct the table name using the naming schema. This updates it to directly reference the exported value from the GraphQL CFN.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.