### PR TITLE
fix: source BASH_ENV before installing dotnet tools

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -184,10 +184,10 @@ jobs:
             sudo apt-get update
             sudo apt-get install dotnet-sdk-3.1
             dotnet --version
-            dotnet tool install -g amazon.lambda.tools
-            dotnet tool install -g amazon.lambda.testtool-3.1
             echo "export PATH=$PATH:$HOME/.dotnet/tools" >> $BASH_ENV
             source $BASH_ENV
+            dotnet tool install -g amazon.lambda.tools
+            dotnet tool install -g amazon.lambda.testtool-3.1
             dotnet tool list -g
       - run:
           name: Start verdaccio and Install Amplify CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,13 +237,13 @@ jobs:
 
             dotnet --version
 
-            dotnet tool install -g amazon.lambda.tools
-
-            dotnet tool install -g amazon.lambda.testtool-3.1
-
             echo "export PATH=$PATH:$HOME/.dotnet/tools" >> $BASH_ENV
 
             source $BASH_ENV
+
+            dotnet tool install -g amazon.lambda.tools
+
+            dotnet tool install -g amazon.lambda.testtool-3.1
 
             dotnet tool list -g
       - run:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.