### PR TITLE
fix: #4549 #4550 init and folder exist checks

### DIFF
--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Publish.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Publish.js
@@ -39,7 +39,7 @@ function getPublishIgnoreFilePath(context) {
     return path.join(projectPath, PublishIgnoreFileName);
   }
   const error = new Error(
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
+    "You are not working inside a valid Amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project, or 'amplify pull' to pull down an existing project.",
   );
 
   error.name = 'NotInitialized';

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Publish.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Publish.js
@@ -38,9 +38,14 @@ function getPublishIgnoreFilePath(context) {
   if (projectPath || fs.existsSync(projectPath)) {
     return path.join(projectPath, PublishIgnoreFileName);
   }
-  throw new Error(
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify"
+  const error = new Error(
+    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
   );
+
+  error.name = 'NotInitialized';
+  error.stack = undefined;
+
+  throw error;
 }
 
 async function configurePublishIgnore(context, publishIgnore) {

--- a/packages/amplify-cli/src/attach-backend.js
+++ b/packages/amplify-cli/src/attach-backend.js
@@ -68,6 +68,16 @@ function backupAmplifyFolder(context) {
   const amplifyDirPath = context.amplify.pathManager.getAmplifyDirPath(projectPath);
   if (fs.existsSync(amplifyDirPath)) {
     const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
+
+    if (fs.existsSync(backupAmplifyDirPath)) {
+      const error = new Error(`Backup folder at ${backupAmplifyDirPath} already exist, remove the folder and retry the operation.`);
+
+      error.name = 'BackupFolderAlreadyExist';
+      error.stack = null;
+
+      throw error;
+    }
+
     fs.moveSync(amplifyDirPath, backupAmplifyDirPath);
   }
 }

--- a/packages/amplify-cli/src/attach-backend.js
+++ b/packages/amplify-cli/src/attach-backend.js
@@ -70,7 +70,7 @@ function backupAmplifyFolder(context) {
     const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
 
     if (fs.existsSync(backupAmplifyDirPath)) {
-      const error = new Error(`Backup folder at ${backupAmplifyDirPath} already exist, remove the folder and retry the operation.`);
+      const error = new Error(`Backup folder at ${backupAmplifyDirPath} already exists, remove the folder and retry the operation.`);
 
       error.name = 'BackupFolderAlreadyExist';
       error.stack = null;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
@@ -25,7 +25,7 @@ async function deleteProject(context) {
         }
       }
     } catch (ex) {
-      spinner.fail(`Project delete failed ${ex.message}`);
+      spinner.fail('Project delete failed');
       throw ex;
     }
     spinner.succeed('Project deleted in the cloud');

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-project-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-project-meta.js
@@ -7,7 +7,7 @@ function getProjectMeta() {
 
   if (!amplifyMetaFilePath || !fs.existsSync(amplifyMetaFilePath)) {
     const error = new Error(
-      "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
+      "You are not working inside a valid Amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project, or 'amplify pull' to pull down an existing project.",
     );
 
     error.name = 'NotInitialized';

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-project-meta.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-project-meta.js
@@ -1,8 +1,21 @@
+const fs = require('fs-extra');
 const pathManager = require('./path-manager');
 const { readJsonFile } = require('./read-json-file');
 
 function getProjectMeta() {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
+
+  if (!amplifyMetaFilePath || !fs.existsSync(amplifyMetaFilePath)) {
+    const error = new Error(
+      "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
+    );
+
+    error.name = 'NotInitialized';
+    error.stack = undefined;
+
+    throw error;
+  }
+
   const amplifyMeta = readJsonFile(amplifyMetaFilePath);
   return amplifyMeta;
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
@@ -122,7 +122,7 @@ function getCurrentAmplifyMetaFilePath(projectPath) {
 
 function createNotInitializedError() {
   const error = new Error(
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
+    "You are not working inside a valid Amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project, or 'amplify pull' to pull down an existing project.",
   );
 
   error.name = 'NotInitialized';

--- a/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/path-manager.js
@@ -50,9 +50,7 @@ function getAmplifyDirPath(projectPath) {
   if (projectPath) {
     return path.normalize(path.join(projectPath, amplifyCLIConstants.AmplifyCLIDirName));
   }
-  throw new Error(
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify"
-  );
+  throw createNotInitializedError();
 }
 
 // ///////////////////level 1
@@ -75,9 +73,7 @@ function getAmplifyRcFilePath(projectPath) {
   if (projectPath) {
     return path.normalize(path.join(projectPath, '.amplifyrc'));
   }
-  throw new Error(
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify"
-  );
+  throw createNotInitializedError();
 }
 
 function getGitIgnoreFilePath(projectPath) {
@@ -87,9 +83,7 @@ function getGitIgnoreFilePath(projectPath) {
   if (projectPath) {
     return path.normalize(path.join(projectPath, '.gitignore'));
   }
-  throw new Error(
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify"
-  );
+  throw createNotInitializedError();
 }
 
 // ///////////////////level 2
@@ -124,6 +118,17 @@ function getAmplifyMetaFilePath(projectPath) {
 
 function getCurrentAmplifyMetaFilePath(projectPath) {
   return path.normalize(path.join(getCurrentCloudBackendDirPath(projectPath), amplifyCLIConstants.amplifyMetaFileName));
+}
+
+function createNotInitializedError() {
+  const error = new Error(
+    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
+  );
+
+  error.name = 'NotInitialized';
+  error.stack = undefined;
+
+  return error;
 }
 
 module.exports = {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -226,7 +226,7 @@ async function getResourceStatus(category, resourceName, providerName, filteredR
     amplifyMeta = readJsonFile(backendConfigFilePath);
   } else {
     const error = new Error(
-      "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
+      "You are not working inside a valid Amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project, or 'amplify pull' to pull down an existing project.",
     );
 
     error.name = 'NotInitialized';

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -225,9 +225,14 @@ async function getResourceStatus(category, resourceName, providerName, filteredR
     const backendConfigFilePath = pathManager.getBackendConfigFilePath();
     amplifyMeta = readJsonFile(backendConfigFilePath);
   } else {
-    throw new Error(
+    const error = new Error(
       "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
     );
+
+    error.name = 'NotInitialized';
+    error.stack = undefined;
+
+    throw error;
   }
 
   let resourcesToBeCreated = getResourcesToBeCreated(amplifyMeta, currentamplifyMeta, category, resourceName, filteredResources);

--- a/packages/amplify-cli/src/migrate-project.js
+++ b/packages/amplify-cli/src/migrate-project.js
@@ -148,7 +148,7 @@ function backup(amplifyDirPath, projectPath) {
   const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
 
   if (fs.existsSync(backupAmplifyDirPath)) {
-    const error = new Error(`Backup folder at ${backupAmplifyDirPath} already exist, remove the folder and retry the operation.`);
+    const error = new Error(`Backup folder at ${backupAmplifyDirPath} already exists, remove the folder and retry the operation.`);
 
     error.name = 'BackupFolderAlreadyExist';
     error.stack = null;

--- a/packages/amplify-cli/src/migrate-project.js
+++ b/packages/amplify-cli/src/migrate-project.js
@@ -147,6 +147,15 @@ function backup(amplifyDirPath, projectPath) {
   const backupAmplifyDirName = `${constants.AmplifyCLIDirName}-${makeId(5)}`;
   const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
 
+  if (fs.existsSync(backupAmplifyDirPath)) {
+    const error = new Error(`Backup folder at ${backupAmplifyDirPath} already exist, remove the folder and retry the operation.`);
+
+    error.name = 'BackupFolderAlreadyExist';
+    error.stack = null;
+
+    throw error;
+  }
+
   fs.copySync(amplifyDirPath, backupAmplifyDirPath);
 
   return backupAmplifyDirPath;

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -40,9 +40,9 @@ module.exports = {
   ERROR_APPSYNC_API_NOT_FOUND:
     'Could not find the AppSync API. If you have removed the AppSync API in the console run amplify codegen remove',
   MSG_CODEGEN_PENDING_API_PUSH: `${chalk.bold(
-    'WARNING:'
+    'WARNING:',
   )} You have modified your schema locally and not pushed to the cloud, which may result in incomplete type generation.\nWe recommend you first run ${chalk.underline(
-    '$amplify push'
+    '$amplify push',
   )}`,
   INFO_AUTO_SELECTED_API: 'Using AppSync API:',
   INFO_MSG_REMOVE_API_SUCCESS: 'removed project',
@@ -54,6 +54,4 @@ module.exports = {
   INFO_MESSAGE_OPS_GEN: 'Generating GraphQL operations',
   INFO_MESSAGE_OPS_GEN_SUCCESS: 'Generated GraphQL operations successfully and saved at ',
   INFO_MESSAGE_ADD_ERROR: 'amplify codegen add takes only apiId as parameter. \n$ amplify codegen add [--apiId <API_ID>]',
-  ERROR_NOT_AMPLIFY_PROJECT:
-    "You are not working inside a valid amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project with Amplify",
 };


### PR DESCRIPTION
*Issue #, if available:*

fix: #4549 #4550

*Description of changes:*

- Remove duplicated error message about uninitialized environment, enrich the error with name, clear stack from error, without stack customers are seeing a friendlier error message without tech details 
- Add check for backup folder existence to prevent further errors
- Remove unused error message constant

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.