### PR TITLE
fix(amplify-appsync-simulator): support inline resolver templates 

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import {
   AppSyncMockFile,
   AppSyncSimulatorBaseResolverConfig,
   RESOLVER_KIND,
+  AppSyncSimulatorUnitResolverConfig,
 } from '../type-definition';
 
 jest.mock('../schema');
@@ -48,9 +49,10 @@ describe('AmplifyAppSyncSimulator', () => {
   });
 
   it('should retain the original configuration when config has error', () => {
-    const resolver: AppSyncSimulatorBaseResolverConfig = {
+    const resolver: AppSyncSimulatorUnitResolverConfig = {
       fieldName: 'echo',
       typeName: 'Query',
+      dataSourceName: 'echoFn',
       kind: RESOLVER_KIND.UNIT,
       requestMappingTemplateLocation: 'missing/Resolver.req.vtl',
       responseMappingTemplateLocation: 'missing/Resolver.resp.vtl',

--- a/packages/amplify-appsync-simulator/src/__tests__/resolvers/pipeline-resolver.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/resolvers/pipeline-resolver.test.ts
@@ -1,0 +1,202 @@
+import { AppSyncPipelineResolver } from '../../resolvers/pipeline-resolver';
+import { AmplifyAppSyncSimulator } from '../..';
+import { RESOLVER_KIND, AppSyncSimulatorPipelineResolverConfig } from '../../type-definition';
+describe('Pipeline Resolvers', () => {
+  const getFunction = jest.fn();
+  const getMappingTemplate = jest.fn();
+  const simulatorContext: AmplifyAppSyncSimulator = ({
+    getFunction,
+    getMappingTemplate,
+  } as any) as AmplifyAppSyncSimulator;
+  let baseConfig;
+  beforeEach(() => {
+    jest.resetAllMocks();
+    getFunction.mockReturnValue({ resolve: () => 'foo' });
+    getMappingTemplate.mockReturnValue('TEMPLATE');
+    baseConfig = {
+      fieldName: 'fn1',
+      typeName: 'Query',
+      kind: RESOLVER_KIND.PIPELINE,
+      functions: ['fn1', 'fn2'],
+    };
+  });
+  it('should initialize when the request and response mapping templates are inline templates', () => {
+    const config: AppSyncSimulatorPipelineResolverConfig = {
+      ...baseConfig,
+      requestMappingTemplate: 'request',
+      responseMappingTemplate: 'response',
+    };
+    expect(() => new AppSyncPipelineResolver(config, simulatorContext)).not.toThrow();
+    expect(getMappingTemplate).not.toHaveBeenCalled();
+  });
+
+  it('should work when the request and response mapping are external template', () => {
+    const config: AppSyncSimulatorPipelineResolverConfig = {
+      ...baseConfig,
+      requestMappingTemplateLocation: 'resolvers/request',
+      responseMappingTemplateLocation: 'resolvers/response',
+    };
+    expect(() => new AppSyncPipelineResolver(config, simulatorContext)).not.toThrow();
+    expect(getMappingTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw error when request templates are missing', () => {
+    getMappingTemplate.mockImplementation(() => {
+      throw new Error('Missing template');
+    });
+    expect(() => new AppSyncPipelineResolver(baseConfig, simulatorContext)).toThrowError('Missing request mapping template');
+    expect(getMappingTemplate).toHaveBeenCalled();
+  });
+
+  describe('resolve', () => {
+    let resolver: AppSyncPipelineResolver;
+    const baseConfig: AppSyncSimulatorPipelineResolverConfig = {
+      fieldName: 'fn1',
+      typeName: 'Query',
+      kind: RESOLVER_KIND.PIPELINE,
+      functions: ['fn1', 'fn2'],
+      requestMappingTemplateLocation: 'request',
+      responseMappingTemplateLocation: 'response',
+    };
+    let templates;
+    let fnImpl;
+    beforeEach(() => {
+      fnImpl = {
+        fn1: {
+          resolve: jest.fn().mockImplementation((source, args, stash, prevResult, context, info) => {
+            return {
+              result: 'FN1-RESULT',
+              stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'fn1'] },
+            };
+          }),
+        },
+        fn2: {
+          resolve: jest.fn().mockImplementation((source, args, stash, prevResult, context, info) => {
+            return {
+              result: 'FN2-RESULT',
+              stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'fn2'] },
+            };
+          }),
+        },
+      };
+      getFunction.mockImplementation(fnName => fnImpl[fnName]);
+      templates = {
+        request: {
+          render: jest.fn().mockImplementation(({ stash }) => ({
+            result: 'REQUEST_TEMPLATE_RESULT',
+            errors: [],
+            stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'REQUEST-MAPPING-TEMPLATE'] },
+          })),
+        },
+        response: {
+          render: jest.fn().mockImplementation(({ stash }) => ({
+            result: 'RESPONSE_TEMPLATE_RESULT',
+            errors: [],
+            stash: { ...stash, exeSeq: [...stash.exeSeq, 'fn2'] },
+          })),
+        },
+      };
+
+      getMappingTemplate.mockImplementation(templateName => templates[templateName]);
+      resolver = new AppSyncPipelineResolver(baseConfig, simulatorContext);
+    });
+
+    it('should render requestMapping template', async () => {
+      const source = 'SOURCE';
+      const args = { arg1: 'val' };
+      const context = {
+        appsyncErrors: [],
+      };
+      const info = {};
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual('RESPONSE_TEMPLATE_RESULT');
+      expect(templates['request'].render).toHaveBeenCalledWith(
+        {
+          source,
+          arguments: args,
+          stash: {},
+        },
+        context,
+        info,
+      );
+
+      expect(getMappingTemplate).toHaveBeenCalledTimes(4); // 2 times in constructor and 2 times for resolving
+      expect(getFunction).toHaveBeenCalled();
+    });
+
+    it('should pass stash and prevResult between functions and templates', async () => {
+      const source = 'SOURCE';
+      const args = { arg1: 'val' };
+      const context = {
+        appsyncErrors: [],
+      };
+      const info = {};
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual('RESPONSE_TEMPLATE_RESULT');
+      expect(fnImpl.fn1.resolve).toHaveBeenLastCalledWith(
+        source,
+        args,
+        { exeSeq: ['REQUEST-MAPPING-TEMPLATE'] },
+        'REQUEST_TEMPLATE_RESULT',
+        context,
+        info,
+      );
+
+      expect(fnImpl.fn2.resolve).toHaveBeenLastCalledWith(
+        source,
+        args,
+        { exeSeq: ['REQUEST-MAPPING-TEMPLATE', 'fn1'] },
+        'FN1-RESULT',
+        context,
+        info,
+      );
+
+      expect(templates['response'].render).toHaveBeenCalledWith(
+        {
+          source,
+          arguments: args,
+          prevResult: 'FN2-RESULT',
+          stash: { exeSeq: ['REQUEST-MAPPING-TEMPLATE', 'fn1', 'fn2'] },
+        },
+        context,
+        info,
+      );
+    });
+
+    it('should not call response mapping template when #return is called', async () => {
+      templates.request.render.mockReturnValue({ isReturn: true, result: 'REQUEST_TEMPLATE_RESULT', templateErrors: [] });
+      const source = 'SOURCE';
+      const args = { arg1: 'val' };
+      const context = {
+        appsyncErrors: [],
+      };
+      const info = {};
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual('REQUEST_TEMPLATE_RESULT');
+    });
+
+    it('should merge template errors', async () => {
+      templates.request.render.mockReturnValue({
+        isReturn: false,
+        stash: {},
+        result: 'REQUEST_TEMPLATE_RESULT',
+        errors: ['REQUEST_TEMPLATE_ERROR'],
+      });
+      templates.response.render.mockReturnValue({
+        isReturn: false,
+        result: 'RESPONSE_TEMPLATE_RESULT',
+        errors: ['RESPONSE_TEMPLATE_ERROR'],
+      });
+
+      const source = 'SOURCE';
+      const args = { arg1: 'val' };
+      const context = {
+        appsyncErrors: [],
+      };
+      const info = {};
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual('RESPONSE_TEMPLATE_RESULT');
+      expect(context.appsyncErrors).toEqual(['REQUEST_TEMPLATE_ERROR', 'RESPONSE_TEMPLATE_ERROR']);
+    });
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/resolvers/unit-resolver.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/resolvers/unit-resolver.test.ts
@@ -1,0 +1,176 @@
+import { AppSyncUnitResolver } from '../../resolvers/unit-resolver';
+import { AmplifyAppSyncSimulator } from '../..';
+import { RESOLVER_KIND, AppSyncSimulatorUnitResolverConfig } from '../../type-definition';
+
+describe('Unit resolver', () => {
+  const getDataLoader = jest.fn();
+  const getMappingTemplate = jest.fn();
+  const simulatorContext: AmplifyAppSyncSimulator = ({
+    getDataLoader,
+    getMappingTemplate,
+  } as any) as AmplifyAppSyncSimulator;
+  let baseConfig;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    getDataLoader.mockReturnValue({
+      load: () => {
+        return 'DATA';
+      },
+    });
+    getMappingTemplate.mockReturnValue('TEMPLATE');
+    baseConfig = {
+      fieldName: 'getPost',
+      typeName: 'Query',
+      kind: RESOLVER_KIND.UNIT,
+      dataSourceName: 'TodoTable',
+    };
+  });
+
+  it('should initialize when the request and response mapping templates are inline templates', () => {
+    const config: AppSyncSimulatorUnitResolverConfig = {
+      ...baseConfig,
+      requestMappingTemplate: 'request',
+      responseMappingTemplate: 'response',
+    };
+    expect(() => new AppSyncUnitResolver(config, simulatorContext)).not.toThrow();
+    expect(getMappingTemplate).not.toHaveBeenCalled();
+  });
+
+  it('should work when the request and response mapping are external template', () => {
+    const config: AppSyncSimulatorUnitResolverConfig = {
+      ...baseConfig,
+      requestMappingTemplateLocation: 'resolvers/request',
+      responseMappingTemplateLocation: 'resolvers/response',
+    };
+    expect(() => new AppSyncUnitResolver(config, simulatorContext)).not.toThrow();
+    expect(getMappingTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw error when request templates are missing', () => {
+    getMappingTemplate.mockImplementation(() => {
+      throw new Error('Missing template');
+    });
+    expect(() => new AppSyncUnitResolver(baseConfig, simulatorContext)).toThrowError('Missing request mapping template');
+    expect(getMappingTemplate).toHaveBeenCalled();
+  });
+
+  describe('resolve', () => {
+    let templates;
+    let resolver;
+
+    const info = {};
+    const DATA_FROM_DATA_SOURCE = 'DATA FROM DATA SOURCE';
+    const REQUEST_TEMPLATE_RESULT = {
+      version: '2017-02-29',
+      result: 'REQUEST_TEMPLATE_RESULT',
+    };
+    const RESPONSE_TEMPLATE_RESULT = {
+      version: '2017-02-29',
+      data: 'RESPONSE_TEMPLATE_RESULT',
+    };
+    let dataFetcher;
+
+    const source = 'SOURCE';
+    const args = { key: 'value' };
+    const context = {
+      appsyncErrors: [],
+    };
+
+    beforeEach(() => {
+      context.appsyncErrors = [];
+      templates = {
+        request: {
+          render: jest.fn().mockImplementation(() => ({
+            result: REQUEST_TEMPLATE_RESULT,
+            errors: [],
+          })),
+        },
+        response: {
+          render: jest.fn().mockImplementation(() => ({
+            result: RESPONSE_TEMPLATE_RESULT,
+            errors: [],
+          })),
+        },
+      };
+
+      dataFetcher = jest.fn().mockResolvedValue(DATA_FROM_DATA_SOURCE);
+
+      getDataLoader.mockReturnValue({
+        load: dataFetcher,
+      });
+      getMappingTemplate.mockImplementation(templateName => {
+        return templates[templateName];
+      });
+
+      resolver = new AppSyncUnitResolver(
+        { ...baseConfig, requestMappingTemplateLocation: 'request', responseMappingTemplateLocation: 'response' },
+        simulatorContext,
+      );
+    });
+
+    it('should resolve', async () => {
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual(RESPONSE_TEMPLATE_RESULT);
+      expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
+      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(getDataLoader).toBeCalledWith('TodoTable');
+      expect(templates.response.render).toHaveBeenCalledWith({ source, arguments: args, result: DATA_FROM_DATA_SOURCE }, context, info);
+    });
+
+    it('should not call the response mapping template with template version 2017-02-29 and data fetcher throws error', async () => {
+      dataFetcher.mockImplementation(() => {
+        throw new Error('Some request template error');
+      });
+
+      await expect(() => resolver.resolve(source, args, context, info)).rejects.toThrowError('Some request template error');
+      expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
+      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(getDataLoader).toBeCalledWith('TodoTable');
+      expect(templates.response.render).not.toHaveBeenCalled();
+    });
+
+    it('should render response mapping when data fetcher throws error and template version is 2018-05-29', async () => {
+      REQUEST_TEMPLATE_RESULT.version = '2018-05-29';
+      const error = new Error('Some request template error');
+      dataFetcher.mockImplementation(() => {
+        throw error;
+      });
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual(RESPONSE_TEMPLATE_RESULT);
+      expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
+      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(getDataLoader).toBeCalledWith('TodoTable');
+      expect(templates.response.render).toHaveBeenCalledWith({ source, arguments: args, error: error, result: null }, context, info);
+    });
+
+    it('should not render response mapping template when #return is used in request mapping template', async () => {
+      REQUEST_TEMPLATE_RESULT.version = '2018-05-29';
+      templates.request.render.mockReturnValue({
+        ...REQUEST_TEMPLATE_RESULT,
+        errors: [],
+        isReturn: true,
+      });
+
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual(REQUEST_TEMPLATE_RESULT.result);
+      expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
+      expect(dataFetcher).not.toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(templates.response.render).not.toHaveBeenCalled();
+    });
+
+    it('should collect all the errors in context object', async () => {
+      templates.request.render.mockReturnValue({
+        ...REQUEST_TEMPLATE_RESULT,
+        errors: ['request error'],
+      });
+      templates.response.render.mockReturnValue({
+        ...REQUEST_TEMPLATE_RESULT,
+        errors: ['response error'],
+      });
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual(REQUEST_TEMPLATE_RESULT.result);
+      expect(context.appsyncErrors).toEqual(['request error', 'response error']);
+    });
+  });
+});

--- a/packages/amplify-appsync-simulator/src/index.ts
+++ b/packages/amplify-appsync-simulator/src/index.ts
@@ -85,17 +85,7 @@ export class AmplifyAppSyncSimulator {
 
       this.functions = (config.functions || []).reduce((map, fn) => {
         const { dataSourceName, requestMappingTemplateLocation, responseMappingTemplateLocation } = fn;
-        map.set(
-          fn.name,
-          new AmplifySimulatorFunction(
-            {
-              dataSourceName,
-              requestMappingTemplateLocation: requestMappingTemplateLocation,
-              responseMappingTemplateLocation: responseMappingTemplateLocation,
-            },
-            this,
-          ),
-        );
+        map.set(fn.name, new AmplifySimulatorFunction(fn, this));
         return map;
       }, new Map());
 

--- a/packages/amplify-appsync-simulator/src/resolvers/base-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/base-resolver.ts
@@ -1,0 +1,46 @@
+import { AmplifyAppSyncSimulator } from '..';
+import { AppSyncSimulatorBaseResolverConfig } from '../type-definition';
+import { VelocityTemplate } from '../velocity';
+
+export abstract class AppSyncBaseResolver {
+  constructor(protected config: AppSyncSimulatorBaseResolverConfig, protected simulatorContext: AmplifyAppSyncSimulator) {
+    try {
+      this.getResponseMappingTemplate();
+    } catch (e) {
+      throw new Error(`Missing request mapping template`);
+    }
+
+    try {
+      this.getResponseMappingTemplate();
+    } catch (e) {
+      throw new Error(`Missing request mapping template`);
+    }
+  }
+  // abstract async resolve(source, args, context, info): Promise<any>;
+
+  protected getResponseMappingTemplate(): VelocityTemplate {
+    if (this.config.responseMappingTemplate) {
+      return new VelocityTemplate(
+        {
+          path: 'INLINE_TEMPLATE',
+          content: this.config.responseMappingTemplate,
+        },
+        this.simulatorContext,
+      );
+    }
+    return this.simulatorContext.getMappingTemplate(this.config.responseMappingTemplateLocation);
+  }
+
+  protected getRequestMappingTemplate(): VelocityTemplate {
+    if (this.config.requestMappingTemplate) {
+      return new VelocityTemplate(
+        {
+          path: 'INLINE_TEMPLATE',
+          content: this.config.requestMappingTemplate,
+        },
+        this.simulatorContext,
+      );
+    }
+    return this.simulatorContext.getMappingTemplate(this.config.requestMappingTemplateLocation);
+  }
+}

--- a/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
@@ -33,26 +33,22 @@ export class AppSyncPipelineResolver extends AppSyncBaseResolver {
       info,
     ));
 
-    context.appsyncErrors = [...context.appsyncErrors, ...templateErrors];
+    context.appsyncErrors = [...context.appsyncErrors, ...(templateErrors || [])];
 
     if (isReturn) {
       //Request mapping template called #return, don't process further
       return result;
     }
 
-    let prevResult;
+    let prevResult = result;
     for (let fnName of this.config.functions) {
       const fnResolver = this.simulatorContext.getFunction(fnName);
       ({ result: prevResult, stash } = await fnResolver.resolve(source, args, stash, prevResult, context, info));
     }
 
     // pipeline response mapping template
-    ({ result, errors: templateErrors } = responseMappingTemplate.render(
-      { source, arguments: args, result, prevResult, stash },
-      context,
-      info,
-    ));
-    context.appsyncErrors = [...context.appsyncErrors, ...templateErrors];
+    ({ result, errors: templateErrors } = responseMappingTemplate.render({ source, arguments: args, prevResult, stash }, context, info));
+    context.appsyncErrors = [...context.appsyncErrors, ...(templateErrors || [])];
     return result;
   }
 }

