### PR TITLE
fix: e2e raise test timeout because of CFN

### DIFF
--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -20,7 +20,7 @@ import strip = require('strip-ansi');
 import { EOL } from 'os';
 import retimer = require('retimer');
 
-const DEFAULT_NO_OUTPUT_TIMEOUT = 2 * 60 * 1000; //  Minutes
+const DEFAULT_NO_OUTPUT_TIMEOUT = 5 * 60 * 1000; //  Minutes
 const EXIT_CODE_TIMEOUT = 2;
 const EXIT_CODE_GENERIC_ERROR = 3;
 


### PR DESCRIPTION
*Description of changes:*

fix: e2e raise test timeout because of CFN

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.