### PR TITLE
feat: add and update layers on functions

### DIFF
--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -27,6 +27,7 @@
     "graphql-transformer-core": "6.18.1",
     "inquirer": "^7.0.3",
     "inquirer-datepicker": "^1.1.0",
+    "enquirer": "^2.3.5",
     "jstreemap": "^1.28.2",
     "lodash": "^4.17.15",
     "mime-types": "^2.1.26",

--- a/packages/amplify-category-function/resources/awscloudformation/cloudformation-templates/lambda-function-cloudformation-template.json.ejs
+++ b/packages/amplify-category-function/resources/awscloudformation/cloudformation-templates/lambda-function-cloudformation-template.json.ejs
@@ -70,6 +70,7 @@
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
             "Runtime": "<%= props.runtime.cloudTemplateValue %>",
+            "Layers": <%- JSON.stringify(props.lambdaLayersCFNArray) %>,
             "Timeout": "25"
           }
         },

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
@@ -1,0 +1,130 @@
+import {
+  askLayerSelection,
+  askCustomArnQuestion,
+  askLayerOrderQuestion,
+} from '../../../../provider-utils/awscloudformation/utils/addLayerToFunctionUtils';
+import { addLayersToFunctionWalkthrough } from '../../../../provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough';
+import { LambdaLayer, FunctionDependency } from 'amplify-function-plugin-interface';
+
+jest.mock('../../../../provider-utils/awscloudformation/utils/addLayerToFunctionUtils');
+
+const askLayerSelection_mock = askLayerSelection as jest.MockedFunction<typeof askLayerSelection>;
+const askCustomArnQuestion_mock = askCustomArnQuestion as jest.MockedFunction<typeof askCustomArnQuestion>;
+const askLayerOrderQuestion_mock = askLayerOrderQuestion as jest.MockedFunction<typeof askLayerOrderQuestion>;
+
+const confirmPromptFalse_mock = jest.fn(() => false);
+const confirmPromptTrue_mock = jest.fn(() => true);
+const getContextStubWith = (prompt: jest.Mock) => ({
+  amplify: {
+    confirmPrompt: {
+      run: prompt,
+    },
+    getProjectMeta: () => {},
+  },
+});
+
+const runtimeStub = {
+  value: 'lolcode', // http://www.lolcode.org/
+};
+
+const layerSelectionStub: LambdaLayer[] = [
+  {
+    type: 'ProjectLayer',
+    resourceName: 'myLayer',
+    version: 10,
+  },
+  {
+    type: 'ProjectLayer',
+    resourceName: 'anotherLayer',
+    version: 123498,
+  },
+];
+
+const arnEntryStub: LambdaLayer[] = [
+  {
+    type: 'ExternalLayer',
+    arn: 'superCoolArn',
+  },
+  {
+    type: 'ExternalLayer',
+    arn: 'literalGarbage',
+  },
+];
+
+const dependsOnStub: FunctionDependency[] = [
+  {
+    category: 'aCategory',
+    resourceName: 'myLayer',
+    attributes: ['AnAttribute'],
+  },
+];
+
+const previousSelectionsStub: LambdaLayer[] = [
+  {
+    type: 'ExternalLayer',
+    arn: 'previousARN',
+  },
+];
+
+askLayerSelection_mock.mockImplementation(async () => ({
+  lambdaLayers: layerSelectionStub,
+  dependsOn: dependsOnStub,
+  askArnQuestion: false,
+}));
+
+askCustomArnQuestion_mock.mockImplementation(async () => arnEntryStub);
+
+askLayerOrderQuestion_mock.mockImplementation(async layers => layers);
+
+describe('add layer to function walkthrough', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty layers and dependsOn if the customer does not want to add layers', async () => {
+    const result = await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptFalse_mock), runtimeStub);
+
+    expect(confirmPromptFalse_mock.mock.calls.length).toBe(1);
+    expect(askLayerSelection_mock.mock.calls.length).toBe(0);
+
+    expect(result.lambdaLayers).toStrictEqual([]);
+    expect(result.dependsOn).toStrictEqual([]);
+  });
+
+  it('asks the layer selection question', async () => {
+    const result = await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptTrue_mock), runtimeStub);
+
+    expect(confirmPromptTrue_mock.mock.calls.length).toBe(1);
+    expect(askLayerSelection_mock.mock.calls.length).toBe(1);
+    expect(askLayerOrderQuestion_mock.mock.calls.length).toBe(1);
+
+    expect(result.lambdaLayers).toStrictEqual(layerSelectionStub);
+    expect(result.dependsOn).toStrictEqual(dependsOnStub);
+  });
+
+  it('only asks for ARNs if the customer selects the option', async () => {
+    askLayerSelection_mock.mockImplementation(async () => ({
+      lambdaLayers: layerSelectionStub,
+      dependsOn: dependsOnStub,
+      askArnQuestion: true,
+    }));
+    const result = await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptTrue_mock), runtimeStub);
+
+    expect(askCustomArnQuestion_mock.mock.calls.length).toBe(1);
+    const expectedLayers = layerSelectionStub.concat(arnEntryStub);
+    expect(result.lambdaLayers).toStrictEqual(expectedLayers);
+  });
+
+  it('asks to reorder the selected layers', async () => {
+    const result = await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptTrue_mock), runtimeStub);
+
+    expect(askLayerOrderQuestion_mock.mock.calls.length).toBe(1);
+  });
+
+  it('uses previous selections to populate default selections', async () => {
+    await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptTrue_mock), runtimeStub, previousSelectionsStub);
+
+    expect(askLayerSelection_mock.mock.calls[0][2]).toStrictEqual(previousSelectionsStub);
+    expect(askLayerOrderQuestion_mock.mock.calls[0][1]).toStrictEqual(previousSelectionsStub);
+  });
+});

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
@@ -1,0 +1,242 @@
+import {
+  askLayerSelection,
+  provideExistingARNsPrompt,
+  askCustomArnQuestion,
+  askLayerOrderQuestion,
+} from '../../../../provider-utils/awscloudformation/utils/addLayerToFunctionUtils';
+import inquirer, { CheckboxQuestion, ListQuestion, InputQuestion } from 'inquirer';
+import enquirer from 'enquirer';
+import { ServiceName } from '../../../../provider-utils/awscloudformation/utils/constants';
+import { LambdaLayer, FunctionDependency } from 'amplify-function-plugin-interface';
+import { category } from '../../../../constants';
+
+jest.mock('inquirer');
+jest.mock('enquirer', () => ({ prompt: jest.fn() }));
+
+const inquirer_mock = inquirer as jest.Mocked<typeof inquirer>;
+const enquirer_mock = enquirer as jest.Mocked<typeof enquirer>;
+
+const runtimeValue = 'lolcode';
+
+const amplifyMetaStub = {
+  function: {
+    aLayer: {
+      service: ServiceName.LambdaLayer,
+      runtimes: [
+        {
+          value: runtimeValue,
+        },
+      ],
+    },
+  },
+};
+
+const previousSelectionsStub: LambdaLayer[] = [
+  {
+    type: 'ProjectLayer',
+    resourceName: 'aLayer',
+    version: 2,
+  },
+];
+
+describe('layer selection question', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty and prompts for arns when no layers available', async () => {
+    const amplifyMetaStub = {};
+    const result = await askLayerSelection(amplifyMetaStub, runtimeValue);
+    expect(result.lambdaLayers).toStrictEqual([]);
+    expect(result.dependsOn).toStrictEqual([]);
+    expect(result.askArnQuestion).toBe(true);
+  });
+
+  it('sets default layer choices based on previous selections', async () => {
+    (inquirer_mock.prompt as any).mockImplementation(() => ({
+      layerSelections: [],
+    }));
+
+    const result = await askLayerSelection(amplifyMetaStub, runtimeValue, previousSelectionsStub);
+    expect((inquirer_mock.prompt.mock.calls[0][0] as CheckboxQuestion).choices[1].checked).toBe(true);
+  });
+
+  it('sets askArnQuestion to true when the customer selects the option', async () => {
+    (inquirer_mock.prompt as any).mockImplementation(() => ({
+      layerSelections: [provideExistingARNsPrompt],
+    }));
+
+    const result = await askLayerSelection(amplifyMetaStub, runtimeValue);
+    expect(result.askArnQuestion).toBe(true);
+  });
+
+  it('sets the default version for each layer to the previous selection', async () => {
+    (inquirer_mock.prompt as any).mockImplementationOnce(() => ({
+      layerSelections: ['aLayer'],
+    }));
+    (inquirer_mock.prompt as any).mockImplementationOnce(() => ({
+      versionSelection: 2,
+    }));
+    await askLayerSelection(amplifyMetaStub, runtimeValue, previousSelectionsStub);
+    expect((inquirer_mock.prompt.mock.calls[1][0] as ListQuestion).default).toBe('2');
+  });
+
+  it('returns the selected layers', async () => {
+    (inquirer_mock.prompt as any).mockImplementationOnce(() => ({
+      layerSelections: [provideExistingARNsPrompt, 'aLayer'],
+    }));
+    (inquirer_mock.prompt as any).mockImplementationOnce(() => ({
+      versionSelection: 2,
+    }));
+    const result = await askLayerSelection(amplifyMetaStub, runtimeValue);
+    const expectedLambdaLayers: LambdaLayer[] = [
+      {
+        type: 'ProjectLayer',
+        resourceName: 'aLayer',
+        version: 2,
+      },
+    ];
+    const expectedDependsOn: FunctionDependency[] = [
+      {
+        category,
+        resourceName: 'aLayer',
+        attributes: ['Arn'],
+      },
+    ];
+    expect(result.lambdaLayers).toStrictEqual(expectedLambdaLayers);
+    expect(result.dependsOn).toStrictEqual(expectedDependsOn);
+    expect(result.askArnQuestion).toBe(true);
+  });
+});
+
+describe('custom arn question', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('sets default ARNs to previous values', async () => {
+    const previousSelectionsStub: LambdaLayer[] = [
+      {
+        type: 'ExternalLayer',
+        arn: 'someArn',
+      },
+    ];
+    (inquirer_mock.prompt as any).mockImplementationOnce(() => ({
+      arns: [],
+    }));
+    await askCustomArnQuestion(1, previousSelectionsStub);
+    expect((inquirer_mock.prompt.mock.calls[0][0] as InputQuestion).default).toBe('someArn');
+  });
+  it('returns ARNs as LambdaLayer array', async () => {
+    (inquirer_mock.prompt as any).mockImplementationOnce(() => ({
+      arns: ['arn1', 'arn2'],
+    }));
+    const result = await askCustomArnQuestion(1, previousSelectionsStub);
+    const expectedResult: LambdaLayer[] = [
+      {
+        type: 'ExternalLayer',
+        arn: 'arn1',
+      },
+      {
+        type: 'ExternalLayer',
+        arn: 'arn2',
+      },
+    ];
+    expect(result).toStrictEqual(expectedResult);
+  });
+});
+
+describe('layer order question', () => {
+  beforeAll(() => {
+    enquirer_mock.prompt.mockImplementation(async () => ({
+      sortedNames: ['myLayer', 'anotherLayer', 'someArn'],
+    }));
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('orders list based on previous selections', async () => {
+    const currentSelectionsStub: LambdaLayer[] = [
+      {
+        type: 'ExternalLayer',
+        arn: 'someArn',
+      },
+      {
+        type: 'ProjectLayer',
+        resourceName: 'myLayer',
+        version: 2,
+      },
+      {
+        type: 'ProjectLayer',
+        resourceName: 'anotherLayer',
+        version: 1,
+      },
+    ];
+
+    const previousSelectionsStub: LambdaLayer[] = [
+      {
+        type: 'ProjectLayer',
+        resourceName: 'myLayer',
+        version: 2,
+      },
+      {
+        type: 'ExternalLayer',
+        arn: 'someArn',
+      },
+    ];
+
+    await askLayerOrderQuestion(currentSelectionsStub, previousSelectionsStub);
+    const presentedOrder = (enquirer_mock.prompt.mock.calls[0][0] as any).choices as string[];
+    expect(presentedOrder).toStrictEqual(['myLayer', 'someArn', 'anotherLayer']);
+  });
+
+  it('returns customer-defined ordering of layers', async () => {
+    const currentSelectionsStub: LambdaLayer[] = [
+      {
+        type: 'ExternalLayer',
+        arn: 'someArn',
+      },
+      {
+        type: 'ProjectLayer',
+        resourceName: 'myLayer',
+        version: 2,
+      },
+      {
+        type: 'ProjectLayer',
+        resourceName: 'anotherLayer',
+        version: 1,
+      },
+    ];
+
+    const expectedResultOrder: LambdaLayer[] = [
+      {
+        type: 'ProjectLayer',
+        resourceName: 'myLayer',
+        version: 2,
+      },
+      {
+        type: 'ProjectLayer',
+        resourceName: 'anotherLayer',
+        version: 1,
+      },
+      {
+        type: 'ExternalLayer',
+        arn: 'someArn',
+      },
+    ];
+    const result = await askLayerOrderQuestion(currentSelectionsStub);
+    expect(result).toStrictEqual(expectedResultOrder);
+  });
+
+  it('does not prompt for order when only one selection', async () => {
+    const currentSelectionsStub: LambdaLayer[] = [
+      {
+        type: 'ExternalLayer',
+        arn: 'someArn',
+      },
+    ];
+    const result = await askLayerOrderQuestion(currentSelectionsStub);
+    expect(enquirer_mock.prompt.mock.calls.length).toBe(0);
+    expect(result).toStrictEqual(currentSelectionsStub);
+  });
+});

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -87,6 +87,9 @@ async function addFunctionResource(
       },
     });
 
