### PR TITLE
fix(amplify-util-mock): pass env vars to lambda when invoked with mock

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -49,7 +49,7 @@ export function appSyncDataSourceHandler(
   const typeName = resource.Properties.Type;
   const commonProps = {
     cfnExposedAttributes: { DataSourceArn: 'Arn', Name: 'name' },
-    Arn: `arn:aws:appsync:us-east-1:123456789012:apis/graphqlapiid/datasources/${resource.Properties.Name}`,
+    Arn: `arn:aws:appsync:us-fake-1:123456789012:apis/graphqlapiid/datasources/${resource.Properties.Name}`,
   };
   if (typeName === 'AMAZON_DYNAMODB') {
     return {

--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/hydrate-env-vars.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/hydrate-env-vars.test.ts
@@ -1,0 +1,137 @@
+import { hydrateAllEnvVars, Resources, ApiDetails } from '../../../utils/lambda/hydrate-env-vars';
+
+describe('hydrateAllEnvVars', () => {
+  it('should return values from resource output', () => {
+    expect(hydrateAllEnvVars([], { test: 'test-val' })).toEqual({ test: 'test-val' });
+  });
+  it('should return values from resource outputs', () => {
+    const resources: Resources = [
+      {
+        resourceName: 'resource-1',
+        category: 'category1',
+        output: {
+          output1: 'expected output 1',
+        },
+      },
+    ];
+    const sourceEnvVar = {
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'source value',
+    };
+    expect(hydrateAllEnvVars(resources, sourceEnvVar)).toEqual({
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'expected output 1',
+    });
+  });
+  it('should include api mocked API details in output env vars', () => {
+    const resources: Resources = [
+      {
+        resourceName: 'resource-1',
+        category: 'category1',
+        output: {
+          output1: 'expected output 1',
+        },
+      },
+    ];
+    const sourceEnvVar = {
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'source value',
+      API_FOO_GRAPHQLAPIENDPOINTOUTPUT: 'http://appsync.com',
+      API_FOO_GRAPHQLAPIKEYOUTPUT: 'My-Api-Key-from-cfn',
+      API_FOO_GRAPHQLAPIIDOUTPUT: 'my-api-from-cfn',
+    };
+
+    const apiDetails: ApiDetails = {
+      apiId: 'my-api-id-from-mock',
+      apiKey: 'my-api-key-from-mock',
+      apiName: 'foo',
+      url: 'http://url-from-mock',
+      dataSources: [
+        {
+          Arn: 'arn-from-api',
+          name: 'TodoTable',
+          type: 'AMAZON_DYNAMODB',
+        },
+        {
+          name: 'TodoTable',
+          type: 'LAMBDA',
+          Arn: 'lambda-arn',
+        },
+      ],
+    };
+    expect(hydrateAllEnvVars(resources, sourceEnvVar, apiDetails)).toEqual({
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'expected output 1',
+      API_FOO_GRAPHQLAPIENDPOINTOUTPUT: apiDetails.url,
+      API_FOO_GRAPHQLAPIKEYOUTPUT: apiDetails.apiKey,
+      API_FOO_GRAPHQLAPIIDOUTPUT: apiDetails.apiId,
+    });
+  });
+
+  it('should geneate DynamoDB table name and arn', () => {
+    const resources: Resources = [
+      {
+        resourceName: 'resource-1',
+        category: 'category1',
+        output: {
+          output1: 'expected output 1',
+        },
+      },
+    ];
+    const sourceEnvVar = {
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'source value',
+      API_FOO_TODOTABLE_ARN: 'un-known',
+      API_FOO_TODOTABLE_NAME: 'un-known',
+    };
+
+    const apiDetails: ApiDetails = {
+      apiId: 'my-api-id-from-mock',
+      apiKey: 'my-api-key-from-mock',
+      apiName: 'foo',
+      url: 'http://url-from-mock',
+      dataSources: [
+        {
+          Arn: 'arn-from-api',
+          name: 'TodoTable',
+          type: 'AMAZON_DYNAMODB',
+        },
+      ],
+    };
+    expect(hydrateAllEnvVars(resources, sourceEnvVar, apiDetails)).toEqual({
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'expected output 1',
+      API_FOO_TODOTABLE_NAME: apiDetails.dataSources[0].name,
+      API_FOO_TODOTABLE_ARN: apiDetails.dataSources[0].Arn,
+    });
+  });
+  it('should not generate Arn and Table name for non Lambda data sources', () => {
+    const resources: Resources = [
+      {
+        resourceName: 'resource-1',
+        category: 'category1',
+        output: {
+          output1: 'expected output 1',
+        },
+      },
+    ];
+    const sourceEnvVar = {
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'source value',
+      API_FOO_TODOTABLE_ARN: 'un-known-Arn',
+      API_FOO_TODOTABLE_NAME: 'un-known-table-name',
+    };
+
+    const apiDetails: ApiDetails = {
+      apiId: 'my-api-id-from-mock',
+      apiKey: 'my-api-key-from-mock',
+      apiName: 'foo',
+      url: 'http://url-from-mock',
+      dataSources: [
+        {
+          Arn: 'arn-from-api',
+          name: 'TodoTable',
+          type: 'Lambda',
+        },
+      ],
+    };
+    expect(hydrateAllEnvVars(resources, sourceEnvVar, apiDetails)).toEqual({
+      'CATEGORY1_RESOURCE-1_OUTPUT1': 'expected output 1',
+      API_FOO_TODOTABLE_ARN: 'un-known-Arn',
+      API_FOO_TODOTABLE_NAME: 'un-known-table-name',
+    });
+  });
+});

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -190,10 +190,11 @@ export class APITest {
             if (!lambdaConfig) {
               throw new Error(`Lambda function ${functionName} does not exist in your project. \nPlease run amplify add function`);
             }
+            const envVars = await this.hydrateLambdaEnvVars(context, lambdaConfig.environment, config);
             const invoker = await getInvoker(context, {
               resourceName: functionName,
               handler: lambdaConfig.handler,
-              envVars: lambdaConfig.environment,
+              envVars,
             });
             return {
               ...d,
@@ -332,5 +333,43 @@ export class APITest {
 
     this.configOverrideManager.addOverride('api', override);
     await this.configOverrideManager.generateOverriddenFrontendExports(context);
+  }
+
+  private async hydrateLambdaEnvVars(context, sourceEnvVars: Record<string, any>, config): Promise<Record<string, any>> {
+    const resources = await context.amplify.getResourceStatus();
+    const allResources = resources.allResources;
+    const outputMap = allResources.reduce((acc, r) => {
+      const category = r.category;
+      const resourceName = r.resourceName.toLowerCase();
+      const outputs = Object.entries(r.output || {}).reduce((sum, [name, value]) => {
+        return { ...sum, [name.toLowerCase()]: value };
+      }, {});
+
+      return { ...acc, [category]: { ...acc.category, [resourceName]: outputs } };
+    }, {});
+    outputMap.api = {
+      ...outputMap.api,
+      [this.apiName]: {
+        graphqlapiendpointoutput: this.appSyncSimulator.url,
+        graphqlapikeyoutput: config.appSync.apiKey,
+        graphqlapiidoutput: 'fake-api-id',
+        ...config.dataSources
+          .filter(ds => ds.type === 'AMAZON_DYNAMODB')
+          .reduce((acc, ds) => {
+            return { ...acc, [`${ds.name}_NAME`.toLowerCase()]: ds.name, [`${ds.name}_ARN`.toLowerCase()]: ds.Arn };
+          }, {}),
+      },
+    };
+    return Object.entries(sourceEnvVars).reduce((acc, [name, value]) => {
+      const [category, resourceName, ...outputName] = name.split('_').map(f => f.toLowerCase());
+      let computedValue = value;
+      if (category && resourceName && outputName) {
+        if (outputMap[category] && outputMap[category][resourceName] && outputMap[category][resourceName][outputName.join('_')]) {
+          computedValue = outputMap[category][resourceName][outputName.join('_')];
+        }
+      }
+
+      return { ...acc, [name]: computedValue };
+    }, {});
   }
 }

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -2,9 +2,10 @@ import { getInvoker } from 'amplify-category-function';
 import * as path from 'path';
 import * as inquirer from 'inquirer';
 import { loadMinimalLambdaConfig } from '../utils/lambda/loadMinimal';
+import { hydrateAllEnvVars } from '../utils';
 
 export async function start(context) {
-  if (context.input.subCommands.length < 1) {
+  if (!context.input.subCommands || context.input.subCommands.length < 1) {
     throw new Error('Specify the function name to invoke with "amplify mock function <function name>"');
   }
 
@@ -31,8 +32,10 @@ export async function start(context) {
   if (!lambdaConfig || !lambdaConfig.handler) {
     throw new Error(`Could not parse handler for ${resourceName} from cloudformation file`);
   }
+  const { allResources } = await context.amplify.getResourceStatus();
 
-  const invoker = await getInvoker(context, { resourceName, handler: lambdaConfig.handler, envVars: lambdaConfig.environment });
+  const envVars = hydrateAllEnvVars(allResources, lambdaConfig.environment);
+  const invoker = await getInvoker(context, { resourceName, handler: lambdaConfig.handler, envVars });
   context.print.success('Starting execution...');
   await invoker({ event })
     .then(result => {

--- a/packages/amplify-util-mock/src/utils/index.ts
+++ b/packages/amplify-util-mock/src/utils/index.ts
@@ -5,3 +5,4 @@ export async function getAmplifyMeta(context: any) {
   const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
   return context.amplify.readJsonFile(amplifyMetaFilePath);
 }
+export { hydrateAllEnvVars } from './lambda/hydrate-env-vars';

--- a/packages/amplify-util-mock/src/utils/lambda/hydrate-env-vars.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/hydrate-env-vars.ts
@@ -1,0 +1,59 @@
+export type Resource = {
+  resourceName: string;
+  category: string;
+  output: Record<string, string>;
+};
+export type Resources = Resource[];
+export type ApiDetails = {
+  apiName: string;
+  apiKey: string;
+  apiId: string;
+  url: string;
+  dataSources: {
+    name: string;
+    Arn: string;
+    type: string;
+  }[];
+};
+export function hydrateAllEnvVars(
+  resources: Resources,
+  sourceEnvVars: Record<string, string>,
+  apiDetails?: ApiDetails,
+): Record<string, string> {
+  const outputMap: Record<string, object> = resources.reduce((acc: Record<string, object>, r) => {
+    const category = r.category;
+    const resourceName = r.resourceName.toLowerCase();
+    const outputs = Object.entries(r.output || {}).reduce((sum, [name, value]) => {
+      return { ...sum, [name.toLowerCase()]: value };
+    }, {});
+
+    return { ...acc, [category]: { ...acc.category, [resourceName]: outputs } };
+  }, {});
+  if (apiDetails) {
+    outputMap.api = {
+      ...outputMap.api,
+      [apiDetails.apiName]: {
+        graphqlapiendpointoutput: apiDetails.url,
+        graphqlapikeyoutput: apiDetails.apiKey,
+        graphqlapiidoutput: apiDetails.apiId,
+        ...apiDetails.dataSources
+          .filter(ds => ds.type === 'AMAZON_DYNAMODB')
+          .reduce((acc, ds) => {
+            return { ...acc, [`${ds.name}_NAME`.toLowerCase()]: ds.name, [`${ds.name}_ARN`.toLowerCase()]: ds.Arn };
+          }, {}),
+      },
+    };
+  }
+
+  return Object.entries(sourceEnvVars).reduce((acc, [name, value]) => {
+    const [category, resourceName, ...outputName] = name.split('_').map(f => f.toLowerCase());
+    let computedValue = value;
+    if (category && resourceName && outputName) {
+      if (outputMap[category] && outputMap[category][resourceName] && outputMap[category][resourceName][outputName.join('_')]) {
+        computedValue = outputMap[category][resourceName][outputName.join('_')];
+      }
+    }
+
+    return { ...acc, [name]: computedValue };
+  }, {});
+}


### PR DESCRIPTION
Updated the mock lambda invoker to pass the env vars related to resources suck as API Key and
GraphQL endpoint

fix #2453 and #2690

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.