### PR TITLE
fix(amplify-appsync-simulator): support more than 1 operation in query

### DIFF
--- a/packages/amplify-appsync-simulator/src/server/operations.ts
+++ b/packages/amplify-appsync-simulator/src/server/operations.ts
@@ -72,7 +72,7 @@ export class OperationServer {
         headers: request.headers,
         appsyncErrors: [],
       };
-      switch (getOperationType(doc)) {
+      switch (getOperationType(doc, operationName)) {
         case 'query':
         case 'mutation':
           const gqlResult = await runQueryOrMutation(this.simulatorContext.schema, doc, variables, operationName, context);


### PR DESCRIPTION
Fixed an error  when there were more than 1 operation in query document

fix #4181

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.