### PR TITLE
feat(packages/amplify-codegen-appsync-model-plugin): add support for keyName in connection

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/utils/process-connections.test.ts
@@ -278,11 +278,9 @@ describe('process connection', () => {
       };
     });
 
-    it('should throw error if connection directive has keyName', () => {
+    it('should not throw error if connection directive has keyName', () => {
       const commentsField = modelMap.Post.fields[0];
-      expect(() => processConnections(commentsField, modelMap.Post, modelMap)).toThrowError(
-        'DataStore does not support connection directive with keyName',
-      );
+      expect(() => processConnections(commentsField, modelMap.Post, modelMap)).not.toThrowError();
     });
 
     it('should support connection with @key on BELONGS_TO side', () => {

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -452,7 +452,7 @@ describe('AppSyncSwiftVisitor', () => {
     });
 
     describe('connection with key directive', () => {
-      it('should support throw error when connection has keyName', () => {
+      it('should not throw error when connection has keyName', () => {
         const schema = /* GraphQL */ `
           type Post @model {
             id: ID!
@@ -480,7 +480,7 @@ describe('AppSyncSwiftVisitor', () => {
           }
         `;
         const postVisitor = getVisitor(schema, 'Post');
-        expect(() => postVisitor.generate()).toThrowError('connection directive with keyName');
+        expect(() => postVisitor.generate()).not.toThrowError();
       });
 
       it('should support connection directive with fields', () => {

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-connections.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-connections.ts
@@ -51,16 +51,14 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
   if (connectionFields) {
     let keyDirective;
     if (keyName) {
-      throw new Error('DataStore does not support connection directive with keyName');
-      // When the library starts supporting remove the exception
-      // keyDirective = connectedModel.directives.find(dir => {
-      //   return dir.name === 'key' && dir.arguments.name === keyName;
-      // });
-      // if (!keyDirective) {
-      //   throw new Error(
-      //     `Error processing @connection directive on ${model.name}.${field.name}, @key directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
-      //   );
-      // }
+      keyDirective = connectedModel.directives.find(dir => {
+        return dir.name === 'key' && dir.arguments.name === keyName;
+      });
+      if (!keyDirective) {
+        throw new Error(
+          `Error processing @connection directive on ${model.name}.${field.name}, @key directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
+        );
+      }
     } else {
       keyDirective = connectedModel.directives.find(dir => {
         return dir.name === 'key' && typeof dir.arguments.name === 'undefined';


### PR DESCRIPTION
Update modelgen to support @connection directive with `keyName`. 

related change in Amplify JS: https://github.com/aws-amplify/amplify-js/pull/5778

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.