### PR TITLE
fix: point editor to correct nodejs trigger template file

### DIFF
--- a/packages/amplify-nodejs-function-template-provider/src/providers/triggerProvider.ts
+++ b/packages/amplify-nodejs-function-template-provider/src/providers/triggerProvider.ts
@@ -20,7 +20,7 @@ export async function provideTrigger(context: any): Promise<FunctionTemplatePara
         'package.json.ejs': path.join('src', 'package.json'),
         'event.json': path.join('src', 'event.json'),
       },
-      defaultEditorFile: path.join('src', templateFile),
+      defaultEditorFile: path.join('src', 'index.js'),
     },
   };
 }


### PR DESCRIPTION
*Issue #, if available:*
#3914
*Description of changes:*
Change defaultEditorFile of dynamodb trigger to correct name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.