### PR TITLE
Runtime support enhancement

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -23,7 +23,6 @@ export async function templateWalkthrough(context: any, params: Partial<Function
     pluginType: 'functionTemplate',
     listOptionsField: 'templates',
     predicate: condition => {
-      console.log(`Inspecting plugin. Condition: ${JSON.stringify(condition)} params.runtime.value: ${params.runtime.value}`);
       return (
         condition.provider === params.providerContext.provider &&
         condition.service === params.providerContext.service &&

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -37,6 +37,7 @@ export async function templateWalkthrough(context: any, params: Partial<Function
   const contributionRequest: ContributionRequest = {
     selection: selection.value,
     contributionContext: {
+      runtime: params.runtime,
       functionName: params.functionName,
       resourceName: params.resourceName,
     },
@@ -69,6 +70,7 @@ export async function runtimeWalkthrough(
   const contributionRequest: ContributionRequest = {
     selection: selection.value,
     contributionContext: {
+      runtime: params.runtime,
       functionName: params.functionName,
       resourceName: params.resourceName,
     },

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -23,10 +23,11 @@ export async function templateWalkthrough(context: any, params: Partial<Function
     pluginType: 'functionTemplate',
     listOptionsField: 'templates',
     predicate: condition => {
+      console.log(`Inspecting plugin. Condition: ${JSON.stringify(condition)} params.runtime.value: ${params.runtime.value}`);
       return (
         condition.provider === params.providerContext.provider &&
         condition.service === params.providerContext.service &&
-        condition.runtime === params.runtime.value
+        (condition.runtime === params.runtime.value || condition.runtime.includes(params.runtime.value))
       );
     },
     selectionPrompt: 'Choose the function template that you want to use:',

--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -178,7 +178,7 @@ export interface FunctionDependency {
 interface FunctionContributorCondition {
   provider?: string;
   service?: string;
-  runtime?: string;
+  runtime?: string | Array<string>;
 }
 
 export type FunctionTemplateCondition = FunctionContributorCondition;

--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -36,6 +36,7 @@ export interface FunctionRuntimeLifecycleManager {
 export type ContributionRequest = {
   selection: string;
   contributionContext: {
+    runtime: FunctionRuntime;
     functionName: string;
     resourceName: string;
   };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added support for providing runtime info to template providers.
Also adds support for function runtime template packages to support more than one runtime identifier. This is originally intended to support multiple versions of the same runtime, but could also be used to add a plugin for the same kind of template across multiple runtimes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.