### PR TITLE
fix: github partial rename for sync query constant

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -596,7 +596,7 @@ export class ResourceFactory {
       RequestMappingTemplate: print(
         DynamoDBMappingTemplate.syncItem({
           filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
-          limit: ref(`util.defaultIfNull($ctx.args.limit, ${ResourceConstants.DEFAULT_DATASYNC_PAGE_LIMIT})`),
+          limit: ref(`util.defaultIfNull($ctx.args.limit, ${ResourceConstants.DEFAULT_SYNC_QUERY_PAGE_LIMIT})`),
           lastSync: ref('util.toJson($util.defaultIfNull($ctx.args.lastSync, null))'),
           nextToken: ref('util.toJson($util.defaultIfNull($ctx.args.nextToken, null))'),
         }),


### PR DESCRIPTION
*Description of changes:*

fix: missing rename of constant

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.