### PR TITLE
fix: do not remove resources group

### DIFF
--- a/packages/amplify-app/src/xcodeHelpers.js
+++ b/packages/amplify-app/src/xcodeHelpers.js
@@ -180,7 +180,10 @@ async function addAmplifyFiles() {
         }
 
         // adding resources (i.e. files that are added to the app bundle)
-        project.addPbxGroup([], 'Resources', 'Resources', '"<group>"');
+        const resourcesGroup = project.pbxGroupByName('Resources');
+        if (!resourcesGroup) {
+          project.addPbxGroup([], 'Resources');
+        }
         const amplifyConfigFile = 'amplifyconfiguration.json';
         const awsConfigFile = 'awsconfiguration.json';
         if (!groupHasFile(amplifyConfigGroup, amplifyConfigFile)) {
@@ -188,7 +191,6 @@ async function addAmplifyFiles() {
           project.addResourceFile(awsConfigFile, null, amplifyConfigGroup.uuid);
           hasGeneratedFiles = true;
         }
-        project.removePbxGroup('Resources');
 
         // add schema.graphql
         if (!groupHasFile(amplifyConfigGroup, 'schema.graphql')) {


### PR DESCRIPTION
check if resources group exists and add it iff it does not

fix #4518

*Issue #, if available:*

*Description of changes:*
get or create resources logical group instead of adding and then removing it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.