### PR TITLE
Added logging when Zipping Fails

### DIFF
--- a/packages/amplify-console-hosting/hosting/manual/publish.js
+++ b/packages/amplify-console-hosting/hosting/manual/publish.js
@@ -30,6 +30,7 @@ async function publish(context, doSkipBuild, doSkipPush) {
     spinner.start(ZIPPING_MESSAGE);
     artifactsPath = await zipArtifacts(context).catch((err) => {
       spinner.fail(ZIPPING_FAILURE_MESSAGE);
+      console.log(err);
       throw err;
     });
     spinner.succeed(ZIPPING_SUCCESS_MESSAGE);


### PR DESCRIPTION
Added reason for zipping fails
'Zipping artifacts failed.' is not enough to determine what when wrong. 
When I added this line, I got the error "Please ensure your build artifacts path exists. which immediately Pointed me towards the issue.

*Description of changes:*
Added `console.log` to zipping error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.