### PR TITLE
fix: remove duplicate env vars in top level comment

### DIFF
--- a/packages/amplify-category-function/src/constants.ts
+++ b/packages/amplify-category-function/src/constants.ts
@@ -1,1 +1,7 @@
 export const category = 'function';
+
+export const envVarPrintoutPrefix =
+  '\nYou can access the following resource attributes as environment variables from your Lambda function\n\t';
+const topLevelCommentBlockTitle = 'Amplify Params - DO NOT EDIT';
+export const topLevelCommentPrefix = `/* ${topLevelCommentBlockTitle}\n\t`;
+export const topLevelCommentSuffix = `\n${topLevelCommentBlockTitle} */`;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -11,6 +11,7 @@ import { getNewCFNParameters, getNewCFNEnvVariables } from '../utils/cloudformat
 import { askExecRolePermissionsQuestions } from './execPermissionsWalkthrough';
 import { scheduleWalkthrough } from './scheduleWalkthrough';
 import { merge } from '../utils/funcParamsUtils';
+import { topLevelCommentPrefix, topLevelCommentSuffix } from '../../../constants';
 
 /**
  * Starting point for CLI walkthrough that generates a lambda function
@@ -155,7 +156,9 @@ export async function updateWalkthrough(context, lambdaToUpdate) {
     // Update top level comment in app.js or index.js file
 
     const updateTopLevelComment = filePath => {
-      const commentRegex = /\/\* Amplify Params - DO NOT EDIT[a-zA-Z0-9\-\s._=]+Amplify Params - DO NOT EDIT \*\//;
+      const commentRegex = new RegExp(
+        `${_.escapeRegExp(topLevelCommentPrefix)}[a-zA-Z0-9\\-\\s._=]+${_.escapeRegExp(topLevelCommentSuffix)}`,
+      );
       let fileContents = fs.readFileSync(filePath).toString();
       const commentMatches = fileContents.match(commentRegex);
       if (!commentMatches || commentMatches.length === 0) {

--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/function.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nodejs amplify add function with additional permissions environment vars comment should update on permission update 1`] = `
+"/* Amplify Params - DO NOT EDIT
+	ENV
+	REGION
+	STORAGE_NODETESTDDB9138_ARN
+	STORAGE_NODETESTDDB9138_NAME
+Amplify Params - DO NOT EDIT */
+
+exports.handler = async (event) => {
+    // TODO implement
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify('Hello from Lambda!'),
+    };
+    return response;
+};
+"
+`;

--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -14,7 +14,8 @@ import { addApiWithSchema } from '../categories/api';
 
 import { appsyncGraphQLRequest } from '../utils/appsync';
 import { getCloudWatchLogs, putKinesisRecords, invokeFunction, getCloudWatchEventRule } from '../utils/sdk-calls';
-import { Lambda } from 'aws-sdk';
+import fs from 'fs-extra';
+import path from 'path';
 
 describe('nodejs', () => {
   describe('amplify add function', () => {
@@ -374,6 +375,40 @@ describe('nodejs', () => {
       expect(lambdaSource.includes('TODOTABLE_NAME')).toBeTruthy();
       expect(lambdaSource.includes('TODOTABLE_ARN')).toBeTruthy();
       expect(lambdaSource.includes('GRAPHQLAPIIDOUTPUT')).toBeTruthy();
+    });
+
+    it('environment vars comment should update on permission update', async () => {
+      await initJSProjectWithProfile(projRoot, {});
+      const random = Math.floor(Math.random() * 10000);
+      const funcName = `nodetestfn${random}`;
+      const ddbName = `nodetestddb${random}`;
+
+      await addFunction(
+        projRoot,
+        {
+          name: funcName,
+          functionTemplate: 'Hello World',
+        },
+        'nodejs',
+      );
+      await addSimpleDDB(projRoot, { name: ddbName });
+      await updateFunction(
+        projRoot,
+        {
+          additionalPermissions: {
+            permissions: ['storage'],
+            choices: ['function', 'storage'],
+            operations: ['read'],
+            resources: [ddbName],
+          },
+        },
+        'nodejs',
+      );
+      const lambdaHandlerContents = fs.readFileSync(
+        path.join(projRoot, 'amplify', 'backend', 'function', funcName, 'src', 'index.js'),
+        'utf8',
+      );
+      expect(lambdaHandlerContents).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
#3744

*Description of changes:*
Store env vars in a set to eliminate possibility of duplicates.

Also removes JS specific syntax for listing the environment variables because we support different languages now

Add a snapshot test to ensure the expected env vars are generated in an add => update scenario

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.