### PR TITLE
feat: Prompt user for previous/default permissions on new layer version created during push

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
@@ -19,7 +19,7 @@ const inquirer_mock = inquirer as jest.Mocked<typeof inquirer>;
 const enquirer_mock = enquirer as jest.Mocked<typeof enquirer>;
 const layerMetadataFactory_stub: LayerMetadataFactory = () =>
   ({
-    listVersions: () => [1, 2, 3],
+    listVersions: () => [3, 2, 1],
   } as any);
 
 const runtimeValue = 'lolcode';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -66,8 +66,6 @@ export const askLayerSelection = async (
       message: versionSelectionPrompt(selection),
       choices: layerMetadataFactory(selection)
         .listVersions()
-        .sort()
-        .reverse()
         .map(num => num.toString()),
       default: currentVersion,
       filter: numStr => parseInt(numStr, 10),

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -66,6 +66,7 @@ export function layerPermissionsQuestion(params?: Permission[]) {
         },
         {
           name: 'Public (everyone on AWS can use this layer)',
+          short: 'Public',
           value: Permission.public,
           checked: _.includes(params, Permission.public),
         },
@@ -123,6 +124,29 @@ export function layerOrgAccessQuestion(defaultorgs?: string[]) {
         return true;
       },
       default: defaultorgs !== undefined ? defaultorgs.join(',') : '',
+    },
+  ];
+}
+
+export function prevPermsQuestion(layerName: string) {
+  return [
+    {
+      type: 'list',
+      name: 'usePrevPerms',
+      message: `Content changes in Lambda layer ${layerName} detected. What permissions do you want to grant to this new layer version?`,
+      choices: [
+        {
+          name: 'The same permission as the latest layer version',
+          short: 'Previous version permissions',
+          value: 'previous',
+        },
+        {
+          name: 'Only accessible by the current account. You can always edit this later with: amplify update function',
+          short: 'Private',
+          value: 'default',
+        },
+      ],
+      default: 0,
     },
   ];
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
@@ -80,7 +80,7 @@ class LayerState implements LayerMetadata {
   }
 
   listVersions(): number[] {
-    return Array.from(this.versionMap.keys());
+    return Array.from(this.versionMap.keys()).sort((a, b) => Number(b) - Number(a));
   }
 
   getLatestVersion(): number {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -80,7 +80,7 @@ async function getNewVersionPermissions(
     const { usePrevPerms } = await prompt(prevPermsQuestion(layerName));
     usePrevPermissions = usePrevPerms === 'previous';
   }
-  return new Promise(resolve => (usePrevPermissions ? prevPermissions : defaultPermissions));
+  return usePrevPermissions ? prevPermissions : defaultPermissions;
 }
 
 async function hashLayerDir(layerPath: string): Promise<any> {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -73,23 +73,25 @@ export function copyTemplateFiles(context: any, parameters: FunctionParameters |
 export function createLayerFolders(context, parameters) {
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
   const layerDirPath = path.join(projectBackendDirPath, categoryName, parameters.layerName);
-  fs.mkdirSync(path.join(layerDirPath, 'opt'), { recursive: true });
-
-  let moduleDirPath;
+  fs.ensureDirSync(path.join(layerDirPath, 'opt'));
   for (let runtime of parameters.runtimes) {
-    moduleDirPath = path.join(layerDirPath, 'lib', runtime.layerExecutablePath);
-    fs.mkdirSync(moduleDirPath, { recursive: true });
-    fs.writeFileSync(path.join(moduleDirPath, 'README.txt'), 'Replace this file with your layer files');
+    ensureLayerRuntimeFolder(layerDirPath, runtime);
+  }
+  return layerDirPath;
+}
 
+// Default files are only created if the path does not exist
+function ensureLayerRuntimeFolder(layerDirPath: string, runtime) {
+  const runtimeDirPath = path.join(layerDirPath, 'lib', runtime.layerExecutablePath);
+  if (!fs.pathExistsSync(runtimeDirPath)) {
+    fs.ensureDirSync(runtimeDirPath);
+    fs.writeFileSync(path.join(runtimeDirPath, 'README.txt'), 'Replace this file with your layer files');
     if (runtime.layerDefaultFiles) {
       for (let defaultFile of runtime.layerDefaultFiles) {
-        moduleDirPath = path.join(layerDirPath, 'lib', defaultFile.path);
-        fs.ensureDirSync(moduleDirPath);
-        fs.writeFileSync(path.join(moduleDirPath, defaultFile.filename), defaultFile.content);
+        fs.writeFileSync(path.join(layerDirPath, 'lib', defaultFile.path, defaultFile.filename), defaultFile.content);
       }
     }
   }
-  return layerDirPath;
 }
 
 export function createLayerCfnFile(context, parameters: LayerParameters, layerDirPath: string) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -74,9 +74,7 @@ export function createLayerFolders(context, parameters) {
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
   const layerDirPath = path.join(projectBackendDirPath, categoryName, parameters.layerName);
   fs.ensureDirSync(path.join(layerDirPath, 'opt'));
-  for (let runtime of parameters.runtimes) {
-    ensureLayerRuntimeFolder(layerDirPath, runtime);
-  }
+  parameters.runtimes.forEach(runtime => ensureLayerRuntimeFolder(layerDirPath, runtime));
   return layerDirPath;
 }
 
@@ -86,11 +84,9 @@ function ensureLayerRuntimeFolder(layerDirPath: string, runtime) {
   if (!fs.pathExistsSync(runtimeDirPath)) {
     fs.ensureDirSync(runtimeDirPath);
     fs.writeFileSync(path.join(runtimeDirPath, 'README.txt'), 'Replace this file with your layer files');
-    if (runtime.layerDefaultFiles) {
-      for (let defaultFile of runtime.layerDefaultFiles) {
-        fs.writeFileSync(path.join(layerDirPath, 'lib', defaultFile.path, defaultFile.filename), defaultFile.content);
-      }
-    }
+    (runtime.layerDefaultFiles || []).forEach(defaultFile =>
+      fs.writeFileSync(path.join(layerDirPath, 'lib', defaultFile.path, defaultFile.filename), defaultFile.content),
+    );
   }
 }
 

--- a/packages/amplify-dotnet-function-runtime-provider/src/index.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/index.ts
@@ -17,7 +17,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
               value: dotnetcore31,
               cloudTemplateValue: dotnetcore31,
               defaultHandler: `${contributionRequest.contributionContext.resourceName}::${contributionRequest.contributionContext.resourceName}.${contributionRequest.contributionContext.functionName}::LambdaHandler`,
-              layerExecutablePath: `${dotnetcore31}/`,
+              layerExecutablePath: dotnetcore31,
             },
           };
         default:

--- a/packages/amplify-go-function-runtime-provider/src/index.ts
+++ b/packages/amplify-go-function-runtime-provider/src/index.ts
@@ -14,7 +14,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
           value: 'go1.x',
           cloudTemplateValue: 'go1.x',
           defaultHandler: 'main',
-          layerExecutablePath: 'go1.x/',
+          layerExecutablePath: 'go1.x',
         },
       });
     },

