### PR TITLE
feat(amplify-category-api): change default graphql query limit to 100

### DIFF
--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -9,7 +9,7 @@ import {
   InputValueDefinitionNode,
 } from 'graphql';
 import { GraphQLTransform } from 'graphql-transformer-core';
-import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common';
+import { ResolverResourceIDs, ModelResourceIDs, ResourceConstants } from 'graphql-transformer-common';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { ModelConnectionTransformer } from '../ModelConnectionTransformer';
 
@@ -572,7 +572,9 @@ test('Test ModelConnectionTransformer uses the default limit', () => {
   expect(out.stacks.ConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
 
   // Post.comments field
-  expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 10) )');
+  expect(out.resolvers['Post.comments.req.vtl']).toContain(
+    `#set( $limit = $util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT}) )`,
+  );
 });
 
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {

--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -185,8 +185,7 @@ export class ResourceFactory {
     sortKeyInfo?: { fieldName: string; attributeType: 'S' | 'B' | 'N' },
     limit?: number,
   ) {
-    const defaultPageLimit = 10;
-    const pageLimit = limit || defaultPageLimit;
+    const pageLimit = limit || ResourceConstants.DEFAULT_PAGE_LIMIT;
     const setup: Expression[] = [
       set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${pageLimit})`)),
       set(
@@ -311,9 +310,8 @@ export class ResourceFactory {
     keySchema: KeySchema[],
     indexName: string,
   ) {
-    const defaultPageLimit = 10;
     const setup: Expression[] = [
-      set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
+      set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT})`)),
       set(ref('query'), this.makeExpression(keySchema, connectionAttributes)),
     ];
 

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -596,7 +596,7 @@ export class ResourceFactory {
       RequestMappingTemplate: print(
         DynamoDBMappingTemplate.syncItem({
           filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
-          limit: ref(`'util.defaultIfNull($ctx.args.limit, ${ResourceConstants.DEFAULT_DATASYNC_PAGE_LIMIT})`),
+          limit: ref(`util.defaultIfNull($ctx.args.limit, ${ResourceConstants.DEFAULT_DATASYNC_PAGE_LIMIT})`),
           lastSync: ref('util.toJson($util.defaultIfNull($ctx.args.lastSync, null))'),
           nextToken: ref('util.toJson($util.defaultIfNull($ctx.args.nextToken, null))'),
         }),

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -459,7 +459,7 @@ export class ResourceFactory {
           ),
           ElasticsearchMappingTemplate.searchItem({
             path: str('$indexPath'),
-            size: ifElse(ref('context.args.limit'), ref('context.args.limit'), int(10), true),
+            size: ifElse(ref('context.args.limit'), ref('context.args.limit'), int(ResourceConstants.DEFAULT_SEARCHABLE_PAGE_LIMIT), true),
             search_after: list([ref('util.toJson($context.args.nextToken)')]),
             query: ifElse(
               ref('context.args.filter'),
@@ -468,11 +468,7 @@ export class ResourceFactory {
                 match_all: obj({}),
               }),
             ),
-            sort: list([
-              raw(
-                '{$sortField0: { "order" : $util.toJson($sortDirection) }}',
-              ),
-            ]),
+            sort: list([raw('{$sortField0: { "order" : $util.toJson($sortDirection) }}')]),
           }),
         ]),
       ),

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -820,7 +820,6 @@ function makeQueryResolver(definition: ObjectTypeDefinitionNode, directive: Dire
   const index = directiveArgs.name;
   const fieldName = directiveArgs.queryField;
   const queryTypeName = ctx.getQueryTypeName();
-  const defaultPageLimit = 10;
   const requestVariable = 'QueryRequest';
   return new AppSync.Resolver({
     ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -830,7 +829,7 @@ function makeQueryResolver(definition: ObjectTypeDefinitionNode, directive: Dire
     RequestMappingTemplate: print(
       compoundExpression([
         setQuerySnippet(definition, directive, ctx),
-        set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${defaultPageLimit})`)),
+        set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT})`)),
         set(
           ref(requestVariable),
           obj({

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -347,7 +347,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 ## [End] Applying Key Condition **
 ## [End] Set query expression for @key **
-#set( $limit = $util.defaultIfNull($context.args.limit, 10) )
+#set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $QueryRequest = {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"Query\\",
@@ -422,7 +422,7 @@ $util.toJson($QueryRequest)",
 #end
 ## [End] Applying Key Condition **
 ## [End] Set query expression for @key **
-#set( $limit = $util.defaultIfNull($context.args.limit, 10) )
+#set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $QueryRequest = {
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"Query\\",
@@ -543,7 +543,7 @@ $util.toJson($QueryRequest)",
 
 ## [End] Applying Key Condition **
 ## [End] Set query expression for @key **
-#set( $limit = $util.defaultIfNull($context.args.limit, 10) )
+#set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
   \\"version\\": \\"2017-02-28\\",
   \\"limit\\": $limit

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -2,7 +2,7 @@ export class ResourceConstants {
   public static NONE = 'NONE';
 
   public static DEFAULT_PAGE_LIMIT = 100;
-  public static DEFAULT_DATASYNC_PAGE_LIMIT = 100;
+  public static DEFAULT_SYNC_QUERY_PAGE_LIMIT = 100;
   public static DEFAULT_SEARCHABLE_PAGE_LIMIT = 100;
 
   public static readonly RESOURCES = {

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -1,6 +1,10 @@
 export class ResourceConstants {
   public static NONE = 'NONE';
 
+  public static DEFAULT_PAGE_LIMIT = 100;
+  public static DEFAULT_DATASYNC_PAGE_LIMIT = 100;
+  public static DEFAULT_SEARCHABLE_PAGE_LIMIT = 100;
+
   public static readonly RESOURCES = {
     // AppSync
     GraphQLAPILogicalID: 'GraphQLAPI',


### PR DESCRIPTION
*Description of changes:*

For generated GraphQL queries for types, ```@searchable``` and ```@connection``` directive the default item count was 10, this default limit has been raised to 100, without specifying the ```limit``` parameter DynamoDB and ElasticSearch is queried for 100 items.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.