### PR TITLE
feat: add check for extra command line args provided with amplify delete

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/delete.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/delete.test.ts
@@ -1,0 +1,96 @@
+import { run as runDeleteCmd } from '../../commands/delete';
+
+// amplify delete run method calls process.exit() in certain situations. To avoid this affecting tests when they run, spy on process.exit()
+// calls and intercept them, performing a NOP, instead.
+//
+// https://stackoverflow.com/questions/46148169/stubbing-process-exit-with-jest
+const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+describe('amplify delete: ', () => {
+  it('delete run method should exist', () => {
+    expect(runDeleteCmd).toBeDefined();
+  });
+
+  const mockContextNoCLArgs = {
+    amplify: {
+      deleteProject: jest.fn(),
+    },
+    parameters: {
+      array: [],
+    },
+  };
+
+  describe('case: amplify delete is run with no additional command line arguments', () => {
+    it('delete run method should call context.amplify.deleteProject()', async () => {
+      await runDeleteCmd(mockContextNoCLArgs);
+      expect(mockContextNoCLArgs.amplify.deleteProject).toBeCalled();
+    });
+  });
+
+  const mockContextWithCLArgs = {
+    amplify: {
+      deleteProject: jest.fn(),
+    },
+    parameters: {
+      array: ['foo'],
+    },
+    print: {
+      error: jest.fn(),
+    },
+  };
+
+  describe('case: amplify delete is run with additional command line arguments', () => {
+    it('delete run method should display an error message', async () => {
+      await runDeleteCmd(mockContextWithCLArgs);
+      expect(mockContextWithCLArgs.print.error).toBeCalledWith('"delete" command does not expect additional arguments.');
+      expect(mockContextWithCLArgs.print.error).toBeCalledWith('Perhaps you meant to use the "remove" command instead of "delete"?');
+      expect(mockExit).toBeCalledWith(1);
+    });
+  });
+
+  const mockContextWithForceOption = {
+    amplify: {
+      deleteProject: jest.fn(),
+    },
+    parameters: {
+      array: [],
+    },
+    options: {
+      force: true,
+    },
+  };
+
+  describe('case: amplify delete is run with the --force command line option', () => {
+    it('delete run method should call context.amplify.deleteProject()', async () => {
+      await runDeleteCmd(mockContextWithForceOption);
+      expect(mockContextWithForceOption.amplify.deleteProject).toBeCalled();
+    });
+  });
+
+  const mockContextWithForceOptionAndCLArgs = {
+    amplify: {
+      deleteProject: jest.fn(),
+    },
+    parameters: {
+      array: ['foo'],
+    },
+    options: {
+      force: true,
+    },
+    print: {
+      error: jest.fn(),
+    },
+  };
+
+  describe('case: amplify delete is run with the --force command line option, as well as additional command line arguments', () => {
+    it('delete run method should display an error message', async () => {
+      console.log('did we run?');
+      await runDeleteCmd(mockContextWithForceOptionAndCLArgs);
+      expect(mockContextWithForceOptionAndCLArgs.print.error).toBeCalledWith('"delete" command does not expect additional arguments.');
+      expect(mockContextWithForceOptionAndCLArgs.print.error).toBeCalledWith(
+        'Perhaps you meant to use the "remove" command instead of "delete"?',
+      );
+      expect(mockExit).toBeCalledWith(1);
+    });
+  });
+});

--- a/packages/amplify-cli/src/commands/delete.js
+++ b/packages/amplify-cli/src/commands/delete.js
@@ -1,6 +1,12 @@
 module.exports = {
   name: 'delete',
   run: async context => {
+    if (Array.isArray(context.parameters.array) && context.parameters.array.length > 0) {
+      context.print.error('"delete" command does not expect additional arguments.');
+      context.print.error('Perhaps you meant to use the "remove" command instead of "delete"?');
+      process.exit(1);
+    }
+
     await context.amplify.deleteProject(context);
   },
 };


### PR DESCRIPTION
*Issue #, if available:*
#4115 

*Description of changes:*
Since `$ amplify delete` is a sensitive and dangerous command, there should be checks in place to ensure that users truly mean to execute it. `$ amplify delete` may be confused with `$ amplify remove <category>`. If `$ amplify delete` is executed with any additional command line arguments, then an error message should be displayed indicating that the `delete` command does not accept any arguments, and a suggestion should be printed that asks the user if they meant to use the `remove` command instead of `delete`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.