### PR TITLE
feat: allow layer deployment for nodejs

### DIFF
--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -73,6 +73,7 @@ export type PackageRequest = {
   runtime: string;
   lastBuildTimestamp: Date;
   lastPackageTimestamp?: Date;
+  isLayer: boolean;
 };
 
 // Result of building a function

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -50,6 +50,9 @@ function runPackageManager(cwd: string, scriptName?: string) {
     stdio: 'pipe',
     encoding: 'utf-8',
   });
+  if (childProcessResult.error) {
+    throw childProcessResult.error;
+  }
   if (childProcessResult.status !== 0) {
     throw new Error(childProcessResult.output.join());
   }

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyPackage.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyPackage.ts
@@ -17,7 +17,7 @@ export async function packageResource(request: PackageRequest, context: any): Pr
       });
       const zip = archiver.create('zip', {});
       zip.pipe(output);
-      zip.directory(path.join(request.srcRoot, 'src'), false);
+      zip.directory(path.join(request.srcRoot, 'src'), request.isLayer ? 'nodejs' : false);
       zip.finalize();
     });
   }

--- a/packages/amplify-provider-awscloudformation/lib/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/build-resources.js
@@ -66,6 +66,7 @@ async function buildResource(context, resource) {
       runtime: breadcrumbs.functionRuntime,
       lastPackageTimestamp: resource.lastPackageTimestamp ? new Date(resource.lastPackageTimestamp) : undefined,
       lastBuildTimestamp: rebuilt ? new Date() : new Date(resource.lastBuildTimeStamp),
+      isLayer: resource.service === 'LambdaLayer',
     };
     packagePromise = runtimePlugin.package(packageRequest);
   }


### PR DESCRIPTION
This CL allows users to deploy lambda layer manually.
The interactive shell is missing, only nodejs support, but it should be
enough for the initial support.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.