### PR TITLE
feat: notify if a CLI update is available

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@types/fs-extra": "^8.0.1",
     "@types/global-prefix": "^3.0.0",
+    "@types/update-notifier": "^4.1.0",
     "amplify-category-analytics": "2.16.3",
     "amplify-category-api": "2.19.0",
     "amplify-category-auth": "2.15.4",
@@ -82,6 +83,7 @@
     "parse-json": "^5.0.0",
     "promise-sequential": "^1.1.1",
     "semver": "^7.1.1",
+    "update-notifier": "^4.1.0",
     "which": "^2.0.2"
   },
   "devDependencies": {

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -20,13 +20,6 @@ EventEmitter.defaultMaxListeners = 1000;
 // entry from commandline
 export async function run(): Promise<number> {
   try {
-    // Checks for available update on each use
-    const notifier = updateNotifier({
-      pkg,
-      updateCheckInterval: 0,
-    });
-    notifier.notify({ defer: false, isGlobal: true });
-
     let pluginPlatform = await getPluginPlatform();
     let input = getCommandLineInput(pluginPlatform);
     let verificationResult = verifyInput(pluginPlatform, input);
@@ -110,4 +103,10 @@ export async function executeAmplifyCommand(context: Context) {
   const commandPath = path.normalize(path.join(__dirname, 'commands', context.input.command!));
   const commandModule = require(commandPath);
   await commandModule.run(context);
+  // Checks for available update on each use
+  const notifier = updateNotifier({
+    pkg,
+    updateCheckInterval: 0,
+  });
+  notifier.notify({ defer: false, isGlobal: true });
 }

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -8,6 +8,8 @@ import { executeCommand } from './execution-manager';
 import { Context } from './domain/context';
 import { constants } from './domain/constants';
 import { checkProjectConfigVersion } from './project-config-version-check';
+import { default as updateNotifier } from 'update-notifier';
+const pkg = require('../package.json');
 
 // Adjust defaultMaxListeners to make sure Inquirer will not fail under Windows because of the multiple subscriptions
 // https://github.com/SBoudrias/Inquirer.js/issues/887
@@ -18,6 +20,13 @@ EventEmitter.defaultMaxListeners = 1000;
 // entry from commandline
 export async function run(): Promise<number> {
   try {
+    // Checks for available update on each use
+    const notifier = updateNotifier({
+      pkg,
+      updateCheckInterval: 0,
+    });
+    notifier.notify({ defer: false, isGlobal: true });
+
     let pluginPlatform = await getPluginPlatform();
     let input = getCommandLineInput(pluginPlatform);
     let verificationResult = verifyInput(pluginPlatform, input);


### PR DESCRIPTION
Will notify on every amplify call with a daily interval if an update to the CLI is available.

*Issue #, if available:*
re #2488 

*Description of changes:*
Notify if an update to the CLI is available with a daily interval.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.