### PR TITLE
fix(graphql-dynamodb-transformer): support model without id

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -116,11 +116,16 @@ export class DynamoDBModelTransformer extends Transformer {
     // append hoisted initalization code to the top of request mapping template
     const ddbMetata = ctx.metadata.get(METADATA_KEY);
     if (ddbMetata) {
-      Object.entries(ddbMetata.hoistedRequestMappingContent || {}).forEach(([resourceId, hoistedContent]) => {
-        const resource: AppSync.Resolver = ctx.getResource(resourceId) as any;
-        resource.Properties.RequestMappingTemplate = [hoistedContent, resource.Properties.RequestMappingTemplate].join('\n');
-        ctx.setResource(resourceId, resource);
-      });
+      Object.entries(ddbMetata.hoistedRequestMappingContent || {}).forEach(
+        ([resourceId, hoistedContentGenerator]: [string, () => string | void]) => {
+          const hoistedContent = hoistedContentGenerator();
+          if (hoistedContent) {
+            const resource: AppSync.Resolver = ctx.getResource(resourceId) as any;
+            resource.Properties.RequestMappingTemplate = [hoistedContent, resource.Properties.RequestMappingTemplate].join('\n');
+            ctx.setResource(resourceId, resource);
+          }
+        },
+      );
     }
   };
 
@@ -142,6 +147,8 @@ export class DynamoDBModelTransformer extends Transformer {
         ctx.addInput(nonModelObject);
       }
     });
+
+    this.addIdField(def, directive, ctx);
 
     // Set Sync Config if it exists
 
@@ -240,6 +247,19 @@ export class DynamoDBModelTransformer extends Transformer {
     ctx.updateObject(newObj);
   }
 
+  // Add ID field to type when does not have id
+  private addIdField(def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void {
+    const hasIdField = def.fields.find(f => f.name.value === 'id');
+    if (!hasIdField) {
+      const obj = ctx.getObject(def.name.value);
+      const newObj: ObjectTypeDefinitionNode = {
+        ...obj,
+        fields: [makeField('id', [], wrapNonNull(makeNamedType('ID'))), ...obj.fields],
+      };
+      ctx.updateObject(newObj);
+    }
+  }
+
   private createMutations = (
     def: ObjectTypeDefinitionNode,
     directive: DirectiveNode,
@@ -311,9 +331,14 @@ export class DynamoDBModelTransformer extends Transformer {
         nameOverride: createFieldNameOverride,
         syncConfig: this.opts.SyncConfig,
       });
-      const hositedInitalization = this.resources.initalizeDefaultInputForCreateMutation(createInput, timestampFields);
       const resourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
-      this.addInitalizationMetadata(ctx, resourceId, hositedInitalization);
+      this.addInitalizationMetadata(ctx, resourceId, () => {
+        const inputObj = ctx.getType(createInput.name.value) as InputObjectTypeDefinitionNode;
+        if (inputObj) {
+          return this.resources.initalizeDefaultInputForCreateMutation(inputObj, timestampFields);
+        }
+      });
+
       ctx.setResource(resourceId, createResolver);
       ctx.mapResourceToStack(typeName, resourceId);
       const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))];
@@ -708,11 +733,11 @@ export class DynamoDBModelTransformer extends Transformer {
     return true;
   }
 
