### PR TITLE
perf: use node's async esm module loader above node>=12

### DIFF
--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -1,3 +1,6 @@
 #!/usr/bin/env node
-require = require('esm')(module, { cache: false });
+const semver = require('semver');
+if (semver.compare(process.version, "v12.0.0") < 0) {
+  require = require('esm')(module, { cache: false });
+}
 require('../lib/index').run();

--- a/packages/amplify-cli/scripts/post-install.js
+++ b/packages/amplify-cli/scripts/post-install.js
@@ -1,4 +1,7 @@
-require = require('esm')(module, { cache: false });
+const semver = require('semver');
+if (semver.compare(process.version, 'v12.0.0') < 0) {
+  require = require('esm')(module, { cache: false });
+}
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const path = require('path');


### PR DESCRIPTION
*Description of changes:*

perf: If CLI is running under Node 12 or later, use its new async capable module loader instead of ESM package. This change affects the overall startup time for any command.

before:
```
> time amplify -v
amplify -v  0.64s user 0.10s system 120% cpu 0.613 total
```

after:
```
> time amplify-dev -v
amplify-dev -v  0.22s user 0.05s system 108% cpu 0.249 total
```

note: version 4.18.1 because it is running on dev build.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.