### PR TITLE
Allow AuthConfig to be passed into headless pull

### DIFF
--- a/packages/amplify-category-auth/index.js
+++ b/packages/amplify-category-auth/index.js
@@ -208,7 +208,8 @@ async function checkRequirements(requirements, context) {
 
 async function initEnv(context) {
   const { amplify } = context;
-  const { resourcesToBeCreated, resourcesToBeDeleted, resourcesToBeUpdated } = await amplify.getResourceStatus('auth');
+  const { resourcesToBeCreated, resourcesToBeDeleted, resourcesToBeUpdated, allResources } = await amplify.getResourceStatus('auth');
+  const isPulling = context.input.command === 'pull' || (context.input.command === 'env' && context.input.subCommands[0] === 'pull');
   let toBeCreated = [];
   let toBeDeleted = [];
   let toBeUpdated = [];
@@ -228,6 +229,10 @@ async function initEnv(context) {
   });
 
   const tasks = toBeCreated.concat(toBeUpdated);
+  // check if this initialization is happening on a pull
+  if (isPulling && allResources.length > 0) {
+    tasks.push(...allResources);
+  }
 
   const authTasks = tasks.map(authResource => {
     const { resourceName } = authResource;

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -431,8 +431,13 @@ function isInHeadlessMode(context) {
 
 function getHeadlessParams(context) {
   const { inputParams } = context.exeInfo;
-  const { categories = {} } = inputParams;
-  return categories.auth || {};
+  try {
+    // If the input given is a string validate it using JSON parse
+    const { categories = {} } = (typeof inputParams === 'string') ? JSON.parse(inputParams) : inputParams;
+    return categories.auth || {};
+  } catch (err) {
+    throw new Error(`Could not load input params: ${err}`);
+  }
 }
 
 function getOAuthProviderKeys(currentEnvSpecificValues, resourceParams) {

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -340,7 +340,6 @@ async function updateResource(context, category, serviceResult) {
 async function updateConfigOnEnvInit(context, category, service) {
   const srvcMetaData = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`).Cognito;
   const { defaultValuesFilename, stringMapFilename, serviceWalkthroughFilename } = srvcMetaData;
-  const isPulling = context.input.command === 'pull' || (context.input.command === 'env' && context.input.subCommands[0] === 'pull');
 
   const providerPlugin = context.amplify.getPluginInstance(context, srvcMetaData.provider);
   // previously selected answers
@@ -367,7 +366,7 @@ async function updateConfigOnEnvInit(context, category, service) {
       });
 
       if (missingParams.length) {
-        throw new Error(`auth headless ${isPulling ? 'pull' : 'init'} is missing the following inputParams ${missingParams.join(', ')}`);
+        throw new Error(`auth headless is missing the following inputParams ${missingParams.join(', ')}`);
       }
     }
     if (resourceParams.hostedUIProviderMeta) {
@@ -437,7 +436,7 @@ function getHeadlessParams(context) {
     const { categories = {} } = typeof inputParams === 'string' ? JSON.parse(inputParams) : inputParams;
     return categories.auth || {};
   } catch (err) {
-    throw new Error(`Could not load input params: ${err}`);
+    throw new Error(`Failed to parse auth headless parameters: ${err}`);
   }
 }
 

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -340,6 +340,7 @@ async function updateResource(context, category, serviceResult) {
 async function updateConfigOnEnvInit(context, category, service) {
   const srvcMetaData = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`).Cognito;
   const { defaultValuesFilename, stringMapFilename, serviceWalkthroughFilename } = srvcMetaData;
+  const isPulling = context.input.command === 'pull' || (context.input.command === 'env' && context.input.subCommands[0] === 'pull');
 
   const providerPlugin = context.amplify.getPluginInstance(context, srvcMetaData.provider);
   // previously selected answers
@@ -366,7 +367,7 @@ async function updateConfigOnEnvInit(context, category, service) {
       });
 
       if (missingParams.length) {
-        throw new Error(`auth headless init is missing the following inputParams ${missingParams.join(', ')}`);
+        throw new Error(`auth headless ${isPulling ? 'pull' : 'init'} is missing the following inputParams ${missingParams.join(', ')}`);
       }
     }
     if (resourceParams.hostedUIProviderMeta) {
@@ -433,7 +434,7 @@ function getHeadlessParams(context) {
   const { inputParams } = context.exeInfo;
   try {
     // If the input given is a string validate it using JSON parse
-    const { categories = {} } = (typeof inputParams === 'string') ? JSON.parse(inputParams) : inputParams;
+    const { categories = {} } = typeof inputParams === 'string' ? JSON.parse(inputParams) : inputParams;
     return categories.auth || {};
   } catch (err) {
     throw new Error(`Could not load input params: ${err}`);

--- a/packages/amplify-cli/src/attach-backend.js
+++ b/packages/amplify-cli/src/attach-backend.js
@@ -6,6 +6,7 @@ const analyzeProject = require('./attach-backend-steps/a20-analyzeProject');
 const initFrontend = require('./attach-backend-steps/a30-initFrontend');
 const generateFiles = require('./attach-backend-steps/a40-generateFiles');
 const { postPullCodeGenCheck } = require('./amplify-service-helper');
+const { initializeEnv } = require('./initialize-env');
 
 const backupAmplifyDirName = 'amplify-backup';
 
@@ -42,10 +43,13 @@ async function onSuccess(context) {
   }
 
   await postPullCodeGenCheck(context);
-
+  const currentAmplifyMetafilePath = context.amplify.pathManager.getCurrentAmplifyMetaFilePath();
   if (!inputParams.yes) {
     const confirmKeepCodebase = await context.amplify.confirmPrompt.run('Do you plan on modifying this backend?', true);
     if (confirmKeepCodebase) {
+      if (fs.existsSync(currentAmplifyMetafilePath)) {
+        await initializeEnv(context, context.amplify.readJsonFile(currentAmplifyMetafilePath));
+      }
       const { envName } = context.exeInfo.localEnvInfo;
       context.print.info('');
       context.print.success(`Successfully pulled backend environment ${envName} from the cloud.`);
@@ -57,6 +61,10 @@ async function onSuccess(context) {
       context.print.success(`Added backend environment config object to your project.`);
       context.print.info(`Run 'amplify pull' to sync upstream changes.`);
       context.print.info('');
+    }
+  } else {
+    if (fs.existsSync(currentAmplifyMetafilePath)) {
+      await initializeEnv(context, context.amplify.readJsonFile(currentAmplifyMetafilePath));
     }
   }
 

--- a/packages/amplify-cli/src/attach-backend.js
+++ b/packages/amplify-cli/src/attach-backend.js
@@ -24,7 +24,6 @@ async function attachBackend(context, inputParams) {
       removeFolderStructure(context);
       restoreOriginalAmplifyFolder(context);
       context.print.error('Failed to pull the backend.');
-      context.print.info(util.inspect(e));
       context.telemetry.emitError(e);
     });
 }

--- a/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
@@ -19,7 +19,7 @@ import {
   getAmplifyDirPath,
 } from 'amplify-e2e-core';
 import { headlessInit } from '../src/pullAndInit/initProject';
-import { headlessPull } from '../src/pullAndInit/pullProject';
+import { headlessPull, authConfigPull } from '../src/pullAndInit/pullProject';
 import { headlessDelete } from '../src/pullAndInit/deleteProject';
 import {
   removeFilesForTeam,
@@ -224,6 +224,42 @@ describe('amplify app console tests', () => {
         loginwithamazonAppSecretUserPool: AMAZON_APP_SECRET,
       },
     });
+
+    teamInfo = getTeamProviderInfo(projRoot);
+    expect(teamInfo).toBeDefined();
+    appId = teamInfo[envName].awscloudformation.AmplifyAppId;
+    expect(appId).toBeDefined();
+    expect(teamInfo[envName].categories.auth).toBeDefined();
+    authTeamInfo = Object.keys(teamInfo[envName].categories.auth).map(key => teamInfo[envName].categories.auth[key])[0];
+    expect(authTeamInfo).toHaveProperty('hostedUIProviderCreds');
+  });
+
+  it('test pull with auth config', async () => {
+    const envName = 'dev';
+    const providersParam = {
+      awscloudformation: {
+        configLevel: 'project',
+        useProfile: true,
+        profileName: util.getProfileName(),
+      },
+    };
+    await initJSProjectWithProfile(projRoot, { name: 'authConsoleTest', envName });
+    await addAuthWithDefaultSocial(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    let teamInfo = getTeamProviderInfo(projRoot);
+    expect(teamInfo).toBeDefined();
+    let appId = teamInfo[envName].awscloudformation.AmplifyAppId;
+    AmplifyAppID = appId;
+    stackName = teamInfo[envName].awscloudformation.StackName;
+    expect(stackName).toBeDefined();
+    expect(appId).toBeDefined();
+    expect(teamInfo[envName].categories.auth).toBeDefined();
+    let authTeamInfo = Object.keys(teamInfo[envName].categories.auth).map(key => teamInfo[envName].categories.auth[key])[0];
+    expect(authTeamInfo).toHaveProperty('hostedUIProviderCreds');
+
+    deleteAmplifyDir(projRoot);
+
+    await authConfigPull(projRoot, { appId, envName });
 
     teamInfo = getTeamProviderInfo(projRoot);
     expect(teamInfo).toBeDefined();

--- a/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-sdk';
+import { Amplify, CloudFormation } from 'aws-sdk';
 import moment from 'moment';
 
 import { getConfigFromProfile } from '../profile-helper';
@@ -6,6 +6,11 @@ import { getConfigFromProfile } from '../profile-helper';
 export function getConfiguredAmplifyClient() {
   const config = getConfigFromProfile();
   return new Amplify(config);
+}
+
+export function getConfiguredCFNClient() {
+  const config = getConfigFromProfile();
+  return new CloudFormation(config);
 }
 
 //delete all existing amplify console projects
@@ -17,6 +22,11 @@ export async function deleteAllAmplifyProjects(amplifyClient?: any) {
   do {
     token = await PaginatedDeleteProjects(amplifyClient, token);
   } while (token);
+}
+
+export async function deleteAmplifyStack(stackName: string, cfnClient?: any) {
+  if (!cfnClient) cfnClient = getConfiguredCFNClient();
+  await cfnClient.deleteStack({ StackName: stackName }).promise();
 }
 
 async function PaginatedDeleteProjects(amplifyClient: any, token?: any) {

--- a/packages/amplify-console-integration-tests/src/pullAndInit/pullProject.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/pullProject.ts
@@ -1,7 +1,12 @@
 import * as util from '../util';
 import { nspawn as spawn } from 'amplify-e2e-core';
 
-export function headlessPull(projectRootDirPath: string, amplifyParam: Object, providersParam: Object, authConfig?: Object): Promise<void> {
+export function headlessPull(
+  projectRootDirPath: string,
+  amplifyParam: Object,
+  providersParam: Object,
+  categoryConfig?: Object,
+): Promise<void> {
   const pullCommand: string[] = [
     'pull',
     '--amplify',
@@ -11,7 +16,7 @@ export function headlessPull(projectRootDirPath: string, amplifyParam: Object, p
     '--no-override',
     '--yes',
   ];
-  if (authConfig) pullCommand.push(`--categories ${JSON.stringify(authConfig)}`);
+  if (categoryConfig) pullCommand.push(...['--categories', JSON.stringify(categoryConfig)]);
   return new Promise((resolve, reject) => {
     spawn(util.getCLIPath(), pullCommand, { cwd: projectRootDirPath, stripColors: true }).run((err: Error) => {
       if (!err) {

--- a/packages/amplify-console-integration-tests/src/pullAndInit/pullProject.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/pullProject.ts
@@ -1,13 +1,19 @@
 import * as util from '../util';
 import { nspawn as spawn } from 'amplify-e2e-core';
 
-export function headlessPull(projectRootDirPath, amplifyParam, providersParam): Promise<void> {
+export function headlessPull(projectRootDirPath: string, amplifyParam: Object, providersParam: Object, authConfig?: Object): Promise<void> {
+  const pullCommand: string[] = [
+    'pull',
+    '--amplify',
+    JSON.stringify(amplifyParam),
+    '--providers',
+    JSON.stringify(providersParam),
+    '--no-override',
+    '--yes',
+  ];
+  if (authConfig) pullCommand.push(`--categories ${JSON.stringify(authConfig)}`);
   return new Promise((resolve, reject) => {
-    spawn(
-      util.getCLIPath(),
-      ['pull', '--amplify', JSON.stringify(amplifyParam), '--providers', JSON.stringify(providersParam), '--no-override', '--yes'],
-      { cwd: projectRootDirPath, stripColors: true },
-    ).run((err: Error) => {
+    spawn(util.getCLIPath(), pullCommand, { cwd: projectRootDirPath, stripColors: true }).run((err: Error) => {
       if (!err) {
         resolve();
       } else {

--- a/packages/amplify-console-integration-tests/src/pullAndInit/pullProject.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/pullProject.ts
@@ -1,5 +1,18 @@
 import * as util from '../util';
-import { nspawn as spawn } from 'amplify-e2e-core';
+import { nspawn as spawn, getSocialProviders } from 'amplify-e2e-core';
+
+const defaultSettings = {
+  name: '\r',
+  editor: '\r',
+  appType: '\r',
+  framework: '\r',
+  srcDir: '\r',
+  distDir: '\r',
+  buildCmd: '\r',
+  startCmd: '\r',
+  useProfile: '\r',
+  profileName: '\r',
+};
 
 export function headlessPull(
   projectRootDirPath: string,
@@ -25,5 +38,57 @@ export function headlessPull(
         reject(err);
       }
     });
+  });
+}
+
+export function authConfigPull(projectRootDirPath: string, params: { appId: string; envName: string }, settings: Object = {}) {
+  const pullCommand: string[] = ['pull'];
+  Object.keys(params).forEach(key => {
+    if (params[key]) pullCommand.push(...[`--${key}`, JSON.stringify(params[key])]);
+  });
+  const s = { ...defaultSettings, ...settings };
+  const { FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, GOOGLE_APP_ID, GOOGLE_APP_SECRET, AMAZON_APP_ID, AMAZON_APP_SECRET } = getSocialProviders();
+  return new Promise((resolve, reject) => {
+    spawn(util.getCLIPath(), pullCommand, { cwd: projectRootDirPath, stripColors: true })
+      .wait('Do you want to use an AWS profile?')
+      .sendLine('y')
+      .wait('Please choose the profile you want to use')
+      .sendLine(s.profileName)
+      .wait('Choose your default editor:')
+      .sendLine(s.editor)
+      .wait("Choose the type of app that you're building")
+      .sendLine(s.appType)
+      .wait('What javascript framework are you using')
+      .sendLine(s.framework)
+      .wait('Source Directory Path:')
+      .sendLine(s.srcDir)
+      .wait('Distribution Directory Path:')
+      .sendLine(s.distDir)
+      .wait('Build Command:')
+      .sendLine(s.buildCmd)
+      .wait('Start Command:')
+      .sendLine(s.startCmd)
+      .wait('Do you plan on modifying this backend?')
+      .sendLine('y')
+      .wait('Enter your Facebook App ID for your OAuth flow:')
+      .sendLine(FACEBOOK_APP_ID)
+      .wait('Enter your Facebook App Secret for your OAuth flow:')
+      .sendLine(FACEBOOK_APP_SECRET)
+      .wait('Enter your Google Web Client ID for your OAuth flow:')
+      .sendLine(GOOGLE_APP_ID)
+      .wait('Enter your Google Web Client Secret for your OAuth flow:')
+      .sendLine(GOOGLE_APP_SECRET)
+      .wait('Enter your Amazon App ID for your OAuth flow:')
+      .sendLine(AMAZON_APP_ID)
+      .wait('Enter your Amazon App Secret for your OAuth flow:')
+      .sendLine(AMAZON_APP_SECRET)
+      .wait('Successfully pulled backend environment dev from the cloud.')
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
   });
 }

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath, getEnvVars } from '../../src';
+import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath, getSocialProviders } from '../../src';
 
 export function addAuthWithDefault(cwd: string, settings: any) {
   return new Promise((resolve, reject) => {
@@ -413,31 +413,15 @@ export function addAuthWithSignInSignOutUrl(cwd: string, settings: any) {
 
 export function addAuthWithDefaultSocial(cwd: string, settings: any) {
   return new Promise((resolve, reject) => {
-    const { FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, GOOGLE_APP_ID, GOOGLE_APP_SECRET, AMAZON_APP_ID, AMAZON_APP_SECRET }: any = getEnvVars();
+    const {
+      FACEBOOK_APP_ID,
+      FACEBOOK_APP_SECRET,
+      GOOGLE_APP_ID,
+      GOOGLE_APP_SECRET,
+      AMAZON_APP_ID,
+      AMAZON_APP_SECRET,
+    }: any = getSocialProviders();
 
-    const missingVars = [];
-    if (!FACEBOOK_APP_ID) {
-      missingVars.push('FACEBOOK_APP_ID');
-    }
-    if (!FACEBOOK_APP_SECRET) {
-      missingVars.push('FACEBOOK_APP_SECRET');
-    }
-    if (!GOOGLE_APP_ID) {
-      missingVars.push('GOOGLE_APP_ID');
-    }
-    if (!GOOGLE_APP_SECRET) {
-      missingVars.push('GOOGLE_APP_SECRET');
-    }
-    if (!AMAZON_APP_ID) {
-      missingVars.push('AMAZON_APP_ID');
-    }
-    if (!AMAZON_APP_SECRET) {
-      missingVars.push('AMAZON_APP_SECRET');
-    }
-
-    if (missingVars.length > 0) {
-      throw new Error(`.env file is missing the following key/values: ${missingVars.join(', ')} `);
-    }
     spawn(getCLIPath(), ['add', 'auth'], { cwd, stripColors: true })
       .wait('Do you want to use the default authentication and security configuration?')
       .send(KEY_DOWN_ARROW)

--- a/packages/amplify-e2e-core/src/utils/envVars.ts
+++ b/packages/amplify-e2e-core/src/utils/envVars.ts
@@ -1,0 +1,47 @@
+type AWSCredentials = {
+  ACCESS_KEY_ID: string;
+  SECRET_ACCESS_KEY: string;
+};
+type SocialProviders = {
+  FACEBOOK_APP_ID?: string;
+  FACEBOOK_APP_SECRET?: string;
+  GOOGLE_APP_ID?: string;
+  GOOGLE_APP_SECRET?: string;
+  AMAZON_APP_ID?: string;
+  AMAZON_APP_SECRET?: string;
+};
+
+type EnvironmentVariables = AWSCredentials | SocialProviders;
+
+export function getEnvVars(): EnvironmentVariables {
+  return { ...process.env } as EnvironmentVariables;
+}
+
+export function getSocialProviders(): SocialProviders {
+  const { FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, GOOGLE_APP_ID, GOOGLE_APP_SECRET, AMAZON_APP_ID, AMAZON_APP_SECRET }: any = getEnvVars();
+
+  const missingVars = [];
+  if (!FACEBOOK_APP_ID) {
+    missingVars.push('FACEBOOK_APP_ID');
+  }
+  if (!FACEBOOK_APP_SECRET) {
+    missingVars.push('FACEBOOK_APP_SECRET');
+  }
+  if (!GOOGLE_APP_ID) {
+    missingVars.push('GOOGLE_APP_ID');
+  }
+  if (!GOOGLE_APP_SECRET) {
+    missingVars.push('GOOGLE_APP_SECRET');
+  }
+  if (!AMAZON_APP_ID) {
+    missingVars.push('AMAZON_APP_ID');
+  }
+  if (!AMAZON_APP_SECRET) {
+    missingVars.push('AMAZON_APP_SECRET');
+  }
+
+  if (missingVars.length > 0) {
+    throw new Error(`.env file is missing the following key/values: ${missingVars.join(', ')} `);
+  }
+  return { FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, GOOGLE_APP_ID, GOOGLE_APP_SECRET, AMAZON_APP_ID, AMAZON_APP_SECRET };
+}

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './sdk-calls';
 export * from './selectors';
 export * from './sleep';
 export * from './transformConfig';
+export * from './envVars';
 
 // run dotenv config to update env variable
 config();
@@ -23,8 +24,8 @@ export function deleteProjectDir(root: string) {
   return rimraf.sync(root);
 }
 
-export function getEnvVars(): { ACCESS_KEY_ID: string; SECRET_ACCESS_KEY: string } {
-  return { ...process.env } as { ACCESS_KEY_ID: string; SECRET_ACCESS_KEY: string };
+export function deleteAmplifyDir(root: string) {
+  return rimraf.sync(path.join(root, 'amplify'));
 }
 
 export function overrideFunctionSrc(root: string, name: string, code: string) {

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -13,6 +13,10 @@ function getAmplifyConfigIOSPath(projRoot: string): string {
   return path.join(projRoot, 'amplifyconfiguration.json');
 }
 
+function getAmplifyDirPath(projRoot: string) {
+  return path.join(projRoot, 'amplify');
+}
+
 function getAWSConfigIOSPath(projRoot: string): string {
   return path.join(projRoot, 'awsconfiguration.json');
 }
@@ -49,4 +53,5 @@ export {
   getAmplifyConfigIOSPath,
   getAWSConfigIOSPath,
   getS3StorageBucketName,
+  getAmplifyDirPath,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10851,7 +10851,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4, ignore@^5.1.8:
+ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10851,7 +10851,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-console/issues/206
https://github.com/aws-amplify/amplify-cli/issues/3642
*Description of changes:*
- This allows authConfig (inside Categories) to be passed into headless pull.
- When doing a pull with hostedUI enabled the pull will prompt for the social provider info
- Removed error log from `attach-backend` as this a duplicate error that is logged.
- added e2e tests for headless and question pull workflow 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.