-  private addInitalizationMetadata(ctx: TransformerContext, resourceId: string, initCode: string): void {
+  private addInitalizationMetadata(ctx: TransformerContext, resourceId: string, initCodeGenerator: () => string | void): void {
     const ddbMetadata = ctx.metadata.has(METADATA_KEY) ? ctx.metadata.get(METADATA_KEY) : {};
     ddbMetadata.hoistedRequestMappingContent = {
       ...ddbMetadata?.hoistedRequestMappingContent,
-      [resourceId]: initCode,
+      [resourceId]: initCodeGenerator,
     };
     ctx.metadata.set(METADATA_KEY, ddbMetadata);
   }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -13,6 +13,7 @@ import {
 } from 'graphql';
 import { GraphQLTransform, TRANSFORM_BASE_VERSION, TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
 import { DynamoDBModelTransformer } from '../DynamoDBModelTransformer';
+import { getBaseType } from 'graphql-transformer-common';
 
 test('Test DynamoDBModelTransformer validation happy case', () => {
   const validSchema = `
@@ -591,6 +592,57 @@ test(`V5 transformer snapshot test`, () => {
 test(`Current version transformer snapshot test`, () => {
   const schema = transformerVersionSnapshot(TRANSFORM_CURRENT_VERSION);
   expect(schema).toMatchSnapshot();
+});
+
+test('DynmoDB transformer should add default primary key when not defined', () => {
+  const validSchema = `
+  type Post @model{
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toBeDefined();
+  const schema = parse(result.schema);
+
+  const createPostInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+    d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreatePostInput',
+  ) as InputObjectTypeDefinitionNode | undefined;
+  expect(createPostInput).toBeDefined();
+  const defaultIdField: InputValueDefinitionNode = createPostInput.fields.find(f => f.name.value === 'id');
+  expect(defaultIdField).toBeDefined();
+  expect(getBaseType(defaultIdField.type)).toEqual('ID');
+});
+
+test('DynmoDB transformer should add not default primary key when ID is defined', () => {
+  const validSchema = `
+  type Post @model{
+    id: Int
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toBeDefined();
+  const schema = parse(result.schema);
+
+  const createPostInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+    d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreatePostInput',
+  ) as InputObjectTypeDefinitionNode | undefined;
+  expect(createPostInput).toBeDefined();
+  const defaultIdField: InputValueDefinitionNode = createPostInput.fields.find(f => f.name.value === 'id');
+  expect(defaultIdField).toBeDefined();
+  expect(getBaseType(defaultIdField.type)).toEqual('Int');
+  // It should not add default value for ctx.arg.id as id is of type Int
+  expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
 });
 
 function transformerVersionSnapshot(version: number): string {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -182,7 +182,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -152,6 +152,47 @@ type Subscription {
 "
 `;
 
+exports[`DynmoDB transformer should add not default primary key when ID is defined 1`] = `
+"## [Start] Set default values. **
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  }
+} )
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2017-02-28\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
 exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 1`] = `
 "type Post {
   id: ID!

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -142,6 +142,7 @@ export function makeCreateInputObject(
     [updatedAtField]: ['AWSDateTime', 'String'],
   };
 
+  const hasIdField = obj.fields.find(f => f.name.value === 'id');
   const fields: InputValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.getType(getBaseType(field.type));
@@ -193,7 +194,11 @@ export function makeCreateInputObject(
       kind: 'Name',
       value: name,
     },
-    fields,
+    fields: [
+      // add default id field and expose that
+      ...(hasIdField ? [] : [makeInputValueDefinition('id', makeNamedType('ID'))]),
+      ...fields,
+    ],
     directives: [],
   };
 }

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -116,6 +116,10 @@ export class KeyTransformer extends Transformer {
   private updateSchema = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
     this.updateQueryFields(definition, directive, ctx);
     this.updateInputObjects(definition, directive, ctx);
+    const isPrimaryKey = this.isPrimaryKey(directive);
+    if (isPrimaryKey) {
+      this.removeAutocreatedPrimaryKey(definition, directive, ctx);
+    }
   };
 
   /**
@@ -193,6 +197,19 @@ export class KeyTransformer extends Transformer {
         ctx.mapResourceToStack(definition.name.value, queryResolverId);
         ctx.setResource(queryResolverId, queryResolver);
       }
+    }
+  };
+
+  private removeAutocreatedPrimaryKey = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
+    const schemaHasIdField = definition.fields.find(f => f.name.value === 'id');
+    if (!schemaHasIdField) {
+      const obj = ctx.getObject(definition.name.value);
+      const fields = obj.fields.filter(f => f.name.value !== 'id');
+      const newObj: ObjectTypeDefinitionNode = {
+        ...obj,
+        fields,
+      };
+      ctx.updateObject(newObj);
     }
   };
 
@@ -351,10 +368,15 @@ export class KeyTransformer extends Transformer {
     if (this.isPrimaryKey(directive)) {
       const directiveArgs: KeyArguments = getDirectiveArguments(directive);
 
-      // There is no need to update the create Input as fields that can be in the index have to be non-nullable (which is enforece by
-      // @key directive). The @model transformer generates the createXInput where non-nullable fields  are
-      // also non-nullables in the input types as wekk. Only exception to this is when these fields can be automatically populated
-      // like id, createdAt and updatedAt, which will automatically get default value
+      const hasIdField = definition.fields.find(f => f.name.value === 'id');
+      if (!hasIdField) {
+        const createInput = ctx.getType(
+          ModelResourceIDs.ModelCreateInputObjectName(definition.name.value),
+        ) as InputObjectTypeDefinitionNode;
+        if (createInput) {
+          ctx.putType(replaceCreateInput(definition, createInput, directiveArgs.fields));
+        }
+      }
 
       const updateInput = ctx.getType(ModelResourceIDs.ModelUpdateInputObjectName(definition.name.value)) as InputObjectTypeDefinitionNode;
       if (updateInput) {
@@ -720,6 +742,18 @@ function replaceUpdateInput(
 
       return f;
     }),
+  };
+}
+
+// Remove the id field added by @model transformer
+function replaceCreateInput(
+  definition: ObjectTypeDefinitionNode,
+  input: InputObjectTypeDefinitionNode,
+  keyFields: string[],
+): InputObjectTypeDefinitionNode {
+  return {
+    ...input,
+    fields: input.fields.filter(f => f.name.value !== 'id'),
   };
 }
 

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -118,7 +118,7 @@ export class KeyTransformer extends Transformer {
     this.updateInputObjects(definition, directive, ctx);
     const isPrimaryKey = this.isPrimaryKey(directive);
     if (isPrimaryKey) {
-      this.removeAutocreatedPrimaryKey(definition, directive, ctx);
+      this.removeAutoCreatedPrimaryKey(definition, directive, ctx);
     }
   };
 
@@ -200,7 +200,7 @@ export class KeyTransformer extends Transformer {
     }
   };
 
-  private removeAutocreatedPrimaryKey = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
+  private removeAutoCreatedPrimaryKey = (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
     const schemaHasIdField = definition.fields.find(f => f.name.value === 'id');
     if (!schemaHasIdField) {
       const obj = ctx.getObject(definition.name.value);


### PR DESCRIPTION
Updatd graphql-dynamodb-transformer to automatically add id to the model when
id is missing in the type. Id will not be added if `@key` directive changes
the primary index

fix #4502 
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.