### PR TITLE
feat: make 'dev' the default envname if it's not present

### DIFF
--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.js
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.js
@@ -113,10 +113,16 @@ async function getEnvName(context) {
   }
 
   const newEnvQuestion = async () => {
+    let defaultEnvName;
+    if (isNewProject(context) || !context.amplify.getAllEnvs().includes('dev')) {
+      defaultEnvName = 'dev';
+    }
+
     const envNameQuestion = {
       type: 'input',
       name: 'envName',
       message: 'Enter a name for the environment',
+      default: defaultEnvName,
       validate: input => (!isEnvNameValid(input) ? INVALID_ENV_NAME_MSG : true),
     };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make 'dev' the default environment name if it's a new project or doesn't exist yet

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.