### PR TITLE
feat(graphql-key-transformer): auto population of id and timestamp

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -5,7 +5,15 @@ exports[`Test "create", "update", "delete" auth operations 1`] = `"$util.toJson(
 exports[`Test "create", "update", "delete" auth operations 2`] = `"$util.toJson($ctx.result)"`;
 
 exports[`Test "create", "update", "delete" auth operations 3`] = `
-"## [Start] Determine request authentication mode **
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+## [Start] Determine request authentication mode **
 #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
   #set( $authMode = \\"userPools\\" )
 #end
@@ -42,11 +50,6 @@ exports[`Test "create", "update", "delete" auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
-#set( $createdAt = $util.time.nowISO8601() )
-## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -71,7 +74,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)
@@ -635,7 +638,15 @@ exports[`Test that operation overwrites queries in auth operations 1`] = `"$util
 exports[`Test that operation overwrites queries in auth operations 2`] = `"$util.toJson($ctx.result)"`;
 
 exports[`Test that operation overwrites queries in auth operations 3`] = `
-"## [Start] Determine request authentication mode **
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+## [Start] Determine request authentication mode **
 #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
   #set( $authMode = \\"userPools\\" )
 #end
@@ -672,11 +683,6 @@ exports[`Test that operation overwrites queries in auth operations 3`] = `
 ## [End] Check authMode and execute owner/group checks **
 
 ## [Start] Prepare DynamoDB PutItem Request. **
-#set( $createdAt = $util.time.nowISO8601() )
-## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -701,7 +707,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -313,7 +313,7 @@ export class DynamoDBModelTransformer extends Transformer {
       });
       const hositedInitalization = this.resources.initalizeDefaultInputForCreateMutation(createInput, timestampFields);
       const resourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
-      this.addInitalizationMetaData(ctx, resourceId, hositedInitalization);
+      this.addInitalizationMetadata(ctx, resourceId, hositedInitalization);
       ctx.setResource(resourceId, createResolver);
       ctx.mapResourceToStack(typeName, resourceId);
       const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))];
@@ -708,7 +708,7 @@ export class DynamoDBModelTransformer extends Transformer {
     return true;
   }
 
