### PR TITLE
fix: nodejs staleBuild glob

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/legacyBuild.test.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/legacyBuild.test.ts
@@ -1,0 +1,38 @@
+import glob from 'glob';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import { buildResource } from '../../../src/utils/legacyBuild';
+
+jest.mock('glob');
+jest.mock('fs-extra');
+
+const glob_mock = glob as jest.Mocked<typeof glob>;
+const fs_mock = fs as jest.Mocked<typeof fs>;
+
+const timestamp = new Date().getTime();
+const stubFileTimestamps = new Map<string, number>([
+  ['resourceDir', timestamp - 1],
+  ['package.json', timestamp - 1],
+  ['dist/latest-build.zip', timestamp + 1],
+  ['src/index.js', timestamp - 2],
+  ['cfnTemplate.json', timestamp - 3],
+  ['node_modules/somepackage', timestamp + 2],
+]);
+
+describe('legacy build resource', () => {
+  it('checks resource directory excluding node_modules and dist for changes', async () => {
+    glob_mock.sync.mockImplementationOnce(() => Array.from(stubFileTimestamps.keys()));
+    fs_mock.statSync.mockImplementation(file => ({ mtime: new Date(stubFileTimestamps.get(file.toString())!) } as any));
+
+    const result = await buildResource({
+      lastBuildTimestamp: new Date(timestamp),
+      srcRoot: 'resourceDir',
+      env: 'something',
+      runtime: 'other',
+    });
+
+    expect(result.rebuilt).toEqual(false);
+    expect(glob_mock.sync.mock.calls.length).toBe(1);
+    expect(fs_mock.statSync.mock.calls.length).toBe(5);
+  });
+});

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -68,7 +68,9 @@ function isBuildStale(resourceDir: string, lastBuildTimestamp: Date) {
     return true;
   }
   const fileUpdatedAfterLastBuild = glob
-    .sync(`${resourceDir}/*/!(node_modules)/**`)
+    .sync(`${resourceDir}/**`)
+    .filter(p => !p.includes('dist'))
+    .filter(p => !p.includes('node_modules'))
     .find(file => new Date(fs.statSync(file).mtime) > lastBuildTimestamp);
   return !!fileUpdatedAfterLastBuild;
 }


### PR DESCRIPTION
*Issue #, if available:*
#4479

*Description of changes:*
fIx glob pattern and filter to include files in the root of the function directory when determining a stale build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.