### PR TITLE
fix(amplify-provider-awscloudformation): hide IAM secrets on entry

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -305,7 +305,8 @@ async function promptForProjectConfigConfirmation(context) {
 
   const configurationSettings = [
     {
-      type: 'input',
+      type: 'password',
+      mask: '*',
       name: 'accessKeyId',
       message: 'accessKeyId: ',
       default: awsConfigInfo.config.accessKeyId
@@ -314,7 +315,8 @@ async function promptForProjectConfigConfirmation(context) {
       transformer: obfuscateUtil.transform,
     },
     {
-      type: 'input',
+      type: 'password',
+      mask: '*',
       name: 'secretAccessKey',
       message: 'secretAccessKey: ',
       default: awsConfigInfo.config.secretAccessKey

--- a/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/lib/setup-new-user.js
@@ -57,14 +57,16 @@ function run(context) {
       context.print.info('Enter the access key of the newly created user:');
       return inquirer.prompt([
         {
-          type: 'input',
+          type: 'password',
+          mask: '*',
           name: 'accessKeyId',
           message: 'accessKeyId: ',
           default: awsConfig.accessKeyId,
           transformer: obfuscationUtil.transform,
         },
         {
-          type: 'input',
+          type: 'password',
+          mask: '*',
           name: 'secretAccessKey',
           message: 'secretAccessKey: ',
           default: awsConfig.secretAccessKey,


### PR DESCRIPTION
Change prompts where we ask for IAM User credentials from "input" to "password" so that the values are not printed to stdout

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.