### PR TITLE
fix(amplify-dotnet-function-template-provider): s'less returns app/json

### DIFF
--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Serverless/FunctionHandler.cs.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Serverless/FunctionHandler.cs.ejs
@@ -44,8 +44,8 @@ namespace <%= props.resourceName %>
                 case "GET":
                     context.Logger.LogLine($"Get Request: {request.Path}\n");
                     response.StatusCode = (int)HttpStatusCode.OK;
-                    response.Body = "Hello AWS Serverless";
-                    response.Headers["Content-Type"] = "text/plain";
+                    response.Body = "{ \"message\": \"Hello AWS Serverless\" }";
+                    response.Headers["Content-Type"] = "application/json";
                     break;
                 case "POST":
                     context.Logger.LogLine($"Post Request: {request.Path}\n");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the response of the Serverless template to return a JSON object and sets the Content-Type header to "application/json" so that callers can receive a valid response from API.get() "out of the box."

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.