### PR TITLE
test: implement retries and CFN polls in e2e tests

### DIFF
--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import { spawnSync, execSync } from 'child_process';
 
 export * from './utils/nexpect';
+export * from './utils/retrier';
 
 declare global {
   namespace NodeJS {

--- a/packages/amplify-e2e-core/src/utils/retrier.ts
+++ b/packages/amplify-e2e-core/src/utils/retrier.ts
@@ -1,0 +1,50 @@
+import _ from 'lodash';
+import { sleep } from './sleep';
+
+const defaultSettings: RetrySettings = {
+  times: Infinity,
+  delayMS: 1000 * 10, // 10 seconds
+  timeoutMS: 1000 * 60 * 5, // 5 minutes
+  stopOnError: true, // terminate the retries if a func calls throws an exception
+};
+
+/**
+ * Retries the function func until the predicate pred returns true, or until one of the retry limits is met.
+ * @param func The function to retry
+ * @param pred The predicate that determines successful output of func
+ * @param settings Retry limits (defaults to defaultSettings above)
+ */
+export const retry = async <T>(func: () => Promise<T>, pred: (res?: T) => boolean, settings?: Partial<RetrySettings>) => {
+  const { times, delayMS, timeoutMS, stopOnError } = _.merge({}, defaultSettings, settings);
+
+  let count = 0;
+  let result: T = undefined;
+  let terminate = false;
+  const startTime = Date.now();
+
+  do {
+    try {
+      result = await func();
+      if (pred(result)) {
+        console.info(`Retryable function execution succeeded.`);
+        return result;
+      } else {
+        console.warn(`Retryable function execution did not match predicate. Result was [${JSON.stringify(result)}]. Retrying...`);
+      }
+    } catch (err) {
+      console.warn(`Retryable function execution failed with [${err}]. Retrying...`);
+      terminate = stopOnError;
+    }
+    count++;
+    await sleep(delayMS);
+  } while (!terminate && count <= times && Date.now() - startTime < timeoutMS);
+
+  throw new Error('Retryable function did not match predicate within the given retry constraints');
+};
+
+export type RetrySettings = {
+  times: number; // specifying 1 will execute func once and if not successful, retry one time
+  delayMS: number; // delay between each attempt to execute func (there is no initial delay)
+  timeoutMS: number; // total amount of time to retry execution
+  stopOnError: boolean; // if retries should stop if func throws an error
+};

--- a/packages/amplify-e2e-core/src/utils/sleep.ts
+++ b/packages/amplify-e2e-core/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(millis) {
+  return new Promise(resolve => setTimeout(resolve, millis));
+}

--- a/packages/amplify-e2e-tests/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-tests/src/init/amplifyPush.ts
@@ -1,9 +1,11 @@
 import { nspawn as spawn } from 'amplify-e2e-core';
 import { getCLIPath } from '../utils';
 
+const pushTimeoutMS = 1000 * 60 * 10; // 10 minutes;
+
 export function amplifyPush(cwd: string) {
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['push'], { cwd, stripColors: true })
+    spawn(getCLIPath(), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
       .wait('Are you sure you want to continue?')
       .sendLine('y')
       .wait('Do you want to generate code for your newly created GraphQL API')
@@ -21,7 +23,7 @@ export function amplifyPush(cwd: string) {
 
 export function amplifyPushUpdate(cwd: string, waitForText?: RegExp) {
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['push'], { cwd, stripColors: true })
+    spawn(getCLIPath(), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
       .wait('Are you sure you want to continue?')
       .sendLine('y')
       .wait(waitForText || /.*/)
@@ -37,7 +39,7 @@ export function amplifyPushUpdate(cwd: string, waitForText?: RegExp) {
 
 export function amplifyPushAuth(cwd: string) {
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['push'], { cwd, stripColors: true })
+    spawn(getCLIPath(), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
       .wait('Are you sure you want to continue?')
       .sendLine('y')
       .wait(/.*/)

--- a/packages/amplify-e2e-tests/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-tests/src/init/deleteProject.ts
@@ -1,7 +1,12 @@
-import { nspawn as spawn } from 'amplify-e2e-core';
-import { getCLIPath } from '../utils';
+import { nspawn as spawn, retry } from 'amplify-e2e-core';
+import { getCLIPath, describeCloudFormationStack, getProjectMeta } from '../utils';
 
-export function deleteProject(cwd: string, deleteDeploymentBucket: Boolean = true) {
+export const deleteProject = async (cwd: string, deleteDeploymentBucket: Boolean = true) => {
+  const { StackName: stackName, Region: region } = getProjectMeta(cwd).providers.awscloudformation;
+  await retry(
+    () => describeCloudFormationStack(stackName, region),
+    stack => stack.StackStatus.endsWith('_COMPLETE'),
+  );
   return new Promise((resolve, reject) => {
     const noOutputTimeout = 10 * 60 * 1000; // 10 minutes
     spawn(getCLIPath(), ['delete'], { cwd, stripColors: true, noOutputTimeout })
@@ -17,4 +22,4 @@ export function deleteProject(cwd: string, deleteDeploymentBucket: Boolean = tru
         }
       });
   });
-}
+};

--- a/packages/amplify-e2e-tests/src/utils/index.ts
+++ b/packages/amplify-e2e-tests/src/utils/index.ts
@@ -21,10 +21,6 @@ export function getEnvVars(): { ACCESS_KEY_ID: string; SECRET_ACCESS_KEY: string
   return { ...process.env } as { ACCESS_KEY_ID: string; SECRET_ACCESS_KEY: string };
 }
 
-export function sleep(millis) {
-  return new Promise(resolve => setTimeout(resolve, millis));
-}
-
 export function overrideFunctionSrc(root: string, name: string, code: string) {
   let indexPath = path.join(root, `amplify/backend/function/${name}/src/index.js`);
   fs.writeFileSync(indexPath, code);

--- a/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-tests/src/utils/sdk-calls.ts
@@ -10,19 +10,20 @@ import {
   CloudWatchLogs,
   CloudWatchEvents,
   Kinesis,
+  CloudFormation,
 } from 'aws-sdk';
 
-const getDDBTable = async (tableName: string, region: string) => {
+export const getDDBTable = async (tableName: string, region: string) => {
   const service = new DynamoDB({ region });
   return await service.describeTable({ TableName: tableName }).promise();
 };
 
-const checkIfBucketExists = async (bucketName: string, region: string) => {
+export const checkIfBucketExists = async (bucketName: string, region: string) => {
   const service = new S3({ region });
   return await service.headBucket({ Bucket: bucketName }).promise();
 };
 
-const getUserPool = async (userpoolId, region) => {
+export const getUserPool = async (userpoolId, region) => {
   config.update({ region });
   let res;
   try {
@@ -33,7 +34,7 @@ const getUserPool = async (userpoolId, region) => {
   return res;
 };
 
-const getLambdaFunction = async (functionName, region) => {
+export const getLambdaFunction = async (functionName, region) => {
   const lambda = new Lambda();
   let res;
   try {
@@ -44,7 +45,7 @@ const getLambdaFunction = async (functionName, region) => {
   return res;
 };
 
-const getUserPoolClients = async (userPoolId: string, clientIds: string[], region: string) => {
+export const getUserPoolClients = async (userPoolId: string, clientIds: string[], region: string) => {
   const provider = new CognitoIdentityServiceProvider({ region });
   const res = [];
   try {
@@ -63,47 +64,54 @@ const getUserPoolClients = async (userPoolId: string, clientIds: string[], regio
   return res;
 };
 
-const getBot = async (botName: string, region: string) => {
+export const getBot = async (botName: string, region: string) => {
   const service = new LexModelBuildingService({ region });
   return await service.getBot({ name: botName, versionOrAlias: '$LATEST' }).promise();
 };
 
-const getFunction = async (functionName: string, region: string) => {
+export const getFunction = async (functionName: string, region: string) => {
   const service = new Lambda({ region });
   return await service.getFunction({ FunctionName: functionName }).promise();
 };
 
-const invokeFunction = async (functionName: string, payload: string, region: string) => {
+export const invokeFunction = async (functionName: string, payload: string, region: string) => {
   const service = new Lambda({ region });
   return await service.invoke({ FunctionName: functionName, Payload: payload }).promise();
 };
 
-const getCollection = async (collectionId: string, region: string) => {
+export const getCollection = async (collectionId: string, region: string) => {
   const service = new Rekognition({ region });
   return await service.describeCollection({ CollectionId: collectionId }).promise();
 };
 
-const getTable = async (tableName: string, region: string) => {
+export const getTable = async (tableName: string, region: string) => {
   const service = new DynamoDB({ region });
   return await service.describeTable({ TableName: tableName }).promise();
 };
 
-const deleteTable = async (tableName: string, region: string) => {
+export const getEventSourceMappings = async (functionName: string, region: string) => {
+  const service = new Lambda({ region });
+  return (await service.listEventSourceMappings({ FunctionName: functionName }).promise()).EventSourceMappings;
+};
+
+export const deleteTable = async (tableName: string, region: string) => {
   const service = new DynamoDB({ region });
   return await service.deleteTable({ TableName: tableName }).promise();
 };
 
-const getAppSyncApi = async (appSyncApiId: string, region: string) => {
+export const getAppSyncApi = async (appSyncApiId: string, region: string) => {
   const service = new AppSync({ region });
   return await service.getGraphqlApi({ apiId: appSyncApiId }).promise();
 };
 
-const getCloudWatchLogs = async (region: string, logGroupName: string, logStreamName: string | undefined = undefined) => {
+export const getCloudWatchLogs = async (region: string, logGroupName: string, logStreamName: string | undefined = undefined) => {
   const cloudwatchlogs = new CloudWatchLogs({ region, retryDelayOptions: { base: 500 } });
 
   let targetStreamName = logStreamName;
   if (targetStreamName === undefined) {
-    const describeStreamsResp = await cloudwatchlogs.describeLogStreams({ logGroupName, descending: true }).promise();
+    const describeStreamsResp = await cloudwatchlogs
+      .describeLogStreams({ logGroupName, descending: true, orderBy: 'LastEventTime' })
+      .promise();
     if (describeStreamsResp.logStreams === undefined || describeStreamsResp.logStreams.length == 0) {
       return [];
     }
@@ -115,7 +123,12 @@ const getCloudWatchLogs = async (region: string, logGroupName: string, logStream
   return logsResp.events || [];
 };
 
-const putKinesisRecords = async (data: string, partitionKey: string, streamName: string, region: string) => {
+export const describeCloudFormationStack = async (stackName: string, region: string) => {
+  const service = new CloudFormation({ region });
+  return (await service.describeStacks({ StackName: stackName }).promise()).Stacks.find(stack => stack.StackName === stackName);
+};
+
+export const putKinesisRecords = async (data: string, partitionKey: string, streamName: string, region: string) => {
   const kinesis = new Kinesis({ region });
 
   return await kinesis
@@ -131,7 +144,7 @@ const putKinesisRecords = async (data: string, partitionKey: string, streamName:
     .promise();
 };
 
-const getCloudWatchEventRule = async (targetName: string, region: string) => {
+export const getCloudWatchEventRule = async (targetName: string, region: string) => {
   config.update({ region });
   const service = new CloudWatchEvents();
   var params = {
@@ -144,22 +157,4 @@ const getCloudWatchEventRule = async (targetName: string, region: string) => {
     console.log(e);
   }
   return ruleName;
-};
-
-export {
-  getDDBTable,
-  checkIfBucketExists,
-  getUserPool,
-  getUserPoolClients,
-  getBot,
-  getLambdaFunction,
-  getFunction,
-  invokeFunction,
-  getTable,
-  deleteTable,
-  getAppSyncApi,
-  getCollection,
-  getCloudWatchLogs,
-  putKinesisRecords,
-  getCloudWatchEventRule,
 };


### PR DESCRIPTION
Should reduce e2e test flakiness by:
1. removing sleeps() from tests and instead polling resource status to determine availability
2. there is some inconsistency between when lambda event sources report that they are active and when the lambda is actually triggered by the events. To mitigate this, the tests retry the event twice
3. On `amplify push` wait for the CFN stack to report UPDATE_COMPLETE rather than waiting for CLI output. Sometimes if a stack took a long time to provision, nexpect would timeout even though everything was fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.