### PR TITLE
fix: pass deserialized obj to node lambda when mocking

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
@@ -72,7 +72,7 @@ function invokeFunction(options: InvokeOptions) {
 
     const { event } = options;
     try {
-      const result = await lambdaHandler(event, context, callback);
+      const result = await lambdaHandler(JSON.parse(event), context, callback);
       if (result !== undefined) {
         context.done(null, result);
       } else {


### PR DESCRIPTION
*Issue #, if available:*
#3178

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.