### PR TITLE
fix: add dotnet tool install to base yaml

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -184,6 +184,8 @@ jobs:
             sudo apt-get update
             sudo apt-get install dotnet-sdk-3.1
             dotnet --version
+            dotnet tool install -g amazon.lambda.tools
+            dotnet tool install -g amazon.lambda.testtool-3.1
       - run:
           name: Start verdaccio and Install Amplify CLI
           command: |


### PR DESCRIPTION
*Description of changes:*

fix: dotnet lambda tool install was missing from base yaml file used for parallel test generation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.