### PR TITLE
feat: support for overriding pipeline function templates in transformer

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -439,13 +439,13 @@ async function transformGraphQLSchema(context, options) {
   }
 
   const buildConfig = {
+    ...options,
     buildParameters,
     projectDirectory: options.dryrun ? false : resourceDir,
     transformersFactory: transformerListFactory,
     transformersFactoryArgs: [searchableTransformerFlag, storageConfig],
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
-    disableResolverOverrides: options.disableResolverOverrides,
     minify: options.minify,
   };
   const transformerOutput = await TransformPackage.buildAPIProject(buildConfig);

--- a/packages/amplify-util-mock/src/api/resolver-overrides.ts
+++ b/packages/amplify-util-mock/src/api/resolver-overrides.ts
@@ -8,8 +8,8 @@ export class ResolverOverrides {
 
   constructor(
     private _rootFolder: string,
-    private _foldersToWatch: string[] = ['resolvers', 'pipelineFunctions'],
-    private fileExtensions: string[] = ['.vtl']
+    private _foldersToWatch: string[] = ['resolvers', 'pipelineFunctions', 'functions'],
+    private fileExtensions: string[] = ['.vtl'],
   ) {
     this.overrides = new Set();
     this.contentMap = new Map();

--- a/packages/amplify-util-mock/src/api/run-graphql-transformer.ts
+++ b/packages/amplify-util-mock/src/api/run-graphql-transformer.ts
@@ -4,6 +4,8 @@ export async function runTransformer(context: any) {
     forceCompile: true,
     dryRun: true,
     disableResolverOverrides: true,
+    disableFunctionOverrides: true,
+    disablePipelineFunctionOverrides: true,
   });
   return { transformerOutput };
 }

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -19,6 +19,7 @@ export interface ProjectOptions {
   rootStackFileName?: string;
   dryRun?: boolean;
   disableFunctionOverrides?: boolean;
+  disablePipelineFunctionOverrides?: boolean;
   disableResolverOverrides?: boolean;
   buildParameters?: Object;
   minify?: boolean;
@@ -195,8 +196,16 @@ function mergeUserConfigWithTransformOutput(userConfig: Partial<DeploymentResour
   // Override user defined functions.
   const userFunctions = userConfig.functions || {};
   const transformFunctions = transformOutput.functions;
+  const pipelineFunctions = transformOutput.pipelineFunctions;
+
+  // override functions
   for (const userFunction of Object.keys(userFunctions)) {
     transformFunctions[userFunction] = userConfig.functions[userFunction];
+  }
+
+  // override pipeline functions
+  for (const pipelineFunction of Object.keys(userConfig.pipelineFunctions)) {
+    pipelineFunctions[pipelineFunction] = userConfig.pipelineFunctions[pipelineFunction];
   }
 
   // Override user defined resolvers.

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -138,6 +138,9 @@ interface ProjectConfiguration {
   functions: {
     [k: string]: string;
   };
+  pipelineFunctions: {
+    [k: string]: string;
+  };
   resolvers: {
     [k: string]: string;
   };
@@ -163,6 +166,23 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
         }
         const functionFilePath = path.join(functionDirectory, functionFile);
         functions[functionFile] = functionFilePath;
+      }
+    }
+  }
+
+  // load pipeline functions
+  const pipelineFunctions = {};
+  if (!(opts && opts.disablePipelineFunctionOverrides === true)) {
+    const pipelineFunctionDirectory = path.join(projectDirectory, 'pipelineFunctions');
+    const pipelineFunctionDirectoryExists = await fs.exists(pipelineFunctionDirectory);
+    if (pipelineFunctionDirectoryExists) {
+      const pipelineFunctionFiles = await fs.readdir(pipelineFunctionDirectory);
+      for (const pipelineFunctionFile of pipelineFunctionFiles) {
+        if (pipelineFunctionFile.indexOf('.') === 0) {
+          continue;
+        }
+        const pipelineFunctionPath = path.join(pipelineFunctionDirectory, pipelineFunctionFile);
+        pipelineFunctions[pipelineFunctionFile] = await fs.readFile(pipelineFunctionPath);
       }
     }
   }
@@ -209,6 +229,7 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
   const config = await loadConfig(projectDirectory);
   return {
     functions,
+    pipelineFunctions,
     stacks,
     resolvers,
     schema,


### PR DESCRIPTION
Add support for overriding pipeline function tempalte in graphql transformer. Updated mock to
support this as well

fix #4192

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.