### PR TITLE
fix: remove use of deprecated context.done() and context.succeed()

### DIFF
--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/index.js
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/index.js
@@ -5,5 +5,5 @@ const server = awsServerlessExpress.createServer(app);
 
 exports.handler = (event, context) => {
   console.log(`EVENT: ${JSON.stringify(event)}`);
-  awsServerlessExpress.proxy(server, event, context);
+  return awsServerlessExpress.proxy(server, event, context, 'PROMISE').promise;
 };

--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/serverless/index.js
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/serverless/index.js
@@ -5,5 +5,5 @@ const server = awsServerlessExpress.createServer(app);
 
 exports.handler = (event, context) => {
   console.log(`EVENT: ${JSON.stringify(event)}`);
-  awsServerlessExpress.proxy(server, event, context);
+  return awsServerlessExpress.proxy(server, event, context, 'PROMISE').promise;
 };

--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/trigger/trigger-dynamodb.js
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/trigger/trigger-dynamodb.js
@@ -1,4 +1,4 @@
-exports.handler = function(event, context) {
+exports.handler = event => {
   //eslint-disable-line
   console.log(JSON.stringify(event, null, 2));
   event.Records.forEach(record => {
@@ -6,5 +6,5 @@ exports.handler = function(event, context) {
     console.log(record.eventName);
     console.log('DynamoDB Record: %j', record.dynamodb);
   });
-  context.done(null, 'Successfully processed DynamoDB record'); // SUCCESS with message
+  return Promise.resolve('Successfully processed DynamoDB record');
 };

--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/trigger/trigger-kinesis.js
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/trigger/trigger-kinesis.js
@@ -1,4 +1,4 @@
-exports.handler = (event, context, callback) => {
+exports.handler = event => {
   // insert code to be executed by your lambda trigger
   console.log(JSON.stringify(event, null, 2));
   let res = '';
@@ -13,5 +13,5 @@ exports.handler = (event, context, callback) => {
     res += 'Kinesis records not present in event';
   }
 
-  context.done(null, res); // SUCCESS with message
+  return Promise.resolve(res);
 };


### PR DESCRIPTION
*Issue #, if available:*
#3995

*Description of changes:*
The serverless and crud node templates used a deprecated version of `awsServerlessExpress.proxy()` which called the deprecated `context.succeed()` lambda operation under the hood. This updates to use the newer `proxy()` function call that returns a promise.

Also replaced the deprecated `context.done()` calls in the dynamo and kinesis trigger templates with promises.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.