### PR TITLE
perf: fulfill promises to upload files to S3 concurrently

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/utils/trigger-file-uploader.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/utils/trigger-file-uploader.js
@@ -2,7 +2,6 @@ const { readdirSync, existsSync } = require('fs');
 const { createReadStream } = require('fs-extra');
 const Ora = require('ora');
 const mime = require('mime-types');
-const sequential = require('promise-sequential');
 const { getAuthResourceName } = require('../../../utils/getAuthResourceName');
 
 const providerName = 'awscloudformation';
@@ -32,13 +31,13 @@ async function uploadFiles(context) {
     const fileList = readdirSync(assetPath);
     const uploadFileTasks = [];
     fileList.forEach(file => {
-      uploadFileTasks.push(async () => await uploadFile(s3Client, bucketName, `${assetPath}/${file}`, file));
+      uploadFileTasks.push(uploadFile(s3Client, bucketName, `${assetPath}/${file}`, file));
     });
 
     const spinner = new Ora('Uploading files...');
     try {
       spinner.start();
-      await sequential(uploadFileTasks);
+      await Promise.all(uploadFileTasks);
       spinner.succeed('Uploaded files successfully.');
     } catch (e) {
       spinner.fail('Error has occured during file upload.');

--- a/packages/amplify-category-auth/tests/commands/push.test.js
+++ b/packages/amplify-category-auth/tests/commands/push.test.js
@@ -1,0 +1,48 @@
+const push = require('../../commands/auth/push');
+
+jest.mock('../../provider-utils/awscloudformation/utils/trigger-file-uploader', () => {
+  return {
+    uploadFiles: jest.fn(() => Promise.reject(new Error())),
+  };
+});
+
+describe('auth push: ', () => {
+  const mockConstructExeInfo = jest.fn();
+  const mockPushResources = jest.fn();
+
+  const mockContext = {
+    amplify: {
+      constructExeInfo: mockConstructExeInfo,
+      pushResources: mockPushResources,
+    },
+    parameters: {
+      first: '',
+    },
+    print: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+
+  it('push run method should exist', () => {
+    expect(push.run).toBeDefined();
+  });
+
+  describe('case: amplify pushResources fails to make updates to backend environment', () => {
+    beforeEach(() => {
+      mockPushResources.mockReturnValue(Promise.reject(new Error('mocking pushResources() promise rejection')));
+    });
+
+    it('push run method should fail to push resources and print an error message', async () => {
+      await push.run(mockContext);
+      expect(mockContext.print.error).toBeCalledWith('There was an error pushing the auth resource');
+    });
+  });
+
+  describe('case: uploadFiles fails to upload trigger files to S3', () => {
+    it('push run method should fail to push resources and print an error message', async () => {
+      await push.run(mockContext);
+      expect(mockContext.print.error).toBeCalledWith('There was an error pushing the auth resource');
+    });
+  });
+});

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -2,7 +2,6 @@ const fs = require('fs-extra');
 const path = require('path');
 const Ora = require('ora');
 const mime = require('mime-types');
-const sequential = require('promise-sequential');
 const fileScanner = require('./file-scanner');
 const constants = require('../../constants');
 
@@ -28,13 +27,13 @@ async function run(context, distributionDirPath) {
   }
 
   fileList.forEach(filePath => {
-    uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, cloudFrontS3CanonicalUserId));
+    uploadFileTasks.push(uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, cloudFrontS3CanonicalUserId));
   });
 
   const spinner = new Ora('Uploading files...');
   try {
     spinner.start();
-    await sequential(uploadFileTasks);
+    await Promise.all(uploadFileTasks);
     spinner.succeed('Uploaded files successfully.');
   } catch (e) {
     spinner.fail('Error has occured during file upload.');


### PR DESCRIPTION
*Issue #, if available:*
#4158

*Description of changes:*
When uploading multiple files to S3 after running `$ amplify publish`, those uploads are handled one after the other when they could be handled concurrently. Rather than fulfilling promises to upload each file sequentially, this PR proposes that we let the node runtime handle fulfilling those promises concurrently with `Promise.all()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.