### PR TITLE
fix(amplify-dotnet-function-runtime-provider): packaging now uses glob

### DIFF
--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/package.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/package.ts
@@ -10,6 +10,7 @@ export const packageAssemblies = async (request: PackageRequest, context: any): 
     fs.removeSync(request.dstFilename);
   }
 
+  const zipFile = path.basename(request.dstFilename);
   const packageHash = (await context.amplify.hashDir(distPath, [])) as string;
   const output = fs.createWriteStream(request.dstFilename);
 
@@ -25,7 +26,10 @@ export const packageAssemblies = async (request: PackageRequest, context: any): 
     const zip = archiver.create('zip', {});
 
     zip.pipe(output);
-    zip.directory(distPath, false);
+    zip.glob('**', {
+      cwd: distPath,
+      ignore: [zipFile],
+    });
     zip.finalize();
   });
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change replaces the call to zip the dist directory with one that uses a glob '**' combined with the option to ignore the target zip file; on Windows, the zip file would occasionally contain the zipfile and cause the Lambda deployment to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.