### PR TITLE
fix(amplify-dotnet-function-runtime-provider): 5.1-pre breaks detection

### DIFF
--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/detect.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/detect.ts
@@ -15,21 +15,22 @@ export const detectDotNetCore = async (): Promise<CheckDependenciesResult> => {
     };
   }
 
-  const result = execa.sync(executableName, ['--version']);
-  const versionString = result.stdout;
+  const result = execa.sync(executableName, ['--list-sdks']);
+  const installedSdks = result.stdout;
 
   if (result.exitCode !== 0) {
     throw new Error(`${executableName} failed, exit code was ${result.exitCode}`);
   }
 
-  if (versionString && versionString.startsWith('3.1')) {
+  // Verify that a dotnet 3.1 SDK is installed locally
+  if (installedSdks && installedSdks.match(/^3\.1/)) {
     return {
       hasRequiredDependencies: true,
     };
   } else {
     return {
       hasRequiredDependencies: false,
-      errorMessage: `Expected ${executableName} minimum version ${currentSupportedVersion}, but found: ${versionString}`,
+      errorMessage: `Expected ${executableName} minimum version ${currentSupportedVersion}, but found: ${installedSdks}`,
     };
   }
 };

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/global.json
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/packages/amplify-dotnet-function-template-provider/src/providers/crudProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/crudProvider.ts
@@ -1,5 +1,6 @@
 import { FunctionTemplateParameters, ContributionRequest } from 'amplify-function-plugin-interface';
-import { templateRoot } from '../utils/constants';
+import { commonFiles, templateRoot } from '../utils/constants';
+import { getDstMap } from '../utils/destFileMapper';
 import path from 'path';
 import { askDynamoDBQuestions, getTableParameters } from '../utils/dynamoDBWalkthrough';
 
