### PR TITLE
fix(amplify-codegen-appsync-model-plugin):  Support Embeddable Types for iOS 

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -820,7 +820,7 @@ describe('AppSyncSwiftVisitor', () => {
       import Amplify
       import Foundation
 
-      public struct Location: Embedded {
+      public struct Location: Embeddable {
         var lat: String
         var lang: String
         var tags: [String]?

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -696,19 +696,19 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.fields(
             .id(),
-            .field(objectWithNativeTypes.intArr, is: .optional, ofType: .customType([Int].self)),
-            .field(objectWithNativeTypes.strArr, is: .optional, ofType: .customType([String].self)),
-            .field(objectWithNativeTypes.floatArr, is: .optional, ofType: .customType([Double].self)),
-            .field(objectWithNativeTypes.boolArr, is: .optional, ofType: .customType([Bool].self)),
-            .field(objectWithNativeTypes.dateArr, is: .optional, ofType: .customType([Temporal.Date].self)),
-            .field(objectWithNativeTypes.enumArr, is: .optional, ofType: .customType([EnumType].self))
+            .field(objectWithNativeTypes.intArr, is: .optional, ofType: .embeddedCollection(of: Int.self)),
+            .field(objectWithNativeTypes.strArr, is: .optional, ofType: .embeddedCollection(of: String.self)),
+            .field(objectWithNativeTypes.floatArr, is: .optional, ofType: .embeddedCollection(of: Double.self)),
+            .field(objectWithNativeTypes.boolArr, is: .optional, ofType: .embeddedCollection(of: Bool.self)),
+            .field(objectWithNativeTypes.dateArr, is: .optional, ofType: .embeddedCollection(of: Temporal.Date.self)),
+            .field(objectWithNativeTypes.enumArr, is: .optional, ofType: .embeddedCollection(of: EnumType.self))
           )
           }
       }"
     `);
   });
 
-  it('should support using non model types in models', () => {
+  it('should support using embedded types in models', () => {
     const schema = /* GraphQL */ `
       type Attraction @model {
         id: ID!
@@ -792,11 +792,11 @@ describe('AppSyncSwiftVisitor', () => {
           model.fields(
             .id(),
             .field(attraction.name, is: .required, ofType: .string),
-            .field(attraction.location, is: .required, ofType: .customType(Location.self)),
-            .field(attraction.nearByLocations, is: .optional, ofType: .customType([Location].self)),
+            .field(attraction.location, is: .required, ofType: .embedded(type: Location.self)),
+            .field(attraction.nearByLocations, is: .optional, ofType: .embeddedCollection(of: Location.self)),
             .field(attraction.status, is: .required, ofType: .enum(type: Status.self)),
-            .field(attraction.statusHistory, is: .optional, ofType: .customType([Status].self)),
-            .field(attraction.tags, is: .optional, ofType: .customType([String].self))
+            .field(attraction.statusHistory, is: .optional, ofType: .embeddedCollection(of: Status.self)),
+            .field(attraction.tags, is: .optional, ofType: .embeddedCollection(of: String.self))
           )
           }
       }"
@@ -820,10 +820,40 @@ describe('AppSyncSwiftVisitor', () => {
       import Amplify
       import Foundation
 
-      public struct Location: Codable {
+      public struct Location: Embedded {
         var lat: String
         var lang: String
         var tags: [String]?
+      }"
+    `);
+
+    const visitorLocationSchema = getVisitor(schema, 'Location', CodeGenGenerateEnum.metadata);
+    expect(visitorLocationSchema.generate()).toMatchInlineSnapshot(`
+      "// swiftlint:disable all
+      import Amplify
+      import Foundation
+
+      extension Location {
+        // MARK: - CodingKeys 
+         public enum CodingKeys: String, ModelKey {
+          case lat
+          case lang
+          case tags
+        }
+        
+        public static let keys = CodingKeys.self
+        //  MARK: - ModelSchema 
+        
+        public static let schema = defineSchema { model in
+          let location = Location.keys
+          
+          model.fields(
+            .id(),
+            .field(location.lat, is: .required, ofType: .string),
+            .field(location.lang, is: .required, ofType: .string),
+            .field(location.tags, is: .optional, ofType: .embeddedCollection(of: String.self))
+          )
+          }
       }"
     `);
 
@@ -1213,7 +1243,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.fields(
               .id(),
               .field(post.title, is: .required, ofType: .string),
-              .field(post.groups, is: .required, ofType: .customType([String].self))
+              .field(post.groups, is: .required, ofType: .embeddedCollectioon(of: String.self))
             )
             }
         }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -828,7 +828,9 @@ describe('AppSyncSwiftVisitor', () => {
     `);
 
     const visitorLocationSchema = getVisitor(schema, 'Location', CodeGenGenerateEnum.metadata);
-    expect(visitorLocationSchema.generate()).toMatchInlineSnapshot(`
+    const generatedCode = visitorLocationSchema.generate()
+    console.log(generatedCode)
+    expect(generatedCode).toMatchInlineSnapshot(`
       "// swiftlint:disable all
       import Amplify
       import Foundation
@@ -847,8 +849,9 @@ describe('AppSyncSwiftVisitor', () => {
         public static let schema = defineSchema { model in
           let location = Location.keys
           
+          model.pluralName = "Locations"
+          
           model.fields(
-            .id(),
             .field(location.lat, is: .required, ofType: .string),
             .field(location.lang, is: .required, ofType: .string),
             .field(location.tags, is: .optional, ofType: .embeddedCollection(of: String.self))

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -1243,7 +1243,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.fields(
               .id(),
               .field(post.title, is: .required, ofType: .string),
-              .field(post.groups, is: .required, ofType: .embeddedCollectioon(of: String.self))
+              .field(post.groups, is: .required, ofType: .embeddedCollection(of: String.self))
             )
             }
         }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -828,9 +828,7 @@ describe('AppSyncSwiftVisitor', () => {
     `);
 
     const visitorLocationSchema = getVisitor(schema, 'Location', CodeGenGenerateEnum.metadata);
-    const generatedCode = visitorLocationSchema.generate()
-    console.log(generatedCode)
-    expect(generatedCode).toMatchInlineSnapshot(`
+    expect(visitorLocationSchema.generate()).toMatchInlineSnapshot(`
       "// swiftlint:disable all
       import Amplify
       import Foundation
@@ -849,7 +847,7 @@ describe('AppSyncSwiftVisitor', () => {
         public static let schema = defineSchema { model in
           let location = Location.keys
           
-          model.pluralName = "Locations"
+          model.pluralName = \\"Locations\\"
           
           model.fields(
             .field(location.lat, is: .required, ofType: .string),

--- a/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
@@ -83,7 +83,6 @@ const generateSwiftPreset = (
         selectedType: modelName,
       },
     });
-    // TODO: need to generate metadata for non models here
     if (model.kind !== Kind.ENUM_TYPE_DEFINITION) {
       config.push({
         ...options,

--- a/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
@@ -83,7 +83,8 @@ const generateSwiftPreset = (
         selectedType: modelName,
       },
     });
-    if (model.kind !== Kind.ENUM_TYPE_DEFINITION && hasDirective('model')(model)) {
+    // TODO: need to generate metadata for non models here
+    if (model.kind !== Kind.ENUM_TYPE_DEFINITION) {
       config.push({
         ...options,
         filename: join(options.baseOutputDir, `${modelName}+Schema.swift`),

--- a/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
@@ -26,13 +26,6 @@ export type AppSyncModelCodeGenPresetConfig = {
   target: 'java' | 'android' | 'ios' | 'swift' | 'javascript' | 'typescript';
 };
 
-const hasDirective = (directiveName: string) => (typeObj: TypeDefinitionNode): boolean => {
-  if (typeObj && typeObj.directives && typeObj.directives.length) {
-    return typeObj.directives.find(d => d.name.value === directiveName) !== undefined;
-  }
-  return false;
-};
-
 const generateJavaPreset = (
   options: Types.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
   models: TypeDefinitionNode[],

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -95,7 +95,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       const structBlock: SwiftDeclarationBlock = new SwiftDeclarationBlock()
         .withName(this.getModelName(obj))
         .access('public')
-        .withProtocols(['Embedded']);
+        .withProtocols(['Embeddable']);
       Object.values(obj.fields).forEach(field => {
         const fieldType = this.getNativeType(field);
         structBlock.addProperty(this.getFieldName(field), fieldType, undefined, 'DEFAULT', {

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -130,7 +130,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
         const schemaDeclarations = new SwiftDeclarationBlock().asKind('extension').withName(this.getModelName(model));
 
         this.generateCodingKeys(this.getNonModelName(model), model, schemaDeclarations),
-          this.generateModelSchema(this.getModelName(model), model, schemaDeclarations);
+          this.generateModelSchema(this.getNonModelName(model), model, schemaDeclarations);
 
         result.push(schemaDeclarations.string);
       });

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -95,7 +95,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       const structBlock: SwiftDeclarationBlock = new SwiftDeclarationBlock()
         .withName(this.getModelName(obj))
         .access('public')
-        .withProtocols(['Codable']);
+        .withProtocols(['Embedded']);
       Object.values(obj.fields).forEach(field => {
         const fieldType = this.getNativeType(field);
         structBlock.addProperty(this.getFieldName(field), fieldType, undefined, 'DEFAULT', {
@@ -269,19 +269,17 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
 
   private getSwiftModelTypeName(field: CodeGenField) {
     if (this.isEnumType(field)) {
-      const name = this.getEnumName(field.type);
-      return field.isList ? `[${name}].self` : `${name}.self`;
+      return `${this.getEnumName(field.type)}.self`;
     }
     if (this.isModelType(field)) {
       return `${this.getModelName(this.modelMap[field.type])}.self`;
     }
     if (this.isNonModelType(field)) {
-      const name = this.getNonModelName(this.nonModelMap[field.type]);
-      return field.isList ? `[${name}].self` : `${name}.self`;
+      return `${this.getNonModelName(this.nonModelMap[field.type])}.self`;
     }
     if (field.type in schemaTypeMap) {
       if (field.isList) {
-        return `[${this.getNativeType(field)}].self`;
+       return `${this.getNativeType(field)}.self`;
       }
       return schemaTypeMap[field.type];
     }

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -249,7 +249,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       if (isModelType) {
         ofType = `.collection(of: ${this.getSwiftModelTypeName(field)})`;
       } else {
-        ofType = `.customType(${this.getSwiftModelTypeName(field)})`;
+        ofType = `.embeddedCollection(of: ${this.getSwiftModelTypeName(field)})`;
       }
     } else {
       if (isEnumType) {
@@ -257,7 +257,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       } else if (isModelType) {
         ofType = `.model(${typeName})`;
       } else if (isNonModelType) {
-        ofType = `.customType(${typeName})`;
+        ofType = `.embedded(type: ${typeName})`;
       } else {
         ofType = typeName;
       }

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -124,6 +124,16 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
 
         result.push(schemaDeclarations.string);
       });
+
+    Object.values(this.getSelectedNonModels())
+      .forEach(model => {
+        const schemaDeclarations = new SwiftDeclarationBlock().asKind('extension').withName(this.getModelName(model));
+
+        this.generateCodingKeys(this.getModelName(model), model, schemaDeclarations),
+          this.generateModelSchema(this.getModelName(model), model, schemaDeclarations);
+
+        result.push(schemaDeclarations.string);
+      });
     return result.join('\n');
   }
 

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -129,7 +129,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       .forEach(model => {
         const schemaDeclarations = new SwiftDeclarationBlock().asKind('extension').withName(this.getModelName(model));
 
-        this.generateCodingKeys(this.getModelName(model), model, schemaDeclarations),
+        this.generateCodingKeys(this.getNonModelName(model), model, schemaDeclarations),
           this.generateModelSchema(this.getModelName(model), model, schemaDeclarations);
 
         result.push(schemaDeclarations.string);

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -127,7 +127,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
 
     Object.values(this.getSelectedNonModels())
       .forEach(model => {
-        const schemaDeclarations = new SwiftDeclarationBlock().asKind('extension').withName(this.getModelName(model));
+        const schemaDeclarations = new SwiftDeclarationBlock().asKind('extension').withName(this.getNonModelName(model));
 
         this.generateCodingKeys(this.getNonModelName(model), model, schemaDeclarations),
           this.generateModelSchema(this.getNonModelName(model), model, schemaDeclarations);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Renamed `customType` to `embedded(type)` and `embeddedCollection(of)`
- Adds support in `amplify codegen models` to generate Extensions for embedded types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.