### PR TITLE
fix: save default editor on add and load on update

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -107,11 +107,13 @@ function createBreadcrumbs(params: FunctionParameters | FunctionTriggerParameter
       pluginId: 'amplify-nodejs-function-runtime-provider',
       functionRuntime: 'nodejs',
       useLegacyBuild: true,
+      defaultEditorFile: 'src/index.js',
     };
   }
   return {
     pluginId: params.runtimePluginId,
     functionRuntime: params.runtime.value,
-    useLegacyBuild: true, // unconditionally setting to true for now until new node build is implemented
+    useLegacyBuild: params.runtime.value === 'nodejs' ? true : false, // so we can update node builds in the future
+    defaultEditorFile: params.functionTemplate.defaultEditorFile,
   };
 }

--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -191,6 +191,7 @@ export interface FunctionBreadcrumbs {
   pluginId: string;
   functionRuntime: string;
   useLegacyBuild: boolean;
+  defaultEditorFile: string;
   scripts?: Record<'build' & 'package', FunctionScript>;
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#3821

*Description of changes:*
Saves the template provided defaultEditorFile in the function breadcrumb and then loads in on update so the file can be opened again.

For older projects, we default to opening the function folder if no defaultEditorFile can be found

Also only set useLegacyBuild breadcrumb param if the runtime is node
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.