### PR TITLE
fix: remove duplicate permissions from resources in same category

### DIFF
--- a/packages/amplify-e2e-core/src/utils/retrier.ts
+++ b/packages/amplify-e2e-core/src/utils/retrier.ts
@@ -26,7 +26,6 @@ export const retry = async <T>(func: () => Promise<T>, pred: (res?: T) => boolea
     try {
       result = await func();
       if (pred(result)) {
-        console.info(`Retryable function execution succeeded.`);
         return result;
       } else {
         console.warn(`Retryable function execution did not match predicate. Result was [${JSON.stringify(result)}]. Retrying...`);

--- a/packages/amplify-e2e-tests/schemas/two-model-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/two-model-schema.graphql
@@ -1,0 +1,11 @@
+type Post @model {
+  id: ID!
+  title: String
+  comments: [Comment!]! @connection(keyName: "byPost", fields: ["id"])
+}
+
+type Comment @model @key(name: "byPost", fields: ["postID"]) {
+  id: ID!
+  content: String
+  postID: ID!
+}

--- a/packages/amplify-e2e-tests/src/__tests__/function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function.test.ts
@@ -2,21 +2,14 @@ import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush }
 import { addFunction, updateFunction, functionBuild, addLambdaTrigger, functionMockAssert, functionCloudInvoke } from 'amplify-e2e-core';
 import { addSimpleDDB } from 'amplify-e2e-core';
 import { addKinesis } from 'amplify-e2e-core';
-import {
-  createNewProjectDir,
-  deleteProjectDir,
-  getProjectMeta,
-  getFunction,
-  overrideFunctionSrc,
-  getFunctionSrc,
-} from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getFunction, overrideFunctionSrc, getFunctionSrc } from 'amplify-e2e-core';
 import { addApiWithSchema } from 'amplify-e2e-core';
 
 import { appsyncGraphQLRequest } from 'amplify-e2e-core';
 import { getCloudWatchLogs, putKinesisRecords, invokeFunction, getCloudWatchEventRule, getEventSourceMappings } from 'amplify-e2e-core';
 import fs from 'fs-extra';
 import path from 'path';
-import { retry } from 'amplify-e2e-core';
+import { retry, readJsonFile } from 'amplify-e2e-core';
 
 describe('nodejs', () => {
   describe('amplify add function', () => {
@@ -428,6 +421,37 @@ describe('nodejs', () => {
         'utf8',
       );
       expect(lambdaHandlerContents).toMatchSnapshot();
+    });
+
+    it('adding api and storage permissions should not add duplicates to CFN', async () => {
+      await initJSProjectWithProfile(projRoot, {});
+      await addApiWithSchema(projRoot, 'two-model-schema.graphql');
+
+      const random = Math.floor(Math.random() * 10000);
+      const fnName = `integtestfn${random}`;
+      const ddbName = `ddbTable${random}`;
+
+      await addSimpleDDB(projRoot, { name: ddbName });
+      await addFunction(
+        projRoot,
+        {
+          name: fnName,
+          functionTemplate: 'Hello World',
+          additionalPermissions: {
+            permissions: ['storage'],
+            choices: ['api', 'storage'],
+            resources: [ddbName, 'Post:@model(appsync)', 'Comment:@model(appsync)'],
+            resourceChoices: [ddbName, 'Post:@model(appsync)', 'Comment:@model(appsync)'],
+            operations: ['read'],
+          },
+        },
+        'nodejs',
+      );
+
+      const lambdaCFN = readJsonFile(
+        path.join(projRoot, 'amplify', 'backend', 'function', fnName, `${fnName}-cloudformation-template.json`),
+      );
+      expect(lambdaCFN.Resources.AmplifyResourcesPolicy.Properties.PolicyDocument.Statement.length).toBe(3);
     });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
#4051
*Description of changes:*
The call to `getPermissionPolicies` was passing in an object of all resources that was appended to on every iteration of a loop through all of the selected resources, thus adding n^2/2 resource policies when only n were selected. Amended the call to only pass in the resource of the current iteration of the loop rather than the full list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.