### PR TITLE
refactor: copy awsconfig into amplifyconfig

### DIFF
--- a/packages/amplify-frontend-android/index.js
+++ b/packages/amplify-frontend-android/index.js
@@ -23,8 +23,9 @@ function onInitSuccessful(context) {
 function createFrontendConfigs(context, amplifyResources, amplifyCloudResources) {
   const newOutputsForFrontend = amplifyResources.outputsForFrontend;
   const cloudOutputsForFrontend = amplifyCloudResources.outputsForFrontend;
+  const awsConfig = createAWSConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
   createAmplifyConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
-  return createAWSConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
+  return awsConfig;
 }
 
 function configure(context) {

--- a/packages/amplify-frontend-android/index.js
+++ b/packages/amplify-frontend-android/index.js
@@ -23,9 +23,8 @@ function onInitSuccessful(context) {
 function createFrontendConfigs(context, amplifyResources, amplifyCloudResources) {
   const newOutputsForFrontend = amplifyResources.outputsForFrontend;
   const cloudOutputsForFrontend = amplifyCloudResources.outputsForFrontend;
-  const awsConfig = createAWSConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
   createAmplifyConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
-  return awsConfig;
+  return createAWSConfig(context, newOutputsForFrontend, cloudOutputsForFrontend);
 }
 
 function configure(context) {

--- a/packages/amplify-frontend-android/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-android/lib/amplify-config-helper.js
@@ -6,6 +6,7 @@ function generateConfig(context, amplifyConfig, newAWSConfig) {
   };
   constructAnalytics(metadata, amplifyConfig);
   constructApi(metadata, amplifyConfig);
+  // Auth plugin with entire awsconfiguration contained required for Native GA release
   constructAuth(metadata, amplifyConfig, newAWSConfig);
   constructPredictions(metadata, amplifyConfig);
   constructStorage(metadata, amplifyConfig);

--- a/packages/amplify-frontend-android/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-android/lib/amplify-config-helper.js
@@ -1,9 +1,4 @@
-const constants = require('./constants');
-const fs = require('fs');
-const path = require('path');
-
-function generateConfig(context, amplifyConfig) {
-  const awsConfig = getCurrentAWSConfig(context);
+function generateConfig(context, amplifyConfig, newAWSConfig) {
   const metadata = context.amplify.getProjectMeta();
   amplifyConfig = amplifyConfig || {
     UserAgent: 'aws-amplify-cli/2.0',
@@ -11,7 +6,7 @@ function generateConfig(context, amplifyConfig) {
   };
   constructAnalytics(metadata, amplifyConfig);
   constructApi(metadata, amplifyConfig);
-  constructAuth(metadata, amplifyConfig, awsConfig);
+  constructAuth(metadata, amplifyConfig, newAWSConfig);
   constructPredictions(metadata, amplifyConfig);
   constructStorage(metadata, amplifyConfig);
 
@@ -184,23 +179,6 @@ function constructStorage(metadata, amplifyConfig) {
   }
 }
 
-function getCurrentAWSConfig(context) {
-  const { amplify } = context;
-  const projectPath = context.exeInfo ? context.exeInfo.localEnvInfo.projectPath : amplify.getEnvInfo().projectPath;
-  const projectConfig = context.exeInfo ? context.exeInfo.projectConfig[constants.Label] : amplify.getProjectConfig()[constants.Label];
-  const frontendConfig = projectConfig.config;
-  const srcDirPath = path.join(projectPath, frontendConfig.ResDir, 'raw');
-
-  const targetFilePath = path.join(srcDirPath, constants.awsConfigFilename);
-  let awsConfig = {};
-
-  if (fs.existsSync(targetFilePath)) {
-    awsConfig = amplify.readJsonFile(targetFilePath);
-  }
-  return awsConfig;
-}
-
 module.exports = {
   generateConfig,
-  getCurrentAWSConfig,
 };

--- a/packages/amplify-frontend-android/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-android/lib/amplify-config-helper.js
@@ -1,4 +1,9 @@
+const constants = require('./constants');
+const fs = require('fs');
+const path = require('path');
+
 function generateConfig(context, amplifyConfig) {
+  const awsConfig = getCurrentAWSConfig(context);
   const metadata = context.amplify.getProjectMeta();
   amplifyConfig = amplifyConfig || {
     UserAgent: 'aws-amplify-cli/2.0',
@@ -6,10 +11,21 @@ function generateConfig(context, amplifyConfig) {
   };
   constructAnalytics(metadata, amplifyConfig);
   constructApi(metadata, amplifyConfig);
+  constructAuth(metadata, amplifyConfig, awsConfig);
   constructPredictions(metadata, amplifyConfig);
   constructStorage(metadata, amplifyConfig);
 
   return amplifyConfig;
+}
+
+function constructAuth(metadata, amplifyConfig, awsConfig) {
+  const categoryName = 'auth';
+  const pluginName = 'awsCognitoAuthPlugin';
+  if (metadata[categoryName]) {
+    amplifyConfig[categoryName] = {};
+    amplifyConfig[categoryName].plugins = {};
+    amplifyConfig[categoryName].plugins[pluginName] = awsConfig;
+  }
 }
 
 function constructAnalytics(metadata, amplifyConfig) {
@@ -168,6 +184,23 @@ function constructStorage(metadata, amplifyConfig) {
   }
 }
 
+function getCurrentAWSConfig(context) {
+  const { amplify } = context;
+  const projectPath = context.exeInfo ? context.exeInfo.localEnvInfo.projectPath : amplify.getEnvInfo().projectPath;
+  const projectConfig = context.exeInfo ? context.exeInfo.projectConfig[constants.Label] : amplify.getProjectConfig()[constants.Label];
+  const frontendConfig = projectConfig.config;
+  const srcDirPath = path.join(projectPath, frontendConfig.ResDir, 'raw');
+
+  const targetFilePath = path.join(srcDirPath, constants.awsConfigFilename);
+  let awsConfig = {};
+
+  if (fs.existsSync(targetFilePath)) {
+    awsConfig = amplify.readJsonFile(targetFilePath);
+  }
+  return awsConfig;
+}
+
 module.exports = {
   generateConfig,
+  getCurrentAWSConfig,
 };

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -77,7 +77,7 @@ function createAmplifyConfig(context) {
 function createAWSConfig(context, amplifyResources, cloudAmplifyResources) {
   const newAWSConfig = getAWSConfigObject(amplifyResources);
   const cloudAWSConfig = getAWSConfigObject(cloudAmplifyResources);
-  const currentAWSConfig = getCurrentAWSConfig(context);
+  const currentAWSConfig = amplifyConfigHelper.getCurrentAWSConfig(context);
 
   const customConfigs = getCustomConfigs(cloudAWSConfig, currentAWSConfig);
 
@@ -128,22 +128,6 @@ function getAWSConfigObject(amplifyResources) {
   });
 
   return configOutput;
-}
-
-function getCurrentAWSConfig(context) {
-  const { amplify } = context;
-  const projectPath = context.exeInfo ? context.exeInfo.localEnvInfo.projectPath : amplify.getEnvInfo().projectPath;
-  const projectConfig = context.exeInfo ? context.exeInfo.projectConfig[constants.Label] : amplify.getProjectConfig()[constants.Label];
-  const frontendConfig = projectConfig.config;
-  const srcDirPath = path.join(projectPath, frontendConfig.ResDir, 'raw');
-
-  const targetFilePath = path.join(srcDirPath, constants.awsConfigFilename);
-  let awsConfig = {};
-
-  if (fs.existsSync(targetFilePath)) {
-    awsConfig = amplify.readJsonFile(targetFilePath);
-  }
-  return awsConfig;
 }
 
 function getCustomConfigs(cloudAWSConfig, currentAWSConfig) {

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -68,6 +68,7 @@ function createAmplifyConfig(context, amplifyResources, cloudAmplifyResources) {
     amplifyConfig = context.amplify.readJsonFile(targetFilePath);
   }
 
+  // Native GA release requires entire awsconfiguration inside amplifyconfiguration auth plugin
   const newAWSConfig = getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources);
   amplifyConfig = amplifyConfigHelper.generateConfig(context, amplifyConfig, newAWSConfig);
 

--- a/packages/amplify-frontend-ios/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-ios/lib/amplify-config-helper.js
@@ -6,6 +6,7 @@ function generateConfig(context, amplifyConfig, newAWSConfig) {
   };
   constructAnalytics(metadata, amplifyConfig);
   constructApi(metadata, amplifyConfig);
+  // Auth plugin with entire awsconfiguration contained required for Native GA release
   constructAuth(metadata, amplifyConfig, newAWSConfig);
   constructPredictions(metadata, amplifyConfig);
   constructStorage(metadata, amplifyConfig);

--- a/packages/amplify-frontend-ios/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-ios/lib/amplify-config-helper.js
@@ -1,4 +1,4 @@
-function generateConfig(context, amplifyConfig) {
+function generateConfig(context, amplifyConfig, newAWSConfig) {
   const metadata = context.amplify.getProjectMeta();
   amplifyConfig = amplifyConfig || {
     UserAgent: 'aws-amplify-cli/2.0',
@@ -6,10 +6,21 @@ function generateConfig(context, amplifyConfig) {
   };
   constructAnalytics(metadata, amplifyConfig);
   constructApi(metadata, amplifyConfig);
+  constructAuth(metadata, amplifyConfig, newAWSConfig);
   constructPredictions(metadata, amplifyConfig);
   constructStorage(metadata, amplifyConfig);
 
   return amplifyConfig;
+}
+
+function constructAuth(metadata, amplifyConfig, awsConfig) {
+  const categoryName = 'auth';
+  const pluginName = 'awsCognitoAuthPlugin';
+  if (metadata[categoryName]) {
+    amplifyConfig[categoryName] = {};
+    amplifyConfig[categoryName].plugins = {};
+    amplifyConfig[categoryName].plugins[pluginName] = awsConfig;
+  }
 }
 
 function constructAnalytics(metadata, amplifyConfig) {

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -47,7 +47,7 @@ function getSrcDir(context) {
   return path.join(projectPath);
 }
 
-function createAmplifyConfig(context) {
+function createAmplifyConfig(context, amplifyResources, cloudAmplifyResources) {
   const { amplify } = context;
   const projectPath = context.exeInfo ? context.exeInfo.localEnvInfo.projectPath : amplify.getEnvInfo().projectPath;
   const srcDirPath = path.join(projectPath);
@@ -59,14 +59,15 @@ function createAmplifyConfig(context) {
       amplifyConfig = context.amplify.readJsonFile(targetFilePath);
     }
 
-    amplifyConfig = amplifyConfigHelper.generateConfig(context, amplifyConfig);
+    const newAWSConfig = getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources);
+    amplifyConfig = amplifyConfigHelper.generateConfig(context, amplifyConfig, newAWSConfig);
 
     const jsonString = JSON.stringify(amplifyConfig, null, 4);
     fs.writeFileSync(targetFilePath, jsonString, 'utf8');
   }
 }
 
-function createAWSConfig(context, amplifyResources, cloudAmplifyResources) {
+function getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources) {
   const newAWSConfig = getAWSConfigObject(amplifyResources);
   const cloudAWSConfig = getAWSConfigObject(cloudAmplifyResources);
   const currentAWSConfig = getCurrentAWSConfig(context);
@@ -74,7 +75,11 @@ function createAWSConfig(context, amplifyResources, cloudAmplifyResources) {
   const customConfigs = getCustomConfigs(cloudAWSConfig, currentAWSConfig);
 
   Object.assign(newAWSConfig, customConfigs);
+  return newAWSConfig;
+}
 
+function createAWSConfig(context, amplifyResources, cloudAmplifyResources) {
+  const newAWSConfig = getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources);
   generateAWSConfigFile(context, newAWSConfig);
   return context;
 }

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -59,6 +59,7 @@ function createAmplifyConfig(context, amplifyResources, cloudAmplifyResources) {
       amplifyConfig = context.amplify.readJsonFile(targetFilePath);
     }
 
+    // Native GA release requires entire awsconfiguration inside amplifyconfiguration auth plugin
     const newAWSConfig = getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources);
     amplifyConfig = amplifyConfigHelper.generateConfig(context, amplifyConfig, newAWSConfig);
 


### PR DESCRIPTION
Create an auth block that contains the contents of awsconfiguration.json

*Issue #, if available:*

*Description of changes:*
Copy awsconfiguration.json contents into amplifyconfiguration.json according to specification in this readme: https://github.com/aws-amplify/amplify-android/tree/AuthCategory/aws-auth-cognito (step 11)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.