### PR TITLE
fix: add custom enum filter to connection filter

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -18,6 +18,7 @@ import {
   SortKeyFieldInfoTypeName,
   CONDITIONS_MINIMUM_VERSION,
   makeAttributeTypeEnum,
+  makeEnumFilterInputObjects,
 } from 'graphql-dynamodb-transformer';
 import {
   getBaseType,
@@ -673,6 +674,14 @@ export class ModelConnectionTransformer extends Transformer {
   ): void {
     const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
     for (const filter of scalarFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    // Create the Enum filters
+    const enumFilters = makeEnumFilterInputObjects(field, ctx, this.supportsConditions(ctx));
+    for (const filter of enumFilters) {
       if (!this.typeExist(filter.name.value, ctx)) {
         ctx.addInput(filter);
       }

--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -602,6 +602,36 @@ test('Connection on models with no codegen includes AttributeTypeEnum', () => {
   expect(out.schema).toMatchSnapshot();
 });
 
+test('Connection on models with no codegen includes custom enum filters', () => {
+  const validSchema = `
+    type Cart @model(queries: null, mutations: null, subscriptions: null) {
+      id: ID!,
+      cartItems: [CartItem] @connection(name: "CartCartItem")
+    }
+    
+    type CartItem @model(queries: null, mutations: null, subscriptions: null) {
+      id: ID!
+      productType: PRODUCT_TYPE!
+      cart: Cart @connection(name: "CartCartItem")
+    }
+    
+    enum PRODUCT_TYPE {
+      UNIT
+      PACKAGE
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new ModelConnectionTransformer()],
+    transformConfig: {
+      Version: TRANSFORM_CURRENT_VERSION,
+    },
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toMatchSnapshot();
+});
+
 function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
   for (const fieldName of fields) {
     const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName);

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
@@ -121,3 +121,135 @@ enum ModelAttributeTypes {
 }
 "
 `;
+
+exports[`Connection on models with no codegen includes custom enum filters 1`] = `
+"type Cart {
+  id: ID!
+  cartItems(filter: ModelCartItemFilterInput, sortDirection: ModelSortDirection, limit: Int, nextToken: String): ModelCartItemConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type CartItem {
+  id: ID!
+  productType: PRODUCT_TYPE!
+  cart: Cart
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum PRODUCT_TYPE {
+  UNIT
+  PACKAGE
+}
+
+type ModelCartItemConnection {
+  items: [CartItem]
+  nextToken: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPRODUCT_TYPEInput {
+  eq: PRODUCT_TYPE
+  ne: PRODUCT_TYPE
+}
+
+input ModelCartItemFilterInput {
+  id: ModelIDInput
+  productType: ModelPRODUCT_TYPEInput
+  and: [ModelCartItemFilterInput]
+  or: [ModelCartItemFilterInput]
+  not: ModelCartItemFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+"
+`;

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -460,7 +460,7 @@ export function makeModelXConditionInputObject(
 }
 
 export function makeEnumFilterInputObjects(
-  obj: ObjectTypeDefinitionNode,
+  obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
   ctx: TransformerContext,
   supportsConditions: Boolean,
 ): InputObjectTypeDefinitionNode[] {


### PR DESCRIPTION
*Issue #, if available:*
#4081

*Description of changes:*
The connection transformer did not add the enum type filter to connections even though the list item filter referenced it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.