### PR TITLE
chore: remove unnecessary stack trace log when adding services

### DIFF
--- a/packages/amplify-category-analytics/index.js
+++ b/packages/amplify-category-analytics/index.js
@@ -72,15 +72,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-api/index.js
+++ b/packages/amplify-category-api/index.js
@@ -22,7 +22,7 @@ async function migrate(context, serviceName) {
             if (providerController) {
               if (!serviceName || serviceName === amplifyMeta[category][resourceName].service) {
                 migrateResourcePromises.push(
-                  providerController.migrateResource(context, projectPath, amplifyMeta[category][resourceName].service, resourceName)
+                  providerController.migrateResource(context, projectPath, amplifyMeta[category][resourceName].service, resourceName),
                 );
               }
             }
@@ -149,7 +149,7 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
           context,
           amplifyMeta[category][resourceName].service,
           resourceName,
-          resourceOpsMapping[resourceName]
+          resourceOpsMapping[resourceName],
         );
         permissionPolicies.push(policy);
         resourceAttributes.push({ resourceName, attributes, category });
@@ -165,15 +165,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-auth/index.js
+++ b/packages/amplify-category-auth/index.js
@@ -294,15 +294,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -131,15 +131,19 @@ export async function getInvoker(context: any, params: InvokerParameters): Promi
 }
 
 export async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
-  }
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
 
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
+  }
 }
 
 export async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -114,14 +114,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-interactions/index.js
+++ b/packages/amplify-category-interactions/index.js
@@ -12,7 +12,7 @@ async function migrate(context) {
           const providerController = require(`./provider-utils/${amplifyMeta[category][resourceName].providerPlugin}/index`);
           if (providerController) {
             migrateResourcePromises.push(
-              providerController.migrateResource(context, projectPath, amplifyMeta[category][resourceName].service, resourceName)
+              providerController.migrateResource(context, projectPath, amplifyMeta[category][resourceName].service, resourceName),
             );
           } else {
             context.print.error(`Provider not configured for ${category}: ${resourceName}`);
@@ -42,7 +42,7 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
           context,
           amplifyMeta[category][resourceName].service,
           resourceName,
-          resourceOpsMapping[resourceName]
+          resourceOpsMapping[resourceName],
         );
         permissionPolicies.push(policy);
         resourceAttributes.push({ resourceName, attributes, category });
@@ -58,15 +58,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-notifications/index.js
+++ b/packages/amplify-category-notifications/index.js
@@ -21,15 +21,18 @@ async function migrate(context) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-predictions/commands/predictions/add.js
+++ b/packages/amplify-category-predictions/commands/predictions/add.js
@@ -27,12 +27,12 @@ module.exports = {
         print.success('Some next steps:');
         print.info('"amplify push" builds all of your local backend resources and provisions them in the cloud');
         print.info(
-          '"amplify publish" builds all of your local backend and front-end resources (if you added hosting category) and provisions them in the cloud'
+          '"amplify publish" builds all of your local backend and front-end resources (if you added hosting category) and provisions them in the cloud',
         );
         print.info('');
       })
       .catch(err => {
-        context.print.info(err.stack);
+        context.print.error(err.message);
         context.print.error('An error occurred when adding the predictions resource');
       }),
 };

--- a/packages/amplify-category-predictions/commands/predictions/remove.js
+++ b/packages/amplify-category-predictions/commands/predictions/remove.js
@@ -68,7 +68,7 @@ module.exports = {
         }
       })
       .catch(err => {
-        context.print.info(err.stack);
+        context.print.error(err.message);
         context.print.error('An error occurred when removing the predictions resource');
       });
   },

--- a/packages/amplify-category-predictions/commands/predictions/update.js
+++ b/packages/amplify-category-predictions/commands/predictions/update.js
@@ -20,7 +20,7 @@ module.exports = {
         context.print.success(`Successfully updated resource ${resourceName} locally`);
       })
       .catch(err => {
-        context.print.info(err.stack);
+        context.print.error(err.message);
         context.print.error('An error occurred when updating predictions resource!');
       }),
 };

--- a/packages/amplify-category-predictions/index.js
+++ b/packages/amplify-category-predictions/index.js
@@ -55,15 +55,18 @@ async function console(context) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-storage/index.js
+++ b/packages/amplify-category-storage/index.js
@@ -29,7 +29,7 @@ async function migrate(context) {
           const providerController = require(`./provider-utils/${amplifyMeta[category][resourceName].providerPlugin}/index`);
           if (providerController) {
             migrateResourcePromises.push(
-              providerController.migrateResource(context, projectPath, amplifyMeta[category][resourceName].service, resourceName)
+              providerController.migrateResource(context, projectPath, amplifyMeta[category][resourceName].service, resourceName),
             );
           } else {
             context.print.error(`Provider not configured for ${category}: ${resourceName}`);
@@ -68,7 +68,7 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
           context,
           service,
           resourceName,
-          resourceOpsMapping[resourceName]
+          resourceOpsMapping[resourceName],
         );
         permissionPolicies.push(policy);
         resourceAttributes.push({ resourceName, attributes, category });
@@ -84,15 +84,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {

--- a/packages/amplify-category-xr/index.js
+++ b/packages/amplify-category-xr/index.js
@@ -88,15 +88,18 @@ async function getPermissionPolicies(context, resourceOpsMapping) {
 }
 
 async function executeAmplifyCommand(context) {
-  let commandPath = path.normalize(path.join(__dirname, 'commands'));
-  if (context.input.command === 'help') {
-    commandPath = path.join(commandPath, category);
-  } else {
-    commandPath = path.join(commandPath, category, context.input.command);
+  try {
+    let commandPath = path.normalize(path.join(__dirname, 'commands'));
+    if (context.input.command === 'help') {
+      commandPath = path.join(commandPath, category);
+    } else {
+      commandPath = path.join(commandPath, category, context.input.command);
+    }
+    const commandModule = require(commandPath);
+    await commandModule.run(context);
+  } catch (err) {
+    context.print.error(err.message);
   }
-
-  const commandModule = require(commandPath);
-  await commandModule.run(context);
 }
 
 async function handleAmplifyEvent(context, args) {


### PR DESCRIPTION
*Issue #, if available:*
[aws-amplify#4283](https://github.com/aws-amplify/amplify-cli/issues/4283)

*Description of changes:*
The unnecessary stack traces that were displayed through the console when a user tried to run `amplify add <service>` without initializing amplify first was because of a lacking try/catch block which displays only the error message, so I added that onto the parts where the addition of services was being called.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.