### PR TITLE
fix(amplify-dotnet-function-template-provider): ddb/kinesis templates

### DIFF
--- a/packages/amplify-dotnet-function-template-provider/src/utils/analyticsWalkthrough.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/utils/analyticsWalkthrough.ts
@@ -35,7 +35,8 @@ export async function askAnalyticsCategoryKinesisQuestions(context: any) {
         batchSize: 100,
         startingPosition: 'LATEST',
         eventSourceArn: streamArnParamRef,
-        functionTemplateName: 'trigger-kinesis.js',
+        functionTemplateType: 'kinesis',
+        functionTemplateName: 'Kinesis.cs.ejs',
         triggerPolicies: [
           {
             Effect: 'Allow',

--- a/packages/amplify-dotnet-function-template-provider/src/utils/dynamoDBWalkthrough.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/utils/dynamoDBWalkthrough.ts
@@ -164,7 +164,8 @@ export async function askAPICategoryDynamoDBQuestions(context: any) {
       batchSize: 100,
       startingPosition: 'LATEST',
       eventSourceArn: streamArnParamRef,
-      functionTemplateName: 'trigger-dynamodb.js',
+      functionTemplateType: 'dynamoDB',
+      functionTemplateName: 'DynamoDb.cs.ejs',
       triggerPolicies: [
         {
           Effect: 'Allow',

--- a/packages/amplify-dotnet-function-template-provider/src/utils/eventSourceWalkthrough.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/utils/eventSourceWalkthrough.ts
@@ -168,7 +168,7 @@ export async function askEventSourceQuestions(context: any) {
                 startingPosition: 'LATEST',
                 eventSourceArn: dynamoDBCategoryStorageStreamArnRef,
                 functionTemplateType: eventSourceTypeAnswer.eventSourceType,
-                functionTemplateName: 'trigger-dynamodb.js',
+                functionTemplateName: 'DynamoDb.cs.ejs',
                 triggerPolicies: [
                   {
                     Effect: 'Allow',


### PR DESCRIPTION
*Issue #, if available:*
#4037, #4042 

*Description of changes:*
Fixes incomplete porting of ddb gql/analytics walkthroughs from NodeJS templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.