+    // make sure the lambda layers array is initialized
+    funcParams = merge(funcParams, { lambdaLayers: [] });
+
     // populate the parameters for the resource
     // This will modify funcParams
     await serviceConfig.walkthroughs.createWalkthrough(context, funcParams);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
@@ -1,0 +1,40 @@
+import { FunctionParameters, FunctionRuntime, LambdaLayer, FunctionDependency } from 'amplify-function-plugin-interface';
+import _ from 'lodash';
+import { askLayerSelection, askCustomArnQuestion, askLayerOrderQuestion } from '../utils/addLayerToFunctionUtils';
+
+const confirmationPrompt = 'Do you want to modify the layers this function can access?';
+
+/**
+ * Performs the walkthrough to add layers to a function
+ * @param context Amplify platform context
+ * @param runtime Runtime of the function that is being modified
+ * @param previousSelections Array of layers already added to this function (if any)
+ */
+export const addLayersToFunctionWalkthrough = async (
+  context,
+  runtime: Pick<FunctionRuntime, 'value'>,
+  previousSelections: LambdaLayer[] = [],
+): Promise<Required<Pick<FunctionParameters, 'lambdaLayers' | 'dependsOn'>>> => {
+  let lambdaLayers: LambdaLayer[] = [];
+  let dependsOn: FunctionDependency[] = [];
+
+  // ask initial confirmation
+  if (!(await context.amplify.confirmPrompt.run(confirmationPrompt))) {
+    return { lambdaLayers, dependsOn };
+  }
+
+  let askArnQuestion: boolean;
+  ({ lambdaLayers, dependsOn, askArnQuestion } = await askLayerSelection(
+    context.amplify.getProjectMeta(),
+    runtime.value,
+    previousSelections,
+  ));
+
+  if (askArnQuestion) {
+    lambdaLayers = lambdaLayers.concat(await askCustomArnQuestion(lambdaLayers.length, previousSelections));
+  }
+
+  lambdaLayers = await askLayerOrderQuestion(lambdaLayers, previousSelections);
+
+  return { lambdaLayers, dependsOn };
+};

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 import { ServiceName, functionParametersFileName, parametersFileName } from '../utils/constants';
-import { category as categoryName, category } from '../../../constants';
+import { category } from '../../../constants';
 import { getNewCFNParameters, getNewCFNEnvVariables } from '../utils/cloudformationHelpers';
 import { askExecRolePermissionsQuestions } from './execPermissionsWalkthrough';
 import { scheduleWalkthrough } from './scheduleWalkthrough';
