### PR TITLE
Performance: Upload more than one file at a time

### DIFF
--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -34,7 +34,7 @@ async function run(context, distributionDirPath) {
   const spinner = new Ora('Uploading files...');
   try {
     spinner.start();
-    await sequential(uploadFileTasks);
+    await Promise.all(uploadFileTasks);
     spinner.succeed('Uploaded files successfully.');
   } catch (e) {
     spinner.fail('Error has occured during file upload.');


### PR DESCRIPTION
Instead of uploading one file at a time, send them all to node and let it figure out how many to execute in parallel. Much faster when publishing lots of files, or large projects. 

#4158 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.