--- a/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
@@ -1,12 +1,12 @@
 import { AmplifyAppSyncSimulator } from '..';
 import { AppSyncSimulatorUnitResolverConfig } from '../type-definition';
+import { AppSyncBaseResolver } from './base-resolver';
 
-export class AppSyncUnitResolver {
-  private config: AppSyncSimulatorUnitResolverConfig;
-  constructor(config: AppSyncSimulatorUnitResolverConfig, private simulatorContext: AmplifyAppSyncSimulator) {
+export class AppSyncUnitResolver extends AppSyncBaseResolver {
+  protected config: AppSyncSimulatorUnitResolverConfig;
+  constructor(config: AppSyncSimulatorUnitResolverConfig, simulatorContext: AmplifyAppSyncSimulator) {
+    super(config, simulatorContext);
     try {
-      simulatorContext.getMappingTemplate(config.requestMappingTemplateLocation);
-      simulatorContext.getMappingTemplate(config.responseMappingTemplateLocation);
       simulatorContext.getDataLoader(config.dataSourceName);
     } catch (e) {
       throw new Error(`Invalid config for UNIT_RESOLVER ${JSON.stringify(config)} \n ${e.message}`);
@@ -18,9 +18,9 @@ export class AppSyncUnitResolver {
     this.config = config;
   }
 
-  async resolve(source, args, context, info) {
-    const requestMappingTemplate = this.simulatorContext.getMappingTemplate(this.config.requestMappingTemplateLocation);
-    const responseMappingTemplate = this.simulatorContext.getMappingTemplate(this.config.responseMappingTemplateLocation);
+  async resolve(source, args, context, info): Promise<any> {
+    const requestMappingTemplate = this.getRequestMappingTemplate();
+    const responseMappingTemplate = this.getResponseMappingTemplate();
     const dataLoader = this.simulatorContext.getDataLoader(this.config.dataSourceName);
     const { result: requestPayload, errors: requestTemplateErrors, isReturn } = requestMappingTemplate.render(
       { source, arguments: args },

--- a/packages/amplify-appsync-simulator/src/schema/index.ts
+++ b/packages/amplify-appsync-simulator/src/schema/index.ts
@@ -1,7 +1,7 @@
 import { buildASTSchema, concatAST, DocumentNode, GraphQLObjectType, parse, Source } from 'graphql';
 import { makeExecutableSchema } from 'graphql-tools';
 import { AmplifyAppSyncSimulator } from '..';
-import { AppSyncSimulatorBaseResolverConfig } from '../type-definition';
+import { AppSyncSimulatorPipelineResolverConfig, AppSyncSimulatorUnitResolverConfig } from '../type-definition';
 import { scalars } from './appsync-scalars';
 import { AwsAuth, AwsSubscribe, protectResolversWithAuthRules } from './directives';
 import { AppSyncSimulatorDirectiveBase } from './directives/directive-base';
@@ -12,7 +12,7 @@ const KNOWN_DIRECTIVES: {
 
 export function generateResolvers(
   schema: Source,
-  resolversConfig: AppSyncSimulatorBaseResolverConfig[] = [],
+  resolversConfig: (AppSyncSimulatorUnitResolverConfig | AppSyncSimulatorPipelineResolverConfig)[] = [],
   simulatorContext: AmplifyAppSyncSimulator,
 ) {
   const appSyncScalars = new Source(
@@ -105,7 +105,7 @@ export function generateResolvers(
 
 function generateDefaultSubscriptions(
   doc: DocumentNode,
-  configuredResolvers: AppSyncSimulatorBaseResolverConfig[],
+  configuredResolvers: (AppSyncSimulatorUnitResolverConfig | AppSyncSimulatorPipelineResolverConfig)[],
   simulatorContext: AmplifyAppSyncSimulator,
 ) {
   const configuredSubscriptions = configuredResolvers.filter(cfg => cfg.fieldName === 'Subscription').map(cfg => cfg.typeName);

--- a/packages/amplify-appsync-simulator/src/type-definition.ts
+++ b/packages/amplify-appsync-simulator/src/type-definition.ts
@@ -14,35 +14,31 @@ export enum RESOLVER_KIND {
   UNIT = 'UNIT',
   PIPELINE = 'PIPELINE',
 }
+
 export interface AppSyncSimulatorBaseResolverConfig {
-  kind: RESOLVER_KIND;
-  fieldName: string;
-  typeName: string;
-  requestMappingTemplateLocation: string;
-  responseMappingTemplateLocation: string;
+  requestMappingTemplateLocation?: string;
+  responseMappingTemplateLocation?: string;
+  requestMappingTemplate?: string;
+  responseMappingTemplate?: string;
 }
 export interface AppSyncSimulatorUnitResolverConfig extends AppSyncSimulatorBaseResolverConfig {
   kind: RESOLVER_KIND.UNIT;
   fieldName: string;
   typeName: string;
-  requestMappingTemplateLocation: string;
-  responseMappingTemplateLocation: string;
   dataSourceName: string;
 }
 export interface AppSyncSimulatorPipelineResolverConfig extends AppSyncSimulatorBaseResolverConfig {
-  requestMappingTemplateLocation: string;
-  responseMappingTemplateLocation: string;
+  kind: RESOLVER_KIND.PIPELINE;
   typeName: string;
   fieldName: string;
   functions: string[];
 }
-export interface AppSyncSimulatorFunctionResolverConfig {
+export interface AppSyncSimulatorFunctionResolverConfig extends AppSyncSimulatorBaseResolverConfig {
   dataSourceName: string;
-  requestMappingTemplateLocation: string;
-  responseMappingTemplateLocation: string;
 }
 export type AppSyncSimulatorMappingTemplate = AppSyncMockFile;
 export type AppSyncSimulatorTable = string;
+
 export interface AppSyncSimulatorUnitResolver extends AppSyncSimulatorUnitResolverConfig {
   datSourceName: string;
 }
@@ -122,7 +118,7 @@ export type AmplifyAppSyncAPIConfig = {
 
 export type AmplifyAppSyncSimulatorConfig = {
   schema: AppSyncSimulatorSchemaConfig;
-  resolvers?: AppSyncSimulatorBaseResolverConfig[];
+  resolvers?: (AppSyncSimulatorUnitResolverConfig | AppSyncSimulatorPipelineResolverConfig)[];
   functions?: AppSyncSimulatorFunctionsConfig[];
   dataSources?: AppSyncSimulatorDataSourceConfig[];
   mappingTemplates?: AppSyncSimulatorMappingTemplate[];

--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -29,8 +29,10 @@ export function processApiResources(
       case 'AWS::AppSync::Resolver':
         appSyncConfig.resolvers.push({
           ...result,
-          requestMappingTemplateLocation: result.requestMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
-          responseMappingTemplateLocation: result.responseMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
+          requestMappingTemplateLocation:
+            result.requestMappingTemplateLocation && result.requestMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
+          responseMappingTemplateLocation:
+            result.responseMappingTemplateLocation && result.responseMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
         });
         break;
       case 'AWS::DynamoDB::Table':
@@ -39,8 +41,10 @@ export function processApiResources(
       case 'AWS::AppSync::FunctionConfiguration':
         appSyncConfig.functions.push({
           ...result,
-          requestMappingTemplateLocation: result.requestMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
-          responseMappingTemplateLocation: result.responseMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
+          requestMappingTemplateLocation:
+            result.requestMappingTemplateLocation && result.requestMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
+          responseMappingTemplateLocation:
+            result.responseMappingTemplateLocation && result.responseMappingTemplateLocation.replace(RESOLVER_TEMPLATE_LOCATION_PREFIX, ''),
         });
         break;
       case 'AWS::AppSync::GraphQLSchema':

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -170,16 +170,27 @@ export type AppSyncResolverProcessedResource = CloudFormationProcessedResourceRe
   functions: string[];
   typeName: string;
   fieldName: string;
-  requestMappingTemplateLocation: string;
-  responseMappingTemplateLocation: string;
+  requestMappingTemplateLocation?: string;
+  responseMappingTemplateLocation?: string;
+  requestMappingTemplate?: string;
+  responseMappingTemplate?: string;
   ResolverArn: string;
   kind: 'UNIT' | 'PIPELINE';
 };
 
 export function appSyncResolverHandler(resourceName, resource, cfnContext: CloudFormationParseContext): AppSyncResolverProcessedResource {
   const { Properties: properties } = resource;
-  const requestMappingTemplate = parseValue(properties.RequestMappingTemplateS3Location, cfnContext);
-  const responseMappingTemplate = parseValue(properties.ResponseMappingTemplateS3Location, cfnContext);
+  const requestMappingTemplateLocation = properties.RequestMappingTemplateS3Location
+    ? parseValue(properties.RequestMappingTemplateS3Location, cfnContext)
+    : undefined;
+  const responseMappingTemplateLocation = properties.ResponseMappingTemplateS3Location
+    ? parseValue(properties.ResponseMappingTemplateS3Location, cfnContext)
+    : undefined;
+  const requestMappingTemplate = properties.RequestMappingTemplate ? parseValue(properties.RequestMappingTemplate, cfnContext) : undefined;
+  const responseMappingTemplate = properties.ResponseMappingTemplate
+    ? parseValue(properties.ResponseMappingTemplate, cfnContext)
+    : undefined;
+
   let dataSourceName;
   let functions;
 
@@ -198,8 +209,10 @@ export function appSyncResolverHandler(resourceName, resource, cfnContext: Cloud
     typeName: properties.TypeName,
     functions,
     fieldName: properties.FieldName,
-    requestMappingTemplateLocation: requestMappingTemplate,
-    responseMappingTemplateLocation: responseMappingTemplate,
+    requestMappingTemplateLocation: requestMappingTemplateLocation,
+    responseMappingTemplateLocation: responseMappingTemplateLocation,
+    requestMappingTemplate,
+    responseMappingTemplate,
     kind: properties.Kind || 'UNIT',
     ResolverArn: `arn:aws:appsync:us-east-1:123456789012:apis/graphqlapiid/types/${properties.TypeName}/resolvers/${properties.FieldName}`,
   };
@@ -209,14 +222,24 @@ export type AppSyncFunctionProcessedResource = CloudFormationProcessedResourceRe
   dataSourceName: string;
   ref: string;
   name: string;
-  requestMappingTemplateLocation: string;
-  responseMappingTemplateLocation: string;
+  requestMappingTemplateLocation?: string;
+  responseMappingTemplateLocation?: string;
+  requestMappingTemplate?: string;
+  responseMappingTemplate?: string;
 };
 
 export function appSyncFunctionHandler(resourceName, resource, cfnContext: CloudFormationParseContext): AppSyncFunctionProcessedResource {
   const { Properties: properties } = resource;
-  const requestMappingTemplate = parseValue(properties.RequestMappingTemplateS3Location, cfnContext);
-  const responseMappingTemplate = parseValue(properties.ResponseMappingTemplateS3Location, cfnContext);
+  const requestMappingTemplateLocation = properties.RequestMappingTemplateS3Location
+    ? parseValue(properties.RequestMappingTemplateS3Location, cfnContext)
+    : undefined;
+  const responseMappingTemplateLocation = properties.ResponseMappingTemplateS3Location
+    ? parseValue(properties.ResponseMappingTemplateS3Location, cfnContext)
+    : undefined;
+  const requestMappingTemplate = properties.RequestMappingTemplate ? parseValue(properties.RequestMappingTemplate, cfnContext) : undefined;
+  const responseMappingTemplate = properties.ResponseMappingTemplate
+    ? parseValue(properties.ResponseMappingTemplate, cfnContext)
+    : undefined;
 
   const dataSourceName = parseValue(properties.DataSourceName, cfnContext);
   return {
@@ -224,7 +247,9 @@ export function appSyncFunctionHandler(resourceName, resource, cfnContext: Cloud
     cfnExposedAttributes: { DataSourceName: 'dataSourceName', FunctionArn: 'Ref', FunctionId: 'name', Name: 'name' },
     name: resource.Properties.Name,
     dataSourceName,
-    requestMappingTemplateLocation: requestMappingTemplate,
-    responseMappingTemplateLocation: responseMappingTemplate,
+    requestMappingTemplateLocation: requestMappingTemplateLocation,
+    responseMappingTemplateLocation: responseMappingTemplateLocation,
+    requestMappingTemplate,
+    responseMappingTemplate,
   };
 }

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -111,6 +111,7 @@ export class APITest {
   private async reload(context, filePath, action) {
     const apiDir = await this.getAPIBackendDirectory(context);
     const inputSchemaPath = path.join(apiDir, 'schema');
+    const customStackPath = path.join(apiDir, 'stacks');
     const parameterFilePath = await this.getAPIParameterFilePath(context);
     try {
       let shouldReload;
@@ -143,6 +144,11 @@ export class APITest {
       } else if (filePath.includes(parameterFilePath)) {
         context.print.info('API Parameter change detected. Reloading...');
         this.apiParameters = await this.loadAPIParameters(context);
+        const config = await this.runTransformer(context, this.apiParameters);
+        await this.appSyncSimulator.reload(config);
+        await this.generateCode(context);
+      } else if (filePath.includes(customStackPath)) {
+        context.print.info('Custom stack change detected. Reloading...');
         const config = await this.runTransformer(context, this.apiParameters);
         await this.appSyncSimulator.reload(config);
         await this.generateCode(context);


### PR DESCRIPTION
Updated mock to support inline resolver templates

fix #3834