### PR TITLE
feat: minor tweaks to multi-runtime platform changes

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -110,7 +110,8 @@ async function getSelectionFromContributors<T>(context: any, selectionOptions: P
     })
     .map(meta => meta.manifest[selectionOptions.pluginType])
     .map(contributes => contributes[selectionOptions.listOptionsField])
-    .reduce((acc, it) => acc.concat(it), []);
+    .reduce((acc, it) => acc.concat(it), [])
+    .sort((a, b) => a.name.localeCompare(b.name)); // sort by display name so that selections order is deterministic
 
   // sanity checks
   let selection;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
@@ -4,8 +4,12 @@ const { getProviderPlugins } = require('./get-provider-plugins');
 const spinner = ora('Building resources. This may take a few minutes...');
 
 function buildResources(context, category, resourceName) {
-  return context.amplify.confirmPrompt
-    .run('Are you sure you want to continue building the resources?')
+  const confirmationPromise =
+    context.input.options && context.input.options.yes
+      ? Promise.resolve(true)
+      : context.amplify.confirmPrompt.run('Are you sure you want to continue building the resources?');
+
+  return confirmationPromise
     .then(answer => {
       if (answer) {
         const providerPlugins = getProviderPlugins(context);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/load-runtime-plugin.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/load-runtime-plugin.js
@@ -1,4 +1,7 @@
 async function loadRuntimePlugin(context, pluginId) {
+  if (!context.pluginPlatform.plugins.functionRuntime) {
+    throw new Error('No function runtime plugins found. Try "amplify plugin scan" and then rerun the command.');
+  }
   const pluginMeta = context.pluginPlatform.plugins.functionRuntime.find(meta => meta.manifest.functionRuntime.pluginId === pluginId);
   if (!pluginMeta) {
     throw new Error(`Could not find runtime plugin with id [${pluginId}]`);

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -11,23 +11,40 @@ export async function start(context) {
   const resourceName = context.input.subCommands[0];
   const { amplify } = context;
   const resourcePath = path.join(amplify.pathManager.getBackendDirPath(), 'function', resourceName);
-  const resourceQuestions = [
-    {
-      type: 'input',
-      name: 'eventName',
-      message: `Provide the path to the event JSON object relative to ${resourcePath}`,
-      validate: amplify.inputValidation({
-        operator: 'regex',
-        value: '^[a-zA-Z0-9/._-]+?\\.json$',
-        onErrorMsg: 'Provide a valid unix-like path to a .json file',
-        required: true,
-      }),
-      default: 'src/event.json',
-    },
-  ];
-  const resourceAnswers = await inquirer.prompt(resourceQuestions);
-  const event = amplify.readJsonFile(path.resolve(path.join(resourcePath, resourceAnswers.eventName as string)));
-  const lambdaConfig = loadMinimalLambdaConfig(context, resourceName);
+  const eventNameValidator = amplify.inputValidation({
+    operator: 'regex',
+    value: '^[a-zA-Z0-9/._-]+?\\.json$',
+    onErrorMsg: 'Provide a valid unix-like path to a .json file',
+    required: true,
+  });
+  let eventName: string = context.input.options ? context.input.options.event : undefined;
+  let promptForEvent = true;
+  if (eventName) {
+    const validatorOutput = eventNameValidator(eventName);
+    const isValid = typeof validatorOutput !== 'string';
+    if (!isValid) {
+      context.print.warning(validatorOutput);
+    } else {
+      promptForEvent = false;
+    }
+  }
+
+  if (promptForEvent) {
+    const resourceQuestions = [
+      {
+        type: 'input',
+        name: 'eventName',
+        message: `Provide the path to the event JSON object relative to ${resourcePath}`,
+        validate: eventNameValidator,
+        default: 'src/event.json',
+      },
+    ];
+    const resourceAnswers = await inquirer.prompt(resourceQuestions);
+    eventName = resourceAnswers.eventName as string;
+  }
+
+  const event = amplify.readJsonFile(path.resolve(path.join(resourcePath, eventName)));
+  const lambdaConfig = loadMinimalLambdaConfig(context, resourceName, { env: context.amplify.getEnvInfo().envName });
   if (!lambdaConfig || !lambdaConfig.handler) {
     throw new Error(`Could not parse handler for ${resourceName} from cloudformation file`);
   }
@@ -38,11 +55,11 @@ export async function start(context) {
     .then(result => {
       const msg = typeof result === 'object' ? JSON.stringify(result) : result;
       context.print.success('Result:');
-      console.log(typeof result === 'undefined' ? '' : msg);
+      context.print.info(typeof result === 'undefined' ? '' : msg);
     })
     .catch(error => {
       context.print.error(`${resourceName} failed with the following error:`);
-      console.error(error);
+      context.print.info(error);
     })
     .then(() => context.print.success('Finished execution.'));
 }

--- a/packages/amplify-util-mock/src/utils/lambda/loadMinimal.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/loadMinimal.ts
@@ -2,9 +2,9 @@ import { LambdaFunctionConfig, processResources } from '../../CFNParser/lambda-r
 import * as path from 'path';
 
 // Performs a minimal parsing of a lambda CFN.
-export function loadMinimalLambdaConfig(context: any, resourceName: string): LambdaFunctionConfig {
+export function loadMinimalLambdaConfig(context: any, resourceName: string, params: { [key: string]: string } = {}): LambdaFunctionConfig {
   const resourcePath = path.join(context.amplify.pathManager.getBackendDirPath(), 'function', resourceName);
   const cfn = context.amplify.readJsonFile(path.join(resourcePath, `${resourceName}-cloudformation-template.json`));
 
-  return processResources(cfn.Resources, {}, {});
+  return processResources(cfn.Resources, {}, params);
 }


### PR DESCRIPTION
Support `amplify function build --yes` to bypass "are you sure" prompt
Support `amplify mock function <func name> --event <path to event json>` to bypass CLI prompt for event name
Load environment substitution when parsing CFN for local function invoke
Adds a sanity check to finding runtime plugins to ensure the list is not undefined
Changes some `console.log()` lines to `context.print.info()`
Sorts runtime and template selections so that list order is deterministic (for testing)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.