### PR TITLE
feat: change `amplify delete` prompt default value from yes to no

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.js
@@ -61,6 +61,7 @@ async function getConfirmation(context, env) {
       `Are you sure you want to continue? This CANNOT be undone. (This would delete ${environmentText} of the project from the cloud${
         env ? '' : ' and wipe out all the local files created by Amplify CLI'
       })`,
+      false,
     ),
     // Place holder for later selective deletes
     deleteS3: true,


### PR DESCRIPTION
*Issue #, if available:*
#4579 

*Description of changes:*
After running `$ amplify delete`, an "are you sure you want to continue" prompt appears. This PR proposes to change that prompt's default response value from "yes" to "no."

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.