### PR TITLE
fix(amplify-provider-awscloudformation): response type fix on grant

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/display-helpful-urls.js
+++ b/packages/amplify-provider-awscloudformation/lib/display-helpful-urls.js
@@ -49,7 +49,7 @@ function showGraphQLURL(context, resourcesToBeCreated) {
       hasApiKey = securityType === 'API_KEY';
     } else {
       const apiKeyProvider = [...(authConfig.additionalAuthenticationProviders || []), authConfig.defaultAuthentication].find(
-        provider => provider.authenticationType === 'API_KEY'
+        provider => provider.authenticationType === 'API_KEY',
       );
 
       hasApiKey = !!apiKeyProvider;
@@ -61,7 +61,7 @@ function showGraphQLURL(context, resourcesToBeCreated) {
         context.print.info(chalk`GraphQL API KEY: {blue.underline ${GraphQLAPIKeyOutput}}`);
       } else {
         context.print.warning(
-          chalk`GraphQL API is configured to use API_KEY authentication, but API Key deployment is disabled, don't forget to create one.`
+          chalk`GraphQL API is configured to use API_KEY authentication, but API Key deployment is disabled, don't forget to create one.`,
         );
       }
     }
@@ -106,7 +106,11 @@ function showHostedUIURLs(context, resourcesToBeCreated) {
       context.print.info(chalk`Hosted UI Endpoint: {blue.underline ${hostedUIEndpoint}}`);
       const redirectURIs = oAuthMetadata.CallbackURLs.concat(oAuthMetadata.LogoutURLs);
       if (redirectURIs.length > 0) {
-        const testHostedUIEndpoint = `https://${HostedUIDomain}.auth.${Region}.amazoncognito.com/login?response_type=code&client_id=${AppClientIDWeb}&redirect_uri=${redirectURIs[0]}\n`;
+        const [responseType] = oAuthMetadata.AllowedOAuthFlows;
+
+        const testHostedUIEndpoint = `https://${HostedUIDomain}.auth.${Region}.amazoncognito.com/login?response_type=${
+          responseType === 'implicit' ? 'token' : 'code'
+        }&client_id=${AppClientIDWeb}&redirect_uri=${redirectURIs[0]}\n`;
         context.print.info(chalk`Test Your Hosted UI Endpoint: {blue.underline ${testHostedUIEndpoint}}`);
       }
     }


### PR DESCRIPTION




*Issue #, if available:*
#3428
*Description of changes:*

Check for response type on Allowed Oauth flow when creating the hosted UI endpoint and then setting the `response_type` in the URL
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.