### PR TITLE
feat(amplify-appsync-simulator): implement BatchInvoke

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -29,6 +29,7 @@
     "aws-sdk": "^2.608.0",
     "chalk": "^3.0.0",
     "cors": "^2.8.5",
+    "dataloader": "^2.0.0",
     "event-to-promise": "^0.8.0",
     "express": "^4.17.1",
     "graphql": "^14.5.8",

--- a/packages/amplify-appsync-simulator/src/__tests__/resolvers/unit-resolver.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/resolvers/unit-resolver.test.ts
@@ -113,7 +113,7 @@ describe('Unit resolver', () => {
       const result = await resolver.resolve(source, args, context, info);
       expect(result).toEqual(RESPONSE_TEMPLATE_RESULT);
       expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
-      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT, { source, args, context, info });
       expect(getDataLoader).toBeCalledWith('TodoTable');
       expect(templates.response.render).toHaveBeenCalledWith({ source, arguments: args, result: DATA_FROM_DATA_SOURCE }, context, info);
     });
@@ -125,7 +125,7 @@ describe('Unit resolver', () => {
 
       await expect(() => resolver.resolve(source, args, context, info)).rejects.toThrowError('Some request template error');
       expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
-      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT, { source, args, context, info });
       expect(getDataLoader).toBeCalledWith('TodoTable');
       expect(templates.response.render).not.toHaveBeenCalled();
     });
@@ -139,7 +139,7 @@ describe('Unit resolver', () => {
       const result = await resolver.resolve(source, args, context, info);
       expect(result).toEqual(RESPONSE_TEMPLATE_RESULT);
       expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
-      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(dataFetcher).toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT, { source, args, context, info });
       expect(getDataLoader).toBeCalledWith('TodoTable');
       expect(templates.response.render).toHaveBeenCalledWith({ source, arguments: args, error: error, result: null }, context, info);
     });
@@ -155,7 +155,7 @@ describe('Unit resolver', () => {
       const result = await resolver.resolve(source, args, context, info);
       expect(result).toEqual(REQUEST_TEMPLATE_RESULT.result);
       expect(templates.request.render).toHaveBeenCalledWith({ source, arguments: args }, context, info);
-      expect(dataFetcher).not.toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT);
+      expect(dataFetcher).not.toHaveBeenCalledWith(REQUEST_TEMPLATE_RESULT, { source, args, context, info });
       expect(templates.response.render).not.toHaveBeenCalled();
     });
 

--- a/packages/amplify-appsync-simulator/src/data-loader/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/index.ts
@@ -3,7 +3,7 @@ import { NoneDataLoader } from './none';
 import { LambdaDataLoader } from './lambda';
 
 export interface AmplifyAppSyncSimulatorDataLoader {
-  load(payload: any): Promise<object | null>;
+  load(payload: any, extraData?: any): Promise<object | null>;
 }
 const DATA_LOADER_MAP = new Map();
 export function getDataLoader(sourceType) {

--- a/packages/amplify-appsync-simulator/src/data-loader/lambda/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/lambda/index.ts
@@ -1,10 +1,29 @@
 import { AmplifyAppSyncSimulatorDataLoader } from '..';
+import DataLoader from 'dataloader';
+
+const batchLoaders = {};
+
+const getBatchDataResolver = (loaderName, resolver) => {
+  if (batchLoaders[loaderName] === undefined) {
+    batchLoaders[loaderName] = new DataLoader(resolver, { cache: false });
+  }
+  return batchLoaders[loaderName];
+};
 
 export class LambdaDataLoader implements AmplifyAppSyncSimulatorDataLoader {
   constructor(private _config) {}
-  async load(req) {
+
+  async load(req, extraData) {
     try {
-      const result = await this._config.invoke(req.payload);
+      let result;
+      if (req.operation === 'BatchInvoke') {
+        const { fieldName, parentType } = extraData.info;
+        const batchName = `${parentType}.${fieldName}`;
+        const dataLoader = getBatchDataResolver(batchName, this._config.invoke);
+        result = await dataLoader.load(req.payload);
+      } else {
+        result = await this._config.invoke(req.payload);
+      }
       return result;
     } catch (e) {
       console.log('Lambda Data source failed with the following error');

--- a/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
@@ -35,7 +35,7 @@ export class AppSyncUnitResolver extends AppSyncBaseResolver {
       return requestPayload;
     }
     try {
-      result = await dataLoader.load(requestPayload);
+      result = await dataLoader.load(requestPayload, { source, args, context, info });
     } catch (e) {
       if (requestPayload && requestPayload.version === '2018-05-29') {
         // https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-changelog.html#aws-appsync-resolver-mapping-template-version-2018-05-29

--- a/yarn.lock
+++ b/yarn.lock
@@ -8869,6 +8869,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+dataloader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
+  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #4404

*Description of changes:*
Implements, `BatchInvoke` for lambda resolvers.
Payloads are batched by `parentType` and `fieldName`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.