### PR TITLE
fix(amplify-util-mock): fix API Mock inifinte reload on windows

### DIFF
--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -142,11 +142,14 @@ export class APITest {
         await this.appSyncSimulator.reload(config);
         await this.generateCode(context);
       } else if (filePath.includes(parameterFilePath)) {
-        context.print.info('API Parameter change detected. Reloading...');
-        this.apiParameters = await this.loadAPIParameters(context);
-        const config = await this.runTransformer(context, this.apiParameters);
-        await this.appSyncSimulator.reload(config);
-        await this.generateCode(context);
+        const apiParameters = await this.loadAPIParameters(context);
+        if (JSON.stringify(apiParameters) !== JSON.stringify(this.apiParameters)) {
+          context.print.info('API Parameter change detected. Reloading...');
+          this.apiParameters = apiParameters;
+          const config = await this.runTransformer(context, this.apiParameters);
+          await this.appSyncSimulator.reload(config);
+          await this.generateCode(context);
+        }
       } else if (filePath.includes(customStackPath)) {
         context.print.info('Custom stack change detected. Reloading...');
         const config = await this.runTransformer(context, this.apiParameters);


### PR DESCRIPTION
Mock kept on triggering reload on windows even when there were no changes to the API. Added
additional check to ensure reload happens only if the actual content in the file has changed

fix #2736

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.