### PR TITLE
fix: use same hashing func for amplify status and layer hash

### DIFF
--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -24,6 +24,7 @@
     "amplify-category-storage": "2.4.7",
     "amplify-function-plugin-interface": "1.3.1",
     "fs-extra": "^8.1.0",
+    "folder-hash":"^3.3.2",
     "graphql-transformer-core": "6.19.2",
     "inquirer": "^7.0.3",
     "inquirer-datepicker": "^1.1.0",

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -6,7 +6,7 @@ import sequential from 'promise-sequential';
 import { updateConfigOnEnvInit } from './provider-utils/awscloudformation';
 import { supportedServices } from './provider-utils/supported-services';
 import _ from 'lodash';
-export { packageLayer } from './provider-utils/awscloudformation/utils/packageLayer';
+export { packageLayer, hashLayerDir } from './provider-utils/awscloudformation/utils/packageLayer';
 import { ServiceName } from './provider-utils/awscloudformation/utils/constants';
 export { ServiceName } from './provider-utils/awscloudformation/utils/constants';
 
@@ -94,10 +94,10 @@ export async function getPermissionPolicies(context, resourceOpsMapping) {
 
 export async function initEnv(context) {
   const { amplify } = context;
-  const { resourcesToBeCreated, resourcesToBeDeleted, resourcesToBeUpdated } = await amplify.getResourceStatus('function');
+  const { resourcesToBeCreated, resourcesToBeDeleted, resourcesToBeUpdated } = await amplify.getResourceStatus(category);
 
   resourcesToBeDeleted.forEach(authResource => {
-    amplify.removeResourceParameters(context, 'function', authResource.resourceName);
+    amplify.removeResourceParameters(context, category, authResource.resourceName);
   });
 
   const tasks = resourcesToBeCreated.concat(resourcesToBeUpdated);
@@ -105,8 +105,8 @@ export async function initEnv(context) {
   const functionTasks = tasks.map(functionResource => {
     const { resourceName } = functionResource;
     return async () => {
-      const config = await updateConfigOnEnvInit(context, 'function', resourceName);
-      context.amplify.saveEnvResourceParameters(context, 'function', resourceName, config);
+      const config = await updateConfigOnEnvInit(context, resourceName);
+      context.amplify.saveEnvResourceParameters(context, category, resourceName, config);
     };
   });
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
@@ -16,6 +16,11 @@ export type LayerParameters = {
   build: boolean;
 };
 
+export interface StoredLayerParameters {
+  runtimes: Pick<FunctionRuntime, 'value' | 'layerExecutablePath' | 'cloudTemplateValue'>[];
+  layerVersionMap?: Record<number, Pick<LayerVersionMetadata, 'permissions' | 'hash'>>;
+}
+
 export enum Permission {
   private = 'private',
   public = 'public',

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -69,7 +69,7 @@ async function ensureLayerVersion(context: any, layerPath: string, layerName: st
     const prevPermissions = layerData.getVersion(latestVersion).permissions;
     ++latestVersion; // Content changes detected, bumping version
     layerParameters.layerVersionMap[latestVersion] = {
-      permissions: await getNewVersionPermissions(layerName, prevPermissions),
+      permissions: await getNewVersionPermissions(context.print, layerName, prevPermissions),
       hash: currentHash,
     };
     updateLayerArtifacts(context, layerParameters, { amplifyMeta: false });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -6,8 +6,10 @@ import path from 'path';
 import _ from 'lodash';
 import { hashElement } from 'folder-hash';
 import { prevPermsQuestion } from './layerHelpers';
-import { getLayerMetadataFactory, LayerPermission, Permission, PrivateLayer } from './layerParams';
-import { createLayerParametersFile, updateLayerCfnFile } from './storeResources';
+import { getLayerMetadataFactory, LayerPermission, Permission, PrivateLayer, LayerParameters } from './layerParams';
+import crypto from 'crypto';
+import { updateLayerArtifacts } from './storeResources';
+import { layerParametersFileName } from './constants';
 
 export async function packageLayer(context, resource) {
   const layerName = resource.resourceName;
@@ -49,24 +51,23 @@ export async function packageLayer(context, resource) {
 async function ensureLayerVersion(context: any, layerPath: string, layerName: string) {
   const layerData = getLayerMetadataFactory(context)(layerName);
   let latestVersion: number = layerData.getLatestVersion();
-  const { hash: currentHash } = await hashLayerDir(layerPath);
+  const currentHash = await hashLayerDir(layerPath);
   const previousHash = layerData.getHash(latestVersion);
-  const layerParameters = context.amplify.readJsonFile(path.join(layerPath, 'layer-parameters.json'));
+  const layerParameters = context.amplify.readJsonFile(path.join(layerPath, layerParametersFileName)) as LayerParameters;
+  layerParameters.layerName = layerName;
+  layerParameters.build = true;
 
   if (previousHash && previousHash !== currentHash) {
     const prevPermissions = layerData.getVersion(latestVersion).permissions;
     ++latestVersion; // Content changes detected, bumping version
-    layerParameters.layerVersionMap[`${latestVersion}`] = {
+    layerParameters.layerVersionMap[latestVersion] = {
       permissions: await getNewVersionPermissions(layerName, prevPermissions),
       hash: currentHash,
     };
-    createLayerParametersFile(context, layerParameters, layerPath);
-    layerParameters.layerName = layerName;
-    layerParameters.build = true;
-    updateLayerCfnFile(context, layerParameters, layerPath);
+    updateLayerArtifacts(context, layerParameters, { amplifyMeta: false });
   } else if (!previousHash) {
-    layerParameters.layerVersionMap[`${latestVersion}`].hash = currentHash;
-    createLayerParametersFile(context, layerParameters, layerPath);
+    layerParameters.layerVersionMap[latestVersion].hash = currentHash;
+    updateLayerArtifacts(context, layerParameters, { cfnFile: false, amplifyMeta: false });
   }
 }
 
@@ -83,15 +84,35 @@ async function getNewVersionPermissions(
   return usePrevPermissions ? prevPermissions : defaultPermissions;
 }
 
-async function hashLayerDir(layerPath: string): Promise<any> {
-  const hashOptions = {
-    folders: { exclude: ['.*', 'dist'] },
-    files: { exclude: ['README.txt', 'layer-parameters.json', 'parameters.json', '*-awscloudformation-template.json'] },
+export const hashLayerDir = async (layerPath: string): Promise<string> => {
+  const nodePath = path.join(layerPath, 'lib', 'nodejs');
+  const nodeHashOptions = {
+    files: {
+      include: ['package.json'],
+    },
   };
-  return await hashElement(layerPath, hashOptions).catch(error => {
-    throw new Error(`Hashing the layer directory failed: ${path}`);
-  });
-}
+  const pyPath = path.join(layerPath, 'lib', 'python');
+  const optPath = path.join(layerPath, 'opt');
+
+  const joinedHashes = (await Promise.all([safeHash(nodePath, nodeHashOptions), safeHash(pyPath), safeHash(optPath)])).join();
+
+  return crypto
+    .createHash('sha256')
+    .update(joinedHashes)
+    .digest('base64');
+};
+
+// wrapper around hashElement that will return an empty string if the path does not exist
+const safeHash = async (path: string, opts?: any): Promise<string> => {
+  if (fs.pathExistsSync(path)) {
+    return (
+      await hashElement(path, opts).catch(() => {
+        throw new Error(`An error occurred hashing directory ${path}`);
+      })
+    ).hash;
+  }
+  return '';
+};
 
 function validFilesize(path, maxSize = 250) {
   try {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -8,8 +8,9 @@ const { getEnvInfo } = require('./get-env-info');
 const _ = require('lodash');
 const { CLOUD_INITIALIZED, CLOUD_NOT_INITIALIZED, getCloudInitStatus } = require('./get-cloud-init-status');
 const { readJsonFile } = require('./read-json-file');
+const { ServiceName: FunctionServiceName, hashLayerDir } = require('amplify-category-function');
 
-async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPushTimeStamp) {
+async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPushTimeStamp, isLambdaLayer = false) {
   // Pushing the resource for the first time hence no lastPushTimeStamp
   if (!lastPushTimeStamp) {
     return false;
@@ -23,8 +24,10 @@ async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPus
     return false;
   }
 
-  const localDirHash = await getHashForResourceDir(localBackendDir);
-  const cloudDirHash = await getHashForResourceDir(cloudBackendDir);
+  const hashingFunc = isLambdaLayer ? hashLayerDir : getHashForResourceDir;
+
+  const localDirHash = await hashingFunc(localBackendDir);
+  const cloudDirHash = await hashingFunc(cloudBackendDir);
 
   return localDirHash !== cloudDirHash;
 }
@@ -177,10 +180,12 @@ async function getResourcesToBeUpdated(amplifyMeta, currentamplifyMeta, category
     await asyncForEach(Object.keys(categoryItem), async resource => {
       if (currentamplifyMeta[categoryName]) {
         if (currentamplifyMeta[categoryName][resource] !== undefined && amplifyMeta[categoryName][resource] !== undefined) {
+          const isLambdaLayer = amplifyMeta[categoryName][resource].service === FunctionServiceName.LambdaLayer;
           const backendModified = await isBackendDirModifiedSinceLastPush(
             resource,
             categoryName,
             currentamplifyMeta[categoryName][resource].lastPushTimeStamp,
+            isLambdaLayer,
           );
 
           if (backendModified) {

--- a/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
@@ -24,7 +24,7 @@ describe('amplify add lambda layer', () => {
     const { Arn: Arn, Region: region } = Object.keys(meta.function).map(key => meta.function[key])[0].output;
     const runtimes = Object.keys(meta.function).map(key => meta.function[key])[0].runtimes;
     const runtimeValue = Object.keys(runtimes).map(key => runtimes[key].cloudTemplateValue);
-    const layerVersions = Object.keys(meta.function).map(key => meta.function[key])[0].versionsMap;
+    const layerVersions = Object.keys(meta.function).map(key => meta.function[key])[0].layerVersionMap;
     const localVersions = Object.keys(layerVersions);
 
     expect(Arn).toBeDefined();

--- a/packages/amplify-nodejs-function-runtime-provider/src/index.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/index.ts
@@ -22,19 +22,18 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
             {
               path: 'nodejs',
               filename: 'package.json',
-              content: JSON.stringify({
-                name: 'nodejs',
-                version: '1.0.0',
-                description: '',
-                main: 'index.js',
-                dependencies: {},
-                devDependencies: {},
-                scripts: {
-                  test: 'echo "Error: no test specified" && exit 1',
+              content: JSON.stringify(
+                {
+                  // this really needs to be moved to a resource file
+                  version: '1.0.0',
+                  description: '',
+                  main: 'index.js',
+                  dependencies: {},
+                  devDependencies: {},
                 },
-                author: '',
-                license: 'ISC',
-              }),
+                undefined,
+                2,
+              ),
             },
           ],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9470,6 +9470,15 @@ folder-hash@^3.3.0:
     graceful-fs "~4.2.0"
     minimatch "~3.0.4"
 
+folder-hash@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/folder-hash/-/folder-hash-3.3.2.tgz#30c5ee2638ab25074ed2916bde75019c7f11965a"
+  integrity sha512-uxh7WEwwgNCALdyqdiyKi35Ahy9wQcZGb5IXKFig9/tsfByHMsHuQOgeiYyY0gNYF/rYB2kSZJ7BJjMb67PxMA==
+  dependencies:
+    debug "^4.1.1"
+    graceful-fs "~4.2.0"
+    minimatch "~3.0.4"
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"


### PR DESCRIPTION
slightly hacky method for using the layer hashing function for amplify status if the resource is a layer

also fixed the pretty-printing of the default package.json that gets put in the layer folder and only storing necessary layer properties in amplify-meta.json and layer-parameters.json

and a few other housekeeping things
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.