-  private addInitalizationMetaData(ctx: TransformerContext, resourceId: string, initCode: string): void {
+  private addInitalizationMetadata(ctx: TransformerContext, resourceId: string, initCode: string): void {
     const ddbMetadata = ctx.metadata.has(METADATA_KEY) ? ctx.metadata.get(METADATA_KEY) : {};
     ddbMetadata.hoistedRequestMappingContent = {
       ...ddbMetadata?.hoistedRequestMappingContent,

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -1,4 +1,4 @@
-import { DeletionPolicy } from 'cloudform-types';
+import { DeletionPolicy, AppSync } from 'cloudform-types';
 import { DirectiveNode, ObjectTypeDefinitionNode, InputObjectTypeDefinitionNode, FieldDefinitionNode } from 'graphql';
 import {
   blankObject,
@@ -30,6 +30,8 @@ import {
 } from './definitions';
 import { ModelDirectiveArgs, getCreatedAtFieldName, getUpdatedAtFieldName } from './ModelDirectiveArgs';
 import { ResourceFactory } from './resources';
+
+const METADATA_KEY = 'DynamoDBTransformerMetadata';
 
 export interface DynamoDBModelTransformerOptions {
   EnableDeletionProtection?: boolean;
@@ -108,6 +110,18 @@ export class DynamoDBModelTransformer extends Transformer {
     ctx.mergeParameters(template.Parameters);
     ctx.mergeOutputs(template.Outputs);
     ctx.mergeConditions(template.Conditions);
+  };
+
+  public after = (ctx: TransformerContext): void => {
+    // append hoisted initalization code to the top of request mapping template
+    const ddbMetata = ctx.metadata.get(METADATA_KEY);
+    if (ddbMetata) {
+      Object.entries(ddbMetata.hoistedRequestMappingContent || {}).forEach(([resourceId, hoistedContent]) => {
+        const resource: AppSync.Resolver = ctx.getResource(resourceId) as any;
+        resource.Properties.RequestMappingTemplate = [hoistedContent, resource.Properties.RequestMappingTemplate].join('\n');
+        ctx.setResource(resourceId, resource);
+      });
+    }
   };
 
   /**
@@ -296,9 +310,10 @@ export class DynamoDBModelTransformer extends Transformer {
         type: def.name.value,
         nameOverride: createFieldNameOverride,
         syncConfig: this.opts.SyncConfig,
-        timestamps: timestampFields,
       });
+      const hositedInitalization = this.resources.initalizeDefaultInputForCreateMutation(createInput, timestampFields);
       const resourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
+      this.addInitalizationMetaData(ctx, resourceId, hositedInitalization);
       ctx.setResource(resourceId, createResolver);
       ctx.mapResourceToStack(typeName, resourceId);
       const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))];
@@ -691,5 +706,14 @@ export class DynamoDBModelTransformer extends Transformer {
       return false;
     }
     return true;
+  }
+
+  private addInitalizationMetaData(ctx: TransformerContext, resourceId: string, initCode: string): void {
+    const ddbMetadata = ctx.metadata.has(METADATA_KEY) ? ctx.metadata.get(METADATA_KEY) : {};
+    ddbMetadata.hoistedRequestMappingContent = {
+      ...ddbMetadata?.hoistedRequestMappingContent,
+      [resourceId]: initCode,
+    };
+    ctx.metadata.set(METADATA_KEY, ddbMetadata);
   }
 }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -269,12 +269,15 @@ type Subscription {
 `;
 
 exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 2`] = `
-"## [Start] Prepare DynamoDB PutItem Request. **
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
 #set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
 $util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
 $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -299,7 +302,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)
@@ -551,7 +554,10 @@ type Subscription {
 `;
 
 exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 2`] = `
-"## [Start] Prepare DynamoDB PutItem Request. **
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -576,7 +582,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)
@@ -848,7 +854,10 @@ type Subscription {
 `;
 
 exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 2`] = `
-"## [Start] Prepare DynamoDB PutItem Request. **
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -873,7 +882,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)
@@ -1244,12 +1253,15 @@ type Subscription {
 `;
 
 exports[`Test timestamp parameters when generating resolvers and output schema 2`] = `
-"## [Start] Prepare DynamoDB PutItem Request. **
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
 #set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
 $util.qr($context.args.input.put(\\"createdOn\\", $util.defaultIfNull($ctx.args.input.createdOn, $createdAt)))
 ## Automatically set the updatedAt timestamp. **
 $util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $createdAt)))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -1274,7 +1286,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -449,7 +449,7 @@ export class ResourceFactory {
   }
 
   public initalizeDefaultInputForCreateMutation(input: InputObjectTypeDefinitionNode, timestamps): string {
-    const hasDefaultIdField = input.fields?.find(field => field.name.value === 'id' && getBaseType(field.type) === 'ID');
+    const hasDefaultIdField = input.fields?.find(field => field.name.value === 'id' && ['ID', 'String'].includes(getBaseType(field.type)));
     return printBlock('Set default values')(
       compoundExpression([
         ...(hasDefaultIdField ? [qref(`$context.args.input.put("id", $util.defaultIfNull($ctx.args.input.id, $util.autoId()))`)] : []),

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -20,11 +20,20 @@ import {
   forEach,
   and,
 } from 'graphql-mapping-template';
-import { ResourceConstants, plurality, graphqlName, toUpper, ModelResourceIDs, SyncResourceIDs } from 'graphql-transformer-common';
+import {
+  ResourceConstants,
+  plurality,
+  graphqlName,
+  toUpper,
+  ModelResourceIDs,
+  SyncResourceIDs,
+  getBaseType,
+} from 'graphql-transformer-common';
 import { plural } from 'pluralize';
 import { SyncConfig, SyncUtils } from 'graphql-transformer-core';
 import Template from 'cloudform-types/types/template';
 import md5 from 'md5';
+import { InputObjectTypeDefinitionNode } from 'graphql';
 
 type MutationResolverInput = {
   type: string;
@@ -374,7 +383,7 @@ export class ResourceFactory {
    * Create a resolver that creates an item in DynamoDB.
    * @param type
    */
-  public makeCreateResolver({ type, nameOverride, syncConfig, timestamps, mutationTypeName = 'Mutation' }: MutationResolverInput) {
+  public makeCreateResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation' }: MutationResolverInput) {
     const fieldName = nameOverride ? nameOverride : graphqlName('create' + toUpper(type));
     return new AppSync.Resolver({
       ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
@@ -383,25 +392,6 @@ export class ResourceFactory {
       TypeName: mutationTypeName,
       RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
         compoundExpression([
-          ...(timestamps && (timestamps.createdAtField || timestamps.updatedAtField)
-            ? [set(ref('createdAt'), ref('util.time.nowISO8601()'))]
-            : []),
-          ...(timestamps && timestamps.createdAtField
-            ? [
-                comment(`Automatically set the createdAt timestamp.`),
-                qref(
-                  `$context.args.input.put("${timestamps.createdAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.createdAtField}, $createdAt))`,
-                ),
-              ]
-            : []),
-          ...(timestamps && timestamps.updatedAtField
-            ? [
-                comment(`Automatically set the updatedAt timestamp.`),
-                qref(
-                  `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $createdAt))`,
-                ),
-              ]
-            : []),
           qref(`$context.args.input.put("__typename", "${type}")`),
           set(
             ref('condition'),
@@ -442,7 +432,7 @@ export class ResourceFactory {
                 ref(ResourceConstants.SNIPPETS.ModelObjectKey),
                 raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
                 obj({
-                  id: raw(`$util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))`),
+                  id: raw(`$util.dynamodb.toDynamoDBJson($ctx.args.input.id)`),
                 }),
                 true,
               ),
@@ -456,6 +446,34 @@ export class ResourceFactory {
       ResponseMappingTemplate: syncConfig ? print(DynamoDBMappingTemplate.dynamoDBResponse()) : print(ref('util.toJson($ctx.result)')),
       ...(syncConfig && { SyncConfig: SyncUtils.syncResolverConfig(syncConfig) }),
     });
+  }
+
+  public initalizeDefaultInputForCreateMutation(input: InputObjectTypeDefinitionNode, timestamps): string {
+    const hasDefaultIdField = input.fields?.find(field => field.name.value === 'id' && getBaseType(field.type) === 'ID');
+    return printBlock('Set default values')(
+      compoundExpression([
+        ...(hasDefaultIdField ? [qref(`$context.args.input.put("id", $util.defaultIfNull($ctx.args.input.id, $util.autoId()))`)] : []),
+        ...(timestamps && (timestamps.createdAtField || timestamps.updatedAtField)
+          ? [set(ref('createdAt'), ref('util.time.nowISO8601()'))]
+          : []),
+        ...(timestamps && timestamps.createdAtField
+          ? [
+              comment(`Automatically set the createdAt timestamp.`),
+              qref(
+                `$context.args.input.put("${timestamps.createdAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.createdAtField}, $createdAt))`,
+              ),
+            ]
+          : []),
+        ...(timestamps && timestamps.updatedAtField
+          ? [
+              comment(`Automatically set the updatedAt timestamp.`),
+              qref(
+                `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $createdAt))`,
+              ),
+            ]
+          : []),
+      ]),
+    );
   }
 
   public makeUpdateResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation', timestamps }: MutationResolverInput) {

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -703,24 +703,6 @@ function primaryIdFields(definition: ObjectTypeDefinitionNode, keyFields: string
   });
 }
 
-// Key fields are non-nullable, non-key fields follow what their @model declaration makes.
-function replaceCreateInput(
-  definition: ObjectTypeDefinitionNode,
-  input: InputObjectTypeDefinitionNode,
-  keyFields: string[],
-): InputObjectTypeDefinitionNode {
-  return {
-    ...input,
-    fields: input.fields.reduce((acc, f) => {
-      // If the field is a key, make it non-null.
-      if (keyFields.find(k => k === f.name.value)) {
-        return [...acc, makeInputValueDefinition(f.name.value, makeNonNullType(makeNamedType(getBaseType(f.type))))];
-      }
-      return [...acc, f];
-    }, []),
-  };
-}
-
 // Key fields are non-nullable, non-key fields are not non-nullable.
 function replaceUpdateInput(
   definition: ObjectTypeDefinitionNode,

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -348,10 +348,12 @@ export class KeyTransformer extends Transformer {
   private updateInputObjects = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
     if (this.isPrimaryKey(directive)) {
       const directiveArgs: KeyArguments = getDirectiveArguments(directive);
-      const createInput = ctx.getType(ModelResourceIDs.ModelCreateInputObjectName(definition.name.value)) as InputObjectTypeDefinitionNode;
-      if (createInput) {
-        ctx.putType(replaceCreateInput(definition, createInput, directiveArgs.fields));
-      }
+
+      // There is no need to update the create Input as fields that can be in the index have to be non-nullable (which is enforece by
+      // @key directive). The @model transformer generates the createXInput where non-nullable fields  are
+      // also non-nullables in the input types as wekk. Only exception to this is when these fields can be automatically populated
+      // like id, createdAt and updatedAt, which will automatically get default value
+
       const updateInput = ctx.getType(ModelResourceIDs.ModelUpdateInputObjectName(definition.name.value)) as InputObjectTypeDefinitionNode;
       if (updateInput) {
         ctx.putType(replaceUpdateInput(definition, updateInput, directiveArgs.fields));

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -2,7 +2,14 @@
 
 exports[`Check KeyTransformer Resolver Code 1`] = `
 Object {
-  "Mutation.createItem.req.vtl": "
+  "Mutation.createItem.req.vtl": "## [Start] Set default values. **
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+
 
 
 
@@ -21,11 +28,6 @@ Object {
 #end
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 ## [Start] Prepare DynamoDB PutItem Request. **
-#set( $createdAt = $util.time.nowISO8601() )
-## Automatically set the createdAt timestamp. **
-$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
@@ -50,7 +52,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
   \\"version\\": \\"2017-02-28\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
-  \\"id\\":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
   \\"condition\\": $util.toJson($condition)

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -88,7 +88,7 @@
     "globals": {
       "window": {},
       "ts-jest": {
-        "tsConfig": "tsconfig.tests.json"
+        "tsConfig": "<rootDir>/tsconfig.tests.json"
       }
     }
   },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -67,6 +67,87 @@ test('Test that a primary @key with 2 fields changes the hash and sort key.', ()
   expectArguments(getTestField, ['email', 'kind']);
 });
 
+test('Test that a primary @key with id as hashKey does not have it required in createInput', () => {
+  const validSchema = `
+    type Test @model @key(fields: ["id", "kind"]) {
+        id: ID!
+        email: String!
+        kind: Int!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
+  });
+
+  const out = transformer.transform(validSchema);
+  const schema = parse(out.schema);
+  const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(createInput, ['kind', 'email']);
+  expectNullableFields(createInput, ['id']);
+
+  const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(updateInput, ['id', 'kind']);
+  expectNullableFields(updateInput, ['email']);
+
+  const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(deleteInput, ['id', 'kind']);
+});
+
+test('Test that a primary @key with id and createdAt it is not a required in createInput', () => {
+  const validSchema = `
+    type Test @model @key(fields: ["id", "createdAt"]) {
+        id: ID!
+        email: String!
+        createdAt: AWSDateTime!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
+  });
+
+  const out = transformer.transform(validSchema);
+  const schema = parse(out.schema);
+  const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(createInput, ['email']);
+  expectNullableFields(createInput, ['id', 'createdAt']);
+
+  const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(updateInput, ['id', 'createdAt']);
+  expectNullableFields(updateInput, ['email']);
+
+  const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(deleteInput, ['id', 'createdAt']);
+});
+
+test('Test that a primary @key with emailId and location makes it a required in createInput', () => {
+  const validSchema = `
+    type Test @model @key(fields: ["emailId", "location"]) {
+        emailId: AWSEmail!
+        location: String!
+        name: String
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
+  });
+
+  const out = transformer.transform(validSchema);
+  const schema = parse(out.schema);
+  const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(createInput, ['emailId', 'location']);
+  expectNullableFields(createInput, ['name']);
+
+  const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(updateInput, ['emailId', 'location']);
+  expectNullableFields(updateInput, ['name']);
+
+  const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
+  expectNonNullFields(deleteInput, ['emailId', 'location']);
+});
+
 test('Test that a primary @key with 3 fields changes the hash and sort keys.', () => {
   const validSchema = `
     type Test @model @key(fields: ["email", "kind", "date"]) {
@@ -223,7 +304,7 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
 
   // Check the create, update, delete inputs.
   const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTestInput') as ObjectTypeDefinitionNode;
-  expectNonNullFields(createInput, ['email', 'createdAt', 'category']);
+  expectNonNullFields(createInput, ['email', 'category']);
   expectNullableFields(createInput, ['description']);
   expect(createInput.fields).toHaveLength(4);
   const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;


### PR DESCRIPTION
Added support for auto population of id, createdAt and updatedAt fields even when they are part of
the primary key

fix #2671
fix #1657 
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.