### PR TITLE
test(amplify-e2e-tests): add region mapping to e2e

### DIFF
--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "amplify-e2e-core": "1.1.0",
-    "amplify-provider-awscloudformation": "4.18.0",
     "aws-sdk": "^2.608.0",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "amplify-e2e-core": "1.1.0",
+    "amplify-provider-awscloudformation": "4.18.0",
     "aws-sdk": "^2.608.0",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",

--- a/packages/amplify-e2e-tests/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-tests/src/utils/pinpoint.ts
@@ -18,13 +18,42 @@ const settings = {
   pinpointResourceName: 'testpinpoint',
 };
 
+const defaultPinpointRegion = 'us-east-1';
+const serviceRegionMap = {
+  'us-east-1': 'us-east-1',
+  'us-east-2': 'us-east-1',
+  'sa-east-1': 'us-east-1',
+  'ca-central-1': 'us-east-1',
+  'us-west-1': 'us-west-2',
+  'us-west-2': 'us-west-2',
+  'cn-north-1': 'us-west-2',
+  'cn-northwest-1': 'us-west-2',
+  'ap-south-1': 'us-west-2',
+  'ap-northeast-3': 'us-west-2',
+  'ap-northeast-2': 'us-west-2',
+  'ap-southeast-1': 'us-west-2',
+  'ap-southeast-2': 'us-west-2',
+  'ap-northeast-1': 'us-west-2',
+  'eu-central-1': 'eu-central-1',
+  'eu-west-1': 'eu-west-1',
+  'eu-west-2': 'eu-west-1',
+  'eu-west-3': 'eu-west-1',
+};
+
+function mapServiceRegion(region) {
+  if (serviceRegionMap[region]) {
+    return serviceRegionMap[region];
+  }
+  return defaultPinpointRegion;
+}
+
 export async function pinpointAppExist(pinpointProjectId: string): Promise<boolean> {
   let result = false;
 
   const pinpointClient = new Pinpoint({
     accessKeyId: settings.accessKeyId,
     secretAccessKey: settings.secretAccessKey,
-    region: settings.region,
+    region: mapServiceRegion(settings.region),
   });
 
   try {

--- a/packages/amplify-e2e-tests/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-tests/src/utils/pinpoint.ts
@@ -1,6 +1,8 @@
 import { Pinpoint } from 'aws-sdk';
 import { getCLIPath } from '../utils';
 import { nspawn as spawn } from 'amplify-e2e-core';
+import { getPinpointRegionMapping } from 'amplify-provider-awscloudformation';
+import _ from 'lodash';
 
 const settings = {
   name: '\r',
@@ -18,42 +20,13 @@ const settings = {
   pinpointResourceName: 'testpinpoint',
 };
 
-const defaultPinpointRegion = 'us-east-1';
-const serviceRegionMap = {
-  'us-east-1': 'us-east-1',
-  'us-east-2': 'us-east-1',
-  'sa-east-1': 'us-east-1',
-  'ca-central-1': 'us-east-1',
-  'us-west-1': 'us-west-2',
-  'us-west-2': 'us-west-2',
-  'cn-north-1': 'us-west-2',
-  'cn-northwest-1': 'us-west-2',
-  'ap-south-1': 'us-west-2',
-  'ap-northeast-3': 'us-west-2',
-  'ap-northeast-2': 'us-west-2',
-  'ap-southeast-1': 'us-west-2',
-  'ap-southeast-2': 'us-west-2',
-  'ap-northeast-1': 'us-west-2',
-  'eu-central-1': 'eu-central-1',
-  'eu-west-1': 'eu-west-1',
-  'eu-west-2': 'eu-west-1',
-  'eu-west-3': 'eu-west-1',
-};
-
-function mapServiceRegion(region) {
-  if (serviceRegionMap[region]) {
-    return serviceRegionMap[region];
-  }
-  return defaultPinpointRegion;
-}
-
 export async function pinpointAppExist(pinpointProjectId: string): Promise<boolean> {
   let result = false;
 
   const pinpointClient = new Pinpoint({
     accessKeyId: settings.accessKeyId,
     secretAccessKey: settings.secretAccessKey,
-    region: mapServiceRegion(settings.region),
+    region: _.get(getPinpointRegionMapping(), settings.region, 'us-east-1'),
   });
 
   try {

--- a/packages/amplify-e2e-tests/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-tests/src/utils/pinpoint.ts
@@ -1,7 +1,6 @@
 import { Pinpoint } from 'aws-sdk';
 import { getCLIPath } from '../utils';
 import { nspawn as spawn } from 'amplify-e2e-core';
-import { getPinpointRegionMapping } from 'amplify-provider-awscloudformation';
 import _ from 'lodash';
 
 const settings = {
@@ -20,13 +19,35 @@ const settings = {
   pinpointResourceName: 'testpinpoint',
 };
 
+const defaultPinpointRegion = 'us-east-1';
+const serviceRegionMap = {
+  'us-east-1': 'us-east-1',
+  'us-east-2': 'us-east-1',
+  'sa-east-1': 'us-east-1',
+  'ca-central-1': 'us-east-1',
+  'us-west-1': 'us-west-2',
+  'us-west-2': 'us-west-2',
+  'cn-north-1': 'us-west-2',
+  'cn-northwest-1': 'us-west-2',
+  'ap-south-1': 'us-west-2',
+  'ap-northeast-3': 'us-west-2',
+  'ap-northeast-2': 'us-west-2',
+  'ap-southeast-1': 'us-west-2',
+  'ap-southeast-2': 'us-west-2',
+  'ap-northeast-1': 'us-west-2',
+  'eu-central-1': 'eu-central-1',
+  'eu-west-1': 'eu-west-1',
+  'eu-west-2': 'eu-west-1',
+  'eu-west-3': 'eu-west-1',
+};
+
 export async function pinpointAppExist(pinpointProjectId: string): Promise<boolean> {
   let result = false;
 
   const pinpointClient = new Pinpoint({
     accessKeyId: settings.accessKeyId,
     secretAccessKey: settings.secretAccessKey,
-    region: _.get(getPinpointRegionMapping(), settings.region, 'us-east-1'),
+    region: _.get(serviceRegionMap, settings.region, defaultPinpointRegion),
   });
 
   try {


### PR DESCRIPTION
pinpoint is missing region mapping in e2e test when checking if pinpoint app exists

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.