### PR TITLE
fix(amplify-dotnet-function-runtime-provider): remove extra child dir

### DIFF
--- a/packages/amplify-dotnet-function-template-provider/src/providers/serverlessProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/serverlessProvider.ts
@@ -11,7 +11,7 @@ export function provideServerless(request: ContributionRequest): Promise<Functio
     'Serverless/FunctionHandler.cs.ejs',
     'Serverless/event.json.ejs',
   ];
-  const handlerSource = path.join('src', request.contributionContext.functionName, `${request.contributionContext.functionName}.cs`);
+  const handlerSource = path.join('src', `${request.contributionContext.functionName}.cs`);
   return Promise.resolve({
     functionTemplate: {
       sourceRoot: pathToTemplateFiles,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change removes the extra/spurious child directory that the Serverless template creates under the src folder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.