### PR TITLE
Adds feature for allowing on demand dynamo db to be created using the`amplify add storage` command.

### DIFF
--- a/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/dynamoDb-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/cloudformation-templates/dynamoDb-cloudformation-template.json.ejs
@@ -45,6 +45,7 @@
                   } <%if (i != props.AttributeDefinitions.length - 1) { %> , <% } %>
                   <% } %>
                 ],
+                "BillingMode": "<%= props.BillingMode %>",
                 "KeySchema": [
                   <% for(var i=0; i < props.KeySchema.length; i++) { %>
                   {
@@ -52,11 +53,11 @@
                     "KeyType": "<%= props.KeySchema[i].KeyType %>"
                   } <%if (i != props.KeySchema.length - 1) { %> , <% } %>
                   <% } %>
-                ],
+                ], <%if (props.BillingMode == "PROVISIONED") { %>
                 "ProvisionedThroughput": {
                     "ReadCapacityUnits": "5",
                     "WriteCapacityUnits": "5"
-                },
+                },<% } %>
                 "StreamSpecification": {
                     "StreamViewType": "NEW_IMAGE"
                 },
@@ -65,7 +66,7 @@
                         "ShouldNotCreateEnvResources",
                         {
                            "Ref": "tableName"
-                        }, 
+                        },
                         {
 
                             "Fn::Join": [
@@ -95,13 +96,13 @@
                                 "KeyType": "<%= props.GlobalSecondaryIndexes[i].KeySchema[j].KeyType %>"
                             } <%if (j != props.GlobalSecondaryIndexes[i].KeySchema.length - 1) { %> , <% } %>
                             <% } %>
-                        ],
-                        "Projection": {
-                            "ProjectionType": "ALL"
-                        },
+                        ],<%if (props.BillingMode == "PROVISIONED") { %>
                         "ProvisionedThroughput": {
                             "ReadCapacityUnits": "5",
                             "WriteCapacityUnits": "5"
+                        },<% } %>
+                        "Projection": {
+                            "ProjectionType": "ALL"
                         }
                     } <%if (i != props.GlobalSecondaryIndexes.length - 1) { %> , <% } %>
                   <% } %>

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -287,8 +287,6 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
     sortKeyType = answers.AttributeDefinitions[sortKeyAttrTypeIndex].AttributeType;
   }
 
-  answers.KeySchema = answers.KeySchema;
-
   print.info('');
   print.info(
     'You can optionally add global secondary indexes for this table. These are useful when you run queries defined in a different column than the primary key.',

--- a/packages/amplify-category-storage/provider-utils/supported-services.json
+++ b/packages/amplify-category-storage/provider-utils/supported-services.json
@@ -53,6 +53,12 @@
         "required": true
       },
       {
+        "key": "billingMode",
+        "type": "list",
+        "question": "Please provide the billing mode for this table (for more information, see https://aws.amazon.com/dynamodb/pricing/):",
+        "required": true
+      },
+      {
         "key": "attribute",
         "type": "input",
         "question": "What would you like to name this column:",


### PR DESCRIPTION
***Issue #, if available:***
[1417](https://github.com/aws-amplify/amplify-cli/issues/1417)

***Description of changes:***

These changes add an option for on demand billing when setting up dynamodb using the `amplify add storage` command.

This change impacts GSIs if an on demand table is created, by making the GSI also on demand (It seems not possible to specify a BillingMode separately for GSIs and so it takes what the table has ([see docs here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-gsi.html)).

If the table is created using provisioned throughput, the defaults remain at 5 (these are unchanged and setting them seemed out of scope of adding the on demand feature). Depending how this goes, I may create a PR for that separately.

**How has it been tested?**
```stephen@stephen-Virtual-Machine:~/dev/aws-amplify/example$ amplify-dev add storage
? Please select from one of the below mentioned services: NoSQL Database

Welcome to the NoSQL DynamoDB database wizard
This wizard asks you a series of questions to help determine how to set up your NoSQL database table.

? Please provide a friendly name for your resource that will be used to label this category in t
he project: dynamo87814c50
? Please provide table name: dynamo87814c50
? Please provide the billing mode for this table (for more information, see https://aws.amazon.c
om/dynamodb/pricing/): On demand

You can now add columns to the table.

? What would you like to name this column: id
? Please choose the data type: string
? Would you like to add another column? Yes
? What would you like to name this column: anothercolumn
? Please choose the data type: string
? Would you like to add another column? No

Before you create the database, you must specify how items in your table are uniquely organized. You do this by specifying a primary key. The primary key uniquely identifies each item in the table so that no two items can have the same key. This can be an individual column, or a combination that includes a primary key and a sort key.

To learn more about primary keys, see:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey

? Please choose partition key for the table: id
? Do you want to add a sort key to your table? No

You can optionally add global secondary indexes for this table. These are useful when you run queries defined in a different column than the primary key.
To learn more about indexes, see:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.SecondaryIndexes

? Do you want to add global secondary indexes to your table? Yes
? Please provide the GSI name: anothercolumngsi
? Please choose partition key for the GSI: anothercolumn
? Do you want to add more global secondary indexes to your table? No
? Do you want to add a Lambda Trigger for your Table? No
Successfully added resource dynamo87814c50 locally

Some next steps:
"amplify push" builds all of your local backend resources and provisions them in the cloud
"amplify publish" builds all of your local backend and front-end resources (if you added hosting category) and provisions them in the cloud

```

The output of this command has been attached to this PR. This was then successfully deployed using amplify push:



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
[dynamo87814c50-cloudformation-template.txt](https://github.com/aws-amplify/amplify-cli/files/4533838/dynamo87814c50-cloudformation-template.txt)

