### PR TITLE
fix(amplify-codegen): use ResDir directory to compute modelgen output

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -20,7 +20,7 @@ async function generateModels(context) {
 
   const allApiResources = await context.amplify.getResourceStatus('api');
   const apiResource = allApiResources.allResources.find(
-    resource => resource.service === 'AppSync' && resource.providerPlugin === 'awscloudformation'
+    resource => resource.service === 'AppSync' && resource.providerPlugin === 'awscloudformation',
   );
 
   if (!apiResource) {
@@ -105,7 +105,9 @@ function getModelOutputPath(context) {
     case 'javascript':
       return 'src';
     case 'android':
-      return 'app/src/main/java/';
+      return projectConfig.android && projectConfig.android.config && projectConfig.android.config.ResDir
+        ? path.join(projectConfig.android.config.ResDir, '..', 'java')
+        : 'app/src/main/java/';
     case 'ios':
       return 'amplify/generated/models';
     default:

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -106,8 +106,8 @@ function getModelOutputPath(context) {
       return 'src';
     case 'android':
       return projectConfig.android && projectConfig.android.config && projectConfig.android.config.ResDir
-        ? path.join(projectConfig.android.config.ResDir, '..', 'java')
-        : 'app/src/main/java/';
+        ? path.normalize(path.join(projectConfig.android.config.ResDir, '..', 'java'))
+        : path.join('app', 'src', 'main', 'java');
     case 'ios':
       return 'amplify/generated/models';
     default:


### PR DESCRIPTION
Updated model gen to use the Applications ResDirectory to compute the output path for generated
models

fix #3993

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.