--- a/packages/amplify-java-function-runtime-provider/src/index.ts
+++ b/packages/amplify-java-function-runtime-provider/src/index.ts
@@ -4,6 +4,7 @@ import { packageResource } from './utils/package';
 import { checkJava, checkJavaCompiler, checkGradle } from './utils/detect';
 import { invokeResource } from './utils/invoke';
 import { CheckDependenciesResult } from 'amplify-function-plugin-interface/src';
+import path from 'path';
 
 export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactory = context => {
   return {
@@ -20,7 +21,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
           value: 'java',
           cloudTemplateValue: 'java11',
           defaultHandler: 'example.LambdaRequestHandler::handleRequest',
-          layerExecutablePath: 'java/lib/',
+          layerExecutablePath: path.join('java', 'lib'),
         },
       });
     },

--- a/packages/amplify-nodejs-function-runtime-provider/src/index.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/index.ts
@@ -17,7 +17,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
           value: 'nodejs',
           cloudTemplateValue: 'nodejs12.x',
           defaultHandler: 'index.handler',
-          layerExecutablePath: 'nodejs/node_modules/',
+          layerExecutablePath: path.join('nodejs', 'node_modules'),
           layerDefaultFiles: [
             {
               path: 'nodejs/',

--- a/packages/amplify-nodejs-function-runtime-provider/src/index.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/index.ts
@@ -20,7 +20,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
           layerExecutablePath: path.join('nodejs', 'node_modules'),
           layerDefaultFiles: [
             {
-              path: 'nodejs/',
+              path: 'nodejs',
               filename: 'package.json',
               content: JSON.stringify({
                 name: 'nodejs',

--- a/packages/amplify-python-function-runtime-provider/src/index.ts
+++ b/packages/amplify-python-function-runtime-provider/src/index.ts
@@ -3,6 +3,7 @@ import { pythonBuild } from './util/buildUtils';
 import { pythonPackage } from './util/packageUtils';
 import { pythonInvoke } from './util/invokeUtil';
 import { checkDeps } from './util/depUtils';
+import path from 'path';
 
 export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactory = context => {
   return {
@@ -17,7 +18,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
           value: 'python',
           cloudTemplateValue: 'python3.8',
           defaultHandler: 'index.handler',
-          layerExecutablePath: 'python/lib/python3.8/site-packages',
+          layerExecutablePath: path.join('python', 'lib', 'python3.8', 'site-packages'),
         },
       });
     },


### PR DESCRIPTION
*Description of changes:*
Prompt user for previous/default permissions on new layer version created during push

Fix default files being rewritten to disk every time a version update occurred. They are only created when the directory structure is also created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.