### PR TITLE
fix(amplify-e2e-tests): add .NET template and remove ddb uuid

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/function.test.ts.snap
@@ -4,8 +4,8 @@ exports[`nodejs amplify add function with additional permissions environment var
 "/* Amplify Params - DO NOT EDIT
 	ENV
 	REGION
-	STORAGE_NODETESTDDB9138_ARN
-	STORAGE_NODETESTDDB9138_NAME
+	STORAGE_NODETESTDDB_ARN
+	STORAGE_NODETESTDDB_NAME
 Amplify Params - DO NOT EDIT */
 
 exports.handler = async (event) => {

--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -381,7 +381,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {});
       const random = Math.floor(Math.random() * 10000);
       const funcName = `nodetestfn${random}`;
-      const ddbName = `nodetestddb${random}`;
+      const ddbName = `nodetestddb`;
 
       await addFunction(
         projRoot,

--- a/packages/amplify-e2e-tests/src/categories/function.ts
+++ b/packages/amplify-e2e-tests/src/categories/function.ts
@@ -12,7 +12,12 @@ type FunctionCallback = (chain: any, cwd: string, settings: any) => any;
 export const runtimeChoices = ['.NET Core 3.1', 'Go', 'Java', 'NodeJS', 'Python'];
 
 // templateChoices is per runtime
-const dotNetCore31TemplateChoices = ['Hello World', 'Serverless', 'Trigger (DynamoDb, Kinesis)'];
+const dotNetCore31TemplateChoices = [
+  'CRUD function for DynamoDB (Integration with API Gateway)',
+  'Hello World',
+  'Serverless',
+  'Trigger (DynamoDb, Kinesis)',
+];
 
 const goTemplateChoices = ['Hello World'];
 


### PR DESCRIPTION
A new .NET function template was added that also needed to be added to the list in the e2e tests so that correct templates can be selected by nexpect

Also there was a random number in a snapshot test causing it to fail

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.