### PR TITLE
fix(amplify-util-mock): non-promise lambda failing

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf lib tsconfig.tsbuildinfo"
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "test": "jest",
+    "test-ci": "jest"
   },
   "dependencies": {
     "amplify-function-plugin-interface": "1.3.0",
@@ -29,5 +31,25 @@
   "devDependencies": {
     "@types/archiver": "^3.1.0",
     "@types/node": "^10.17.13"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!**/*.d.ts"
+    ],
+    "testURL": "http://localhost/",
+    "testRegex": "(src/__tests__/.*.test.(js|ts))$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   }
 }

--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/__snapshots__/execute.test.ts.snap
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/__snapshots__/execute.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute async handler should fail when throwing an error 1`] = `Object {}`;
+
+exports[`execute async handler should succeed with a returned value 1`] = `"foo"`;
+
+exports[`execute callback handler should fail when returning an error 1`] = `Object {}`;
+
+exports[`execute callback handler should succeed with a returned value 1`] = `"foo"`;
+
+exports[`execute non-promise returned handler should resolve to null 1`] = `null`;

--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/execute.test.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/execute.test.ts
@@ -1,0 +1,64 @@
+import { invokeFunction } from '../../utils/execute';
+
+describe('execute', () => {
+  describe('async handler', () => {
+    it('should succeed with a returned value', async () => {
+      await expect(
+        invokeFunction({
+          packageFolder: __dirname,
+          handler: 'handlers.asyncHandler',
+          event: '{"succeed": true}',
+          environment: {},
+        }),
+      ).resolves.toMatchSnapshot();
+    });
+
+    it('should fail when throwing an error', async () => {
+      await expect(
+        invokeFunction({
+          packageFolder: __dirname,
+          handler: 'handlers.asyncHandler',
+          event: '{"succeed": false}',
+          environment: {},
+        }),
+      ).rejects.toMatchSnapshot();
+    });
+  });
+
+  describe('callback handler', () => {
+    it('should succeed with a returned value', async () => {
+      await expect(
+        invokeFunction({
+          packageFolder: __dirname,
+          handler: 'handlers.callbackHandler',
+          event: '{"succeed": true}',
+          environment: {},
+        }),
+      ).resolves.toMatchSnapshot();
+    });
+
+    it('should fail when returning an error', async () => {
+      await expect(
+        invokeFunction({
+          packageFolder: __dirname,
+          handler: 'handlers.callbackHandler',
+          event: '{"succeed": false}',
+          environment: {},
+        }),
+      ).rejects.toMatchSnapshot();
+    });
+  });
+
+  describe('non-promise returned handler', () => {
+    it('should resolve to null', async () => {
+      await expect(
+        invokeFunction({
+          packageFolder: __dirname,
+          handler: 'handlers.nonAsyncHandler',
+          event: '{}',
+          environment: {},
+        }),
+      ).resolves.toMatchSnapshot();
+    });
+  });
+});

--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/handlers.js
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/handlers.js
@@ -1,0 +1,21 @@
+module.exports.asyncHandler = (event, context, callback) => {
+  return new Promise((resolve, reject) => {
+    if (event.succeed) {
+      resolve('foo');
+    } else {
+      reject(new Error('Fail'));
+    }
+  });
+};
+
+module.exports.callbackHandler = async (event, context, callback) => {
+  if (event.succeed) {
+    callback(null, 'foo');
+  } else {
+    callback(new Error('Fail'), null);
+  }
+};
+
+module.exports.nonAsyncHandler = () => {
+  return 'foo';
+};

--- a/packages/amplify-util-mock/src/utils/lambda/execute.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/execute.ts
@@ -84,6 +84,8 @@ function invokeFunction(options: InvokeOptions) {
         } else {
           context.done(null, null);
         }
+      } else if (response !== undefined) {
+        context.done(null, null);
       }
     } catch (e) {
       context.done(e, null);

--- a/packages/amplify-util-mock/src/utils/lambda/execute.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/execute.ts
@@ -76,11 +76,14 @@ function invokeFunction(options: InvokeOptions) {
         );
         return;
       }
-      const result = await lambda[options.handler](event, context, callback);
-      if (result !== undefined) {
-        context.done(null, result);
-      } else {
-        context.done(null, null);
+      const response = lambda[options.handler](event, context, callback);
+      if (typeof response === 'object' && typeof response.then === 'function') {
+        const result = await response;
+        if (result !== undefined) {
+          context.done(null, result);
+        } else {
+          context.done(null, null);
+        }
       }
     } catch (e) {
       context.done(e, null);


### PR DESCRIPTION
Fixes #4019

Non-async Lambda handlers should only rely on the value returned by the callback function.

See https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.