### PR TITLE
feat(amplify-app): group amplify files in xcode integration

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -6,7 +6,7 @@ const emoji = require('node-emoji');
 const { spawnSync, spawn } = require('child_process');
 const frameworkConfigMapping = require('./framework-config-mapping');
 const args = require('yargs').argv;
-const { addDataStoreFiles } = require('./xcodeHelpers');
+const { addAmplifyFiles } = require('./xcodeHelpers');
 const ini = require('ini');
 const semver = require('semver');
 const stripAnsi = require('strip-ansi');
@@ -400,9 +400,8 @@ async function createIosHelperFiles() {
     fs.writeFileSync(amplifyConfigFile, configJsonStr);
   }
 
-  // add models and schema
   if (fs.existsSync(amplifyDir)) {
-    await addDataStoreFiles();
+    await addAmplifyFiles();
   }
 }
 

--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -6,7 +6,7 @@ const emoji = require('node-emoji');
 const { spawnSync, spawn } = require('child_process');
 const frameworkConfigMapping = require('./framework-config-mapping');
 const args = require('yargs').argv;
-const { addFileToXcodeProj } = require('./xcodeHelpers');
+const { addDataStoreFiles } = require('./xcodeHelpers');
 const ini = require('ini');
 const semver = require('semver');
 const stripAnsi = require('strip-ansi');
@@ -375,7 +375,7 @@ async function createAndroidHelperFiles() {
 }
 
 async function createIosHelperFiles() {
-  const configFile = './amplifyxc.config';
+  const configFile = './amplifytools.xcconfig';
   const awsConfigFile = './awsconfiguration.json';
   const amplifyConfigFile = './amplifyconfiguration.json';
   const amplifyDir = './amplify';
@@ -391,20 +391,18 @@ async function createIosHelperFiles() {
     configxc.envName = 'amplify';
     fs.writeFileSync(configFile, ini.stringify(configxc));
   }
-  await addFileToXcodeProj(configFile);
 
   if (!fs.existsSync(awsConfigFile)) {
     fs.writeFileSync(awsConfigFile, configJsonStr);
   }
-  await addFileToXcodeProj(awsConfigFile, true);
 
   if (!fs.existsSync(amplifyConfigFile)) {
     fs.writeFileSync(amplifyConfigFile, configJsonStr);
   }
-  await addFileToXcodeProj(amplifyConfigFile, true);
 
+  // add models and schema
   if (fs.existsSync(amplifyDir)) {
-    await addFileToXcodeProj(amplifyDir);
+    await addDataStoreFiles();
   }
 }
 
@@ -462,10 +460,10 @@ async function showIOSHelpText() {
   console.log();
   console.log(chalk.green('Some next steps:'));
   console.log(
-    'Setting "modelgen" to true in amplifyxc.config will allow you to generate models/entities for your GraphQL models in your next xcode build',
+    'Setting "modelgen" to true in amplifytools.xcconfig will allow you to generate models/entities for your GraphQL models in your next xcode build',
   );
   console.log(
-    'Setting "push" to true in the amplifyxc.config will build all your local backend resources and provision them in the cloud in your next xcode build',
+    'Setting "push" to true in the amplifytools.xcconfig will build all your local backend resources and provision them in the cloud in your next xcode build',
   );
   console.log('');
 }

--- a/packages/amplify-app/src/xcodeHelpers.js
+++ b/packages/amplify-app/src/xcodeHelpers.js
@@ -1,12 +1,37 @@
 const xcode = require('xcode');
+const glob = require('glob');
 const path = require('path');
 const fs = require('fs-extra');
 
