### PR TITLE
fix(amplify-appsync-simulator): adds equals method to JavaString class

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/value-mapper/string.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/value-mapper/string.test.ts
@@ -31,6 +31,12 @@ describe('JavaString', () => {
     expect(str.endsWith(new JavaString('elit'))).toEqual(true);
   });
 
+  it('equals', () => {
+    const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+    expect(str.equals(new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit'))).toEqual(true);
+    expect(str.equals(new JavaString('ipsum'))).toEqual(false);
+  });
+
   it('indexOf', () => {
     const str = new JavaString('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
     expect(str.indexOf(new JavaString('ipsum'))).toEqual(6);

--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/string.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/string.ts
@@ -18,6 +18,10 @@ export class JavaString {
     return this.value.endsWith(suffix.toString());
   }
 
+  equals(str) {
+    return this.value === str.toString();
+  }
+
   indexOf(val, fromIndex = 0) {
     return this.value.indexOf(val.toString(), fromIndex);
   }


### PR DESCRIPTION
equals method is required for VTL functionality present in the console that is currently missing in
the simulator

*Issue #4334, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.