### PR TITLE
fix: revert service name 'LambdaFunction' to 'Lambda'

### DIFF
--- a/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
+++ b/packages/amplify-category-api/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.js
@@ -5,6 +5,7 @@ const uuid = require('uuid');
 const path = require('path');
 const open = require('open');
 const TransformPackage = require('graphql-transformer-core');
+const { ServiceName: FunctionServiceName } = require('amplify-category-function');
 
 const category = 'api';
 const serviceName = 'AppSync';
@@ -338,7 +339,7 @@ async function createSyncFunction(context) {
   await context.amplify.copyBatch(context, copyJobs, functionProps, true);
 
   const backendConfigs = {
-    service: 'LambdaFunction',
+    service: FunctionServiceName.LambdaFunction,
     providerPlugin: 'awscloudformation',
     build: true,
   };

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -20,6 +20,7 @@
     "test-ci": "jest --ci -i"
   },
   "dependencies": {
+    "amplify-category-function": "2.20.7",
     "aws-sdk": "^2.608.0",
     "chalk": "^3.0.0",
     "chalk-pipe": "^3.0.0",

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -7,6 +7,7 @@ const uuid = require('uuid');
 const { existsSync } = require('fs');
 const { copySync } = require('fs-extra');
 const { getAuthResourceName } = require('../../utils/getAuthResourceName');
+const { ServiceName: FunctionServiceName } = require('amplify-category-function');
 
 let serviceMetadata;
 
@@ -795,7 +796,7 @@ async function createAdminAuthFunction(context, authResourceName, functionName, 
   if (operation === 'add') {
     // add amplify-meta and backend-config
     const backendConfigs = {
-      service: 'LambdaFunction',
+      service: FunctionServiceName.LambdaFunction,
       providerPlugin: 'awscloudformation',
       build: true,
       dependsOn,

--- a/packages/amplify-category-function/src/commands/function/remove.ts
+++ b/packages/amplify-category-function/src/commands/function/remove.ts
@@ -14,7 +14,7 @@ module.exports = {
           LambdaLayer:
             'When you delete a layer version, you can no longer configure functions to use it.\nHowever, any function that already uses the layer version continues to have access to it.',
         },
-        serviceSuffix: { LambdaFunction: '(function)', LambdaLayer: '(layer)' },
+        serviceSuffix: { Lambda: '(function)', LambdaLayer: '(layer)' },
       })
       .catch(err => {
         context.print.info(err.stack);

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -7,6 +7,7 @@ import { updateConfigOnEnvInit } from './provider-utils/awscloudformation';
 import { supportedServices } from './provider-utils/supported-services';
 import _ from 'lodash';
 export { packageLayer } from './provider-utils/awscloudformation/utils/packageLayer';
+import { ServiceName } from './provider-utils/awscloudformation/utils/constants';
 export { ServiceName } from './provider-utils/awscloudformation/utils/constants';
 
 export async function add(context, providerName, service, parameters) {
@@ -136,7 +137,8 @@ export async function getInvoker(context: any, params: InvokerParameters): Promi
 
 export function isMockable(context: any, resourceName: string): IsMockableResponse {
   const { service, dependsOn } = context.amplify.getProjectMeta()[category][resourceName];
-  const hasLayer = service === 'LambdaFunction' && dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
+  const hasLayer =
+    service === ServiceName.LambdaFunction && dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
   if (hasLayer) {
     return {
       isMockable: false,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -140,8 +140,8 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
       cfnContent.Resources.AmplifyResourcesPolicy.Properties.PolicyDocument.Statement = functionParameters.categoryPolicies;
     }
 
-    cfnContent.Resources.LambdaFunction.Properties.Environment.Variables = getNewCFNEnvVariables(
-      cfnContent.Resources.LambdaFunction.Properties.Environment.Variables,
+    cfnContent.Resources[ServiceName.LambdaFunction].Properties.Environment.Variables = getNewCFNEnvVariables(
+      cfnContent.Resources[ServiceName.LambdaFunction].Properties.Environment.Variables,
       currentParameters,
       functionParameters.environmentMap,
       functionParameters.mutableParametersState,
@@ -184,7 +184,9 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
       }
     }
   });
-  cfnContent.Resources.LambdaFunction.Properties.Layers = convertLambdaLayerMetaToLayerCFNArray(functionParameters.lambdaLayers);
+  cfnContent.Resources[ServiceName.LambdaFunction].Properties.Layers = convertLambdaLayerMetaToLayerCFNArray(
+    functionParameters.lambdaLayers,
+  );
   context.amplify.writeObjectAsJson(cfnFilePath, cfnContent, true);
 
   return functionParameters;
@@ -219,9 +221,9 @@ export function migrate(context, projectPath, resourceName) {
   };
 
   // Add if condition for resource name change
-  const oldFunctionName = newCfn.Resources.LambdaFunction.Properties.FunctionName;
+  const oldFunctionName = newCfn.Resources[ServiceName.LambdaFunction].Properties.FunctionName;
 
-  newCfn.Resources.LambdaFunction.Properties.FunctionName = {
+  newCfn.Resources[ServiceName.LambdaFunction].Properties.FunctionName = {
     'Fn::If': [
       'ShouldNotCreateEnvResources',
       oldFunctionName,
@@ -240,7 +242,7 @@ export function migrate(context, projectPath, resourceName) {
     ],
   };
 
-  newCfn.Resources.LambdaFunction.Properties.Environment = { Variables: { ENV: { Ref: 'env' } } };
+  newCfn.Resources[ServiceName.LambdaFunction].Properties.Environment = { Variables: { ENV: { Ref: 'env' } } };
 
   const oldRoleName = newCfn.Resources.LambdaExecutionRole.Properties.RoleName;
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
@@ -1,4 +1,5 @@
 import { category as categoryName } from '../../../constants';
+import { ServiceName } from './constants';
 
 export function getNewCFNEnvVariables(oldCFNEnvVariables, currentDefaults, newCFNEnvVariables, newDefaults) {
   const currentResources = [];
@@ -177,9 +178,9 @@ export function constructCloudWatchEventComponent(cfnFilePath: string, cfnConten
       State: 'ENABLED',
       Targets: [
         {
-          Arn: { 'Fn::GetAtt': ['LambdaFunction', 'Arn'] },
+          Arn: { 'Fn::GetAtt': [ServiceName.LambdaFunction, 'Arn'] },
           Id: {
-            Ref: 'LambdaFunction',
+            Ref: ServiceName.LambdaFunction,
           },
         },
       ],
@@ -190,7 +191,7 @@ export function constructCloudWatchEventComponent(cfnFilePath: string, cfnConten
     Type: 'AWS::Lambda::Permission',
     Properties: {
       FunctionName: {
-        Ref: 'LambdaFunction',
+        Ref: ServiceName.LambdaFunction,
       },
       Action: 'lambda:InvokeFunction',
       Principal: 'events.amazonaws.com',

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/constants.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/constants.ts
@@ -10,7 +10,7 @@ export const parametersFileName = 'parameters.json';
 export const provider = 'awscloudformation';
 
 export const enum ServiceName {
-  LambdaFunction = 'LambdaFunction',
+  LambdaFunction = 'Lambda',
   LambdaLayer = 'LambdaLayer',
 }
 

--- a/packages/amplify-category-function/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-function/src/provider-utils/supported-services.ts
@@ -6,7 +6,7 @@ import { getIAMPolicies } from './awscloudformation/utils/cloudformationHelpers'
 import { askExecRolePermissionsQuestions } from './awscloudformation/service-walkthroughs/execPermissionsWalkthrough';
 
 export const supportedServices: SupportedServices = {
-  LambdaFunction: {
+  Lambda: {
     alias: 'Lambda function (serverless function)',
     walkthroughs: {
       createWalkthrough: createWalkthrough,

--- a/packages/amplify-category-function/src/provider-utils/supportedServicesType.ts
+++ b/packages/amplify-category-function/src/provider-utils/supportedServicesType.ts
@@ -2,7 +2,7 @@ import { FunctionParameters } from 'amplify-function-plugin-interface';
 import { LayerParameters } from './awscloudformation/utils/layerParams';
 
 export interface SupportedServices {
-  LambdaFunction: ServiceConfig<FunctionParameters>;
+  Lambda: ServiceConfig<FunctionParameters>;
   LambdaLayer: ServiceConfig<LayerParameters>;
 }
 

--- a/packages/amplify-category-predictions/package.json
+++ b/packages/amplify-category-predictions/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "amplify-category-auth": "2.15.8",
     "amplify-provider-awscloudformation": "4.21.0",
+    "amplify-category-function": "2.20.7",
     "aws-sdk": "^2.608.0",
     "chalk": "^3.0.0",
     "chalk-pipe": "^3.0.0",

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/prediction-category-walkthroughs/identify-walkthrough.js
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/prediction-category-walkthroughs/identify-walkthrough.js
@@ -9,6 +9,7 @@ import {
   removeTextractPolicies,
   addTextractPolicies,
 } from '../assets/identifyCFNGenerate';
+import { ServiceName as FunctionServiceName } from 'amplify-category-function';
 
 const inquirer = require('inquirer');
 const path = require('path');
@@ -624,7 +625,7 @@ async function createNewFunction(context, predictionsResourceName, s3ResourceNam
   // Update amplify-meta and backend-config
 
   const backendConfigs = {
-    service: 'LambdaFunction',
+    service: FunctionServiceName.LambdaFunction,
     providerPlugin: 'awscloudformation',
     build: true,
   };

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "amplify-category-auth": "2.15.8",
+    "amplify-category-function": "2.20.7",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.0.3",
     "lodash": "^4.17.15",

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -3,6 +3,7 @@ const inquirer = require('inquirer');
 const path = require('path');
 const fs = require('fs-extra');
 const uuid = require('uuid');
+const { ServiceName: FunctionServiceName } = require('amplify-category-function');
 
 const category = 'storage';
 const parametersFileName = 'parameters.json';
@@ -602,7 +603,7 @@ async function addTrigger(context, resourceName, triggerList) {
     // Update amplify-meta and backend-config
 
     const backendConfigs = {
-      service: 'LambdaFunction',
+      service: FunctionServiceName.LambdaFunction,
       providerPlugin: 'awscloudformation',
       build: true,
     };

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const _ = require('lodash');
 const uuid = require('uuid');
+const { ServiceName: FunctionServiceName } = require('amplify-category-function');
 
 const category = 'storage';
 const parametersFileName = 'parameters.json';
@@ -734,7 +735,7 @@ async function addTrigger(context, resourceName, triggerFunction, adminTriggerFu
     // Update amplify-meta and backend-config
 
     const backendConfigs = {
-      service: 'LambdaFunction',
+      service: FunctionServiceName.LambdaFunction,
       providerPlugin: 'awscloudformation',
       build: true,
     };
@@ -970,7 +971,9 @@ async function addTrigger(context, resourceName, triggerFunction, adminTriggerFu
 
 async function getLambdaFunctions(context) {
   const { allResources } = await context.amplify.getResourceStatus();
-  const lambdaResources = allResources.filter(resource => resource.service === 'LambdaFunction').map(resource => resource.resourceName);
+  const lambdaResources = allResources
+    .filter(resource => resource.service === FunctionServiceName.LambdaFunction)
+    .map(resource => resource.resourceName);
 
   return lambdaResources;
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.js
@@ -7,6 +7,7 @@ const { flattenDeep } = require('lodash');
 const { join } = require('path');
 const { uniq } = require('lodash');
 const { readJsonFile } = require('./read-json-file');
+const { ServiceName: FunctionServiceName } = require('amplify-category-function');
 
 /** ADD A TRIGGER
  * @function addTrigger
@@ -52,7 +53,7 @@ const addTrigger = async triggerOptions => {
     throw new Error('Function plugin not installed in the CLI. You need to install it to use this feature.');
   }
 
-  await add(context, 'awscloudformation', 'LambdaFunction', {
+  await add(context, 'awscloudformation', FunctionServiceName.LambdaFunction, {
     trigger: true,
     cloudResourceTemplatePath: join(triggerDir, 'cloudformation-templates', triggerTemplate),
     functionTemplate: {
@@ -135,7 +136,7 @@ const updateTrigger = async triggerOptions => {
     await update(
       context,
       'awscloudformation',
-      'LambdaFunction',
+      FunctionServiceName.LambdaFunction,
       {
         trigger: true,
         modules: values,

--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -10,5 +10,8 @@
   },
   "include": [
     "src/**/*"
+  ],
+  "references": [
+    {"path": "../amplify-category-function"}
   ]
 }

--- a/packages/amplify-dotnet-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-dotnet-function-runtime-provider/amplify-plugin.json
@@ -7,7 +7,7 @@
     "pluginId": "amplify-dotnet-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"]
+      "services": ["Lambda"]
     },
     "runtimes": [
       {

--- a/packages/amplify-dotnet-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-dotnet-function-template-provider/amplify-plugin.json
@@ -6,7 +6,7 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"],
+      "services": ["Lambda"],
       "runtime": ["dotnetcore3.1"]
     },
     "templates": [

--- a/packages/amplify-e2e-tests/src/__tests__/api.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api.test.ts
@@ -335,7 +335,7 @@ describe('amplify add api (REST)', () => {
         lastPushTimeStamp,
         lastPushDirHash,
       } = meta.function[key];
-      expect(service).toBe('LambdaFunction');
+      expect(service).toBe('Lambda');
       expect(build).toBeTruthy();
       expect(lastBuildTimeStamp).toBeDefined();
       expect(lastPackageTimeStamp).toBeDefined();

--- a/packages/amplify-go-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-go-function-runtime-provider/amplify-plugin.json
@@ -7,7 +7,7 @@
     "pluginId": "amplify-go-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"]
+      "services": ["Lambda"]
     },
     "runtimes": [
       {

--- a/packages/amplify-go-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-go-function-template-provider/amplify-plugin.json
@@ -6,7 +6,7 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"],
+      "services": ["Lambda"],
       "runtime": "go1.x"
     },
     "templates": [

--- a/packages/amplify-java-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-java-function-runtime-provider/amplify-plugin.json
@@ -7,7 +7,7 @@
     "pluginId": "amplify-java-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"]
+      "services": ["Lambda"]
     },
     "runtimes": [
       {

--- a/packages/amplify-java-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-java-function-template-provider/amplify-plugin.json
@@ -6,7 +6,7 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"],
+      "services": ["Lambda"],
       "runtime": "java"
     },
     "templates": [

--- a/packages/amplify-nodejs-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-nodejs-function-runtime-provider/amplify-plugin.json
@@ -7,7 +7,7 @@
     "pluginId": "amplify-nodejs-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction", "LambdaLayer"]
+      "services": ["Lambda", "LambdaLayer"]
     },
     "runtimes": [
       {

--- a/packages/amplify-nodejs-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-nodejs-function-template-provider/amplify-plugin.json
@@ -6,7 +6,7 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"],
+      "services": ["Lambda"],
       "runtime": "nodejs"
     },
     "templates": [

--- a/packages/amplify-python-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-python-function-runtime-provider/amplify-plugin.json
@@ -7,7 +7,7 @@
     "pluginId": "amplify-python-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction", "LambdaLayer"]
+      "services": ["Lambda", "LambdaLayer"]
     },
     "runtimes": [
       {

--- a/packages/amplify-python-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-python-function-template-provider/amplify-plugin.json
@@ -6,7 +6,7 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["LambdaFunction"],
+      "services": ["Lambda"],
       "runtime": "python"
     },
     "templates": [

--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/hydrate-env-vars.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/hydrate-env-vars.test.ts
@@ -124,7 +124,7 @@ describe('hydrateAllEnvVars', () => {
         {
           Arn: 'arn-from-api',
           name: 'TodoTable',
-          type: 'LambdaFunction',
+          type: 'Lambda',
         },
       ],
     };

--- a/packages/amplify-util-mock/src/mockAll.ts
+++ b/packages/amplify-util-mock/src/mockAll.ts
@@ -1,6 +1,8 @@
 import { start as startAppSyncServer } from './api';
 import { start as startS3Server } from './storage';
-const MOCK_SUPPORTED_CATEGORY = ['AppSync', 'S3', 'LambdaFunction'];
+import { ServiceName as FunctionServiceName } from 'amplify-category-function';
+const MOCK_SUPPORTED_CATEGORY = ['AppSync', 'S3', FunctionServiceName.LambdaFunction];
+
 export async function mockAllCategories(context: any) {
   const resources = await context.amplify.getResourceStatus();
   const mockableResources = resources.allResources.filter(


### PR DESCRIPTION
*Description of changes:*

Prevents breaking Lambda layers for existing Lambda functions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.