### PR TITLE
test(amplify-e2e-tests): added delay to waitFor

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -205,7 +205,7 @@ async function bucketNotExists(bucket: string) {
   const s3 = new S3();
   const params = {
     Bucket: bucket,
-    $waiter: { maxAttempts: 10 },
+    $waiter: { maxAttempts: 10, delay: 30 },
   };
   try {
     await s3.waitFor('bucketNotExists', params).promise();


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Added a delay of 30 seconds for the check between tests for 'bucketNotExists'
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.