### PR TITLE
fix(amplify-dotnet-function-runtime-provider): mock build fix

### DIFF
--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/build.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/build.ts
@@ -22,7 +22,21 @@ export const buildCore = async (request: BuildRequest, configuration: 'Release' 
       fs.mkdirSync(distPath);
     }
 
-    const result = execa.sync(executableName, ['publish', '-c', configuration, '-o', distPath], {
+    const buildArguments = [];
+    switch (configuration) {
+      case 'Release':
+        buildArguments.push('publish', '-c', configuration, '-o', distPath);
+        break;
+      case 'Debug':
+        // Debug config, copy all required assemblies for mocking.
+        // The CopyLocalLockFileAssemblies really shouldn't be necessary, but
+        // we encountered CircleCI e2e test issues without it.
+        buildArguments.push('build', '-c', configuration, '-p:CopyLocalLockFileAssemblies=true');
+        break;
+      default:
+        throw new Error(`Unexpected configuration '${configuration}'`);
+    }
+    const result = execa.sync(executableName, buildArguments, {
       cwd: sourceFolder,
     });
 


### PR DESCRIPTION
*Issue #, if available:*
aws/aws-lambda-dotnet#594

*Description of changes:*
This PR modifies the behavior of the mock build to use the the "dotnet build" command under the Debug configuration, passing in the CopyLocalLockFileAssemblies property to ensure that all required runtime assemblies are in the output folder (a workaround for the referenced issue)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.