### PR TITLE
fix: append env resource params instead of replacing them

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/envResourceParams.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/envResourceParams.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs-extra';
+import pathManager from '../../../../src/extensions/amplify-helpers/path-manager';
+import { getEnvInfo } from '../../../../src/extensions/amplify-helpers/get-env-info';
+import { readJsonFile } from '../../../../src/extensions/amplify-helpers/read-json-file';
+import { saveEnvResourceParameters } from '../../../../src/extensions/amplify-helpers/envResourceParams';
+
+jest.mock('fs-extra');
+jest.mock('../../../../src/extensions/amplify-helpers/path-manager', () => ({getProviderInfoFilePath: jest.fn()}));
+jest.mock('../../../../src/extensions/amplify-helpers/get-env-info', () => ({getEnvInfo: jest.fn()}));
+jest.mock('../../../../src/extensions/amplify-helpers/read-json-file', () => ({readJsonFile: jest.fn()}));
+
+beforeAll(() => {
+  (fs.existsSync as any).mockReturnValue(true);
+  (getEnvInfo as any).mockReturnValue({envName: 'testEnv'});
+  (pathManager.getProviderInfoFilePath as any).mockReturnValue('test/path');
+});
+
+test('saveEnvResourceParams appends to existing params', () => {
+  const contextStub = {};
+  const existingParams = {
+    testEnv: {
+      categories: {
+        testCategory: {
+          testResourceName: {
+            existingParam: 'existingParamValue',
+          },
+        },
+      },
+    },
+  };
+  (readJsonFile as any).mockReturnValue(existingParams);
+
+  saveEnvResourceParameters(contextStub, 'testCategory', 'testResourceName', {newParam: 'newParamValue'});
+  
+  const writeFileSyncMock: any = fs.writeFileSync;
+  expect(writeFileSyncMock).toHaveBeenCalled();
+  const callParams = writeFileSyncMock.mock.calls[0];
+  expect(callParams[0]).toEqual('test/path');
+  const expectedParams = {
+    testEnv: {
+      categories: {
+        testCategory: {
+          testResourceName: {
+            existingParam: 'existingParamValue',
+            newParam: 'newParamValue',
+          },
+        },
+      },
+    },
+  };
+  expect(JSON.parse(callParams[1])).toEqual(expectedParams);
+});

--- a/packages/amplify-cli/src/extensions/amplify-helpers/envResourceParams.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/envResourceParams.js
@@ -1,7 +1,8 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const pathManager = require('./path-manager');
 const { getEnvInfo } = require('./get-env-info');
 const { readJsonFile } = require('./read-json-file');
+const _ = require('lodash');
 
 const CATEGORIES = 'categories';
 
@@ -69,7 +70,7 @@ function saveEnvResourceParameters(context, category, resource, parameters) {
   const allParams = loadAllResourceParameters(context);
   const currentEnv = getCurrentEnvName(context);
   const resources = getOrCreateSubObject(allParams, [currentEnv, CATEGORIES, category]);
-  resources[resource] = parameters;
+  resources[resource] = _.assign(resources[resource], parameters);
   saveAllResourceParams(context, allParams);
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#3240
*Description of changes:*
Modify saveEnvResourceParameters() to append to the existing map of environment parameters rather than overwriting them

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.