### PR TITLE
test: cleaning up exports in e2e core

### DIFF
--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -2,9 +2,6 @@ import { join } from 'path';
 import * as fs from 'fs-extra';
 import { spawnSync, execSync } from 'child_process';
 
-export * from './utils/nexpect';
-export * from './utils/retrier';
-
 export * from './configure/';
 export * from './init/';
 export * from './utils/';

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -2,14 +2,19 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
-export * from './projectMeta';
-export * from './transformConfig';
-export * from './sdk-calls';
+
 export * from './api';
-export * from './read-json-file';
-export * from './pinpoint';
-export * from './selectors';
+export * from './appsync';
 export * from './nexpect';
+export * from './pinpoint';
+export * from './projectMeta';
+export * from './read-json-file';
+export * from './request';
+export * from './retrier';
+export * from './sdk-calls';
+export * from './selectors';
+export * from './sleep';
+export * from './transformConfig';
 
 // run dotenv config to update env variable
 config();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
-Alphabetical ordering of exports
-Remove redundant exporting of nexpect and retry in core index
-Include appsync export in utils

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.