### PR TITLE
feat(amplify-codegen-appsync-model-plugin): iOS add suport for auth

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/utils/process-auth.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/utils/process-auth.test.ts
@@ -86,7 +86,7 @@ describe('process auth directive', () => {
       const processedAuthDirective = processAuthDirective(directives);
       expect(processedAuthDirective[0].arguments.rules[0]).toEqual({
         ...ownerAuthRule,
-        operations: [AuthModelOperation.create, AuthModelOperation.update, AuthModelOperation.delete],
+        operations: [AuthModelOperation.create, AuthModelOperation.update, AuthModelOperation.delete, AuthModelOperation.read],
       });
     });
 
@@ -164,7 +164,7 @@ describe('process auth directive', () => {
       const processedAuthDirective = processAuthDirective(directives);
       expect(processedAuthDirective[0].arguments.rules[0]).toEqual({
         ...groupsAuthRule,
-        operations: [AuthModelOperation.create, AuthModelOperation.update, AuthModelOperation.delete],
+        operations: [AuthModelOperation.create, AuthModelOperation.update, AuthModelOperation.delete, AuthModelOperation.read],
       });
     });
   });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -829,20 +829,20 @@ describe('AppSyncSwiftVisitor', () => {
 
     const visitorClassLoader = getVisitor(schema, undefined, CodeGenGenerateEnum.loader);
     expect(visitorClassLoader.generate()).toMatchInlineSnapshot(`
-"// swiftlint:disable all
-import Amplify
-import Foundation
+      "// swiftlint:disable all
+      import Amplify
+      import Foundation
 
-// Contains the set of classes that conforms to the \`Model\` protocol. 
+      // Contains the set of classes that conforms to the \`Model\` protocol. 
 
-final public class AmplifyModels: AmplifyModelRegistration {
-  public let version: String = \\"ca73d7dc63498f675fff2b260548d216\\"
-  
-  public func registerModels(registry: ModelRegistry.Type) {
-    ModelRegistry.register(modelType: Attraction.self)
-  }
-}"
-`);
+      final public class AmplifyModels: AmplifyModelRegistration {
+        public let version: String = \\"ca73d7dc63498f675fff2b260548d216\\"
+        
+        public func registerModels(registry: ModelRegistry.Type) {
+          ModelRegistry.register(modelType: Attraction.self)
+        }
+      }"
+    `);
   });
 
   it('should escape swift reserved keywords in enum', () => {
@@ -856,15 +856,15 @@ final public class AmplifyModels: AmplifyModelRegistration {
     const generatedCode = visitor.generate();
 
     expect(generatedCode).toMatchInlineSnapshot(`
-"// swiftlint:disable all
-import Amplify
-import Foundation
+      "// swiftlint:disable all
+      import Amplify
+      import Foundation
 
-public enum PostStatus: String, EnumPersistable {
-  case \`private\`
-  case \`public\`
-}"
-`);
+      public enum PostStatus: String, EnumPersistable {
+        case \`private\`
+        case \`public\`
+      }"
+    `);
   });
 
   describe('reserved word escape', () => {
@@ -879,15 +879,15 @@ public enum PostStatus: String, EnumPersistable {
       const generatedCode = visitor.generate();
 
       expect(generatedCode).toMatchInlineSnapshot(`
-"// swiftlint:disable all
-import Amplify
-import Foundation
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
 
-public enum PostStatus: String, EnumPersistable {
-  case \`private\`
-  case \`public\`
-}"
-`);
+        public enum PostStatus: String, EnumPersistable {
+          case \`private\`
+          case \`public\`
+        }"
+      `);
     });
 
     it('should escape swift reserved keywords in enum name', () => {
@@ -907,43 +907,457 @@ public enum PostStatus: String, EnumPersistable {
       const visitor = getVisitor(schema, 'Class');
       const generatedEnumCode = visitor.generate();
       expect(generatedEnumCode).toMatchInlineSnapshot(`
-"// swiftlint:disable all
-import Amplify
-import Foundation
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
 
-public enum \`Class\`: String, EnumPersistable {
-  case \`private\`
-  case \`public\`
-}"
-`);
+        public enum \`Class\`: String, EnumPersistable {
+          case \`private\`
+          case \`public\`
+        }"
+      `);
 
       const fooVisitor = getVisitor(schema, 'Foo');
       const fooModel = fooVisitor.generate();
       expect(fooModel).toMatchInlineSnapshot(`
-"// swiftlint:disable all
-import Amplify
-import Foundation
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
 
-public struct Foo: Model {
-  public let id: String
-  public var \`Class\`: Class?
-  public var nonNullClass: Class
-  public var classes: [\`Class\`]?
-  public var nonNullClasses: [\`Class\`]
-  
-  public init(id: String = UUID().uuidString,
-      \`Class\`: \`Class\`? = nil,
-      nonNullClass: \`Class\`,
-      classes: [\`Class\`]? = [],
-      nonNullClasses: [\`Class\`] = []) {
-      self.id = id
-      self.\`Class\` = \`Class\`
-      self.nonNullClass = nonNullClass
-      self.classes = classes
-      self.nonNullClasses = nonNullClasses
-  }
-}"
-`);
+        public struct Foo: Model {
+          public let id: String
+          public var \`Class\`: Class?
+          public var nonNullClass: Class
+          public var classes: [\`Class\`]?
+          public var nonNullClasses: [\`Class\`]
+          
+          public init(id: String = UUID().uuidString,
+              \`Class\`: \`Class\`? = nil,
+              nonNullClass: \`Class\`,
+              classes: [\`Class\`]? = [],
+              nonNullClasses: [\`Class\`] = []) {
+              self.id = id
+              self.\`Class\` = \`Class\`
+              self.nonNullClass = nonNullClass
+              self.classes = classes
+              self.nonNullClasses = nonNullClasses
+          }
+        }"
+      `);
     });
+  });
+  describe('auth directives', () => {
+    describe('owner auth', () => {
+      it('should include authRules in schema when owner auth is used', () => {
+        const schema = /* GraphQL */ `
+          type Post @model @auth(rules: [{ allow: owner }]) {
+            id: ID!
+            title: String!
+            owner: String!
+          }
+        `;
+        const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+        const generatedCode = visitor.generate();
+        expect(generatedCode).toMatchInlineSnapshot(`
+          "// swiftlint:disable all
+          import Amplify
+          import Foundation
+
+          extension Post {
+            // MARK: - CodingKeys 
+             public enum CodingKeys: String, ModelKey {
+              case id
+              case title
+              case owner
+            }
+            
+            public static let keys = CodingKeys.self
+            //  MARK: - ModelSchema 
+            
+            public static let schema = defineSchema { model in
+              let post = Post.keys
+              
+              model.authRules = [
+                rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"owner\\", operations: [.create, .update, .delete, .read])
+              ]
+              
+              model.pluralName = \\"Posts\\"
+              
+              model.fields(
+                .id(),
+                .field(post.title, is: .required, ofType: .string),
+                .field(post.owner, is: .required, ofType: .string)
+              )
+              }
+          }"
+        `);
+      });
+
+      it('should include authRules in schema when owner auth is used', () => {
+        const schema = /* GraphQL */ `
+          type Post @model @auth(rules: [{ allow: owner, ownerField: "author" }]) {
+            id: ID!
+            title: String!
+            author: String!
+          }
+        `;
+        const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+        const generatedCode = visitor.generate();
+        expect(generatedCode).toMatchInlineSnapshot(`
+          "// swiftlint:disable all
+          import Amplify
+          import Foundation
+
+          extension Post {
+            // MARK: - CodingKeys 
+             public enum CodingKeys: String, ModelKey {
+              case id
+              case title
+              case author
+            }
+            
+            public static let keys = CodingKeys.self
+            //  MARK: - ModelSchema 
+            
+            public static let schema = defineSchema { model in
+              let post = Post.keys
+              
+              model.authRules = [
+                rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"author\\", operations: [.create, .update, .delete, .read])
+              ]
+              
+              model.pluralName = \\"Posts\\"
+              
+              model.fields(
+                .id(),
+                .field(post.title, is: .required, ofType: .string),
+                .field(post.author, is: .required, ofType: .string)
+              )
+              }
+          }"
+        `);
+      });
+
+      it('should support changing allowed operation', () => {
+        const schema = /* GraphQL */ `
+          type Post @model @auth(rules: [{ allow: owner, ownerField: "author", operations: ["create", "update", "delete"] }]) {
+            id: ID!
+            title: String!
+            author: String!
+          }
+        `;
+
+        const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+        const generatedCode = visitor.generate();
+        expect(generatedCode).toMatchInlineSnapshot(`
+          "// swiftlint:disable all
+          import Amplify
+          import Foundation
+
+          extension Post {
+            // MARK: - CodingKeys 
+             public enum CodingKeys: String, ModelKey {
+              case id
+              case title
+              case author
+            }
+            
+            public static let keys = CodingKeys.self
+            //  MARK: - ModelSchema 
+            
+            public static let schema = defineSchema { model in
+              let post = Post.keys
+              
+              model.authRules = [
+                rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"author\\", operations: [.create, .update, .delete])
+              ]
+              
+              model.pluralName = \\"Posts\\"
+              
+              model.fields(
+                .id(),
+                .field(post.title, is: .required, ofType: .string),
+                .field(post.author, is: .required, ofType: .string)
+              )
+              }
+          }"
+        `);
+      });
+
+      it('should support changing identityClaim ', () => {
+        const schema = /* GraphQL */ `
+          type Post @model @auth(rules: [{ allow: owner, ownerField: "author", identityClaim: "sub" }]) {
+            id: ID!
+            title: String!
+            author: String!
+          }
+        `;
+
+        const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+        const generatedCode = visitor.generate();
+        expect(generatedCode).toMatchInlineSnapshot(`
+          "// swiftlint:disable all
+          import Amplify
+          import Foundation
+
+          extension Post {
+            // MARK: - CodingKeys 
+             public enum CodingKeys: String, ModelKey {
+              case id
+              case title
+              case author
+            }
+            
+            public static let keys = CodingKeys.self
+            //  MARK: - ModelSchema 
+            
+            public static let schema = defineSchema { model in
+              let post = Post.keys
+              
+              model.authRules = [
+                rule(allow: .owner, identityClaim: \\"sub\\", ownerField: \\"author\\", operations: [.create, .update, .delete, .read])
+              ]
+              
+              model.pluralName = \\"Posts\\"
+              
+              model.fields(
+                .id(),
+                .field(post.title, is: .required, ofType: .string),
+                .field(post.author, is: .required, ofType: .string)
+              )
+              }
+          }"
+        `);
+      });
+    });
+  });
+
+  describe('group auth', () => {
+    it('should include authRules in schema when static groups auth is used', () => {
+      const schema = /* GraphQL */ `
+        type Post @model @auth(rules: [{ allow: groups, groups: ["admin", "editors"] }]) {
+          id: ID!
+          title: String!
+        }
+      `;
+      const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+      const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchInlineSnapshot(`
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
+
+        extension Post {
+          // MARK: - CodingKeys 
+           public enum CodingKeys: String, ModelKey {
+            case id
+            case title
+          }
+          
+          public static let keys = CodingKeys.self
+          //  MARK: - ModelSchema 
+          
+          public static let schema = defineSchema { model in
+            let post = Post.keys
+            
+            model.authRules = [
+              rule(allow: .groups, groupClaim: \\"cognito:groups\\", groups: [\\"admin\\", \\"editors\\"], operations: [.create, .update, .delete, .read])
+            ]
+            
+            model.pluralName = \\"Posts\\"
+            
+            model.fields(
+              .id(),
+              .field(post.title, is: .required, ofType: .string)
+            )
+            }
+        }"
+      `);
+    });
+
+    it('should include authRules in schema when dynamoc auth is used', () => {
+      const schema = /* GraphQL */ `
+        type Post @model @auth(rules: [{ allow: groups, groupsField: "groups" }]) {
+          id: ID!
+          title: String!
+          groups: [String!]!
+        }
+      `;
+      const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+      const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchInlineSnapshot(`
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
+
+        extension Post {
+          // MARK: - CodingKeys 
+           public enum CodingKeys: String, ModelKey {
+            case id
+            case title
+            case groups
+          }
+          
+          public static let keys = CodingKeys.self
+          //  MARK: - ModelSchema 
+          
+          public static let schema = defineSchema { model in
+            let post = Post.keys
+            
+            model.authRules = [
+              rule(allow: .groups, groupClaim: \\"cognito:groups\\", groupsField: \\"groups\\", operations: [.create, .update, .delete, .read])
+            ]
+            
+            model.pluralName = \\"Posts\\"
+            
+            model.fields(
+              .id(),
+              .field(post.title, is: .required, ofType: .string),
+              .field(post.groups, is: .required, ofType: .customType([String].self))
+            )
+            }
+        }"
+      `);
+    });
+
+    it('should support changing allowed operation', () => {
+      const schema = /* GraphQL */ `
+        type Post @model @auth(rules: [{ allow: groups, groups: ["admin"], operations: ["create", "update", "delete"] }]) {
+          id: ID!
+          title: String!
+        }
+      `;
+
+      const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+      const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchInlineSnapshot(`
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
+
+        extension Post {
+          // MARK: - CodingKeys 
+           public enum CodingKeys: String, ModelKey {
+            case id
+            case title
+          }
+          
+          public static let keys = CodingKeys.self
+          //  MARK: - ModelSchema 
+          
+          public static let schema = defineSchema { model in
+            let post = Post.keys
+            
+            model.authRules = [
+              rule(allow: .groups, groupClaim: \\"cognito:groups\\", groups: [\\"admin\\"], operations: [.create, .update, .delete])
+            ]
+            
+            model.pluralName = \\"Posts\\"
+            
+            model.fields(
+              .id(),
+              .field(post.title, is: .required, ofType: .string)
+            )
+            }
+        }"
+      `);
+    });
+
+    it('should support changing groupsClaim ', () => {
+      const schema = /* GraphQL */ `
+        type Post @model @auth(rules: [{ allow: groups, groups: ["admin"], groupClaim: "custom:groups" }]) {
+          id: ID!
+          title: String!
+        }
+      `;
+
+      const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+      const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchInlineSnapshot(`
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
+
+        extension Post {
+          // MARK: - CodingKeys 
+           public enum CodingKeys: String, ModelKey {
+            case id
+            case title
+          }
+          
+          public static let keys = CodingKeys.self
+          //  MARK: - ModelSchema 
+          
+          public static let schema = defineSchema { model in
+            let post = Post.keys
+            
+            model.authRules = [
+              rule(allow: .groups, groupClaim: \\"custom:groups\\", groups: [\\"admin\\"], operations: [.create, .update, .delete, .read])
+            ]
+            
+            model.pluralName = \\"Posts\\"
+            
+            model.fields(
+              .id(),
+              .field(post.title, is: .required, ofType: .string)
+            )
+            }
+        }"
+      `);
+    });
+  });
+  it('should support multiple auth rules', () => {
+    const schema = /* GraphQL */ `
+      type Post
+        @model
+        @auth(
+          rules: [
+            { allow: groups, groups: ["admin"] }
+            { allow: owner, operations: ["create", "update"] }
+            { allow: public, operation: ["read"] }
+          ]
+        ) {
+        id: ID!
+        title: String!
+        owner: String!
+      }
+    `;
+
+    const visitor = getVisitor(schema, 'Post', CodeGenGenerateEnum.metadata);
+    const generatedCode = visitor.generate();
+    expect(generatedCode).toMatchInlineSnapshot(`
+      "// swiftlint:disable all
+      import Amplify
+      import Foundation
+
+      extension Post {
+        // MARK: - CodingKeys 
+         public enum CodingKeys: String, ModelKey {
+          case id
+          case title
+          case owner
+        }
+        
+        public static let keys = CodingKeys.self
+        //  MARK: - ModelSchema 
+        
+        public static let schema = defineSchema { model in
+          let post = Post.keys
+          
+          model.authRules = [
+            rule(allow: .groups, groupClaim: \\"cognito:groups\\", groups: [\\"admin\\"], operations: [.create, .update, .delete, .read]),
+            rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"owner\\", operations: [.create, .update])
+          ]
+          
+          model.pluralName = \\"Posts\\"
+          
+          model.fields(
+            .id(),
+            .field(post.title, is: .required, ofType: .string),
+            .field(post.owner, is: .required, ofType: .string)
+          )
+          }
+      }"
+    `);
   });
 });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -978,7 +978,7 @@ describe('AppSyncSwiftVisitor', () => {
               let post = Post.keys
               
               model.authRules = [
-                rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"owner\\", operations: [.create, .update, .delete, .read])
+                rule(allow: .owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", operations: [.create, .update, .delete, .read])
               ]
               
               model.pluralName = \\"Posts\\"
@@ -1023,7 +1023,7 @@ describe('AppSyncSwiftVisitor', () => {
               let post = Post.keys
               
               model.authRules = [
-                rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"author\\", operations: [.create, .update, .delete, .read])
+                rule(allow: .owner, ownerField: \\"author\\", identityClaim: \\"cognito:username\\", operations: [.create, .update, .delete, .read])
               ]
               
               model.pluralName = \\"Posts\\"
@@ -1069,7 +1069,7 @@ describe('AppSyncSwiftVisitor', () => {
               let post = Post.keys
               
               model.authRules = [
-                rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"author\\", operations: [.create, .update, .delete])
+                rule(allow: .owner, ownerField: \\"author\\", identityClaim: \\"cognito:username\\", operations: [.create, .update, .delete])
               ]
               
               model.pluralName = \\"Posts\\"
@@ -1115,7 +1115,7 @@ describe('AppSyncSwiftVisitor', () => {
               let post = Post.keys
               
               model.authRules = [
-                rule(allow: .owner, identityClaim: \\"sub\\", ownerField: \\"author\\", operations: [.create, .update, .delete, .read])
+                rule(allow: .owner, ownerField: \\"author\\", identityClaim: \\"sub\\", operations: [.create, .update, .delete, .read])
               ]
               
               model.pluralName = \\"Posts\\"
@@ -1346,7 +1346,7 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.authRules = [
             rule(allow: .groups, groupClaim: \\"cognito:groups\\", groups: [\\"admin\\"], operations: [.create, .update, .delete, .read]),
-            rule(allow: .owner, identityClaim: \\"cognito:username\\", ownerField: \\"owner\\", operations: [.create, .update])
+            rule(allow: .owner, ownerField: \\"owner\\", identityClaim: \\"cognito:username\\", operations: [.create, .update])
           ]
           
           model.pluralName = \\"Posts\\"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -284,7 +284,7 @@ describe('AppSyncModelVisitor', () => {
       expect(ownerRule.provider).toEqual('userPools');
       expect(ownerRule.identityClaim).toEqual('cognito:username');
       expect(ownerRule.ownerField).toEqual('owner');
-      expect(ownerRule.operations).toEqual(['create', 'update', 'delete']);
+      expect(ownerRule.operations).toEqual(['create', 'update', 'delete', 'read']);
     });
 
     it('should process group with owner authorization', () => {
@@ -309,7 +309,7 @@ describe('AppSyncModelVisitor', () => {
       expect(groupRule).toBeDefined();
       expect(groupRule.provider).toEqual('userPools');
       expect(groupRule.groupClaim).toEqual('cognito:groups');
-      expect(groupRule.operations).toEqual(['create', 'update', 'delete']);
+      expect(groupRule.operations).toEqual(['create', 'update', 'delete', 'read']);
     });
   });
   describe('model less type', () => {

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -317,8 +317,8 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
         switch (rule.allow) {
           case AuthStrategy.owner:
             authRule.push('allow: .owner');
-            authRule.push(`identityClaim: "${rule.identityClaim}"`);
             authRule.push(`ownerField: "${rule.ownerField}"`);
+            authRule.push(`identityClaim: "${rule.identityClaim}"`);
             break;
           case AuthStrategy.groups:
             authRule.push('allow: .groups');

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": ["DOM", "ESnext"] /* Specify library files to be included in the compilation. */,
     //"allowJs": true,                        /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Updated model gen to generate schema with auth rules

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.