### PR TITLE
fix(amplify-appsync-simulator): replace "extend" library with lodash

### DIFF
--- a/packages/amplify-appsync-simulator/src/server/subscription/mqtt-server/server.ts
+++ b/packages/amplify-appsync-simulator/src/server/subscription/mqtt-server/server.ts
@@ -2,7 +2,7 @@ import Connection from 'mqtt-connection';
 import ws from 'ws';
 import steed from 'steed';
 import pino from 'pino';
-import extend from 'extend';
+import { defaultsDeep } from 'lodash';
 import nanoid from 'nanoid';
 import { TrieListener } from './trie-listener';
 import { Client } from './client';
@@ -97,7 +97,7 @@ export class MQTTServer extends EventEmitter {
 
   constructor(options: MQTTServerOptions = {}, private callback = (err: any, data?: any) => {}) {
     super();
-    this.options = extend(true, {}, DEFAULT_OPTIONS, options);
+    this.options = defaultsDeep(options, DEFAULT_OPTIONS);
 
     this._dedupId = 0;
     this.clients = {};


### PR DESCRIPTION
There was "extend" dependency imported in
amplify-appsync-simulator/src/server/subscription/mqtt-server/server.ts but it was missing in
package.json

*Description of changes:*
In https://github.com/bboure/serverless-appsync-simulator/issues/22 I stumbled upon error `Cannot find module 'extend'`. I've traced this error to [amplify-appsync-simulator/src/server/subscription/mqtt-server/server.ts#L5](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-appsync-simulator/src/server/subscription/mqtt-server/server.ts#L5)
I found out that the dependency `extend` is not in `package.json`. 

So accordingly to @jhockett suggestion, I've replaced the `extend` library with "extend" function from `lodash`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.