### PR TITLE
fix(amplify-graphql-types-generator): use zen-observable-ts

### DIFF
--- a/packages/amplify-graphql-types-generator/src/angular/index.ts
+++ b/packages/amplify-graphql-types-generator/src/angular/index.ts
@@ -26,7 +26,7 @@ export function generateSource(context: LegacyCompilerContext) {
   generator.printOnNewline(`import API, { graphqlOperation } from '@aws-amplify/api';`);
   generator.printOnNewline(`import { GraphQLResult } from "@aws-amplify/api/lib/types";`);
 
-  generator.printOnNewline(`import * as Observable from 'zen-observable';`);
+  generator.printOnNewline(`import { Observable } from 'zen-observable-ts';`);
   generator.printNewline();
 
   generateTypes(generator, context);

--- a/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/amplify-graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`Angular code generation #generateSource() should generate correct list 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 // The episodes in the Star Wars trilogy
 export enum Episode {
@@ -87,7 +87,7 @@ exports[`Angular code generation #generateSource() should generate fragmented qu
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type HeroAndFriendsNamesQuery = {
   __typename: \\"Character\\";
@@ -177,7 +177,7 @@ exports[`Angular code generation #generateSource() should generate mutation oper
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 // The episodes in the Star Wars trilogy
 export enum Episode {
@@ -247,7 +247,7 @@ exports[`Angular code generation #generateSource() should generate queries retur
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type CustomScalarQuery = {
   __typename: \\"QueryObject\\";
@@ -279,7 +279,7 @@ exports[`Angular code generation #generateSource() should generate query operati
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type HeroAndDetailsQuery = {
   __typename: \\"Character\\";
@@ -325,7 +325,7 @@ exports[`Angular code generation #generateSource() should generate simple nested
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 // The episodes in the Star Wars trilogy
 export enum Episode {
@@ -393,7 +393,7 @@ exports[`Angular code generation #generateSource() should generate simple nested
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type StarshipCoordsQuery = {
   __typename: \\"Starship\\";
@@ -425,7 +425,7 @@ exports[`Angular code generation #generateSource() should generate simple query 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 @Injectable({
   providedIn: \\"root\\"
@@ -455,7 +455,7 @@ exports[`Angular code generation #generateSource() should generate simple query 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type HeroNameQuery = {
   __typename: \\"Character\\";
@@ -488,7 +488,7 @@ exports[`Angular code generation #generateSource() should generate simple query 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 // The episodes in the Star Wars trilogy
 export enum Episode {
@@ -534,7 +534,7 @@ exports[`Angular code generation #generateSource() should handle comments in enu
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export enum EnumCommentTestCase {
   first = \\"first\\", // This is a single-line comment
@@ -573,7 +573,7 @@ exports[`Angular code generation #generateSource() should handle interfaces at r
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type CustomScalarQuery = {
   __typename: \\"InterfaceTestCase\\";
@@ -611,7 +611,7 @@ exports[`Angular code generation #generateSource() should handle multi-line comm
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
@@ -645,7 +645,7 @@ exports[`Angular code generation #generateSource() should handle single line com
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type CustomScalarQuery = {
   __typename: \\"CommentTest\\";
@@ -678,7 +678,7 @@ exports[`Angular code generation #generateSource() should handle unions at root 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type CustomScalarQuery = {
   __typename: \\"PartialA\\" | \\"PartialB\\";
@@ -714,7 +714,7 @@ exports[`Angular code generation #generateSource() should have __typename value 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type HeroNameQuery = {
   __typename: \\"Character\\";
@@ -759,7 +759,7 @@ exports[`Angular code generation #generateSource() should have __typename value 
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type DroidNameQuery = {
   __typename: \\"Droid\\";
@@ -798,7 +798,7 @@ exports[`Angular code generation #generateSource() should have the correct __typ
 import { Injectable } from \\"@angular/core\\";
 import API, { graphqlOperation } from \\"@aws-amplify/api\\";
 import { GraphQLResult } from \\"@aws-amplify/api/lib/types\\";
-import * as Observable from \\"zen-observable\\";
+import { Observable } from \\"zen-observable-ts\\";
 
 export type FindHumanQuery = {
   __typename: \\"Human\\";


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/4419

*Description of changes:*
As of 3.0.13, aws-amplify is using `zen-onservable-ts`. (See: https://github.com/aws-amplify/amplify-js/commit/49d295eee25d287ad705d878facf07bd6a3cfab9)

While upgrading our project, which was using aws-amplify 2.x.x, our TypeScript failed to compile.

As soon as I make the changes that are part of this PR,  to thé API service generated by thé CLI, TypeScript compilation is succesfull again.

This PR is a first draft for further discussing. I can update the PR accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.