### PR TITLE
fix(amplify-appsync-simulator): after pipeline template mapping

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/resolvers/pipeline-resolver.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/resolvers/pipeline-resolver.test.ts
@@ -156,6 +156,7 @@ describe('Pipeline Resolvers', () => {
           source,
           arguments: args,
           prevResult: 'FN2-RESULT',
+          result: 'FN2-RESULT',
           stash: { exeSeq: ['REQUEST-MAPPING-TEMPLATE', 'fn1', 'fn2'] },
         },
         context,

--- a/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
@@ -47,7 +47,11 @@ export class AppSyncPipelineResolver extends AppSyncBaseResolver {
     }
 
     // pipeline response mapping template
-    ({ result, errors: templateErrors } = responseMappingTemplate.render({ source, arguments: args, prevResult, stash }, context, info));
+    ({ result, errors: templateErrors } = responseMappingTemplate.render(
+      { source, arguments: args, result: prevResult, prevResult, stash },
+      context,
+      info,
+    ));
     context.appsyncErrors = [...context.appsyncErrors, ...(templateErrors || [])];
     return result;
   }


### PR DESCRIPTION

AS per the doc:
> The response mapping template of a pipeline resolver or also called the After step, allows to perform some final mapping logic from the output of the last function to the expected GraphQL field type. The output of the last function in the functions list is available in the pipeline resolver mapping template as $ctx.prev.result or $ctx.result.

*Description of changes:*
`$ctx.result` stopped working after #4225 
This PR resolves the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.