### PR TITLE
fix: update circle ci check to not conflict with vs code jest

### DIFF
--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -20,7 +20,7 @@ export function getCLIPath() {
 }
 
 export function isCI(): boolean {
-  return process.env.CI ? true : false;
+  return process.env.CI && process.env.CIRCLECI ? true : false;
 }
 
 export function npmInstall(cwd: string) {


### PR DESCRIPTION
VS code jest plugin sets CI env var. This additional check prevents circle CI config from being used locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.