### PR TITLE
feat: expose createdAt and updatedAt on model

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -42,10 +42,11 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
+#set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -671,10 +672,11 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
+#set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -42,6 +42,10 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -200,6 +204,8 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 } )
   #end
 #end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -665,6 +671,10 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -823,6 +833,8 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 } )
   #end
 #end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -42,8 +42,6 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -202,8 +200,6 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -669,8 +665,6 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -829,8 +823,6 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -4,6 +4,8 @@ exports[`test auth logic is enabled for iam/apiKey auth rules in response es res
 "type Post @aws_api_key @aws_iam {
   id: ID!
   content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
   secret: String @aws_iam
 }
 

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
@@ -5,11 +5,15 @@ exports[`Connection on models with no codegen includes AttributeTypeEnum 1`] = `
   id: ID!
   title: String!
   comments(filter: ModelCommentFilterInput, sortDirection: ModelSortDirection, limit: Int, nextToken: String): ModelCommentConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type Comment {
   id: ID!
   content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type ModelCommentConnection {

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
@@ -8,6 +8,8 @@ exports[`Many-to-many with conflict resolution generates correct schema 1`] = `
   _version: Int!
   _deleted: Boolean
   _lastChangedAt: AWSTimestamp!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type PostEditor {
@@ -19,6 +21,8 @@ type PostEditor {
   _version: Int!
   _deleted: Boolean
   _lastChangedAt: AWSTimestamp!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type User {
@@ -28,6 +32,8 @@ type User {
   _version: Int!
   _deleted: Boolean
   _lastChangedAt: AWSTimestamp!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {
@@ -290,6 +296,8 @@ exports[`Many-to-many without conflict resolution generates correct schema 1`] =
   id: ID!
   title: String!
   editors(editorID: ModelIDKeyConditionInput, filter: ModelPostEditorFilterInput, sortDirection: ModelSortDirection, limit: Int, nextToken: String): ModelPostEditorConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type PostEditor {
@@ -298,12 +306,16 @@ type PostEditor {
   editorID: ID!
   post: Post!
   editor: User!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type User {
   id: ID!
   username: String!
   posts(postID: ModelIDKeyConditionInput, filter: ModelPostEditorFilterInput, sortDirection: ModelSortDirection, limit: Int, nextToken: String): ModelPostEditorConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -256,7 +256,7 @@ export class DynamoDBModelTransformer extends Transformer {
     const existingUpdatedAtField = def.fields.find(f => f.name.value === updatedAtField);
 
     // auto populate the timestamp field only if they are of AWSDateTime type
-    const timeStampFields = {
+    const timestampFields = {
       createdAtField: DynamoDBModelTransformer.isTimestampCompatibleField(existingCreatedAtField) ? createdAtField : undefined,
       updatedAtField: DynamoDBModelTransformer.isTimestampCompatibleField(existingUpdatedAtField) ? updatedAtField : undefined,
     };
@@ -296,7 +296,7 @@ export class DynamoDBModelTransformer extends Transformer {
         type: def.name.value,
         nameOverride: createFieldNameOverride,
         syncConfig: this.opts.SyncConfig,
-        timestamps: timeStampFields,
+        timestamps: timestampFields,
       });
       const resourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
       ctx.setResource(resourceId, createResolver);
@@ -317,7 +317,7 @@ export class DynamoDBModelTransformer extends Transformer {
         type: def.name.value,
         nameOverride: updateFieldNameOverride,
         syncConfig: this.opts.SyncConfig,
-        timestamps: timeStampFields,
+        timestamps: timestampFields,
       });
       const resourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName);
       ctx.setResource(resourceId, updateResolver);

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -59,46 +59,45 @@ export const CONDITIONS_MINIMUM_VERSION = 5;
  * }
  */
 
+export const directiveDefinition = gql`
+  directive @model(
+    queries: ModelQueryMap
+    mutations: ModelMutationMap
+    subscriptions: ModelSubscriptionMap
+    timestamps: TimestampConfiguration
+  ) on OBJECT
+  input ModelMutationMap {
+    create: String
+    update: String
+    delete: String
+  }
+  input ModelQueryMap {
+    get: String
+    list: String
+  }
+  input ModelSubscriptionMap {
+    onCreate: [String]
+    onUpdate: [String]
+    onDelete: [String]
+    level: ModelSubscriptionLevel
+  }
+  enum ModelSubscriptionLevel {
+    off
+    public
+    on
+  }
+  input TimestampConfiguration {
+    createdAt: String
+    updatedAt: String
+  }
+`;
+
 export class DynamoDBModelTransformer extends Transformer {
   resources: ResourceFactory;
   opts: DynamoDBModelTransformerOptions;
 
   constructor(opts: DynamoDBModelTransformerOptions = {}) {
-    super(
-      'DynamoDBModelTransformer',
-      gql`
-        directive @model(
-          queries: ModelQueryMap
-          mutations: ModelMutationMap
-          subscriptions: ModelSubscriptionMap
-          timestamps: TimestampMap
-        ) on OBJECT
-        input ModelMutationMap {
-          create: String
-          update: String
-          delete: String
-        }
-        input ModelQueryMap {
-          get: String
-          list: String
-        }
-        input ModelSubscriptionMap {
-          onCreate: [String]
-          onUpdate: [String]
-          onDelete: [String]
-          level: ModelSubscriptionLevel
-        }
-        enum ModelSubscriptionLevel {
-          off
-          public
-          on
-        }
-        input TimestampMap {
-          create: String
-          update: String
-        }
-      `,
-    );
+    super('DynamoDBModelTransformer', directiveDefinition);
     this.opts = this.getOpts(opts);
     this.resources = new ResourceFactory();
   }

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -216,11 +216,14 @@ export class DynamoDBModelTransformer extends Transformer {
       );
     }
     const obj = ctx.getObject(def.name.value);
-    const newObj = makeObjectDefinition(obj.name.value, [
-      ...obj.fields,
-      ...(createdAtField && !existingCreatedAtField ? [makeField(createdAtField, [], wrapNonNull(makeNamedType('AWSDateTime')))] : []), // createdAt field
-      ...(updatedAtField && !existingUpdatedAtField ? [makeField(updatedAtField, [], wrapNonNull(makeNamedType('AWSDateTime')))] : []), // updated field
-    ]);
+    const newObj: ObjectTypeDefinitionNode = {
+      ...obj,
+      fields: [
+        ...obj.fields,
+        ...(createdAtField && !existingCreatedAtField ? [makeField(createdAtField, [], wrapNonNull(makeNamedType('AWSDateTime')))] : []), // createdAt field
+        ...(updatedAtField && !existingUpdatedAtField ? [makeField(updatedAtField, [], wrapNonNull(makeNamedType('AWSDateTime')))] : []), // updated field
+      ],
+    };
     ctx.updateObject(newObj);
   }
 

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -205,14 +205,14 @@ export class DynamoDBModelTransformer extends Transformer {
       console.log(
         `${def.name.value}.${existingCreatedAtField.name.value} is of type ${getBaseType(
           existingCreatedAtField.type,
-        )}. To support auto population change the type to AWSDateTime`,
+        )}. To support auto population change the type to AWSDateTime or String`,
       );
     }
     if (!DynamoDBModelTransformer.isTimestampCompatibleField(existingUpdatedAtField)) {
       console.log(
         `${def.name.value}.${existingUpdatedAtField.name.value} is of type ${getBaseType(
           existingUpdatedAtField.type,
-        )}. To support auto population change the type to AWSDateTime`,
+        )}. To support auto population change the type to AWSDateTime or String`,
       );
     }
     const obj = ctx.getObject(def.name.value);
@@ -286,7 +286,7 @@ export class DynamoDBModelTransformer extends Transformer {
 
     // Create the mutations.
     if (shouldMakeCreate) {
-      const createInput = makeCreateInputObject(def, nonModelArray, ctx, isSyncEnabled);
+      const createInput = makeCreateInputObject(def, directive, nonModelArray, ctx, isSyncEnabled);
       if (!ctx.getType(createInput.name.value)) {
         ctx.addInput(createInput);
       }
@@ -685,7 +685,7 @@ export class DynamoDBModelTransformer extends Transformer {
   }
 
   private static isTimestampCompatibleField(field?: FieldDefinitionNode): boolean {
-    if (field && getBaseType(field.type) !== 'AWSDateTime') {
+    if (field && !(getBaseType(field.type) === 'AWSDateTime' || getBaseType(field.type) === 'String')) {
       return false;
     }
     return true;

--- a/packages/graphql-dynamodb-transformer/src/ModelDirectiveArgs.ts
+++ b/packages/graphql-dynamodb-transformer/src/ModelDirectiveArgs.ts
@@ -1,3 +1,6 @@
+import { getDirectiveArguments } from 'graphql-transformer-core';
+import { DirectiveNode } from 'graphql';
+
 export interface QueryNameMap {
   get?: string;
   list?: string;
@@ -19,8 +22,35 @@ export interface SubscriptionNameMap {
   level?: ModelSubscriptionLevel;
 }
 
+export interface ModelDirectiveTimestampMap {
+  create?: string;
+  update?: string;
+}
+
 export interface ModelDirectiveArgs {
   queries?: QueryNameMap;
   mutations?: MutationNameMap;
   subscriptions?: SubscriptionNameMap;
+  timestamps?: ModelDirectiveTimestampMap;
+}
+
+export function getCreatedAtFieldName(directive: DirectiveNode): string | undefined {
+  const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
+  const timestamp = directiveArguments.timestamps;
+  if (timestamp === null) return null;
+  if (timestamp) {
+    return timestamp.create;
+  }
+
+  return 'createdAt';
+}
+
+export function getUpdatedAtFieldName(directive: DirectiveNode): string | undefined {
+  const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
+  const timestamp = directiveArguments.timestamps;
+  if (timestamp === null) return null;
+  if (timestamp) {
+    return timestamp.update;
+  }
+  return 'updatedAt';
 }

--- a/packages/graphql-dynamodb-transformer/src/ModelDirectiveArgs.ts
+++ b/packages/graphql-dynamodb-transformer/src/ModelDirectiveArgs.ts
@@ -22,16 +22,16 @@ export interface SubscriptionNameMap {
   level?: ModelSubscriptionLevel;
 }
 
-export interface ModelDirectiveTimestampMap {
-  create?: string;
-  update?: string;
+export interface ModelDirectiveTimestampConfiguration {
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface ModelDirectiveArgs {
   queries?: QueryNameMap;
   mutations?: MutationNameMap;
   subscriptions?: SubscriptionNameMap;
-  timestamps?: ModelDirectiveTimestampMap;
+  timestamps?: ModelDirectiveTimestampConfiguration;
 }
 
 export function getCreatedAtFieldName(directive: DirectiveNode): string | undefined {
@@ -39,7 +39,7 @@ export function getCreatedAtFieldName(directive: DirectiveNode): string | undefi
   const timestamp = directiveArguments.timestamps;
   if (timestamp === null) return null;
   if (timestamp) {
-    return timestamp.create;
+    return timestamp.createdAt;
   }
 
   return 'createdAt';
@@ -50,7 +50,7 @@ export function getUpdatedAtFieldName(directive: DirectiveNode): string | undefi
   const timestamp = directiveArguments.timestamps;
   if (timestamp === null) return null;
   if (timestamp) {
-    return timestamp.update;
+    return timestamp.updatedAt;
   }
   return 'updatedAt';
 }

--- a/packages/graphql-dynamodb-transformer/src/ModelDirectiveArgs.ts
+++ b/packages/graphql-dynamodb-transformer/src/ModelDirectiveArgs.ts
@@ -35,22 +35,25 @@ export interface ModelDirectiveArgs {
 }
 
 export function getCreatedAtFieldName(directive: DirectiveNode): string | undefined {
-  const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
-  const timestamp = directiveArguments.timestamps;
-  if (timestamp === null) return null;
-  if (timestamp) {
-    return timestamp.createdAt;
-  }
-
-  return 'createdAt';
+  return getTimestampFieldName(directive, 'createdAt', 'createdAt');
 }
 
 export function getUpdatedAtFieldName(directive: DirectiveNode): string | undefined {
+  return getTimestampFieldName(directive, 'updatedAt', 'updatedAt');
+}
+
+export function getTimestampFieldName(directive: DirectiveNode, fieldName: string, defaultFiledValue: string): string | undefined {
   const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
   const timestamp = directiveArguments.timestamps;
+
+  /* When explicitly set to null, note that the check here is strict equality to null and not undefined
+   * type Post @model(timestamps:null) {
+        id: ID!
+   }
+   */
   if (timestamp === null) return null;
-  if (timestamp) {
-    return timestamp.updatedAt;
+  if (timestamp && timestamp[fieldName] !== undefined) {
+    return timestamp[fieldName];
   }
-  return 'updatedAt';
+  return defaultFiledValue;
 }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -500,7 +500,7 @@ test('Test only get does not generate superfluous input and filter types', () =>
 
 test('Test timestamp parameters when generating resolvers and output schema', () => {
   const validSchema = `
-  type Post @model(timestamps: { create: "createdOn", update: "updatedOn"}) {
+  type Post @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn"}) {
     id: ID!
     str: String
   }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/ModelDirectiveArgs.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/ModelDirectiveArgs.test.ts
@@ -55,6 +55,18 @@ describe('getCreatedAtField', () => {
     expect(modelDirective).toBeDefined();
     expect(getCreatedAtFieldName(modelDirective)).toEqual('createdOn');
   });
+
+  it('should return createdAt when createdAt is not set in timestamps', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: { updatedAt: "updatedOn" }) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getCreatedAtFieldName(modelDirective)).toEqual('createdAt');
+  });
 });
 
 describe('getUpdatedAtField', () => {
@@ -104,5 +116,17 @@ describe('getUpdatedAtField', () => {
     const modelDirective = getDirective(doc, 'Post');
     expect(modelDirective).toBeDefined();
     expect(getUpdatedAtFieldName(modelDirective)).toEqual('updatedOn');
+  });
+
+  it('should return updatedAt when updatedAt is not set in timestamps', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: { createdAt: "createdOnOn" }) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getUpdatedAtFieldName(modelDirective)).toEqual('updatedAt');
   });
 });

--- a/packages/graphql-dynamodb-transformer/src/__tests__/ModelDirectiveArgs.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/ModelDirectiveArgs.test.ts
@@ -1,0 +1,108 @@
+import { buildASTSchema, concatAST, DirectiveNode, parse } from 'graphql';
+import { directiveDefinition } from '../DynamoDBModelTransformer';
+import { getCreatedAtFieldName, getUpdatedAtFieldName } from '../ModelDirectiveArgs';
+
+function getDirective(doc: string, typeName: string): DirectiveNode {
+  const schema = buildASTSchema(concatAST([directiveDefinition, parse(doc)]));
+  const selectedType = schema.getTypeMap()[typeName];
+  return selectedType.astNode.directives.find(d => d.name.value === 'model');
+}
+describe('getCreatedAtField', () => {
+  it('should return createdAt when there is no timestamps configuration', () => {
+    const doc = /* GraphQL */ `
+      type Post @model {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getCreatedAtFieldName(modelDirective)).toEqual('createdAt');
+  });
+
+  it('should return null when timestamps are set to null', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: null) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getCreatedAtFieldName(modelDirective)).toBeNull();
+  });
+
+  it('should return null when createdAt is set to null', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: { createdAt: null }) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getCreatedAtFieldName(modelDirective)).toBeNull();
+  });
+
+  it('should return createdOn when createdAt is set to createdOn', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: { createdAt: "createdOn" }) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getCreatedAtFieldName(modelDirective)).toEqual('createdOn');
+  });
+});
+
+describe('getUpdatedAtField', () => {
+  it('should return updatedAt when there is no timestamps configuration', () => {
+    const doc = /* GraphQL */ `
+      type Post @model {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getUpdatedAtFieldName(modelDirective)).toEqual('updatedAt');
+  });
+
+  it('should return null for updatedAt when timestamps are set to null', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: null) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getUpdatedAtFieldName(modelDirective)).toBeNull();
+  });
+
+  it('should return null when updatedAt is set to null', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: { updatedAt: null }) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getUpdatedAtFieldName(modelDirective)).toBeNull();
+  });
+
+  it('should return updatedOn when updatedAt is set to updatedOn', () => {
+    const doc = /* GraphQL */ `
+      type Post @model(timestamps: { updatedAt: "updatedOn" }) {
+        id: ID!
+        title: String
+      }
+    `;
+    const modelDirective = getDirective(doc, 'Post');
+    expect(modelDirective).toBeDefined();
+    expect(getUpdatedAtFieldName(modelDirective)).toEqual('updatedOn');
+  });
+});

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -4,6 +4,8 @@ exports[`Current version transformer snapshot test 1`] = `
 "type Post {
   id: ID!
   content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {
@@ -154,6 +156,8 @@ exports[`Test only get does not generate superfluous input and filter types 1`] 
 "type Entity {
   id: ID!
   str: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 type Query {
@@ -166,6 +170,8 @@ exports[`Test schema includes attribute enum when only queries specified 1`] = `
 "type Entity {
   id: ID!
   str: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {
@@ -283,6 +289,8 @@ exports[`V4 transformer snapshot test 1`] = `
 "type Post {
   id: ID!
   content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {
@@ -391,6 +399,8 @@ exports[`V5 transformer snapshot test 1`] = `
 "type Post {
   id: ID!
   content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -270,10 +270,11 @@ type Subscription {
 
 exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 2`] = `
 "## [Start] Prepare DynamoDB PutItem Request. **
+#set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -1244,10 +1245,11 @@ type Subscription {
 
 exports[`Test timestamp parameters when generating resolvers and output schema 2`] = `
 "## [Start] Prepare DynamoDB PutItem Request. **
+#set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdOn\\", $util.defaultIfNull($ctx.args.input.createdOn, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"createdOn\\", $util.defaultIfNull($ctx.args.input.createdOn, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -152,6 +152,570 @@ type Subscription {
 "
 `;
 
+exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 1`] = `
+"type Post {
+  id: ID!
+  str: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  createdAt: ModelStringFilterInput
+  updatedAt: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+  createdAt: AWSDateTime
+  updatedAt: AWSDateTime
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+  createdAt: AWSDateTime
+  updatedAt: AWSDateTime
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 2`] = `
+"## [Start] Prepare DynamoDB PutItem Request. **
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
+"#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 1`] = `
+"type Post {
+  id: ID!
+  str: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 2`] = `
+"## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
+"#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
 exports[`Test only get does not generate superfluous input and filter types 1`] = `
 "type Entity {
   id: ID!
@@ -164,6 +728,289 @@ type Query {
   getEntity(id: ID!): Entity
 }
 "
+`;
+
+exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 1`] = `
+"type Post {
+  id: ID!
+  str: String
+  createdAt: AWSTimestamp
+  updatedAt: AWSTimestamp
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  createdAt: ModelIntFilterInput
+  updatedAt: ModelIntFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+  createdAt: AWSTimestamp
+  updatedAt: AWSTimestamp
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+  createdAt: AWSTimestamp
+  updatedAt: AWSTimestamp
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 2`] = `
+"## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
+"#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
 `;
 
 exports[`Test schema includes attribute enum when only queries specified 1`] = `
@@ -283,6 +1130,289 @@ type Query {
   listEntitys(filter: ModelEntityFilterInput, limit: Int, nextToken: String): ModelEntityConnection
 }
 "
+`;
+
+exports[`Test timestamp parameters when generating resolvers and output schema 1`] = `
+"type Post {
+  id: ID!
+  str: String
+  createdOn: AWSDateTime!
+  updatedOn: AWSDateTime!
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  items: [Post]
+  nextToken: String
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+}
+
+input DeletePostInput {
+  id: ID
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test timestamp parameters when generating resolvers and output schema 2`] = `
+"## [Start] Prepare DynamoDB PutItem Request. **
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdOn\\", $util.defaultIfNull($ctx.args.input.createdOn, $util.time.nowISO8601())))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test timestamp parameters when generating resolvers and output schema 3`] = `
+"#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
 `;
 
 exports[`V4 transformer snapshot test 1`] = `

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -33,6 +33,7 @@ import {
   isListType,
 } from 'graphql-transformer-common';
 import { TransformerContext } from 'graphql-transformer-core';
+import { getCreatedAtFieldName, getUpdatedAtFieldName } from './ModelDirectiveArgs';
 
 const STRING_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith'];
 const ID_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith'];
@@ -52,7 +53,7 @@ const ATTRIBUTE_TYPES = ['binary', 'binarySet', 'bool', 'list', 'map', 'number',
 export function getNonModelObjectArray(
   obj: ObjectTypeDefinitionNode,
   ctx: TransformerContext,
-  pMap: Map<string, ObjectTypeDefinitionNode>
+  pMap: Map<string, ObjectTypeDefinitionNode>,
 ): ObjectTypeDefinitionNode[] {
   // loop over all fields in the object, picking out all nonscalars that are not @model types
   for (const field of obj.fields) {
@@ -79,7 +80,7 @@ export function getNonModelObjectArray(
 export function makeNonModelInputObject(
   obj: ObjectTypeDefinitionNode,
   nonModelTypes: ObjectTypeDefinitionNode[],
-  ctx: TransformerContext
+  ctx: TransformerContext,
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.NonModelInputObjectName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -125,11 +126,22 @@ export function makeNonModelInputObject(
 
 export function makeCreateInputObject(
   obj: ObjectTypeDefinitionNode,
+  directive: DirectiveNode,
   nonModelTypes: ObjectTypeDefinitionNode[],
   ctx: TransformerContext,
-  isSync: boolean = false
+  isSync: boolean = false,
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelCreateInputObjectName(obj.name.value);
+  const createdAtField = getCreatedAtFieldName(directive);
+  const updatedAtField = getUpdatedAtFieldName(directive);
+
+  // List of fields that can be assigend in resolver if they are not passed in input
+  const autoGeneratableFieldsWithType: Record<string, string[]> = {
+    id: ['ID'],
+    [createdAtField]: ['AWSDateTime', 'String'],
+    [updatedAtField]: ['AWSDateTime', 'String'],
+  };
+
   const fields: InputValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.getType(getBaseType(field.type));
@@ -144,16 +156,14 @@ export function makeCreateInputObject(
     })
     .map((field: FieldDefinitionNode) => {
       let type: TypeNode;
-      if (field.name.value === 'id') {
+      const fieldName = field.name.value;
+      if (
+        Object.keys(autoGeneratableFieldsWithType).indexOf(fieldName) !== -1 &&
+        autoGeneratableFieldsWithType[fieldName].indexOf(unwrapNonNull(field.type).name.value) !== -1
+      ) {
         // ids are always optional. when provided the value is used.
         // when not provided the value is not used.
-        type = {
-          kind: Kind.NAMED_TYPE,
-          name: {
-            kind: Kind.NAME,
-            value: 'ID',
-          },
-        };
+        type = unwrapNonNull(field.type);
       } else {
         type = nonModelTypes.find(e => e.name.value === getBaseType(field.type))
           ? withNamedNodeNamed(field.type, ModelResourceIDs.NonModelInputObjectName(getBaseType(field.type)))
@@ -192,7 +202,7 @@ export function makeUpdateInputObject(
   obj: ObjectTypeDefinitionNode,
   nonModelTypes: ObjectTypeDefinitionNode[],
   ctx: TransformerContext,
-  isSync: boolean = false
+  isSync: boolean = false,
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelUpdateInputObjectName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -282,7 +292,7 @@ export function makeDeleteInputObject(obj: ObjectTypeDefinitionNode, isSync: boo
 export function makeModelXFilterInputObject(
   obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
   ctx: TransformerContext,
-  supportsConditions: Boolean
+  supportsConditions: Boolean,
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelFilterInputTypeName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -345,7 +355,7 @@ export function makeModelXFilterInputObject(
       // TODO: Service does not support new style descriptions so wait.
       // description: field.description,
       directives: [],
-    }
+    },
   );
 
   return {
@@ -367,7 +377,7 @@ export function makeModelXFilterInputObject(
 export function makeModelXConditionInputObject(
   obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
   ctx: TransformerContext,
-  supportsConditions: Boolean
+  supportsConditions: Boolean,
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelConditionInputTypeName(obj.name.value);
   const fields: InputValueDefinitionNode[] = obj.fields
@@ -430,7 +440,7 @@ export function makeModelXConditionInputObject(
       // TODO: Service does not support new style descriptions so wait.
       // description: field.description,
       directives: [],
-    }
+    },
   );
 
   return {
@@ -452,7 +462,7 @@ export function makeModelXConditionInputObject(
 export function makeEnumFilterInputObjects(
   obj: ObjectTypeDefinitionNode,
   ctx: TransformerContext,
-  supportsConditions: Boolean
+  supportsConditions: Boolean,
 ): InputObjectTypeDefinitionNode[] {
   return obj.fields
     .filter((field: FieldDefinitionNode) => {
@@ -737,7 +747,7 @@ export function makeModelConnectionField(
   fieldName: string,
   returnTypeName: string,
   sortKeyInfo?: SortKeyFieldInfo,
-  directives?: DirectiveNode[]
+  directives?: DirectiveNode[],
 ): FieldDefinitionNode {
   const args = [
     makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -31,6 +31,10 @@ type MutationResolverInput = {
   syncConfig: SyncConfig;
   nameOverride?: string;
   mutationTypeName?: string;
+  timestamps?: {
+    createdAtField?: string;
+    updatedAtField?: string;
+  };
 };
 
 export class ResourceFactory {
@@ -370,7 +374,7 @@ export class ResourceFactory {
    * Create a resolver that creates an item in DynamoDB.
    * @param type
    */
-  public makeCreateResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation' }: MutationResolverInput) {
+  public makeCreateResolver({ type, nameOverride, syncConfig, timestamps, mutationTypeName = 'Mutation' }: MutationResolverInput) {
     const fieldName = nameOverride ? nameOverride : graphqlName('create' + toUpper(type));
     return new AppSync.Resolver({
       ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -379,8 +383,22 @@ export class ResourceFactory {
       TypeName: mutationTypeName,
       RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
         compoundExpression([
-          qref('$context.args.input.put("createdAt", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601()))'),
-          qref('$context.args.input.put("updatedAt", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601()))'),
+          ...(timestamps && timestamps.createdAtField
+            ? [
+                comment(`Automatically set the createdAt timestamp.`),
+                qref(
+                  `$context.args.input.put("${timestamps.createdAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.createdAtField}, $util.time.nowISO8601()))`,
+                ),
+              ]
+            : []),
+          ...(timestamps && timestamps.updatedAtField
+            ? [
+                comment(`Automatically set the updatedAt timestamp.`),
+                qref(
+                  `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $util.time.nowISO8601()))`,
+                ),
+              ]
+            : []),
           qref(`$context.args.input.put("__typename", "${type}")`),
           set(
             ref('condition'),
@@ -437,7 +455,7 @@ export class ResourceFactory {
     });
   }
 
