### PR TITLE
fix(amplify-category-interactions): render the correct region in CFN

### DIFF
--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/cloudformation-templates/lex-cloudformation-template.json.ejs
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/cloudformation-templates/lex-cloudformation-template.json.ejs
@@ -312,7 +312,7 @@
     "Outputs": {
         "Region": {
             "Value": {
-                "Ref": "AWS::Region"
+                "Fn::FindInMap": ["RegionMapping", { "Ref": "AWS::Region" }, "lexRegion"]
             }
         },
         "BotName":  {


### PR DESCRIPTION
Update cloudformation template to render the region mapped region in the out instead of rendering
the current AWS region

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.