### PR TITLE
fix(amplify-category-auth): create a new name when generating user roles

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -13,6 +13,7 @@ const roles = {
 };
 
 const generalDefaults = projectName => ({
+  sharedId,
   resourceName: `${projectName}${sharedId}`,
   resourceNameTruncated: `${projectName.substring(0, 6)}${sharedId}`,
   authSelections: 'identityPoolAndUserPool',

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/cloudformation-templates/auth-template.yml.ejs
@@ -73,7 +73,7 @@ Resources:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',[ 'sns', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
+      RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',[ 'sns', '<%=`${props.sharedId}`%>', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"
         Statement: 
@@ -325,7 +325,7 @@ Resources:
   # Created to execute Lambda which gets userpool app client config values
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',['upClientLambdaRole', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
+      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',['upClientLambdaRole', '<%=`${props.sharedId}`%>', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -20,6 +20,24 @@ export function addAuthWithDefault(cwd: string, settings: any) {
   });
 }
 
+export function removeAuthWithDefault(cwd: string, settings: any) {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['remove', 'auth'], { cwd, stripColors: true })
+      .wait('Choose the resource you would want to remove')
+      .sendCarriageReturn()
+      .wait('Are you sure you want to delete the resource? This')
+      .sendLine('y')
+      .sendEof()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
 export function addAuthWithGroupTrigger(cwd: string, settings: any) {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['add', 'auth'], { cwd, stripColors: true })

--- a/packages/amplify-e2e-tests/src/__tests__/auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'amplify-e2e-core';
 import {
   addAuthWithDefault,
+  removeAuthWithDefault,
   addAuthWithDefaultSocial,
   addAuthWithGroupTrigger,
   addAuthWithRecaptchaTrigger,
@@ -55,6 +56,15 @@ describe('amplify add auth...', () => {
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
+  });
+
+  it('...should init a project and add auth with defaults and then remove auth and add another auth and push', async () => {
+    await initJSProjectWithProfile(projRoot, defaultsSettings);
+    await addAuthWithDefault(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    await removeAuthWithDefault(projRoot);
+    await addAuthWithDefault(projRoot, {});
+    await amplifyPushAuth(projRoot);
   });
 
   it('...should init a project and add auth with defaultSocial', async () => {


### PR DESCRIPTION

*Issue #, if available:*
#4186

*Description of changes:*
Fixes issues with creating auth pushing and then removing it and pushing a newly configured auth


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.