### PR TITLE
fix: update verdaccio version

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -1,7 +1,7 @@
   #!/bin/bash
 
 custom_registry_url=http://localhost:4873
-default_verdaccio_package=verdaccio@4.4.3
+default_verdaccio_package=verdaccio@4.5.1
 
 function startLocalRegistry {
   # Start local registry


### PR DESCRIPTION
Verdaccio release step started failing and bumping up the version appears to fix it.

Tested by running the "publish to verdaccio" circle ci steps locally and verifying no errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.