### PR TITLE
fix(amplify-dotnet-function-runtime-provider): added mock/debug build

### DIFF
--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/build.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/build.ts
@@ -6,15 +6,23 @@ import { BuildRequest, BuildResult } from 'amplify-function-plugin-interface';
 import { executableName } from '../constants';
 
 export const build = async (request: BuildRequest): Promise<BuildResult> => {
+  return buildCore(request, 'Release');
+};
+
+export const buildCore = async (request: BuildRequest, configuration: 'Release' | 'Debug'): Promise<BuildResult> => {
   const distPath = path.join(request.srcRoot, 'dist');
   const sourceFolder = path.join(request.srcRoot, 'src');
-
-  if (!request.lastBuildTimestamp || !fs.existsSync(distPath) || isBuildStale(sourceFolder, request.lastBuildTimestamp)) {
+  if (
+    configuration === 'Debug' || // Always refresh for mock builds
+    !request.lastBuildTimestamp ||
+    !fs.existsSync(distPath) ||
+    isBuildStale(sourceFolder, request.lastBuildTimestamp)
+  ) {
     if (!fs.existsSync(distPath)) {
       fs.mkdirSync(distPath);
     }
 
-    const result = execa.sync(executableName, ['publish', '-c', 'Release', '-o', distPath], {
+    const result = execa.sync(executableName, ['publish', '-c', configuration, '-o', distPath], {
       cwd: sourceFolder,
     });
 

--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/invoke.ts
@@ -3,16 +3,19 @@ import fs from 'fs-extra';
 import glob from 'glob';
 import * as execa from 'execa';
 import { InvocationRequest } from 'amplify-function-plugin-interface';
-import { build } from './build';
+import { buildCore } from './build';
 import { executableName } from '../constants';
 
 export const invoke = async (request: InvocationRequest): Promise<string> => {
-  await build({
-    env: request.env,
-    runtime: request.runtime,
-    srcRoot: request.srcRoot,
-    lastBuildTimestamp: request.lastBuildTimestamp,
-  });
+  await buildCore(
+    {
+      env: request.env,
+      runtime: request.runtime,
+      srcRoot: request.srcRoot,
+      lastBuildTimestamp: request.lastBuildTimestamp,
+    },
+    'Debug',
+  );
 
   const sourcePath = path.join(request.srcRoot, 'src');
   let result: execa.ExecaSyncReturnValue<string>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the build process so that mock builds generate a fresh Debug build to ensure the Lambda test tool can execute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.