### PR TITLE
Update to make export ES5 compatible

### DIFF
--- a/packages/amplify-frontend-javascript/lib/aws_exports.js.ejs
+++ b/packages/amplify-frontend-javascript/lib/aws_exports.js.ejs
@@ -3,5 +3,4 @@
 
 const awsmobile = <%- JSON.stringify(props.configOutput, null, 4) %>;
 
-
-export default awsmobile;
+exports.default = awsmobile;


### PR DESCRIPTION
*Issue #, if available:*

Currently the aws-exports.js cannot be required in Node scripts.

*Description of changes:*

Update the aws-exports.js file to be ES5 compatible, so that it can be imported by all versions of Node.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.