### PR TITLE
fix: url of docs on AWS CLI profiles has changed

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/lib/configuration-manager.js
@@ -206,7 +206,7 @@ async function remove(context) {
 }
 
 function printInfo(context) {
-  const url = 'https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html';
+  const url = 'https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html';
   context.print.info('');
   context.print.info('For more information on AWS Profiles, see:');
   context.print.info(chalk.green(url));


### PR DESCRIPTION
(fix) url of docs on AWS CLI profiles has changed

just updating a URL so it doesnt link users to a path that doesnt exist (though it is covered by a redirect for now)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.