### PR TITLE
fix(graphql-dynamodb-transformer): add attribute type enum for queries

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -89,7 +89,7 @@ export class DynamoDBModelTransformer extends Transformer {
           public
           on
         }
-      `
+      `,
     );
     this.opts = this.getOpts(opts);
     this.resources = new ResourceFactory();
@@ -139,7 +139,7 @@ export class DynamoDBModelTransformer extends Transformer {
     ctx.mapResourceToStack(stackName, iamRoleLogicalID);
     ctx.setResource(
       dataSourceRoleLogicalID,
-      this.resources.makeDynamoDBDataSource(tableLogicalID, iamRoleLogicalID, typeName, isSyncEnabled)
+      this.resources.makeDynamoDBDataSource(tableLogicalID, iamRoleLogicalID, typeName, isSyncEnabled),
     );
     ctx.mapResourceToStack(stackName, dataSourceRoleLogicalID);
 
@@ -147,7 +147,7 @@ export class DynamoDBModelTransformer extends Transformer {
     ctx.setOutput(
       // "GetAtt" is a backward compatibility addition to prevent breaking current deploys.
       streamArnOutputId,
-      this.resources.makeTableStreamArnOutput(tableLogicalID)
+      this.resources.makeTableStreamArnOutput(tableLogicalID),
     );
     ctx.mapResourceToStack(stackName, streamArnOutputId);
 
@@ -183,7 +183,7 @@ export class DynamoDBModelTransformer extends Transformer {
     def: ObjectTypeDefinitionNode,
     directive: DirectiveNode,
     ctx: TransformerContext,
-    nonModelArray: ObjectTypeDefinitionNode[]
+    nonModelArray: ObjectTypeDefinitionNode[],
   ) => {
     const typeName = def.name.value;
     const isSyncEnabled = this.opts.SyncConfig ? true : false;
@@ -349,8 +349,8 @@ export class DynamoDBModelTransformer extends Transformer {
             makeInputValueDefinition('nextToken', makeNamedType('String')),
             makeInputValueDefinition('lastSync', makeNamedType('AWSTimestamp')),
           ],
-          makeNamedType(ModelResourceIDs.ModelConnectionTypeName(def.name.value))
-        )
+          makeNamedType(ModelResourceIDs.ModelConnectionTypeName(def.name.value)),
+        ),
       );
     }
 
@@ -365,8 +365,8 @@ export class DynamoDBModelTransformer extends Transformer {
         makeField(
           getResolver.Properties.FieldName.toString(),
           [makeInputValueDefinition('id', makeNonNullType(makeNamedType('ID')))],
-          makeNamedType(def.name.value)
-        )
+          makeNamedType(def.name.value),
+        ),
       );
     }
 
@@ -380,8 +380,8 @@ export class DynamoDBModelTransformer extends Transformer {
       ctx.mapResourceToStack(typeName, resourceId);
 
       queryFields.push(makeConnectionField(listResolver.Properties.FieldName.toString(), def.name.value));
+      this.generateFilterInputs(ctx, def);
     }
-    this.generateFilterInputs(ctx, def);
 
     ctx.addQueryFields(queryFields);
   };
@@ -518,6 +518,13 @@ export class DynamoDBModelTransformer extends Transformer {
     const tableXQueryFilterInput = makeModelXFilterInputObject(def, ctx, this.supportsConditions(ctx));
     if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
       ctx.addInput(tableXQueryFilterInput);
+    }
+
+    if (this.supportsConditions(ctx)) {
+      const attributeTypeEnum = makeAttributeTypeEnum();
+      if (!this.typeExist(attributeTypeEnum.name.value, ctx)) {
+        ctx.addType(attributeTypeEnum);
+      }
     }
   }
 

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -461,6 +461,44 @@ test('Test non model objects contain id as a type for fields', () => {
   verifyMatchingTypes(commentObjectIDField.type, commentInputIDField.type);
 });
 
+test('Test schema includes attribute enum when only queries specified', () => {
+  const validSchema = `
+    type Entity @model(mutations: null, subscriptions: null) {
+      id: ID!
+      str: String
+    }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+    transformConfig: {
+      Version: 5,
+    },
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+});
+
+test('Test only get does not generate superfluous input and filter types', () => {
+  const validSchema = `
+  type Entity @model(mutations: null, subscriptions: null, queries: {get: "getEntity"}) {
+    id: ID!
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+    transformConfig: {
+      Version: 5,
+    },
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+});
+
 test(`V${TRANSFORM_BASE_VERSION} transformer snapshot test`, () => {
   const schema = transformerVersionSnapshot(TRANSFORM_BASE_VERSION);
   expect(schema).toMatchSnapshot();

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -97,6 +97,19 @@ input ModelPostFilterInput {
   not: ModelPostFilterInput
 }
 
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
 type Query {
   getPost(id: ID!): Post
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
@@ -129,6 +142,123 @@ input ModelPostConditionInput {
   not: ModelPostConditionInput
 }
 
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test only get does not generate superfluous input and filter types 1`] = `
+"type Entity {
+  id: ID!
+  str: String
+}
+
+type Query {
+  getEntity(id: ID!): Entity
+}
+"
+`;
+
+exports[`Test schema includes attribute enum when only queries specified 1`] = `
+"type Entity {
+  id: ID!
+  str: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelEntityConnection {
+  items: [Entity]
+  nextToken: String
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelEntityFilterInput {
+  id: ModelIDInput
+  str: ModelStringInput
+  and: [ModelEntityFilterInput]
+  or: [ModelEntityFilterInput]
+  not: ModelEntityFilterInput
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -142,10 +272,9 @@ enum ModelAttributeTypes {
   _null
 }
 
-type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+type Query {
+  getEntity(id: ID!): Entity
+  listEntitys(filter: ModelEntityFilterInput, limit: Int, nextToken: String): ModelEntityConnection
 }
 "
 `;
@@ -355,6 +484,19 @@ input ModelPostFilterInput {
   not: ModelPostFilterInput
 }
 
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
 type Query {
   getPost(id: ID!): Post
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
@@ -385,19 +527,6 @@ input ModelPostConditionInput {
   and: [ModelPostConditionInput]
   or: [ModelPostConditionInput]
   not: ModelPostConditionInput
-}
-
-enum ModelAttributeTypes {
-  binary
-  binarySet
-  bool
-  list
-  map
-  number
-  numberSet
-  string
-  stringSet
-  _null
 }
 
 type Subscription {


### PR DESCRIPTION
*Issue #, if available:*
#3141 
*Description of changes:*
If only queries are specified in a schema, the ModelAttributeTypes enum was not added to the generated schema but the enum was referenced in Input and Filter types causing failures. This change adds the ModelAttributeTypes if list operations are specified.

Also, if only get was specified in the query (and not list) we were still generating a bunch of input and filter types that are not necessary, so this PR removes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.