### PR TITLE
fix(graphql-connection-transformer): error if field not in relatedType

### DIFF
--- a/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
+++ b/packages/graphql-connection-transformer/src/ModelConnectionTransformer.ts
@@ -88,27 +88,31 @@ function validateKeyFieldConnectionWithKey(field: FieldDefinitionNode, ctx: Tran
  * @param fields Array of FieldDefinitionNodes to search within.
  * @param fieldName Name of the field whose type is to be fetched.
  */
-function getFieldType(fields: ReadonlyArray<FieldDefinitionNode>, fieldName: string) {
-  return fields.find(f => f.name.value === fieldName).type;
+function getFieldType(relatedType: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, fieldName: string) {
+  const foundField = relatedType.fields.find(f => f.name.value === fieldName);
+  if (!foundField) {
+    throw new InvalidDirectiveError(`${fieldName} is not defined in ${relatedType.name.value}.`);
+  }
+  return foundField.type;
 }
 
 /**
  * Checks that the fields being used to query match the expected key types for the index being used.
- * @param parentFields: All fields of the parent object.
+ * @param parent: All fields of the parent object.
  * @param relatedTypeFields: All fields of the related object.
  * @param inputFieldNames: The fields passed in to the @connection directive.
  * @param keySchema: The key schema for the index being used.
  */
 function checkFieldsAgainstIndex(
-  parentFields: ReadonlyArray<FieldDefinitionNode>,
-  relatedTypeFields: ReadonlyArray<FieldDefinitionNode>,
+  parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  relatedType: ObjectTypeDefinitionNode,
   inputFieldNames: string[],
   keySchema: KeySchema[],
   field: Readonly<FieldDefinitionNode>,
 ): void {
   const hashAttributeName = keySchema[0].AttributeName;
-  const tablePKType = getFieldType(relatedTypeFields, String(hashAttributeName));
-  const queryPKType = getFieldType(parentFields, inputFieldNames[0]);
+  const tablePKType = getFieldType(relatedType, String(hashAttributeName));
+  const queryPKType = getFieldType(parent, inputFieldNames[0]);
   const numFields = inputFieldNames.length;
 
   if (getBaseType(tablePKType) !== getBaseType(queryPKType)) {
@@ -127,17 +131,17 @@ function checkFieldsAgainstIndex(
   }
   if (numFields === 2) {
     const sortAttributeName = String(keySchema[1].AttributeName).split(ModelResourceIDs.ModelCompositeKeySeparator())[0];
-    const tableSKType = getFieldType(relatedTypeFields, String(sortAttributeName));
-    const querySKType = getFieldType(parentFields, inputFieldNames[1]);
+    const tableSKType = getFieldType(relatedType, String(sortAttributeName));
+    const querySKType = getFieldType(parent, inputFieldNames[1]);
 
     if (getBaseType(tableSKType) !== getBaseType(querySKType)) {
       throw new InvalidDirectiveError(`${inputFieldNames[1]} field is not of type ${getBaseType(tableSKType)}`);
     }
   } else if (numFields > 2) {
     const tableSortFields = String(keySchema[1].AttributeName).split(ModelResourceIDs.ModelCompositeKeySeparator());
-    const tableSortKeyTypes = tableSortFields.map(name => getFieldType(relatedTypeFields, name));
+    const tableSortKeyTypes = tableSortFields.map(name => getFieldType(relatedType, name));
     const querySortFields = inputFieldNames.slice(1);
-    const querySortKeyTypes = querySortFields.map(name => getFieldType(parentFields, name));
+    const querySortKeyTypes = querySortFields.map(name => getFieldType(parent, name));
 
     // Check that types of each attribute match types of the fields that make up the composite sort key for the
     // table or index being queried.
@@ -565,7 +569,7 @@ export class ModelConnectionTransformer extends Transformer {
     // If no index is provided use the default index for the related model type and
     // check that the query fields match the PK/SK of the table. Else confirm that index exists.
     if (!args.keyName) {
-      checkFieldsAgainstIndex(parent.fields, relatedType.fields, args.fields, <KeySchema[]>tableResource.Properties.KeySchema, field);
+      checkFieldsAgainstIndex(parent, relatedType, args.fields, <KeySchema[]>tableResource.Properties.KeySchema, field);
     } else {
       index =
         (tableResource.Properties.GlobalSecondaryIndexes
@@ -581,7 +585,7 @@ export class ModelConnectionTransformer extends Transformer {
       // check the arity
 
       // Confirm that types of query fields match types of PK/SK of the index being queried.
-      checkFieldsAgainstIndex(parent.fields, relatedType.fields, args.fields, <KeySchema[]>index.KeySchema, field);
+      checkFieldsAgainstIndex(parent, relatedType, args.fields, <KeySchema[]>index.KeySchema, field);
     }
 
     // If the related type is not a list, the index has to be the default index and the fields provided must match the PK/SK of the index.

--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -93,6 +93,31 @@ test('Test ModelConnectionTransformer simple one to many happy case with custom 
   expect(connectionUpdateId).toBeTruthy();
 });
 
+test('Test that ModelConnection Transformer throws error when the field in connection is not found in the related Type', () => {
+  const invalidSchema = `
+  type Post @model {
+    name: String!
+    teamID: ID!
+    team: Team @connection(fields: ["teamID"])
+  }
+
+  type Team @model {
+    name: [String!]!
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new ModelConnectionTransformer()],
+  });
+  try {
+    transformer.transform(invalidSchema);
+    expect(true).toEqual(false);
+  } catch (e) {
+    console.log(e);
+    expect(e).toBeTruthy();
+    expect(e.name).toEqual('InvalidDirectiveError');
+  }
+});
+
 test('Test ModelConnectionTransformer simple one to many happy case with custom keyField', () => {
   const validSchema = `
     type Post @model {

--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -18,10 +18,7 @@ import {
   equals,
   iff,
   raw,
-  comment,
-  qref,
   Expression,
-  block,
 } from 'graphql-mapping-template';
 import {
   ResourceConstants,

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -67,7 +67,7 @@ export const MAP_SCALARS: { [k: string]: boolean } = {
   AWSJSON: true,
 };
 
-export function attributeTypeFromScalar(scalar: TypeNode) {
+export function attributeTypeFromScalar(scalar: TypeNode): 'S' | 'N' {
   const baseType = getBaseType(scalar);
   const baseScalar = DEFAULT_SCALARS[baseType];
   if (!baseScalar) {
@@ -280,7 +280,7 @@ export function makeField(
   name: string,
   args: InputValueDefinitionNode[],
   type: TypeNode,
-  directives: DirectiveNode[] = []
+  directives: DirectiveNode[] = [],
 ): FieldDefinitionNode {
   return {
     kind: Kind.FIELD_DEFINITION,
@@ -358,7 +358,6 @@ export function makeInputValueDefinition(name: string, type: TypeNode): InputVal
     directives: [],
   };
 }
-
 
 export function makeNamedType(name: string): NamedTypeNode {
   return {


### PR DESCRIPTION
*Issue #, if available:*
re #4236
*Description of changes:*
- throw an invalid directive error if the primary/sort field does not exist in the related type
- remove unused imports
- update definition for `attributeTypeFromScalar` function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.