### PR TITLE
perf: optimize appsync file upload and bucket exist check

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -15,8 +15,8 @@ const { PredictionsTransformer } = require('graphql-predictions-transformer');
 const { KeyTransformer } = require('graphql-key-transformer');
 const providerName = require('./constants').ProviderName;
 const TransformPackage = require('graphql-transformer-core');
-const { hashElement } = require('folder-hash');
 const { print } = require('graphql');
+const { hashDirectory } = require('./upload-appsync-files');
 
 const {
   collectDirectivesByTypeNames,
@@ -465,17 +465,6 @@ function getProjectBucket(context) {
   const projectDetails = context.amplify.getProjectDetails();
   const projectBucket = projectDetails.amplifyMeta.providers ? projectDetails.amplifyMeta.providers[providerName].DeploymentBucketName : '';
   return projectBucket;
-}
-
-async function hashDirectory(directory) {
-  const options = {
-    encoding: 'hex',
-    folders: {
-      exclude: ['build'],
-    },
-  };
-
-  return hashElement(directory, options).then(result => result.hash);
 }
 
 async function getPreviousDeploymentRootKey(previouslyDeployedBackendDir) {

--- a/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/lib/upload-appsync-files.js
@@ -108,7 +108,7 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
         if (personalParams.CreateAPIKey !== undefined && personalParams.APIKeyExpirationEpoch !== undefined) {
           context.print.warning(
             'APIKeyExpirationEpoch and CreateAPIKey parameters should not used together because it can cause ' +
-              'unwanted behavior. In the future APIKeyExpirationEpoch will be removed, use CreateAPIKey instead.'
+              'unwanted behavior. In the future APIKeyExpirationEpoch will be removed, use CreateAPIKey instead.',
           );
         }
 
@@ -122,7 +122,7 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
 
             context.print.warning(
               "APIKeyExpirationEpoch parameter's -1 value is deprecated to disable " +
-                'the API Key creation. In the future CreateAPIKey parameter replaces this behavior.'
+                'the API Key creation. In the future CreateAPIKey parameter replaces this behavior.',
             );
           } else {
             currentParameters.CreateAPIKey = 1;
@@ -225,9 +225,12 @@ async function hashDirectory(directory) {
     },
   };
 
-  return hashElement(directory, options).then(result => result.hash);
+  const hashResult = await hashElement(directory, options);
+
+  return hashResult.hash;
 }
 
 module.exports = {
   uploadAppSyncFiles,
+  hashDirectory,
 };

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.js
@@ -19,18 +19,32 @@ class S3 {
   }
 
   uploadFile(s3Params) {
-    const projectDetails = this.context.amplify.getProjectDetails();
-    const { envName } = this.context.amplify.getEnvInfo();
-    const projectBucket = projectDetails.amplifyMeta.providers
-      ? projectDetails.amplifyMeta.providers[providerName].DeploymentBucketName
-      : projectDetails.teamProviderInfo[envName][providerName].DeploymentBucketName;
-    s3Params.Bucket = projectBucket;
+    // envName and bucket does not change during execution, cache them into a class level
+    // field.
+    if (this.uploadState === undefined) {
+      const projectDetails = this.context.amplify.getProjectDetails();
+      const { envName } = this.context.amplify.getEnvInfo();
+      const projectBucket = projectDetails.amplifyMeta.providers
+        ? projectDetails.amplifyMeta.providers[providerName].DeploymentBucketName
+        : projectDetails.teamProviderInfo[envName][providerName].DeploymentBucketName;
 
-    return this.putFile(s3Params).then(() => projectBucket);
-  }
+      this.uploadState = {
+        envName,
+        s3Params: {
+          Bucket: projectBucket,
+        },
+      };
+    }
 
-  putFile(s3Params) {
-    return this.s3.putObject(s3Params).promise();
+    const augmentedS3Params = {
+      ...s3Params,
+      ...this.uploadState.s3Params,
+    };
+
+    return this.s3
+      .putObject(augmentedS3Params)
+      .promise()
+      .then(() => this.uploadState.s3Params.Bucket);
   }
 
   getFile(s3Params, envName = this.context.amplify.getEnvInfo().envName) {
@@ -155,14 +169,12 @@ class S3 {
 
   ifBucketExists(bucketName) {
     return this.s3
-      .listBuckets({})
+      .headBucket({
+        Bucket: bucketName,
+      })
       .promise()
       .then(result => {
-        const index = result.Buckets.findIndex(bucket => bucket.Name === bucketName);
-        if (index !== -1) {
-          return true;
-        }
-        return false;
+        return result !== undefined;
       });
   }
 }

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -27,6 +27,7 @@
     "cloudform-types": "^4.2.0",
     "deep-diff": "^1.0.2",
     "fs-extra": "^8.1.0",
+    "glob": "^7.1.6",
     "graphql": "^14.5.8",
     "graphql-transformer-common": "4.16.0"
   },

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -1,10 +1,11 @@
-const fs = require('fs-extra');
+import fs from 'fs-extra';
 import * as path from 'path';
