### PR TITLE
fix: do not delete if generated filename is empty

### DIFF
--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -35,7 +35,7 @@ function deleteAmplifyConfig(context) {
         const file = path.join(srcDirPath, docsFilePath, `${filename}.${FILE_EXTENSION_MAP[codeGenTarget]}`);
         if (fs.existsSync(file)) fs.removeSync(file);
       });
-      if (generatedFileName !== '') {
+      if (generatedFileName.trim() !== '') {
         fs.removeSync(path.join(srcDirPath, generatedFileName));
       }
     });

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -35,8 +35,9 @@ function deleteAmplifyConfig(context) {
         const file = path.join(srcDirPath, docsFilePath, `${filename}.${FILE_EXTENSION_MAP[codeGenTarget]}`);
         if (fs.existsSync(file)) fs.removeSync(file);
       });
-
-      fs.removeSync(path.join(srcDirPath, generatedFileName));
+      if (generatedFileName !== '') {
+        fs.removeSync(path.join(srcDirPath, generatedFileName));
+      }
     });
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
fix #4519
*Description of changes:*
Prevent root files being deleted when generatedfilename is empty

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.