### PR TITLE
chore: update lint rule to fail on undefined variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,6 @@ module.exports = {
     'no-loop-func': 'off',
     'no-self-assign': 'off',
     'no-shadow': 'off',
-    'no-undef': 'off',
     'no-unneeded-ternary': 'off',
     'no-unreachable': 'off',
     'no-unused-expressions': 'off',

--- a/packages/amplify-cli/templates/plugin-template-frontend/index.js
+++ b/packages/amplify-cli/templates/plugin-template-frontend/index.js
@@ -33,6 +33,10 @@ async function handleAmplifyEvent(context, args) {
   await eventHandlerModule.run(context, args);
 }
 
+async function createAWSExports(context, newOutputsForFrontend, cloudOutputsForFrontend) {
+  // to be implemented
+}
+
 module.exports = {
   scanProject,
   init,

--- a/packages/amplify-frontend-javascript/lib/publisher.js
+++ b/packages/amplify-frontend-javascript/lib/publisher.js
@@ -9,6 +9,7 @@ async function run(context) {
   const { projectPath } = context.amplify.getEnvInfo();
   const distributionDirName = projectConfig[constants.Label].config.DistributionDir;
   const distributionDirPath = path.join(projectPath, distributionDirName);
+  let enabledHostingServices = [];
 
   if (amplifyMeta[hostingCategory] || Object.keys(amplifyMeta[hostingCategory]).length > 0) {
     enabledHostingServices = Object.keys(amplifyMeta[hostingCategory]);


### PR DESCRIPTION
Updated lint rule to throw error when and undefined variable is used in code. Update the offending
code to adhere to this rule

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.