### PR TITLE
test(cli): change the scheduled daily console test time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ workflows:
   nightly_console_integration_tests:
     triggers:
       - schedule:
-          cron: '0 0 * * *'
+          cron: '0 14 * * *'
           filters:
             branches:
               only:


### PR DESCRIPTION
Test regions are centered around UTC+9, and Seattle Time is UTC-7. Setting daily test time at 14:00
UTC, so the test occurs close to mid night for the test regions, and at 7AM for Seattle.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.