-async function getXcodeProjectDir() {
-  const EXTENSION = '.xcodeproj';
+/**
+ * @typedef {Object} PBXGroup
+ * @property {Array<object|string>} children
+ * @property {string} isa
+ * @property {string|undefined} name
+ * @property {string|undefined} path
+ * @property {string} sourceTree
+ */
+
+/**
+ * @typedef {Object} PBXGroupRef
+ * @property {string} uuid
+ * @property {PBXGroup} pbxGroup
+ */
+
+/**
+ * @private
+ * Xcode project extension.
+ */
+const XCODE_PROJ_EXTENSION = '.xcodeproj';
+
+/**
+ * @private
+ * @returns {string}
+ */
+function getXcodeProjectDir() {
   const files = fs.readdirSync(process.cwd());
   const targetFiles = files.filter(function extenstionFilter(file) {
-    return path.extname(file).toLowerCase() === EXTENSION;
+    return path.extname(file).toLowerCase() === XCODE_PROJ_EXTENSION;
   });
   let projDir;
   if (targetFiles.length) {
@@ -15,42 +40,143 @@ async function getXcodeProjectDir() {
   return projDir;
 }
 
-async function addFileToXcodeProj(file, isResource) {
-  const projectPath = await getXcodeProjectDir();
-  // Silently return if not in same directory as xcode project
-  if (!projectPath) {
-    return;
+/**
+ * @private
+ * @param {object} project
+ * @param {string} name
+ * @returns {PBXGroupRef|undefined}
+ */
+function getGroupByName(project, name) {
+  /** @type PBXGroupRef */
+  let rootGroup = null;
+
+  const groups = Object.entries(project.hash.project.objects.PBXGroup);
+  for (let i = 0; i < groups.length; i++) {
+    const [key, value] = groups[i];
+    // console.log(value);
+    if (typeof value !== 'string') {
+      // only the root pbx group can have no name, path or description
+      const isRoot = name === undefined && value.name === undefined && value.path === undefined;
+      const matchesName = typeof name === 'string' && (value.name === name || value.path === name);
+
+      if (isRoot || matchesName) {
+        rootGroup = {
+          uuid: key,
+          pbxGroup: value,
+        };
+        break;
+      }
+    }
   }
-  const myProj = xcode.project(projectPath);
-  return new Promise((resolve, reject) =>
-    myProj.parse(function parseCallback(err) {
-      // hash of the group we add the files to, in this case the root of the xcode project
-      let hash = '';
-      Object.entries(myProj.hash.project.objects.PBXGroup).forEach(entry => {
-        const [key, value] = entry;
-        // only the root pbx group can have no name, path or description
-        if (typeof value !== 'string' && value.name === undefined && value.path === undefined) {
-          hash = key;
+  return rootGroup;
+}
+
+/**
+ * @private
+ * @param {object} project
+ * @returns {PBXGroupRef|undefined}
+ */
+function getRootGroup(project) {
+  return getGroupByName(project);
+}
+
+/**
+ * @private
+ * @param {object} project
+ * @param {string} name
+ * @returns {PBXGroupRef}
+ */
+function getOrCreateGroup(project, name) {
+  let group = getGroupByName(project, name);
+  if (!group) {
+    group = project.addPbxGroup([], name, '.');
+    const rootGroup = getRootGroup(project);
+    rootGroup.pbxGroup.children = [{ value: group.uuid, comment: group.pbxGroup.name }, ...rootGroup.pbxGroup.children];
+  }
+  return group;
+}
+
+/**
+ * @private
+ * @param {PBXGroupRef} group
+ * @param {string} name
+ * @returns {boolean}
+ */
+function groupHasFile(group, name) {
+  return group.pbxGroup.children.filter(child => child.comment === name).length > 0;
+}
+
+/**
+ * @public
+ * @return {Promise<void>}
+ */
+async function addDataStoreFiles() {
+  const projectDir = getXcodeProjectDir();
+  const rootDir = path.resolve(projectDir, '..', '..');
+  const project = xcode.project(projectDir);
+  return new Promise((resolve, reject) => {
+    const schemaFilePattern = path.join(rootDir, 'amplify', 'backend', 'api', '*', 'schema.graphql');
+    const [schemaFile] = glob.sync(schemaFilePattern);
+    if (!schemaFile) {
+      reject(new Error('schema.graphql file not found'));
+      return;
+    }
+
+    project.parse(error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      const rootGroup = getRootGroup(project);
+      if (rootGroup == null || typeof rootGroup.uuid !== 'string') {
+        reject(new Error('Could not find root group of Xcode project'));
+        return;
+      }
+
+      try {
+        // step 1: add generated models
+        const modelsFilePattern = path.join(rootDir, 'amplify', 'generated', 'models', '*.swift');
+        const modelFiles = glob.sync(modelsFilePattern).map(file => {
+          return path.relative(rootDir, file);
+        });
+        if (modelFiles && modelFiles.length > 0) {
+          const modelsGroup = getOrCreateGroup(project, 'AmplifyModels');
+          modelFiles.forEach(file => {
+            const { base: filename } = path.parse(file);
+            if (!groupHasFile(modelsGroup, filename)) {
+              console.log(`adding model source file... ${file}`);
+              project.addSourceFile(file, {}, modelsGroup.uuid);
+            }
+          });
         }
-      });
 
-      if (isResource) {
-        myProj.addPbxGroup([], 'Resources', 'Resources', '"<group>"');
-        myProj.addResourceFile(file, null, hash);
-        myProj.removePbxGroup('Resources');
-      } else {
-        myProj.addFile(file, hash, null);
-      }
+        // step 2: add configuration, schema and other amplify resources
+        const amplifyConfigGroup = getOrCreateGroup(project, 'AmplifyConfig');
 
-      fs.writeFileSync(projectPath, myProj.writeSync());
-      if (err) {
-        reject(err);
+        // add the amplifytools config file
+        project.addFile('./amplifytools.xcconfig', amplifyConfigGroup.uuid);
+
+        // adding resources (i.e. files that are added to the app bundle)
+        project.addPbxGroup([], 'Resources', 'Resources', '"<group>"');
+        project.addResourceFile('amplifyconfiguration.json', null, amplifyConfigGroup.uuid);
+        project.addResourceFile('awsconfiguration.json', null, amplifyConfigGroup.uuid);
+        project.removePbxGroup('Resources');
+
+        // add schema.graphql
+        project.addFile(path.relative(rootDir, schemaFile), amplifyConfigGroup.uuid, {
+          lastKnownFileType: 'text',
+        });
+
+        fs.writeFileSync(projectDir, project.writeSync());
+        resolve();
+      } catch (projectError) {
+        reject(projectError);
       }
-      resolve();
-    })
-  );
+    });
+  });
 }
 
 module.exports = {
-  addFileToXcodeProj,
+  addDataStoreFiles,
 };

--- a/packages/amplify-app/src/xcodeHelpers.js
+++ b/packages/amplify-app/src/xcodeHelpers.js
@@ -53,7 +53,6 @@ function getGroupByName(project, name) {
   const groups = Object.entries(project.hash.project.objects.PBXGroup);
   for (let i = 0; i < groups.length; i++) {
     const [key, value] = groups[i];
-    // console.log(value);
     if (typeof value !== 'string') {
       // only the root pbx group can have no name, path or description
       const isRoot = name === undefined && value.name === undefined && value.path === undefined;
@@ -107,10 +106,20 @@ function groupHasFile(group, name) {
 }
 
 /**
+ * Adds amplify files to the Xcode project grouped by categories:
+ *
+ * - `AmplifyConfig`
+ *   - `amplifytools.xcconfig`
+ *   - `amplifyconfiguration.json`
+ *   - `awsconfiguration.json`
+ *   - `schema.graphql`
+ * - `AmplifyModels`
+ *   - *all generated models*
+ *
  * @public
  * @return {Promise<void>}
  */
-async function addDataStoreFiles() {
+async function addAmplifyFiles() {
   const projectDir = getXcodeProjectDir();
   const rootDir = path.resolve(projectDir, '..', '..');
   const project = xcode.project(projectDir);
@@ -178,5 +187,5 @@ async function addDataStoreFiles() {
 }
 
 module.exports = {
-  addDataStoreFiles,
+  addAmplifyFiles,
 };

--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.js
@@ -53,7 +53,7 @@ function getGitIgnoreAppendString() {
     'amplifyconfiguration.json',
     'amplify-build-config.json',
     'amplify-gradle-config.json',
-    'amplifyxc.config',
+    'amplifytools.xcconfig',
   ];
 
   const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}`;

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
@@ -11,7 +11,7 @@ function validateProject(projRoot: string, platform: string) {
       expect(fs.existsSync(path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'amplifyconfiguration.json'))).toBeTruthy();
       break;
     case 'ios':
-      expect(fs.existsSync(path.join(projRoot, 'amplifyxc.config'))).toBeTruthy();
+      expect(fs.existsSync(path.join(projRoot, 'amplifytools.xcconfig'))).toBeTruthy();
       expect(fs.existsSync(path.join(projRoot, 'amplifyconfiguration.json'))).toBeTruthy();
       expect(fs.existsSync(path.join(projRoot, 'awsconfiguration.json'))).toBeTruthy();
       break;


### PR DESCRIPTION
**Notes:**

- change `amplifyxc.config` to `amplifytools.xcconfig` to match standard
xcode config files extension
- create an Xcode group called `AmplifyConfig` and add all
config-related files
  - `amplifytools.xcconfig`
  - `amplifyconfiguration.json`
  - `awsconfiguration.json`
  - `schema.graphql`
- create an Xcode group called `AmplifyModels` and add the generated
models to it and also as project source files
- files are added as references and not copied, so updates to the
original files are automatically reflected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.