### PR TITLE
fix: add dotnet global tools path to $PATH in CI/CD

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -186,6 +186,9 @@ jobs:
             dotnet --version
             dotnet tool install -g amazon.lambda.tools
             dotnet tool install -g amazon.lambda.testtool-3.1
+            echo "export PATH=$PATH:$HOME/.dotnet/tools" >> $BASH_ENV
+            source $BASH_ENV
+            dotnet tool list -g
       - run:
           name: Start verdaccio and Install Amplify CLI
           command: |


### PR DESCRIPTION
*Description of changes:*

Fix: add dotnet global tools path to $PATH

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.