### PR TITLE
fix: match dotnet version per line

### DIFF
--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/detect.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/detect.ts
@@ -22,7 +22,7 @@ export const detectDotNetCore = async (): Promise<CheckDependenciesResult> => {
   if (sdkResult.exitCode !== 0) {
     throw new Error(`${executableName} failed SDK detection, exit code was ${sdkResult.exitCode}`);
   }
-  const sdkInstalled = installedSdks && installedSdks.match(/^3\.1/);
+  const sdkInstalled = installedSdks && installedSdks.match(/^3\.1/m);
 
   const toolResult = execa.sync(executableName, ['tool', 'list', '--global']);
   const installedToolList = toolResult.stdout;


### PR DESCRIPTION
*Issue #, if available:*
#4226

*Description of changes:*
Dotnet version regex matched the first version in the list rather than any version in the list. Change to match per line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.