### PR TITLE
fix(amplify-console-hosting): printout more informative message

### DIFF
--- a/packages/amplify-console-hosting/hosting/index.js
+++ b/packages/amplify-console-hosting/hosting/index.js
@@ -13,7 +13,7 @@ const HELP_INFO_PLACE_HOLDER =
   'Manual deployment allows you to publish your web app to the Amplify Console without connecting a Git provider. Continuous deployment allows you to publish changes on every code commit by connecting your GitHub, Bitbucket, GitLab, or AWS CodeCommit repositories.';
 const REMOVE_ERROR_MESSAGE = 'There was an error removing the auth resource';
 const HOSTING_NOT_ENABLED = 'Amplify Console hosting is not enabled.';
-const HOSTING_ONLY_ENABLED_ONLINE =
+const HOSTING_ENABLED_IN_CONSOLE =
   'You have enabled hosting in the Amplify Console and not through the CLI. To remove hosting with Amplify Console, please visit the console and disconnect your frontend branches.';
 const HOSTING_ALREADY_ENABLED = 'Amplify Console hosting has already been enabled';
 const FRONTEND_EXISTED_WARNING =
@@ -86,7 +86,7 @@ async function initEnv(context) {
 async function remove(context) {
   if (!isHostingEnabled(context)) {
     if (await isFrontendCreatedOnline(context)) {
-      throw new ValidationError(HOSTING_ONLY_ENABLED_ONLINE);
+      throw new ValidationError(HOSTING_ENABLED_IN_CONSOLE);
     }
     throw new ValidationError(HOSTING_NOT_ENABLED);
   }

--- a/packages/amplify-console-integration-tests/__tests__/consoleHosting.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/consoleHosting.test.ts
@@ -4,7 +4,7 @@ import {
   amplifyPush,
   removeHosting,
   removeNonExistingHosting,
-  removeOnlyOnlineHosting,
+  removeHostingEnabledInConsole,
   addCICDHostingWithoutFrontend,
   amplifyStatus,
   checkoutEnv,
@@ -87,7 +87,7 @@ describe('amplify console add hosting', () => {
     await addManualHosting(projRoot);
     await amplifyPush(projRoot);
     cleanHostingLocally(projRoot, ORIGINAL_ENV);
-    await removeOnlyOnlineHosting(projRoot);
+    await removeHostingEnabledInConsole(projRoot);
   });
 
   // CICD tests

--- a/packages/amplify-console-integration-tests/__tests__/consoleHosting.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/consoleHosting.test.ts
@@ -3,6 +3,8 @@ import {
   amplifyPublish,
   amplifyPush,
   removeHosting,
+  removeNonExistingHosting,
+  removeOnlyOnlineHosting,
   addCICDHostingWithoutFrontend,
   amplifyStatus,
   checkoutEnv,
@@ -10,7 +12,7 @@ import {
   deleteProject,
   addEnvironment,
 } from '../src/consoleHosting/consoleHosting';
-import { loadTypeFromTeamProviderInfo, createTestProject } from '../src/consoleHosting/utils';
+import { loadTypeFromTeamProviderInfo, createTestProject, cleanHostingLocally } from '../src/consoleHosting/utils';
 import { deleteProjectDir, getProfileName, npmInstall } from '../src/util';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -78,6 +80,14 @@ describe('amplify console add hosting', () => {
     await removeHosting(projRoot);
     await checkoutEnv(projRoot, ORIGINAL_ENV);
     await amplifyStatus(projRoot, 'Delete');
+  });
+
+  it('amplify remove hosting should print out correct error message when there is no local hosting', async () => {
+    await removeNonExistingHosting(projRoot);
+    await addManualHosting(projRoot);
+    await amplifyPush(projRoot);
+    cleanHostingLocally(projRoot, ORIGINAL_ENV);
+    await removeOnlyOnlineHosting(projRoot);
   });
 
   // CICD tests

--- a/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
@@ -1,6 +1,6 @@
 import { nspawn as spawn } from 'amplify-e2e-core';
 import { getCLIPath } from '../util';
-import { HOSTING_NOT_ENABLED, HOSTING_ONLY_ENABLED_ONLINE, ORIGINAL_ENV } from './constants';
+import { HOSTING_NOT_ENABLED, HOSTING_ENABLED_IN_CONSOLE, ORIGINAL_ENV } from './constants';
 
 const defaultSettings = {
   name: '\r',
@@ -232,12 +232,12 @@ export function removeNonExistingHosting(cwd: string) {
   });
 }
 
-export function removeOnlyOnlineHosting(cwd: string) {
+export function removeHostingEnabledInConsole(cwd: string) {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['remove', 'hosting'], { cwd, stripColors: true })
       .wait(/.*Hosting with Amplify Console*/)
       .sendCarriageReturn()
-      .wait(HOSTING_ONLY_ENABLED_ONLINE)
+      .wait(HOSTING_ENABLED_IN_CONSOLE)
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
@@ -1,9 +1,10 @@
 import { nspawn as spawn } from 'amplify-e2e-core';
 import { getCLIPath } from '../util';
+import { HOSTING_NOT_ENABLED, HOSTING_ONLY_ENABLED_ONLINE, ORIGINAL_ENV } from './constants';
 
 const defaultSettings = {
   name: '\r',
-  envName: 'integtest',
+  envName: ORIGINAL_ENV,
   editor: '\r',
   appType: '\r',
   framework: '\r',
@@ -205,6 +206,38 @@ export function removeHosting(cwd: string) {
       .wait(/.*Are you sure you want to delete the resource*/)
       .sendLine('\r')
       .wait('Successfully removed resource')
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
+export function removeNonExistingHosting(cwd: string) {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['remove', 'hosting'], { cwd, stripColors: true })
+      .wait(/.*Hosting with Amplify Console*/)
+      .sendCarriageReturn()
+      .wait(HOSTING_NOT_ENABLED)
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
+export function removeOnlyOnlineHosting(cwd: string) {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['remove', 'hosting'], { cwd, stripColors: true })
+      .wait(/.*Hosting with Amplify Console*/)
+      .sendCarriageReturn()
+      .wait(HOSTING_ONLY_ENABLED_ONLINE)
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-console-integration-tests/src/consoleHosting/constants.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/constants.ts
@@ -9,3 +9,6 @@ export const TYPE_UNKNOWN = 'unknown';
 export const ORIGINAL_ENV = 'integtest';
 export const NEW_ENV = 'test';
 export const PROVIDER = 'awscloudformation';
+export const HOSTING_ONLY_ENABLED_ONLINE =
+  'You have enabled hosting in the Amplify Console and not through the CLI. To remove hosting with Amplify Console, please visit the console and disconnect your frontend branches.';
+export const HOSTING_NOT_ENABLED = 'Amplify Console hosting is not enabled.';

--- a/packages/amplify-console-integration-tests/src/consoleHosting/constants.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/constants.ts
@@ -9,6 +9,6 @@ export const TYPE_UNKNOWN = 'unknown';
 export const ORIGINAL_ENV = 'integtest';
 export const NEW_ENV = 'test';
 export const PROVIDER = 'awscloudformation';
-export const HOSTING_ONLY_ENABLED_ONLINE =
+export const HOSTING_ENABLED_IN_CONSOLE =
   'You have enabled hosting in the Amplify Console and not through the CLI. To remove hosting with Amplify Console, please visit the console and disconnect your frontend branches.';
 export const HOSTING_NOT_ENABLED = 'Amplify Console hosting is not enabled.';

--- a/packages/amplify-console-integration-tests/src/consoleHosting/utils.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/utils.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 import * as util from '../util';
+import { readJsonFile } from 'amplify-e2e-core';
 
 import { HOSTING, RESOURCE, TYPE, TYPE_UNKNOWN, CATEGORIES, APPID, PROVIDER } from './constants';
 
@@ -22,6 +23,48 @@ export function loadTypeFromTeamProviderInfo(cwd: string, currEnv: string) {
   }
 }
 
+export function cleanHostingLocally(cwd: string, currEnv: string) {
+  const hostingDirPath = path.join(cwd, 'amplify', 'backend', 'hosting');
+  fs.removeSync(hostingDirPath);
+  const currentHostingDirPath = path.join(cwd, 'amplify', '#current-cloud-backend', 'hosting');
+  fs.removeSync(currentHostingDirPath);
+
+  const teamProviderInfoFilePath = path.join(cwd, 'amplify', 'team-provider-info.json');
+  const teamProviderInfo = readJsonFile(teamProviderInfoFilePath);
+  if (teamProviderInfo[currEnv].categories && teamProviderInfo[currEnv].categories.hosting) {
+    delete teamProviderInfo[currEnv].categories.hosting;
+    fs.writeFileSync(teamProviderInfoFilePath, JSON.stringify(teamProviderInfo, null, 4));
+  }
+
+  const amplifyMetaFilePath = path.join(cwd, 'amplify', 'backend', 'amplify-meta.json');
+  const amplifyMeta = readJsonFile(amplifyMetaFilePath);
+  if (amplifyMeta.hosting) {
+    delete amplifyMeta.hosting;
+    fs.writeFileSync(amplifyMetaFilePath, JSON.stringify(amplifyMeta, null, 4));
+  }
+
+  const currentMetaFilePath = path.join(cwd, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+  const currentAmplifyMeta = readJsonFile(currentMetaFilePath);
+  if (currentAmplifyMeta.hosting) {
+    delete currentAmplifyMeta.hosting;
+    fs.writeFileSync(currentMetaFilePath, JSON.stringify(currentAmplifyMeta, null, 4));
+  }
+
+  const backendConfigFilePath = path.join(cwd, 'amplify', 'backend', 'backend-config.json');
+  const backendConfig = readJsonFile(backendConfigFilePath);
+  if (backendConfig.hosting) {
+    delete backendConfig.hosting;
+    fs.writeFileSync(backendConfigFilePath, JSON.stringify(backendConfig, null, 4));
+  }
+
+  const currentBackendConfigFilePath = path.join(cwd, 'amplify', '#current-cloud-backend', 'backend-config.json');
+  const currentBackendConfig = readJsonFile(currentBackendConfigFilePath);
+  if (currentBackendConfig.hosting) {
+    delete currentBackendConfig.hosting;
+    fs.writeFileSync(currentBackendConfigFilePath, JSON.stringify(currentBackendConfig, null, 4));
+  }
+}
+
 export function loadAppIdFromTeamProviderInfo(cwd: string, currEnv: string) {
   const teamProviderPath = path.join(cwd, 'amplify', 'team-provider-info.json');
   const content = readJsonFile(teamProviderPath);
@@ -32,10 +75,6 @@ export function loadAppIdFromTeamProviderInfo(cwd: string, currEnv: string) {
   } else {
     return TYPE_UNKNOWN;
   }
-}
-
-function readJsonFile(jsonFilePath: string, encoding = 'utf8') {
-  return JSON.parse(fs.readFileSync(jsonFilePath, encoding));
 }
 
 export async function createTestProject(): Promise<string> {


### PR DESCRIPTION
When frontend is created in Amplify Console, but hosting is not added locally, if the user execute
amplify hosting remove, this update will print out a more informative error message

fix #4086

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.