### PR TITLE
chore: fix compiler errors in console integ tests

### DIFF
--- a/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
@@ -1,11 +1,11 @@
-import * as aws from 'aws-sdk';
-import * as moment from 'moment';
+import { Amplify } from 'aws-sdk';
+import moment from 'moment';
 
 import { getConfigFromProfile } from '../profile-helper';
 
 export function getConfiguredAmplifyClient() {
   const config = getConfigFromProfile();
-  return new aws.Amplify(config);
+  return new Amplify(config);
 }
 
 //delete all existing amplify console projects

--- a/packages/amplify-console-integration-tests/tsconfig.json
+++ b/packages/amplify-console-integration-tests/tsconfig.json
@@ -3,13 +3,14 @@
     "skipLibCheck": true,
     "target": "es5",
     "module": "commonjs",
+    "esModuleInterop": true,
     "sourceMap": true,
     "rootDir": "./src",
     "types": ["jest"],
     "outDir": "lib",
     "lib": ["es2015", "es2016.array.include", "esnext.asynciterable", "dom"],
     "declaration": true,
-    "typeRoots": ["node_modules/@types", "./typings"]
+    "typeRoots": ["node_modules/@types", "./typings", "../../node_modules/@types"]
   },
   "exclude": ["node_modules", "lib", "__tests__"]
 }


### PR DESCRIPTION
*Issue #, if available:*
https://circleci.com/gh/aws-amplify/amplify-cli/16201?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

*Description of changes:*
Enable esModuleInterop and include root node_module types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.