### PR TITLE
fix(amplify-category-api): toggle datastore in update

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -444,10 +444,10 @@ async function updateWalkthrough(context) {
     await checkForCognitoUserPools(context, parameters, authConfig);
   }
 
-  const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
-
   if (authConfig) {
+    const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
+    const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
+
     if (amplifyMeta[category][resourceName].output.securityType) {
       delete amplifyMeta[category][resourceName].output.securityType;
     }
@@ -466,9 +466,6 @@ async function updateWalkthrough(context) {
     backendConfig[category][resourceName].output.authConfig = authConfig;
     jsonString = JSON.stringify(backendConfig, null, 4);
     fs.writeFileSync(backendConfigFilePath, jsonString, 'utf8');
-  } else {
-    // use existing authConfig
-    authConfig = amplifyMeta[category][resourceName].output.authConfig;
   }
 
   if (resolverConfig) {

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -173,6 +173,26 @@ export function updateApiWithMultiAuth(cwd: string, settings: any) {
   });
 }
 
+export function apiUpdateToggleDataStore(cwd: string, settings: any) {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(settings.testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true })
+      .wait('Please select from one of the below mentioned services:')
+      .sendCarriageReturn()
+      .wait('Select from the options below')
+      .send(KEY_DOWN_ARROW)
+      .sendLine(KEY_DOWN_ARROW) // select enable datastore for the api
+      .wait(/.*Successfully updated resource.*/)
+      .sendEof()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
 export function updateAPIWithResolutionStrategy(cwd: string, settings: any) {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(settings.testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true })


### PR DESCRIPTION
added option to toggle datastore for the api

re #4058

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.