### PR TITLE
chore: enable python for e2e provider selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ defaults: &defaults
   working_directory: ~/repo
   docker:
     - image: circleci/node:10.18
+  resource_class: large
 
 jobs:
   build:

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -55,6 +55,8 @@
     "amplify-go-function-template-provider": "1.0.0",
     "amplify-nodejs-function-runtime-provider": "1.0.0",
     "amplify-nodejs-function-template-provider": "1.0.0",
+    "amplify-python-function-runtime-provider": "1.0.0",
+    "amplify-python-function-template-provider": "1.0.0",
     "amplify-provider-awscloudformation": "4.17.1",
     "amplify-util-mock": "3.17.1",
     "chalk": "^3.0.0",

--- a/packages/amplify-e2e-tests/src/categories/function.ts
+++ b/packages/amplify-e2e-tests/src/categories/function.ts
@@ -8,7 +8,7 @@ type FunctionRuntimes = 'netCore21' | 'netCore31' | 'go' | 'java' | 'nodejs' | '
 type FunctionCallback = (chain: any, cwd: string, settings: any) => any;
 
 // runtimeChoices are shared between tests
-export const runtimeChoices = [/*'.NET Core 2.1', '.NET Core 3.1',*/ 'Go' /*, 'Java'*/, 'NodeJS' /*, 'Python'*/];
+export const runtimeChoices = [/*'.NET Core 2.1', '.NET Core 3.1',*/ 'Go' /*, 'Java'*/, 'NodeJS', 'Python'];
 
 // templateChoices is per runtime
 const dotNetCore21TemplateChoices = ['Hello World'];

--- a/packages/amplify-go-function-template-provider/tsconfig.json
+++ b/packages/amplify-go-function-template-provider/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-
   },
   "references": [
     { "path": "../amplify-function-plugin-interface" }

--- a/packages/amplify-python-function-runtime-provider/package.json
+++ b/packages/amplify-python-function-runtime-provider/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",
+    "@types/node": "^10.17.13",
     "@types/semver":"^7.1.0"
   }
 }

--- a/packages/amplify-python-function-template-provider/package.json
+++ b/packages/amplify-python-function-template-provider/package.json
@@ -11,5 +11,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "amplify-function-plugin-interface": "1.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^10.17.13"
   }
 }

--- a/packages/amplify-python-function-template-provider/tsconfig.json
+++ b/packages/amplify-python-function-template-provider/tsconfig.json
@@ -3,5 +3,8 @@
   "compilerOptions": {
     "outDir": "./lib",
     "rootDir": "./src",
-  }
+  },
+  "references": [
+    {"path": "../amplify-function-plugin-interface"}
+  ]
 }


### PR DESCRIPTION
*Description of changes:*

chore: enable python for e2e provider selection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.