### PR TITLE
feat: show rest api url on amplify status

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/display-helpful-urls.js
+++ b/packages/amplify-provider-awscloudformation/lib/display-helpful-urls.js
@@ -5,6 +5,7 @@ async function displayHelpfulURLs(context, resourcesToBeCreated) {
   context.print.info('');
   showPinpointURL(context, resourcesToBeCreated);
   showGraphQLURL(context, resourcesToBeCreated);
+  showRestAPIURL(context, resourcesToBeCreated);
   showHostingURL(context, resourcesToBeCreated);
   showHostedUIURLs(context, resourcesToBeCreated);
   showRekognitionURLS(context, resourcesToBeCreated);
@@ -64,6 +65,24 @@ function showGraphQLURL(context, resourcesToBeCreated) {
           chalk`GraphQL API is configured to use API_KEY authentication, but API Key deployment is disabled, don't forget to create one.`,
         );
       }
+    }
+  }
+}
+
+function showRestAPIURL(context, resourcesToBeCreated) {
+  const resources = resourcesToBeCreated.filter(resource => resource.service === 'API Gateway');
+
+  if (resources.length > 0) {
+    const resource = resources[0];
+    const { category, resourceName } = resource;
+    const amplifyMeta = context.amplify.getProjectMeta();
+    if (!amplifyMeta[category][resourceName].output) {
+      return;
+    }
+    const { RootUrl } = amplifyMeta[category][resourceName].output;
+
+    if (RootUrl) {
+      context.print.info(chalk`REST API endpoint: {blue.underline ${RootUrl}}`);
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Closes: #3919

*Description of changes:*

`amplify status` will show the endpoint url for the REST API if exist in the project. The first part of the URL is the actual API Id that was requested in the feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.