### PR TITLE
fix(amplify-go-function-runtime-provider): fix issue #3892

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -67,14 +67,14 @@ export const buildResourceInternal = async (
   const buildDir = forLocalInvoke === true ? BIN_LOCAL : BIN;
   const outDir = path.join(request.srcRoot, buildDir);
 
+  const isWindows = /^win/.test(process.platform);
+  const executableName = isWindows === true ? MAIN_BINARY_WIN : MAIN_BINARY;
+  const executablePath = path.join(outDir, executableName);
+
   // For local invoke we've to use the build timestamp of the binary built
   let timestampToCheck;
 
   if (forLocalInvoke === true) {
-    const isWindows = /^win/.test(process.platform);
-    const executableName = isWindows === true ? MAIN_BINARY_WIN : MAIN_BINARY;
-    const executablePath = path.join(outDir, executableName);
-
     if (fs.existsSync(executablePath)) {
       timestampToCheck = new Date(fs.statSync(executablePath).mtime);
     }
@@ -85,7 +85,6 @@ export const buildResourceInternal = async (
   if (force === true || !timestampToCheck || isBuildStale(request.srcRoot, timestampToCheck, outDir)) {
     const srcDir = path.join(request.srcRoot, SRC);
     const entryFile = MAIN_SOURCE;
-    const isWindows = /^win/.test(process.platform);
 
     // Clean and/or create the output directory
     if (fs.existsSync(outDir)) {
@@ -106,7 +105,7 @@ export const buildResourceInternal = async (
     }
 
     // Execute the build command, cwd must be the source file directory (Windows requires it)
-    executeCommand(['build', '-o', outDir, entryFile], true, envVars, srcDir);
+    executeCommand(['build', '-o', executablePath, entryFile], true, envVars, srcDir);
 
     rebuilt = true;
   }


### PR DESCRIPTION
*Issue #, if available:* #3892

*Description of changes:*
Executable path and name should be evaluated irrespective of local build and use full executable
path to build


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.