### PR TITLE
fix(amplify-provider-awscloudformation): push failing from mock

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -25,7 +25,7 @@ async function run(context, resourceDefinition) {
   try {
     const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = resourceDefinition;
     let resources;
-    if (context.exeInfo.forcePush) {
+    if (context.exeInfo && context.exeInfo.forcePush) {
       resources = allResources;
     } else {
       resources = resourcesToBeCreated.concat(resourcesToBeUpdated);


### PR DESCRIPTION
checking for truthy of exeinfo before reading forcepush

closes #3793

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.