+import glob from 'glob';
 import { CloudFormation, Fn, Template } from 'cloudform-types';
 import { DeploymentResources } from '../DeploymentResources';
 import { GraphQLTransform, StackMapping } from '../GraphQLTransform';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { walkDirPosix, readFromPath, writeToPath, throwIfNotJSONExt, emptyDirectory } from './fileUtils';
+import { readFromPath, writeToPath, throwIfNotJSONExt, emptyDirectory, handleFile, FileHandler } from './fileUtils';
 import { writeConfig, TransformConfig, TransformMigrationConfig, loadProject, readSchema, loadConfig } from './transformConfig';
 import * as Sanity from './sanity-check';
 
@@ -313,8 +314,7 @@ function mergeUserConfigWithTransformOutput(userConfig: Partial<DeploymentResour
 
 export interface UploadOptions {
   directory: string;
-
-  upload(blob: { Key: string; Body: Buffer | string }): Promise<string>;
+  upload: FileHandler;
 }
 
 /**
@@ -322,19 +322,32 @@ export interface UploadOptions {
  * @param opts Deployment options.
  */
 export async function uploadDeployment(opts: UploadOptions) {
-  try {
-    if (!opts.directory) {
-      throw new Error(`You must provide a 'directory'`);
-    } else if (!fs.existsSync(opts.directory)) {
-      throw new Error(`Invalid 'directory': directory does not exist at ${opts.directory}`);
-    }
-    if (!opts.upload || typeof opts.upload !== 'function') {
-      throw new Error(`You must provide an 'upload' function`);
-    }
-    await walkDirPosix(opts.directory, opts.upload);
-  } catch (e) {
-    throw e;
+  if (!opts.directory) {
+    throw new Error(`You must provide a 'directory'`);
   }
+
+  if (!fs.existsSync(opts.directory)) {
+    throw new Error(`Invalid 'directory': directory does not exist at ${opts.directory}`);
+  }
+
+  if (!opts.upload || typeof opts.upload !== 'function') {
+    throw new Error(`You must provide an 'upload' function`);
+  }
+
+  const { directory, upload } = opts;
+
+  var fileNames = glob.sync('**/*', {
+    cwd: directory,
+    nodir: true,
+  });
+
+  const uploadPromises = fileNames.map(async fileName => {
+    const resourceContent = fs.createReadStream(path.join(directory, fileName));
+
+    await handleFile(upload, fileName, resourceContent);
+  });
+
+  await Promise.all(uploadPromises);
 }
 
 /**
@@ -472,8 +485,7 @@ export async function readV1ProjectConfiguration(projectDirectory: string): Prom
 
   // Get the template
   const cloudFormationTemplatePath = path.join(projectDirectory, CLOUDFORMATION_FILE_NAME);
-  const cloudFormationTemplateExists = await fs.exists(cloudFormationTemplatePath);
-  if (!cloudFormationTemplateExists) {
+  if (!fs.existsSync(cloudFormationTemplatePath)) {
     throw new Error(`Could not find cloudformation template at ${cloudFormationTemplatePath}`);
   }
   const cloudFormationTemplateStr = await fs.readFile(cloudFormationTemplatePath);
@@ -481,8 +493,7 @@ export async function readV1ProjectConfiguration(projectDirectory: string): Prom
 
   // Get the params
   const parametersFilePath = path.join(projectDirectory, 'parameters.json');
-  const parametersFileExists = await fs.exists(parametersFilePath);
-  if (!parametersFileExists) {
+  if (!fs.existsSync(parametersFilePath)) {
     throw new Error(`Could not find parameters.json at ${parametersFilePath}`);
   }
   const parametersFileStr = await fs.readFile(parametersFilePath);


### PR DESCRIPTION
*Description of changes:*

perf: optimize appsync file upload to use globbing to collect the files and upload all the files in parallel
perf: cache environment and bucket name for S3 operations
perf: optimize bucket exist check to use head operation instead of list and filtering
chore: remove duplicated hashing function

Test schema with 20 simple @model types ~300 files.
 
before: 2 minutes 19 seconds 
after: 2.9 seconds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.