### PR TITLE
fix: validatePathName_validPath matcher

### DIFF
--- a/packages/amplify-category-api/provider-utils/__tests__/apigw-walkthroughs.test.js
+++ b/packages/amplify-category-api/provider-utils/__tests__/apigw-walkthroughs.test.js
@@ -6,8 +6,8 @@ const validatePathName = walkthrough.__get__('validatePathName');
 const stubOtherPaths = [{ name: '/other/path' }, { name: '/sub/path' }];
 
 test('validatePathName_validPath', () => {
-  expect(validatePathName('/some/path', stubOtherPaths)).toBeTruthy();
-  expect(validatePathName('/path/{with}/{params}', stubOtherPaths)).toBeTruthy();
+  expect(validatePathName('/some/path', stubOtherPaths)).toBe(true);
+  expect(validatePathName('/path/{with}/{params}', stubOtherPaths)).toBe(true);
 });
 
 test('validatePath_empty', () => {


### PR DESCRIPTION
The validatePathName function returns either true or a string containing
an error message. The intent of the test is clearly to check for true and not
return value truthiness.