### PR TITLE
perf: plugin scan perf optimization

### DIFF
--- a/packages/amplify-cli/src/commands/plugin/add.ts
+++ b/packages/amplify-cli/src/commands/plugin/add.ts
@@ -156,7 +156,7 @@ async function promptForPluginPath(): Promise<string> {
 
 async function addNewPluginPackage(context: Context, pluginDirPath: string) {
   try {
-    const addUserPluginResult = addUserPluginPackage(context.pluginPlatform, pluginDirPath.trim());
+    const addUserPluginResult = await addUserPluginPackage(context.pluginPlatform, pluginDirPath.trim());
     if (addUserPluginResult.isAdded) {
       context.print.success('Successfully added plugin package.');
       await confirmAndScan(context.pluginPlatform);

--- a/packages/amplify-cli/src/commands/plugin/new.ts
+++ b/packages/amplify-cli/src/commands/plugin/new.ts
@@ -16,7 +16,7 @@ export async function run(context: Context) {
 async function plugIntoLocalAmplifyCli(context: Context, pluginDirPath: string): Promise<boolean> {
   let isPluggedIn = false;
 
-  const addPluginResult = addUserPluginPackage(context.pluginPlatform, pluginDirPath);
+  const addPluginResult = await addUserPluginPackage(context.pluginPlatform, pluginDirPath);
   if (addPluginResult.isAdded) {
     isPluggedIn = true;
   } else {

--- a/packages/amplify-cli/src/plugin-helpers/create-new-plugin.ts
+++ b/packages/amplify-cli/src/plugin-helpers/create-new-plugin.ts
@@ -6,7 +6,7 @@ import { constants } from '../domain/constants';
 import { AmplifyEvent } from '../domain/amplify-event';
 import { AmplifyPluginType } from '../domain/amplify-plugin-type';
 import { readJsonFileSync } from '../utils/readJsonFile';
-import { validPluginNameSync } from './verify-plugin';
+import { validPluginName } from './verify-plugin';
 import { createIndentation } from './display-plugin-platform';
 
 const INDENTATIONSPACE = 4;
@@ -33,8 +33,8 @@ async function getPluginName(context: Context, pluginParentDirPath: string): Pro
       name: 'pluginName',
       message: 'What should be the name of the plugin:',
       default: pluginName,
-      validate: (input: string) => {
-        const pluginNameValidationResult = validPluginNameSync(input);
+      validate: async (input: string) => {
+        const pluginNameValidationResult = await validPluginName(input);
         if (!pluginNameValidationResult.isValid) {
           return pluginNameValidationResult.message || 'Invalid plugin name';
         }

--- a/packages/amplify-cli/src/plugin-helpers/verify-plugin.ts
+++ b/packages/amplify-cli/src/plugin-helpers/verify-plugin.ts
@@ -1,16 +1,15 @@
 import path from 'path';
 import fs from 'fs-extra';
 import { constants } from '../domain/constants';
-import { readJsonFileSync, readJsonFile } from '../utils/readJsonFile';
+import { readJsonFile } from '../utils/readJsonFile';
 import { PluginManifest } from '../domain/plugin-manifest';
 import { PluginVerificationResult, PluginVerificationError } from '../domain/plugin-verification-result';
 
-export function verifyPluginSync(pluginDirPath: string): PluginVerificationResult {
-  if (fs.existsSync(pluginDirPath) && fs.statSync(pluginDirPath).isDirectory()) {
-    return verifyNodePackageSync(pluginDirPath);
-  }
-  return new PluginVerificationResult(false, PluginVerificationError.PluginDirPathNotExist);
-}
+type VerificationContext = {
+  pluginDirPath: string;
+  manifest?: PluginManifest;
+  pluginModule?: any;
+};
 
 export async function verifyPlugin(pluginDirPath: string): Promise<PluginVerificationResult> {
   let exists = await fs.pathExists(pluginDirPath);
@@ -31,18 +30,6 @@ export type PluginNameValidationResult = {
   message?: string;
 };
 
-export function validPluginNameSync(pluginName: string): PluginNameValidationResult {
-  const result: PluginNameValidationResult = {
-    isValid: true,
-  };
-  const corePluginJson = readJsonFileSync(path.normalize(path.join(__dirname, '../../amplify-plugin.json')));
-  if (corePluginJson && corePluginJson.commands && corePluginJson.commands.includes(pluginName)) {
-    result.isValid = false;
-    result.message = 'Amplify CLI core comand names can not be used as plugin name';
-  }
-  return result;
-}
-
 export async function validPluginName(pluginName: string): Promise<PluginNameValidationResult> {
   const result: PluginNameValidationResult = {
     isValid: true,
@@ -55,25 +42,15 @@ export async function validPluginName(pluginName: string): Promise<PluginNameVal
   return result;
 }
 
-function verifyNodePackageSync(pluginDirPath: string): PluginVerificationResult {
-  const pluginPackageJsonFilePath = path.join(pluginDirPath, constants.PACKAGEJSON_FILE_NAME);
-  try {
-    const packageJson = readJsonFileSync(pluginPackageJsonFilePath);
-    const pluginModule = require(pluginDirPath);
-    const result = verifyAmplifyManifestSync(pluginDirPath, pluginModule);
-    result.packageJson = packageJson;
-    return result;
-  } catch (err) {
-    return new PluginVerificationResult(false, PluginVerificationError.InvalidNodePackage, err);
-  }
-}
-
 async function verifyNodePackage(pluginDirPath: string): Promise<PluginVerificationResult> {
   const pluginPackageJsonFilePath = path.join(pluginDirPath, constants.PACKAGEJSON_FILE_NAME);
   try {
     const packageJson = await readJsonFile(pluginPackageJsonFilePath);
-    const pluginModule = require(pluginDirPath);
-    const result = await verifyAmplifyManifest(pluginDirPath, pluginModule);
+    const context: VerificationContext = {
+      pluginDirPath,
+    };
+    // const pluginModule = require(pluginDirPath);
+    const result = await verifyAmplifyManifest(context);
     result.packageJson = packageJson;
     return result;
   } catch (err) {
@@ -81,29 +58,8 @@ async function verifyNodePackage(pluginDirPath: string): Promise<PluginVerificat
   }
 }
 
-function verifyAmplifyManifestSync(pluginDirPath: string, pluginModule: any): PluginVerificationResult {
-  const pluginManifestFilePath = path.join(pluginDirPath, constants.MANIFEST_FILE_NAME);
-  if (!fs.existsSync(pluginManifestFilePath) || !fs.statSync(pluginManifestFilePath).isFile()) {
-    return new PluginVerificationResult(false, PluginVerificationError.MissingManifest);
-  }
-
-  try {
-    const manifest = readJsonFileSync(pluginManifestFilePath) as PluginManifest;
-    const pluginNameValidationResult = validPluginNameSync(manifest.name);
-    if (pluginNameValidationResult.isValid) {
-      let result = verifyCommands(manifest, pluginModule);
-      result = result.verified ? verifyEventHandlers(manifest, pluginModule) : result;
-      result.manifest = manifest;
-      return result;
-    }
-    return new PluginVerificationResult(false, PluginVerificationError.InvalidManifest, pluginNameValidationResult.message);
-  } catch (err) {
-    return new PluginVerificationResult(false, PluginVerificationError.InvalidManifest, err);
-  }
-}
-
-async function verifyAmplifyManifest(pluginDirPath: string, pluginModule: any): Promise<PluginVerificationResult> {
-  const pluginManifestFilePath = path.join(pluginDirPath, constants.MANIFEST_FILE_NAME);
+async function verifyAmplifyManifest(context: VerificationContext): Promise<PluginVerificationResult> {
+  const pluginManifestFilePath = path.join(context.pluginDirPath, constants.MANIFEST_FILE_NAME);
   let exists = await fs.pathExists(pluginManifestFilePath);
   if (exists) {
     const stat = await fs.stat(pluginManifestFilePath);
@@ -117,8 +73,10 @@ async function verifyAmplifyManifest(pluginDirPath: string, pluginModule: any): 
     const manifest = (await readJsonFile(pluginManifestFilePath)) as PluginManifest;
     const pluginNameValidationResult = await validPluginName(manifest.name);
     if (pluginNameValidationResult.isValid) {
-      let result = verifyCommands(manifest, pluginModule);
-      result = result.verified ? verifyEventHandlers(manifest, pluginModule) : result;
+      context.manifest = manifest;
+
+      let result = verifyCommands(context);
+      result = result.verified ? verifyEventHandlers(context) : result;
       result.manifest = manifest;
       return result;
     }
@@ -128,7 +86,7 @@ async function verifyAmplifyManifest(pluginDirPath: string, pluginModule: any): 
   }
 }
 
-function verifyCommands(manifest: PluginManifest, pluginModule: any): PluginVerificationResult {
+function verifyCommands(context: VerificationContext): PluginVerificationResult {
   //   let isVerified = true;
   //   if (manifest.commands && manifest.commands.length > 0) {
   //     isVerified = pluginModule.hasOwnProperty(constants.ExecuteAmplifyCommand) &&
@@ -147,11 +105,17 @@ function verifyCommands(manifest: PluginManifest, pluginModule: any): PluginVeri
   return new PluginVerificationResult(true);
 }
 
-function verifyEventHandlers(manifest: PluginManifest, pluginModule: any): PluginVerificationResult {
+function verifyEventHandlers(context: VerificationContext): PluginVerificationResult {
   let isVerified = true;
-  if (manifest.eventHandlers && manifest.eventHandlers.length > 0) {
+  if (context.manifest!.eventHandlers && context.manifest!.eventHandlers.length > 0) {
+    // Lazy load the plugin if not yet loaded
+    if (!context.pluginModule) {
+      context.pluginModule = require(context.pluginDirPath);
+    }
+
     isVerified =
-      pluginModule.hasOwnProperty(constants.HandleAmplifyEvent) && typeof pluginModule[constants.HandleAmplifyEvent] === 'function';
+      context.pluginModule.hasOwnProperty(constants.HandleAmplifyEvent) &&
+      typeof context.pluginModule[constants.HandleAmplifyEvent] === 'function';
   }
 
   if (isVerified) {

--- a/packages/amplify-cli/src/plugin-helpers/verify-plugin.ts
+++ b/packages/amplify-cli/src/plugin-helpers/verify-plugin.ts
@@ -49,7 +49,6 @@ async function verifyNodePackage(pluginDirPath: string): Promise<PluginVerificat
     const context: VerificationContext = {
       pluginDirPath,
     };
-    // const pluginModule = require(pluginDirPath);
     const result = await verifyAmplifyManifest(context);
     result.packageJson = packageJson;
     return result;

--- a/packages/amplify-cli/src/plugin-manager.ts
+++ b/packages/amplify-cli/src/plugin-manager.ts
@@ -7,7 +7,7 @@ import {
   getCorePluginVersion,
   isUnderScanCoverageSync,
 } from './plugin-helpers/scan-plugin-platform';
-import { verifyPlugin, verifyPluginSync } from './plugin-helpers/verify-plugin';
+import { verifyPlugin } from './plugin-helpers/verify-plugin';
 import createNewPlugin from './plugin-helpers/create-new-plugin';
 import { AddPluginResult, AddPluginError } from './domain/add-plugin-result';
 import { twoPluginsAreTheSame } from './plugin-helpers/compare-plugins';
@@ -154,16 +154,16 @@ export async function confirmAndScan(pluginPlatform: PluginPlatform) {
   }
 }
 
-export function addUserPluginPackage(pluginPlatform: PluginPlatform, pluginDirPath: string): AddPluginResult {
+export const addUserPluginPackage = async (pluginPlatform: PluginPlatform, pluginDirPath: string): Promise<AddPluginResult> => {
   return addPluginPackage(pluginPlatform, pluginDirPath);
-}
+};
 
-export function addExcludedPluginPackage(pluginPlatform: PluginPlatform, pluginInfo: PluginInfo): AddPluginResult {
+export const addExcludedPluginPackage = async (pluginPlatform: PluginPlatform, pluginInfo: PluginInfo): Promise<AddPluginResult> => {
   return addPluginPackage(pluginPlatform, pluginInfo.packageLocation);
-}
+};
 
-export function addPluginPackage(pluginPlatform: PluginPlatform, pluginDirPath: string): AddPluginResult {
-  const pluginVerificationResult = verifyPluginSync(pluginDirPath);
+export const addPluginPackage = async (pluginPlatform: PluginPlatform, pluginDirPath: string): Promise<AddPluginResult> => {
+  const pluginVerificationResult = await verifyPlugin(pluginDirPath);
   const result = new AddPluginResult(false, pluginVerificationResult);
 
   if (pluginVerificationResult.verified) {
@@ -209,7 +209,7 @@ export function addPluginPackage(pluginPlatform: PluginPlatform, pluginDirPath: 
     result.error = AddPluginError.FailedVerification;
   }
   return result;
-}
+};
 
 // remove: select from the plugins only,
 // if the location belongs to the scan directories, put the info inside the excluded.


### PR DESCRIPTION
*Description of changes:*

- fix: optimize plugin scan performance, to lazy load plugins
    before:
        ```amplify plugin scan  5.86s user 1.58s system 89% cpu 8.327 total```
    after:
        ```amplify-dev plugin scan  0.68s user 0.12s system 116% cpu 0.684 total```
- remove extra verification functions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.