-  public makeUpdateResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation' }: MutationResolverInput) {
+  public makeUpdateResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation', timestamps }: MutationResolverInput) {
     const fieldName = nameOverride ? nameOverride : graphqlName(`update` + toUpper(type));
     const isSyncEnabled = syncConfig ? true : false;
     return new AppSync.Resolver({
@@ -496,8 +514,14 @@ export class ResourceFactory {
               ),
             ),
           ),
-          comment('Automatically set the updatedAt timestamp.'),
-          qref('$context.args.input.put("updatedAt", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601()))'),
+          ...(timestamps && timestamps.updatedAtField
+            ? [
+                comment(`Automatically set the updatedAt timestamp.`),
+                qref(
+                  `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $util.time.nowISO8601()))`,
+                ),
+              ]
+            : []),
           qref(`$context.args.input.put("__typename", "${type}")`),
           comment('Update condition if type is @versioned'),
           iff(

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -383,11 +383,14 @@ export class ResourceFactory {
       TypeName: mutationTypeName,
       RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
         compoundExpression([
+          ...(timestamps && (timestamps.createdAtField || timestamps.updatedAtField)
+            ? [set(ref('createdAt'), ref('util.time.nowISO8601()'))]
+            : []),
           ...(timestamps && timestamps.createdAtField
             ? [
                 comment(`Automatically set the createdAt timestamp.`),
                 qref(
-                  `$context.args.input.put("${timestamps.createdAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.createdAtField}, $util.time.nowISO8601()))`,
+                  `$context.args.input.put("${timestamps.createdAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.createdAtField}, $createdAt))`,
                 ),
               ]
             : []),
@@ -395,7 +398,7 @@ export class ResourceFactory {
             ? [
                 comment(`Automatically set the updatedAt timestamp.`),
                 qref(
-                  `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $util.time.nowISO8601()))`,
+                  `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $createdAt))`,
                 ),
               ]
             : []),

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
@@ -272,6 +272,8 @@ exports[`Test SearchableModelTransformer with multiple model searchable directiv
 type User {
   id: ID!
   name: String!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }
 
 enum ModelSortDirection {

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -19,10 +19,11 @@ Object {
 #end
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 ## [Start] Prepare DynamoDB PutItem Request. **
+#set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -19,7 +19,9 @@ Object {
 #end
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 ## [Start] Prepare DynamoDB PutItem Request. **
+## Automatically set the createdAt timestamp. **
 $util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $util.time.nowISO8601())))
+## Automatically set the updatedAt timestamp. **
 $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 #set( $condition = {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -69,7 +69,7 @@ beforeAll(async () => {
       EMPIRE
       JEDI
     }
-    type Comment @model(timestamps: { create: "createdOn", update: "updatedOn" }) {
+    type Comment @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn" }) {
       id: ID!
       title: String!
       content: String

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -37,7 +37,7 @@ beforeAll(async () => {
   const validSchema = `
     type Order @model @key(fields: ["customerEmail", "createdAt"]) {
         customerEmail: String!
-        createdAt: String!
+        createdAt: AWSDateTime!
         orderId: ID!
     }
     type Customer @model @key(fields: ["email"]) {
@@ -517,7 +517,7 @@ async function deleteOrder(customerEmail: string, createdAt: string) {
 
 async function getOrder(customerEmail: string, createdAt: string) {
   const result = await GRAPHQL_CLIENT.query(
-    `query GetOrder($customerEmail: String!, $createdAt: String!) {
+    `query GetOrder($customerEmail: String!, $createdAt: AWSDateTime!) {
         getOrder(customerEmail: $customerEmail, createdAt: $createdAt) {
             customerEmail
             orderId

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -386,14 +386,14 @@ test('Test Customer Mutation with list member', async () => {
 });
 
 test('Test @key directive with customer sortDirection', async () => {
-  await createOrder('testorder1@email.com', '1', '2016-03-10');
-  await createOrder('testorder1@email.com', '2', '2018-05-22');
-  await createOrder('testorder1@email.com', '3', '2019-06-27');
+  await createOrder('testorder1@email.com', '1', '2016-03-10T00:45:08+00:00');
+  await createOrder('testorder1@email.com', '2', '2018-05-22T21:45:08+00:00');
+  await createOrder('testorder1@email.com', '3', '2019-06-27T12:00:08+00:00');
   const newOrders = await listOrders('testorder1@email.com', { beginsWith: '201' }, 'DESC');
   const oldOrders = await listOrders('testorder1@email.com', { beginsWith: '201' }, 'ASC');
-  expect(newOrders.data.listOrders.items[0].createdAt).toEqual('2019-06-27');
+  expect(newOrders.data.listOrders.items[0].createdAt).toEqual('2019-06-27T12:00:08+00:00');
   expect(newOrders.data.listOrders.items[0].orderId).toEqual('3');
-  expect(oldOrders.data.listOrders.items[0].createdAt).toEqual('2016-03-10');
+  expect(oldOrders.data.listOrders.items[0].createdAt).toEqual('2016-03-10T00:45:08+00:00');
   expect(oldOrders.data.listOrders.items[0].orderId).toEqual('1');
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -190,7 +190,7 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
     type Test @model @key(fields: ["email", "createdAt"])
     @key(name: "CategoryGSI", fields: ["category", "createdAt"], queryField: "testsByCategory") {
         email: String!
-        createdAt: String!
+        createdAt: AWSDateTime!
         category: String!
         description: String
     }
@@ -241,8 +241,8 @@ test('Test that a secondary @key with a multiple field adds an LSI.', () => {
         @model @key(fields: ["email", "createdAt"])
         @key(name: "GSI_Email_UpdatedAt", fields: ["email", "updatedAt"], queryField: "testsByEmailByUpdatedAt") {
         email: String!
-        createdAt: String!
-        updatedAt: String!
+        createdAt: AWSDateTime!
+        updatedAt: AWSDateTime!
     }
     `;
 
@@ -294,13 +294,13 @@ test('Test that a primary @key with complex fields will update the input objects
   expect(tableResource.Properties.AttributeDefinitions[0].AttributeType).toEqual('S');
   const schema = parse(out.schema);
   const createInput = schema.definitions.find(
-    (def: any) => def.name && def.name.value === 'CreateTestInput'
+    (def: any) => def.name && def.name.value === 'CreateTestInput',
   ) as InputObjectTypeDefinitionNode;
   const updateInput = schema.definitions.find(
-    (def: any) => def.name && def.name.value === 'UpdateTestInput'
+    (def: any) => def.name && def.name.value === 'UpdateTestInput',
   ) as InputObjectTypeDefinitionNode;
   const deleteInput = schema.definitions.find(
-    (def: any) => def.name && def.name.value === 'DeleteTestInput'
+    (def: any) => def.name && def.name.value === 'DeleteTestInput',
   ) as InputObjectTypeDefinitionNode;
   expect(createInput).toBeDefined();
   expectNonNullInputValues(createInput, ['email', 'nonNullListInput', 'nonNullListInputOfNonNullStrings']);
@@ -352,7 +352,7 @@ test('Test that connection type is generated for custom query when queries is se
   const out = transformer.transform(validSchema);
   const schema = parse(out.schema);
   const modelContentCategoryConnection = schema.definitions.find(
-    (def: any) => def.name && def.name.value === 'ModelContentCategoryConnection'
+    (def: any) => def.name && def.name.value === 'ModelContentCategoryConnection',
   ) as ObjectTypeDefinitionNode;
 
   expect(modelContentCategoryConnection).toBeDefined();

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
@@ -107,7 +107,7 @@ beforeAll(async () => {
         @auth(rules: [{ allow: owner, ownerField: "customerEmail" }, { allow: groups, groups: ["Admin"] }])
     {
         customerEmail: String!
-        createdAt: String
+        createdAt: AWSDateTime
         orderId: String!
     }
     `;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -105,8 +105,8 @@ describe(`ModelAuthTests`, async () => {
       type Post @model @auth(rules: [{ allow: owner }]) {
           id: ID!
           title: String!
-          createdAt: String
-          updatedAt: String
+          createdAt: AWSDateTime
+          updatedAt: AWSDateTime
           owner: String
       }
       type Salary @model @auth(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -38,8 +38,8 @@ beforeAll(async () => {
     type Post @model {
         id: ID!
         title: String!
-        createdAt: String
-        updatedAt: String
+        createdAt: AWSDateTime
+        updatedAt: AWSDateTime
         comments: [Comment] @connection(name: "PostComments", keyField: "postId", limit:50)
         sortedComments: [SortedComment] @connection(name: "SortedPostComments", keyField: "postId", sortField: "when")
     }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/VersionedModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/VersionedModelTransformer.e2e.test.ts
@@ -40,8 +40,8 @@ beforeAll(async () => {
         id: ID!
         title: String!
         version: Int!
-        createdAt: String
-        updatedAt: String
+        createdAt: AWSDateTime
+        updatedAt: AWSDateTime
     }
     `;
   const transformer = new GraphQLTransform({


### PR DESCRIPTION
Expose createdAt and updatedAt automatically in the transformed schema. Added capability to change the createdAt and updatedAt field names using timestamps

```graphql
type Post @model(timestamps:{createAt: "createdOn", updateAt: "updatedOn"}) {
  id: ID!
  title: String!
  tags: [String!]!
}
```

The above schema will generate Post with `createdOn` and `updatedOn` fields as shown

```graphql
type Post {
  id: ID!
  title: String!
  tags: [String!]!
  createdOn: AWSDateTime!
  updatedOn: AWSDateTime!
}
```
fix #401
doc: https://github.com/aws-amplify/docs/pull/1678