### PR TITLE
chore: fix the build for nodejs-function-runtime-provider, standardize tsconfigs, add missing @types/node package references

### DIFF
--- a/packages/amplify-go-function-runtime-provider/package.json
+++ b/packages/amplify-go-function-runtime-provider/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",
+    "@types/node": "^10.17.13",
     "@types/semver": "^7.1.0",
     "@types/which": "^1.3.2"
   }

--- a/packages/amplify-go-function-runtime-provider/tsconfig.json
+++ b/packages/amplify-go-function-runtime-provider/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true,
   },
   "references": [
     { "path": "../amplify-function-plugin-interface" }

--- a/packages/amplify-go-function-runtime-provider/tsconfig.json
+++ b/packages/amplify-go-function-runtime-provider/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-    "composite": true,
   },
   "references": [
     { "path": "../amplify-function-plugin-interface" }

--- a/packages/amplify-go-function-template-provider/package.json
+++ b/packages/amplify-go-function-template-provider/package.json
@@ -11,5 +11,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "amplify-function-plugin-interface": "1.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^10.17.13"
   }
 }

--- a/packages/amplify-go-function-template-provider/tsconfig.json
+++ b/packages/amplify-go-function-template-provider/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true,
+
   },
   "references": [
     { "path": "../amplify-function-plugin-interface" }

--- a/packages/amplify-go-function-template-provider/tsconfig.json
+++ b/packages/amplify-go-function-template-provider/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-    "composite": true,
 
   },
   "references": [

--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -21,6 +21,7 @@
     "glob": "^7.1.6"
   },
   "devDependencies": {
-    "@types/archiver": "^3.1.0"
+    "@types/archiver": "^3.1.0",
+    "@types/node": "^10.17.13"
   }
 }

--- a/packages/amplify-nodejs-function-runtime-provider/tsconfig.json
+++ b/packages/amplify-nodejs-function-runtime-provider/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-    "composite": true,
   },
   "references": [
     {"path": "../amplify-function-plugin-interface"}

--- a/packages/amplify-nodejs-function-runtime-provider/tsconfig.json
+++ b/packages/amplify-nodejs-function-runtime-provider/tsconfig.json
@@ -4,7 +4,6 @@
     "outDir": "./lib",
     "rootDir": "./src",
     "composite": true,
-    "strict": true,
   },
   "references": [
     {"path": "../amplify-function-plugin-interface"}

--- a/packages/amplify-nodejs-function-template-provider/package.json
+++ b/packages/amplify-nodejs-function-template-provider/package.json
@@ -20,6 +20,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@types/inquirer": "^6.5.0"
+    "@types/inquirer": "^6.5.0",
+    "@types/node": "^10.17.13"
   }
 }

--- a/packages/amplify-nodejs-function-template-provider/tsconfig.json
+++ b/packages/amplify-nodejs-function-template-provider/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-    "composite": true,
   },
   "references": [
     {"path": "../amplify-function-plugin-interface"},

--- a/packages/amplify-nodejs-function-template-provider/tsconfig.json
+++ b/packages/amplify-nodejs-function-template-provider/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-    "strict": true,
+    "composite": true,
   },
   "references": [
     {"path": "../amplify-function-plugin-interface"},


### PR DESCRIPTION
*Description of changes:*

chore: fix the build for nodejs-function-runtime-provider, standardize tsconfigs, add missing @types/node package references

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.