### PR TITLE
fix(amplify-nodejs-function-runtime-provider): unhandled errors

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/__snapshots__/execute.test.ts.snap
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/__snapshots__/execute.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`execute async handler should fail when throwing an error 1`] = `Object {}`;
+exports[`execute async handler should fail when throwing an error 1`] = `[Error: Fail]`;
 
 exports[`execute async handler should succeed with a returned value 1`] = `"foo"`;
 
-exports[`execute callback handler should fail when returning an error 1`] = `Object {}`;
+exports[`execute callback handler should fail when returning an error 1`] = `[Error: Fail]`;
 
 exports[`execute callback handler should succeed with a returned value 1`] = `"foo"`;
 

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
@@ -37,7 +37,7 @@ export function invokeFunction(options: InvokeOptions) {
       },
       fail(error: any) {
         returned = true;
-        reject(_.assign({}, error));
+        reject(error);
       },
       awsRequestId: 'LAMBDA_INVOKE',
       logStreamName: 'LAMBDA_INVOKE',
@@ -93,7 +93,15 @@ process.on('message', async options => {
     const result = await invokeFunction(JSON.parse(options));
     process.send!(JSON.stringify({ result, error: null }));
   } catch (error) {
-    process.send!(JSON.stringify({ result: null, error }));
+    process.send!(
+      JSON.stringify({
+        result: null,
+        error: {
+          type: 'Lambda:Unhandled',
+          message: error.message,
+        },
+      }),
+    );
   }
   process.exit(1);
 });


### PR DESCRIPTION
*Description of changes:*
- `_.assign` on an `Error` removes all the fields.
- `JSON.stringify()` also does not work on Errors (serializes to empty object).

This lead to errors becoming empty when reaching the response template, and the following would not work:

````vtl
#if($context.error)
  $util.error($context.error.message, $context.error.type)
````


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.