### PR TITLE
fix: remove permissions from meta files on func update

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -5,6 +5,9 @@ import * as TransformPackage from 'graphql-transformer-core';
 import _ from 'lodash';
 import { topLevelCommentPrefix, topLevelCommentSuffix, envVarPrintoutPrefix } from '../../../constants';
 
+/**
+ * This whole file desperately needs to be refactored
+ */
 export async function askExecRolePermissionsQuestions(context, allDefaultValues, parameters, currentDefaults?) {
   const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
   const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
@@ -12,12 +15,12 @@ export async function askExecRolePermissionsQuestions(context, allDefaultValues,
   let categories = Object.keys(amplifyMeta);
   categories = categories.filter(category => category !== 'providers');
 
-  // retrieve api's appsynch resource name for conditional logic
+  // retrieve api's AppSync resource name for conditional logic
   // in blending appsync @model-backed dynamoDB tables into storage category flow
   const appsyncResourceName =
     'api' in amplifyMeta ? Object.keys(amplifyMeta.api).find(key => amplifyMeta.api[key].service === 'AppSync') : undefined;
 
-  // if there is api category appsynch resource and no storage category, add it back to selection
+  // if there is api category AppSync resource and no storage category, add it back to selection
   // since storage category is responsible for managing appsync @model-backed dynamoDB table permissions
   if (!categories.includes('storage') && appsyncResourceName !== undefined) {
     categories.push('storage');
@@ -189,6 +192,7 @@ export async function askExecRolePermissionsQuestions(context, allDefaultValues,
   const resourceProperties = [];
   const resourcePropertiesJSON = {};
   const envVars = new Set<string>();
+  allDefaultValues.dependsOn = []; // reset the dependsOn field for this resource because it will be re-populated based on the update selections
   resources.forEach(resource => {
     const { category, resourceName, attributes } = resource;
     /**
@@ -218,14 +222,10 @@ export async function askExecRolePermissionsQuestions(context, allDefaultValues,
       const refName = `${category}${resourceName}${attribute}`;
 
       resourceProperties.push(`"${envName}": {"Ref": "${refName}"}`);
-      resourcePropertiesJSON[`${envName}`] = { Ref: `${category}${resourceName}${attribute}` };
+      resourcePropertiesJSON[`${envName}`] = { Ref: refName };
 
       envVars.add(envName);
     });
-
-    if (!allDefaultValues.dependsOn) {
-      allDefaultValues.dependsOn = [];
-    }
 
     let resourceExists = false;
     allDefaultValues.dependsOn.forEach(amplifyResource => {


### PR DESCRIPTION
*Issue #, if available:*
#4239, #2795
*Description of changes:*
Previous logic would only add to the dependsOn field in amplify-meta and backend-config for lambdas. Change to reset the array every time because it is rebuilt based on the selections during update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.