### PR TITLE
ci: update build to run 3 process concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "clean": "lerna run clean && lerna exec yarn rimraf tsconfig.tsbuildinfo && lerna clean --yes && yarn rimraf node_modules",
     "build": "lerna run build",
-    "production-build": "yarn --frozen-lockfile && lerna run build",
+    "production-build": "yarn --frozen-lockfile && lerna run build --concurrency 3 --stream",
     "dev-build": "yarn && lerna run build",
     "link-caa": "cd packages/amplify-app && npm link",
     "link-dev": "cd packages/amplify-cli && ln -s $(pwd)/bin/amplify $(yarn global bin)/amplify-dev && cd -",


### PR DESCRIPTION
Updated proudction build to run only 3 concurrent builds in circle ci to address memory issue

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.