### PR TITLE
fix: set custom verdaccio version id

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "publish:beta": "lerna publish --exact --dist-tag=beta --preid=beta --conventional-commits --conventional-prerelease --message 'chore(release): Publish [ci skip]' --yes",
     "publish:release": "lerna publish --conventional-commits --exact --yes --message 'chore(release): Publish [ci skip]'",
     "postpublish:release": "git fetch . release:master && git push origin master",
-    "publish-to-verdaccio": "lerna publish prerelease --yes --force-publish=* --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest",
+    "publish-to-verdaccio": "lerna publish --yes --force-publish --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest --conventional-commits --conventional-prerelease --preid=verdaccio",
     "commit": "git-cz",
     "coverage": "codecov || exit 0"
   },


### PR DESCRIPTION
When we publish to verdaccio we append an -alpha to the package versions. However, this can conflict with actual alpha publishes, so change to set verdaccio version to x.y.z-verdaccio.0 which will not conflict with anything


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.