@@ -83,7 +83,7 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
   const functionParameters: Partial<FunctionParameters> = { resourceName: lambdaToUpdate };
 
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
-  const resourceDirPath = path.join(projectBackendDirPath, categoryName, functionParameters.resourceName);
+  const resourceDirPath = path.join(projectBackendDirPath, category, functionParameters.resourceName);
   const parametersFilePath = path.join(resourceDirPath, functionParametersFileName);
   const currentParameters = context.amplify.readJsonFile(parametersFilePath, undefined, false) || {};
 
@@ -178,7 +178,7 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
 }
 
 export function migrate(context, projectPath, resourceName) {
-  const resourceDirPath = path.join(projectPath, 'amplify', 'backend', categoryName, resourceName);
+  const resourceDirPath = path.join(projectPath, 'amplify', 'backend', category, resourceName);
   const cfnFilePath = path.join(resourceDirPath, `${resourceName}-cloudformation-template.json`);
   const oldCfn = context.amplify.readJsonFile(cfnFilePath);
   const newCfn: any = {};

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -7,12 +7,14 @@ import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 import { ServiceName, functionParametersFileName, parametersFileName } from '../utils/constants';
-import { category as categoryName } from '../../../constants';
+import { category as categoryName, category } from '../../../constants';
 import { getNewCFNParameters, getNewCFNEnvVariables } from '../utils/cloudformationHelpers';
 import { askExecRolePermissionsQuestions } from './execPermissionsWalkthrough';
 import { scheduleWalkthrough } from './scheduleWalkthrough';
 import { merge } from '../utils/funcParamsUtils';
 import { tryUpdateTopLevelComment } from '../utils/updateTopLevelComment';
+import { addLayersToFunctionWalkthrough } from './addLayerToFunctionWalkthrough';
+import { convertLambdaLayerMetaToLayerCFNArray } from '../utils/layerArnConverter';
 
 /**
  * Starting point for CLI walkthrough that generates a lambda function
@@ -43,6 +45,9 @@ export async function createWalkthrough(
 
   // ask scheduling Lambda questions and merge in results
   templateParameters = merge(templateParameters, await scheduleWalkthrough(context, templateParameters));
+
+  // ask lambda layer questions and merge in results
+  templateParameters = merge(templateParameters, await addLayersToFunctionWalkthrough(context, templateParameters.runtime));
   return templateParameters;
 }
 /**
@@ -152,6 +157,23 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
     resourceName: functionParameters.resourceName,
   };
   merge(functionParameters, await scheduleWalkthrough(context, scheduleParameters));
+
+  const functionRuntime = context.amplify.readBreadcrumbs(context, category, functionParameters.resourceName).functionRuntime as string;
+  const currentFunctionParameters =
+    context.amplify.readJsonFile(path.join(resourceDirPath, functionParametersFileName), undefined, false) || {};
+  merge(
+    functionParameters,
+    await addLayersToFunctionWalkthrough(context, { value: functionRuntime }, currentFunctionParameters.lambdaLayers),
+  );
+
+  // writing to the CFN here because it's done above for the schedule and the permissions but we should really pull all of it into another function
+  const cfnFileName = `${functionParameters.resourceName}-cloudformation-template.json`;
+  const cfnFilePath = path.join(resourceDirPath, cfnFileName);
+  const cfnContent = context.amplify.readJsonFile(cfnFilePath);
+
+  cfnContent.Resources.LambdaFunction.Properties.Layers = convertLambdaLayerMetaToLayerCFNArray(functionParameters.lambdaLayers);
+  context.amplify.writeObjectAsJson(cfnFilePath, cfnContent, true);
+
   return functionParameters;
 }
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -1,0 +1,177 @@
+import _ from 'lodash';
+import { FunctionRuntime, FunctionDependency, LambdaLayer, ProjectLayer, ExternalLayer } from 'amplify-function-plugin-interface';
+import { category } from '../../..';
+import { ServiceName } from './constants';
+import inquirer, { CheckboxQuestion, ListQuestion, InputQuestion } from 'inquirer';
+import enquirer from 'enquirer';
+import { stubLayerMetadataFactory } from './stubLayerMetadataFactory';
+
+const layerSelectionPrompt = 'Provide existing layers or select layers in this project to access from this function (pick up to 5):';
+export const provideExistingARNsPrompt = 'Provide existing Lambda Layer ARNs';
+const versionSelectionPrompt = (layerName: string) => `Select a version for ${layerName}:`;
+const ARNEntryPrompt = (remainingLayers: number) => `Enter up to ${remainingLayers} existing Lambda Layer ARNs (comma-separated):`;
+const layerOrderPrompt = 'Modify the layer order (Layers with conflicting files will overwrite contents of layers earlier in the list):';
+const layerARNRegex = /^arn:[a-zA-Z0-9-]+:lambda:[a-zA-Z0-9-]+:\d{12}:layer:[a-zA-Z0-9-_]+:\d+$/;
+
+/**
+ * Asks the customer to select from project layers and/or custom layer ARNs.
+ *
+ * Returns an array of LambdaLayer objects and a dependsOn array containing layers in the project
+ * @param amplifyMeta current amplify meta (used to fetch layers currently in the project)
+ * @param runtimeValue runtime value of the function being modified (used to filter layers by supported runtime)
+ * @param previousSelections previous layers added to the function (used to populate default selections)
+ */
+export const askLayerSelection = async (
+  amplifyMeta,
+  runtimeValue: string,
+  previousSelections: LambdaLayer[] = [],
+): Promise<{ lambdaLayers: LambdaLayer[]; dependsOn: FunctionDependency[]; askArnQuestion: boolean }> => {
+  const lambdaLayers: LambdaLayer[] = [];
+  const dependsOn: FunctionDependency[] = [];
+
+  const functionMeta = _.get(amplifyMeta, [category]) || {};
+  const layerOptions = _.keys(functionMeta)
+    .filter(key => functionMeta[key].service === ServiceName.LambdaLayer)
+    .filter(key => isRuntime(runtimeValue).inRuntimes(functionMeta[key].runtimes)); // filter by compatible runtimes
+
+  if (layerOptions.length === 0) {
+    return {
+      lambdaLayers,
+      dependsOn,
+      askArnQuestion: true,
+    };
+  }
+  const currentResourceNames = filterProjectLayers(previousSelections).map(sel => (sel as ProjectLayer).resourceName);
+  const choices = layerOptions.map(op => ({ name: op, checked: currentResourceNames.includes(op) }));
+  choices.unshift({ name: provideExistingARNsPrompt, checked: previousSelections.map(sel => sel.type).includes('ExternalLayer') });
+
+  const layerSelectionQuestion: CheckboxQuestion = {
+    type: 'checkbox',
+    name: 'layerSelections',
+    message: layerSelectionPrompt,
+    choices: choices,
+    validate: (input: string[]) => input.length <= 5 || 'Select at most 5 entries from the list',
+  };
+  let layerSelections = (await inquirer.prompt(layerSelectionQuestion)).layerSelections;
+  const askArnQuestion = layerSelections.includes(provideExistingARNsPrompt);
+  layerSelections = layerSelections.filter(selection => selection !== provideExistingARNsPrompt);
+
+  for (let selection of layerSelections) {
+    const currentSelectionDefaults = filterProjectLayers(previousSelections).find(sel => sel.resourceName === selection);
+    const currentVersion = currentSelectionDefaults ? currentSelectionDefaults.version.toString() : undefined;
+    const layerVersionPrompt: ListQuestion = {
+      type: 'list',
+      name: 'versionSelection',
+      message: versionSelectionPrompt(selection),
+      choices: stubLayerMetadataFactory(selection)
+        .versions.sort()
+        .reverse()
+        .map(num => num.toString()),
+      default: currentVersion,
+      filter: numStr => parseInt(numStr, 10),
+    };
+
+    const versionSelection = (await inquirer.prompt(layerVersionPrompt)).versionSelection as number;
+    lambdaLayers.push({
+      type: 'ProjectLayer',
+      resourceName: selection,
+      version: versionSelection,
+    });
+    dependsOn.push({
+      category,
+      resourceName: selection,
+      attributes: ['Arn'], // the layer doesn't actually depend on the ARN but there's some nasty EJS at the top of the function template that breaks without this, so here it is. Hurray for tight coupling!
+    });
+  }
+  return {
+    lambdaLayers,
+    dependsOn,
+    askArnQuestion,
+  };
+};
+
+/**
+ * Asks the customer to enter external layer ARNs
+ * @param numLayersSelected The number of ARNs they can enter
+ * @param previousSelections Array of previous layer selections (used to populate the default string)
+ */
+export const askCustomArnQuestion = async (numLayersSelected: number, previousSelections: LambdaLayer[] = []) => {
+  const arnPrompt: InputQuestion = {
+    type: 'input',
+    name: 'arns',
+    message: ARNEntryPrompt(5 - numLayersSelected),
+    validate: lambdaLayerARNValidator,
+    filter: stringSplitAndTrim,
+    default:
+      filterExternalLayers(previousSelections)
+        .map(sel => sel.arn)
+        .join(', ') || undefined,
+  };
+  return ((await inquirer.prompt(arnPrompt)).arns as string[]).map(arn => ({ type: 'ExternalLayer', arn } as LambdaLayer));
+};
+
+/**
+ * Asks the customer to reorder the selected layers (if more than 1)
+ * @param currentSelections Array of current selections the customer has made
+ * @param previousSelections Array of previous selections, if any (used to reorder the current selections to their previous order)
+ */
+export const askLayerOrderQuestion = async (currentSelections: LambdaLayer[], previousSelections: LambdaLayer[] = []) => {
+  if (currentSelections.length <= 1) {
+    return currentSelections;
+  }
+  // order selections based on previous selection order, if applicable
+  previousSelections.reverse().forEach(prevSel => {
+    let idx = -1;
+    switch (prevSel.type) {
+      case 'ExternalLayer':
+        idx = currentSelections.findIndex(currSel => currSel.type === 'ExternalLayer' && currSel.arn === prevSel.arn);
+        break;
+      default:
+        idx = currentSelections.findIndex(currSel => currSel.type === 'ProjectLayer' && currSel.resourceName === prevSel.resourceName);
+    }
+    if (idx >= 0) {
+      currentSelections.unshift(...currentSelections.splice(idx, 1)); // move element to beginning of list
+    }
+  });
+
+  const sortPrompt = {
+    type: 'sort',
+    name: 'sortedNames',
+    message: layerOrderPrompt,
+    choices: currentSelections.map(ll => (ll.type === 'ExternalLayer' ? ll.arn : ll.resourceName)),
+  };
+
+  const sortedNames = (await enquirer.prompt<{ sortedNames: string[] }>(sortPrompt)).sortedNames;
+
+  // sort the currentSelections based on the sortedNames
+  const finalSelectionOrder: LambdaLayer[] = [];
+  sortedNames.forEach(name =>
+    finalSelectionOrder.push(currentSelections.find(sel => (sel.type === 'ExternalLayer' ? sel.arn === name : sel.resourceName === name))),
+  );
+  return finalSelectionOrder;
+};
+
+const isRuntime = (runtime: string) => ({
+  inRuntimes: (runtimes: FunctionRuntime[]) => runtimes.map(runtime => runtime.value).includes(runtime),
+});
+
+const filterProjectLayers = (layers: LambdaLayer[]): ProjectLayer[] => {
+  return layers.filter(layer => layer.type === 'ProjectLayer') as ProjectLayer[];
+};
+
+const filterExternalLayers = (layers: LambdaLayer[]): ExternalLayer[] => {
+  return layers.filter(layer => layer.type === 'ExternalLayer') as ExternalLayer[];
+};
+
+const stringSplitAndTrim = (input: string): string[] => {
+  return input
+    .split(',')
+    .map(str => str.trim())
+    .filter(str => str); // filter out empty elements
+};
+
+// validats that each string in input is a valid lambda layer ARN
+const lambdaLayerARNValidator = (input: string[]): true | string => {
+  const invalidARNs = input.filter(arn => !arn.match(layerARNRegex));
+  return invalidARNs.length === 0 ? true : `${invalidARNs.join(', ')} are not valid Lambda Layer ARNs`;
+};

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -170,7 +170,7 @@ const stringSplitAndTrim = (input: string): string[] => {
     .filter(str => str); // filter out empty elements
 };
 
-// validats that each string in input is a valid lambda layer ARN
+// validates that each string in input is a valid lambda layer ARN
 const lambdaLayerARNValidator = (input: string[]): true | string => {
   const invalidARNs = input.filter(arn => !arn.match(layerARNRegex));
   return invalidARNs.length === 0 ? true : `${invalidARNs.join(', ')} are not valid Lambda Layer ARNs`;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerArnConverter.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerArnConverter.ts
@@ -1,0 +1,14 @@
+import { LambdaLayer, ProjectLayer } from 'amplify-function-plugin-interface';
+
+/**
+ * Convert the internal LambdaLayer[] structure into an array that can be JSON.stringify-ed into valid CFN
+ */
+export const convertLambdaLayerMetaToLayerCFNArray = (input: LambdaLayer[]): (string | { 'Fn::Sub': string })[] => {
+  return input.map(layer => (layer.type === 'ProjectLayer' ? convertProjectLayer(layer) : layer.arn));
+};
+
+const convertProjectLayer = (layer: ProjectLayer) => {
+  return {
+    'Fn::Sub': `arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:layer:${layer.resourceName}:${layer.version}`,
+  };
+};

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/stubLayerMetadataFactory.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/stubLayerMetadataFactory.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a stub of a class / factory method that will be responsible for loading layer metadata
+ */
+export const stubLayerMetadataFactory: LayerMetadataFactory = () => ({ versions: [1, 2, 3] });
+
+export type LayerMetadataFactory = (layerName: string) => LayerMetadata;
+
+export interface LayerMetadata {
+  versions: number[];
+}

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -72,77 +72,94 @@ const coreFunction = (
       functionConfigCallback(chain, cwd, settings);
     }
 
-    if (!settings.expectFailure) {
-      chain.wait(
-        action === 'create'
-          ? 'Do you want to access other resources in this project from your Lambda function?'
-          : 'Do you want to update the Lambda function permissions to access other resources in this project?',
-      );
-
-      if (settings.additionalPermissions) {
-        multiSelect(
-          chain.sendLine('y').wait('Select the category'),
-          settings.additionalPermissions.permissions,
-          settings.additionalPermissions.choices,
-        );
-        // when single resource, it gets autoselected
-        if (settings.additionalPermissions.resources.length > 1) {
-          multiSelect(
-            chain.wait('Select the one you would like your'),
-            settings.additionalPermissions.resources,
-            settings.additionalPermissions.resourceChoices,
-          );
-        }
-
-        // n-resources repeated questions
-        settings.additionalPermissions.resources.reduce(
-          (chain, elem) =>
-            multiSelect(chain.wait(`Select the operations you want to permit for ${elem}`), settings.additionalPermissions.operations, [
-              'create',
-              'read',
-              'update',
-              'delete',
-            ]),
-          chain,
-        );
-      } else {
-        chain.sendLine('n');
-      }
-
-      //scheduling questions
-      if (action === 'create') {
-        chain.wait('Do you want to invoke this function on a recurring schedule?');
-      } else {
-        if (
-          settings.schedulePermissions === undefined ||
-          (settings.schedulePermissions && settings.schedulePermissions.noScheduleAdd === 'true')
-        ) {
-          chain.wait('Do you want to invoke this function on a recurring schedule?');
-        } else {
-          chain.wait(`Do you want to update or remove the function's schedule?`);
-        }
-      }
-
-      if (settings.schedulePermissions === undefined) {
-        chain.sendLine('n');
-      } else {
-        chain.sendLine('y');
-        cronWalkthrough(chain, settings, action);
-      }
-
-      chain
-        .wait('Do you want to edit the local lambda function now?')
-        .sendLine('n')
-        .sendEof();
+    if (settings.expectFailure) {
+      runChain(chain, resolve, reject);
     }
 
-    chain.run((err: Error) => {
-      if (!err) {
-        resolve();
-      } else {
-        reject(err);
+    // other permissions flow
+    chain.wait(
+      action === 'create'
+        ? 'Do you want to access other resources in this project from your Lambda function?'
+        : 'Do you want to update the Lambda function permissions to access other resources in this project?',
+    );
+
+    if (settings.additionalPermissions) {
+      multiSelect(
+        chain.sendLine('y').wait('Select the category'),
+        settings.additionalPermissions.permissions,
+        settings.additionalPermissions.choices,
+      );
+      // when single resource, it gets autoselected
+      if (settings.additionalPermissions.resources.length > 1) {
+        multiSelect(
+          chain.wait('Select the one you would like your'),
+          settings.additionalPermissions.resources,
+          settings.additionalPermissions.resourceChoices,
+        );
       }
-    });
+
+      // n-resources repeated questions
+      settings.additionalPermissions.resources.reduce(
+        (chain, elem) =>
+          multiSelect(chain.wait(`Select the operations you want to permit for ${elem}`), settings.additionalPermissions.operations, [
+            'create',
+            'read',
+            'update',
+            'delete',
+          ]),
+        chain,
+      );
+    } else {
+      chain.sendLine('n');
+    }
+
+    //scheduling questions
+    if (action === 'create') {
+      chain.wait('Do you want to invoke this function on a recurring schedule?');
+    } else {
+      if (
+        settings.schedulePermissions === undefined ||
+        (settings.schedulePermissions && settings.schedulePermissions.noScheduleAdd === 'true')
+      ) {
+        chain.wait('Do you want to invoke this function on a recurring schedule?');
+      } else {
+        chain.wait(`Do you want to update or remove the function's schedule?`);
+      }
+    }
+
+    if (settings.schedulePermissions === undefined) {
+      chain.sendLine('n');
+    } else {
+      chain.sendLine('y');
+      cronWalkthrough(chain, settings, action);
+    }
+
+    // lambda layers question
+    chain.wait('Do you want to modify the layers this function can access?');
+    if (settings.layerOptions === undefined) {
+      chain.sendLine('n');
+    } else {
+      chain.sendLine('y');
+      addLayerWalkthrough(chain, settings.layerOptions);
+    }
+
+    // edit function question
+    chain
+      .wait('Do you want to edit the local lambda function now?')
+      .sendLine('n')
+      .sendEof();
+
+    runChain(chain, resolve, reject);
+  });
+};
+
+const runChain = (chain, resolve, reject) => {
+  chain.run((err: Error) => {
+    if (!err) {
+      resolve();
+    } else {
+      reject(err);
+    }
   });
 };
 
@@ -215,6 +232,42 @@ export const selectRuntime = (chain: any, runtime: FunctionRuntimes) => {
   moveUp(chain, runtimeChoices.indexOf(getRuntimeDisplayName('nodejs')));
 
   singleSelect(chain, runtimeName, runtimeChoices);
+};
+
+export interface LayerOptions {
+  select: string[]; // list options to select
+  expectedListOptions: string[]; // the expeted list of all layers
+  versions: Record<string, { version: number; expectedVersionOptions: number[] }>; // map with keys for each element of select that determines the verison and expected version for each layer
+  customArns?: string[]; // external ARNs to enter
+}
+
+const addLayerWalkthrough = (chain: ExecutionContext, options: LayerOptions) => {
+  const prependedListOptions = ['Provide existing Lambda Layer ARNs', ...options.expectedListOptions];
+  const amendedSelection = [...options.select];
+  const hasCustomArns = options.customArns && options.customArns.length > 0;
+  if (hasCustomArns) {
+    amendedSelection.unshift('Provide existing Lambda Layer ARNs');
+  }
+  chain.wait('Provide existing layers');
+  multiSelect(chain, amendedSelection, prependedListOptions);
+  options.select.forEach(selection => {
+    chain.wait(`Select a version for ${selection}`);
+    singleSelect(
+      chain,
+      options.versions[selection].version.toString(),
+      options.versions[selection].expectedVersionOptions.map(op => op.toString()),
+    );
+  });
+  if (hasCustomArns) {
+    chain.wait('existing Lambda Layer ARNs (comma-separated)');
+    chain.sendLine(options.customArns.join(', '));
+  }
+  // not going to attempt to automate the reorder thingy. For e2e tests we can just create the lambda layers in the order we want them
+  const totalLength = hasCustomArns ? options.customArns.length : 0 + options.select.length;
+  if (totalLength > 0) {
+    chain.wait('Modify the layer order');
+    chain.sendCarriageReturn();
+  }
 };
 
 const cronWalkthrough = (chain: ExecutionContext, settings: any, action: string) => {

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -34,7 +34,7 @@ export function addLayer(cwd: string, settings?: any) {
   const defaultSettings = {
     layerName: 'test-layer',
     runtimes: ['nodejs'],
-    permission: 'private',
+    permission: 'Only the current AWS account',
   };
   settings = { ...defaultSettings, ...settings };
   return new Promise((resolve, reject) => {
@@ -110,11 +110,7 @@ export function removeLayer(cwd: string) {
 }
 
 function getRuntimeDisplayNames(runtimes: LayerRuntimes[]) {
-  let runtimeDisplayNames = [];
-  for (let i = 0; i < runtimes.length; ++i) {
-    runtimeDisplayNames[i] = getLayerRuntimeInfo(runtimes[i]).displayName;
-  }
-  return runtimeDisplayNames;
+  return runtimes.map(runtime => getLayerRuntimeInfo(runtime).displayName);
 }
 
 function getLayerRuntimeInfo(runtime: LayerRuntimes) {

--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/function.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`nodejs add function with layers can add layers configured in the project 1`] = `
+Array [
+  Object {
+    "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:layer:test-layer:1",
+  },
+  "arn:aws:lambda:us-west-2:123456789012:layer:my-layer:2",
+]
+`;
+
 exports[`nodejs amplify add function with additional permissions environment vars comment should update on permission update 1`] = `
 "/* Amplify Params - DO NOT EDIT
 	ENV

--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -119,6 +119,7 @@ export type FunctionParameters = {
   topLevelComment?: string; // LEGACY Used to write available environment variables at top of template files
   runtimePluginId: string;
   cloudwatchRule?: string;
+  lambdaLayers: LambdaLayer[];
 };
 
 /**
@@ -186,6 +187,18 @@ export interface FunctionDependency {
   resourceName: string; // name of the dependency
   attributes: string[]; // attributes that this function depends on (must be outputs of the dependencies CFN template)
   attributeEnvMap?: { [name: string]: string }; // optional attributes to environment variable names map that will be exposed to the function
+}
+
+export type LambdaLayer = ProjectLayer | ExternalLayer;
+export interface ProjectLayer {
+  type: 'ProjectLayer';
+  resourceName: string;
+  version: number;
+}
+
+export interface ExternalLayer {
+  type: 'ExternalLayer';
+  arn: string;
 }
 
 interface FunctionContributorCondition {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3987,16 +3987,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-frontend-javascript@2.13.2:
-  version "2.13.2"
-  resolved "https://registry.npmjs.org/amplify-frontend-javascript/-/amplify-frontend-javascript-2.13.2.tgz#c97c6e1e792b08a84a9ab6be5333c54379f2eeaf"
-  integrity sha512-VbvqN6gVTPXKWKLGuCCitCy6QF3i8dPsUDvKwIouJvxjk/RnBqaHbQCv25RBza+l29y2cV7w5HuF7KwLOHa+Zg==
-  dependencies:
-    chalk "^3.0.0"
-    fs-extra "^8.1.0"
-    graphql-config "^2.2.1"
-    inquirer "^7.0.3"
-
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -7982,7 +7972,7 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enquirer@^2.3.4:
+enquirer@^2.3.4, enquirer@^2.3.5:
   version "2.3.5"
   resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.5.tgz#3ab2b838df0a9d8ab9e7dff235b0e8712ef92381"
   integrity sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==


### PR DESCRIPTION
also added a boatload of tests

because all of the changes for storing state regarding LL is not implemented yet, I stubbed out retrieving the LL version into a factory function that can easily be updated with the real implementation later.

Also, because pushing LL doesn't work yet, the e2e test for adding layers to functions just tests that the right stuff is added in the CFN template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.