### PR TITLE
fix(graphql-auth-transformer): add a time delay when creating apiKey

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -778,6 +778,8 @@ async function askApiKeyQuestions() {
       message: 'After how many days from now the API key should expire (1-365):',
       default: 7,
       validate: validateDays,
+      // adding filter to ensure parsing input as int -> https://github.com/SBoudrias/Inquirer.js/issues/866
+      filter: value => (isNaN(parseInt(value, 10)) ? value : parseInt(value, 10)),
     },
   ];
 
@@ -832,7 +834,6 @@ async function askOpenIDConnectQuestions() {
 function validateDays(input) {
   const isValid = /^\d+$/.test(input);
   const days = isValid ? parseInt(input, 10) : 0;
-
   if (!isValid || days < 1 || days > 365) {
     return 'Number of days must be between 1 and 365.';
   }

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -57,7 +57,7 @@ export function addApiWithSchema(cwd: string, schemaFile: string) {
       .wait(/.*Enter a description for the API key.*/)
       .sendCarriageReturn()
       .wait(/.*After how many days from now the API key should expire.*/)
-      .sendCarriageReturn()
+      .sendLine('1')
       .wait(/.*Do you want to configure advanced settings for the GraphQL API.*/)
       .sendCarriageReturn()
       .wait('Do you have an annotated GraphQL schema?')

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -106,7 +106,9 @@ export class ResourceFactory {
       expirationDays = apiKeyConfig.apiKeyExpirationDays;
     }
     // add delay expiration time is valid upon resource creation
-    const expirationDateInSeconds = 60 /* s */ * 60 /* m */ * 24 /* h */ * expirationDays /* d */ + 60 * 2;
+    let expirationDateInSeconds = 60 /* s */ * 60 /* m */ * 24 /* h */ * expirationDays /* d */;
+    // Add a 2 minute time delay if set to 1 day: https://github.com/aws-amplify/amplify-cli/issues/4460
+    if (expirationDays == 1) expirationDateInSeconds + 60 * 2;
     const nowEpochTime = Math.floor(Date.now() / 1000);
     return new AppSync.ApiKey({
       ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -105,7 +105,8 @@ export class ResourceFactory {
     if (apiKeyConfig && apiKeyConfig.apiKeyExpirationDays) {
       expirationDays = apiKeyConfig.apiKeyExpirationDays;
     }
-    const expirationDateInSeconds = 60 /* s */ * 60 /* m */ * 24 /* h */ * expirationDays; /* d */
+    // add delay expiration time is valid upon resource creation
+    const expirationDateInSeconds = 60 /* s */ * 60 /* m */ * 24 /* h */ * expirationDays /* d */ + 60 * 2;
     const nowEpochTime = Math.floor(Date.now() / 1000);
     return new AppSync.ApiKey({
       ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -108,7 +108,7 @@ export class ResourceFactory {
     // add delay expiration time is valid upon resource creation
     let expirationDateInSeconds = 60 /* s */ * 60 /* m */ * 24 /* h */ * expirationDays /* d */;
     // Add a 2 minute time delay if set to 1 day: https://github.com/aws-amplify/amplify-cli/issues/4460
-    if (expirationDays == 1) expirationDateInSeconds + 60 * 2;
+    if (expirationDays === 1) expirationDateInSeconds += 60 * 2;
     const nowEpochTime = Math.floor(Date.now() / 1000);
     return new AppSync.ApiKey({
       ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),


### PR DESCRIPTION
added a time delay to the expiration date

re #4460

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.