### PR TITLE
fix(amplify-python-function-runtime-provider): change exec to execa

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/build-resources.js
@@ -26,7 +26,6 @@ function buildResources(context, category, resourceName) {
     })
     .then(() => spinner.succeed('All resources are built.'))
     .catch(err => {
-      console.log(err);
       spinner.fail('An error occurred when building the resources.');
       throw err;
     });

--- a/packages/amplify-python-function-runtime-provider/src/util/buildUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/buildUtils.ts
@@ -5,7 +5,7 @@ import glob from 'glob';
 
 export async function pythonBuild(params: BuildRequest): Promise<BuildResult> {
   if (!params.lastBuildTimestamp || isBuildStale(params.srcRoot, params.lastBuildTimestamp)) {
-    const pipenvLogs = await execAsStringPromise('pipenv install', { cwd: params.srcRoot }, undefined, true);
+    const pipenvLogs = await execAsStringPromise('pipenv install', { cwd: params.srcRoot });
     console.log(pipenvLogs);
     return Promise.resolve({ rebuilt: true });
   }

--- a/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { promisify } from 'util';
-import { exec, ExecOptions } from 'child_process';
+import { ExecOptions } from 'child_process';
+import execa from 'execa';
 
 // Gets the pipenv dir where this function's dependencies are located
 export async function getPipenvDir(srcRoot: string): Promise<string> {
@@ -30,20 +30,10 @@ export function majMinPyVersion(pyVersion: string): string {
 
 // wrapper for executing a shell command and returning the result as a string promise
 // opts are passed directly to the exec command
-// errorMessage is an optional error message to throw if the command fails
-// outputOnStderr is a flag if the 'success' output of the command will be on stderr (for some ungodly reason, this is how python --version works)
-export async function execAsStringPromise(
-  command: string,
-  opts?: ExecOptions,
-  errorMessage?: string,
-  outputOnStderr: boolean = false,
-): Promise<string> {
-  const { stdout, stderr } = await promisify(exec)(command, opts);
-  if (outputOnStderr) {
-    return stderr.toString('utf8').trim();
+export async function execAsStringPromise(command: string, opts?: ExecOptions): Promise<string> {
+  try {
+    return (await execa.command(command, opts)).stdout;
+  } catch (err) {
+    throw new Error(`Recieved error [${err}] running command [${command}]`);
   }
-  if (stderr) {
-    throw new Error(errorMessage || `Received error [${stderr.toString('utf8').trim()}] running command [${command}]`);
-  }
-  return stdout.toString('utf8').trim();
 }


### PR DESCRIPTION
changed execa, removed outputOnStderr as it's not needed for py3, remove console.log from build
process since the err is thrown

ref #4621

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.