### PR TITLE
feat: bump amplify cli version in amplify-app

### DIFF
--- a/packages/amplify-app/package.json
+++ b/packages/amplify-app/package.json
@@ -25,7 +25,7 @@
   },
   "engines": {
     "node": ">=10.0.0",
-    "@aws-amplify/cli": ">=4.13.2"
+    "@aws-amplify/cli": ">=4.18.0"
   },
   "dependencies": {
     "amplify-frontend-android": "2.13.2",


### PR DESCRIPTION
Bump amplify-cli dependency of amplify-app to new release (4.18)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.