### PR TITLE
fix(amplify-category-function): prevent overwriting of parameters

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -78,7 +78,8 @@ export function createParametersFile(context, parameters, resourceName, paramete
   const resourceDirPath = path.join(projectBackendDirPath, categoryName, resourceName);
   fs.ensureDirSync(resourceDirPath);
   const parametersFilePath = path.join(resourceDirPath, parametersFileName);
-  const jsonString = JSON.stringify(parameters, null, 4);
+  const currentParameters = fs.existsSync(parametersFilePath) ? context.amplify.readJsonFile(parametersFilePath) : {};
+  const jsonString = JSON.stringify({ ...currentParameters, ...parameters }, null, 4);
   fs.writeFileSync(parametersFilePath, jsonString, 'utf8');
 }
 


### PR DESCRIPTION
Function update walkthroguh used to overwrite everything in parameter.json and
function-parameter.json when an update was done. Update flow does not account for all the
configuration options function can have and causes deletion of cognito trigger configuration.
Updated this to retain last configuration and only update the parts that have changed

fix #4065

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.