@@ -12,7 +13,7 @@ export async function provideCrud(request: ContributionRequest, context: any): P
   const tableParameters = await getTableParameters(context, dynamoResource);
   Object.assign(dynamoResource, { category: 'storage' }, { tableDefinition: { ...tableParameters } });
   const files = [
-    '.gitignore',
+    ...commonFiles,
     'Crud/aws-lambda-tools-defaults.json.ejs',
     'Crud/Function.csproj.ejs',
     'Crud/FunctionHandler.cs.ejs',
@@ -31,7 +32,7 @@ export async function provideCrud(request: ContributionRequest, context: any): P
       },
       defaultEditorFile: handlerSource,
       destMap: {
-        '.gitignore': path.join('src', '.gitignore'),
+        ...getDstMap(commonFiles),
         'Crud/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
         'Crud/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
         'Crud/FunctionHandler.cs.ejs': handlerSource,

--- a/packages/amplify-dotnet-function-template-provider/src/providers/helloWorldProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/helloWorldProvider.ts
@@ -1,12 +1,13 @@
 import { FunctionTemplateParameters, ContributionRequest } from 'amplify-function-plugin-interface';
-import { templateRoot } from '../utils/constants';
+import { commonFiles, templateRoot } from '../utils/constants';
+import { getDstMap } from '../utils/destFileMapper';
 import path from 'path';
 
 const pathToTemplateFiles = path.join(templateRoot, 'lambda');
 
 export async function provideHelloWorld(request: ContributionRequest): Promise<FunctionTemplateParameters> {
   const files = [
-    '.gitignore',
+    ...commonFiles,
     'HelloWorld/aws-lambda-tools-defaults.json.ejs',
     'HelloWorld/Function.csproj.ejs',
     'HelloWorld/FunctionHandler.cs.ejs',
@@ -19,7 +20,7 @@ export async function provideHelloWorld(request: ContributionRequest): Promise<F
       sourceFiles: files,
       defaultEditorFile: handlerSource,
       destMap: {
-        '.gitignore': path.join('src', '.gitignore'),
+        ...getDstMap(commonFiles),
         'HelloWorld/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
         'HelloWorld/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
         'HelloWorld/FunctionHandler.cs.ejs': handlerSource,

--- a/packages/amplify-dotnet-function-template-provider/src/providers/serverlessProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/serverlessProvider.ts
@@ -1,12 +1,13 @@
 import { FunctionTemplateParameters, ContributionRequest } from 'amplify-function-plugin-interface';
-import { templateRoot } from '../utils/constants';
+import { commonFiles, templateRoot } from '../utils/constants';
+import { getDstMap } from '../utils/destFileMapper';
 import path from 'path';
 
 const pathToTemplateFiles = path.join(templateRoot, 'lambda');
 
 export function provideServerless(request: ContributionRequest): Promise<FunctionTemplateParameters> {
   const files = [
-    '.gitignore',
+    ...commonFiles,
     'Serverless/aws-lambda-tools-defaults.json.ejs',
     'Serverless/Function.csproj.ejs',
     'Serverless/FunctionHandler.cs.ejs',
@@ -23,7 +24,7 @@ export function provideServerless(request: ContributionRequest): Promise<Functio
       },
       defaultEditorFile: handlerSource,
       destMap: {
-        '.gitignore': path.join('src', '.gitignore'),
+        ...getDstMap(commonFiles),
         'Serverless/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
         'Serverless/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
         'Serverless/FunctionHandler.cs.ejs': handlerSource,

--- a/packages/amplify-dotnet-function-template-provider/src/providers/triggerProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/triggerProvider.ts
@@ -1,5 +1,6 @@
 import { FunctionTemplateParameters, ContributionRequest } from 'amplify-function-plugin-interface';
-import { templateRoot } from '../utils/constants';
+import { commonFiles, templateRoot } from '../utils/constants';
+import { getDstMap } from '../utils/destFileMapper';
 import path from 'path';
 import { askEventSourceQuestions } from '../utils/eventSourceWalkthrough';
 
@@ -21,7 +22,7 @@ export async function provideTrigger(request: ContributionRequest, context: any)
     default:
       throw new Error(`Unknown template type ${eventSourceAnswers.triggerEventSourceMappings[0].functionTemplateType}`);
   }
-  const files = ['.gitignore', templateFile, 'Trigger/aws-lambda-tools-defaults.json.ejs', 'Trigger/Function.csproj.ejs', eventFile];
+  const files = [...commonFiles, templateFile, 'Trigger/aws-lambda-tools-defaults.json.ejs', 'Trigger/Function.csproj.ejs', eventFile];
   return {
     triggerEventSourceMappings: eventSourceAnswers.triggerEventSourceMappings,
     dependsOn: eventSourceAnswers.dependsOn,
@@ -29,7 +30,7 @@ export async function provideTrigger(request: ContributionRequest, context: any)
       sourceRoot: pathToTemplateFiles,
       sourceFiles: files,
       destMap: {
-        '.gitignore': path.join('src', '.gitignore'),
+        ...getDstMap(commonFiles),
         [templateFile]: handlerSource,
         'Trigger/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
         'Trigger/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),

--- a/packages/amplify-dotnet-function-template-provider/src/utils/constants.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/utils/constants.ts
@@ -1,1 +1,4 @@
-export const templateRoot = `${__dirname}/../../resources`;
+const templateRoot = `${__dirname}/../../resources`;
+const commonFiles = ['global.json', '.gitignore'];
+
+export { templateRoot, commonFiles };

--- a/packages/amplify-dotnet-function-template-provider/src/utils/destFileMapper.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/utils/destFileMapper.ts
@@ -1,0 +1,9 @@
+import _ from 'lodash';
+import path from 'path';
+
+// Converts files to a map of file to destination filename
+// removes .ejs from file extension and appends src to the path
+// ['a.js.ejs', 'b.json'] => {'a.js.ejs': 'src/a.js', 'b.json': 'src/b.json'}
+export function getDstMap(files: string[]): { [key: string]: string } {
+  return files.reduce((acc, it) => _.assign(acc, { [it]: path.join('src', it.replace(/\.ejs$/, '')) }), {});
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses an issue that occurs when a user has the 5.1 preview SDK installed on their machine:

* The runtime provider will now list all installed SDKs and verify a 3.1 SDK is present
* The templates now include a global.json that ensures the functions are compiled with the 3.1 SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.