### PR TITLE
feat: reflect proper layer versions without push

### DIFF
--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -26,6 +26,7 @@
     "fs-extra": "^8.1.0",
     "folder-hash":"^3.3.2",
     "graphql-transformer-core": "6.19.2",
+    "globby":"^11.0.1",
     "inquirer": "^7.0.3",
     "inquirer-datepicker": "^1.1.0",
     "enquirer": "^2.3.5",

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -6,7 +6,7 @@ import sequential from 'promise-sequential';
 import { updateConfigOnEnvInit } from './provider-utils/awscloudformation';
 import { supportedServices } from './provider-utils/supported-services';
 import _ from 'lodash';
-export { packageLayer, hashLayerDir } from './provider-utils/awscloudformation/utils/packageLayer';
+export { packageLayer, hashLayerResource } from './provider-utils/awscloudformation/utils/packageLayer';
 import { ServiceName } from './provider-utils/awscloudformation/utils/constants';
 export { ServiceName } from './provider-utils/awscloudformation/utils/constants';
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambdaLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambdaLayerWalkthrough.ts
@@ -1,10 +1,9 @@
-import inquirer from 'inquirer';
+import inquirer, { InputQuestion } from 'inquirer';
 import _ from 'lodash';
-import path from 'path';
 import { getLayerMetadataFactory, LayerMetadata, LayerParameters, Permission } from '../utils/layerParams';
 import { runtimeWalkthrough } from '../utils/functionPluginLoader';
 import {
-  createVersionsMap,
+  layerInputParamsToLayerPermissionArray,
   layerAccountAccessQuestion,
   LayerInputParams,
   layerNameQuestion,
@@ -12,7 +11,7 @@ import {
   layerPermissionsQuestion,
   layerVersionQuestion,
 } from '../utils/layerHelpers';
-import { categoryName, layerParametersFileName, ServiceName } from '../utils/constants';
+import { ServiceName } from '../utils/constants';
 
 export async function createLayerWalkthrough(context: any, parameters: Partial<LayerParameters> = {}): Promise<Partial<LayerParameters>> {
   _.assign(parameters, await inquirer.prompt(layerNameQuestion(context)));
@@ -33,16 +32,19 @@ export async function createLayerWalkthrough(context: any, parameters: Partial<L
         break;
     }
   }
-  _.assign(parameters, { layerVersion: '1' });
   // add layer version to parameters
-  _.assign(parameters, { layerVersionMap: createVersionsMap(layerInputParameters, '1') });
-  _.assign(parameters, { build: true });
+  parameters.layerVersionMap = {
+    1: {
+      permissions: layerInputParamsToLayerPermissionArray(layerInputParameters),
+    },
+  };
+  parameters.build = true;
   return parameters;
 }
 
 export async function updateLayerWalkthrough(
   context: any,
-  lambdaToUpdate?: string,
+  lambdaToUpdate?: string, // resourceToUpdate not used in this method but required by the SupportedServices interface
   parameters?: Partial<LayerParameters>,
 ): Promise<Partial<LayerParameters>> {
   const { allResources } = await context.amplify.getResourceStatus();
@@ -51,9 +53,8 @@ export async function updateLayerWalkthrough(
   if (resources.length === 0) {
     context.print.error('No Lambda Layer resource to update. Please use "amplify add function" to create a new Layer');
     process.exit(0);
-    return;
   }
-  const resourceQuestion = [
+  const resourceQuestion: InputQuestion = [
     {
       name: 'resourceName',
       message: 'Select the Lambda Layer to update:',
@@ -62,75 +63,53 @@ export async function updateLayerWalkthrough(
     },
   ];
   if (resources.length === 1) {
-    _.assign(parameters, { layerName: resources[0] });
+    parameters.layerName = resources[0];
   } else {
     const resourceAnswer = await inquirer.prompt(resourceQuestion);
-    _.assign(parameters, { layerName: resourceAnswer.resourceName });
+    parameters.layerName = resourceAnswer.resourceName;
   }
 
-  const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
-  const resourceDirPath = path.join(projectBackendDirPath, categoryName, parameters.layerName);
-  const parametersFilePath = path.join(resourceDirPath, layerParametersFileName);
-  const currentParameters = context.amplify.readJsonFile(parametersFilePath, undefined, false) || {};
+  // load the current layer state
+  const layerState: LayerMetadata = getLayerMetadataFactory(context)(parameters.layerName);
+  await layerState.syncVersions();
 
-  _.assign(parameters, currentParameters);
-
-  // get the LayerObj
-  const layerData: LayerMetadata = getLayerMetadataFactory(context)(parameters.layerName);
   // runtime question
-  let islayerVersionChanged: boolean = false;
-  if (await context.amplify.confirmPrompt.run('Do you want to change the compatible runtimes?', false)) {
+  if (await context.amplify.confirmPrompt.run('Do you want to update the compatible runtimes?', false)) {
     const runtimeReturn = await runtimeWalkthrough(context, parameters as LayerParameters);
-    parameters.runtimes = runtimeReturn.map(val => val.runtime);
+    layerState.updateCompatibleRuntimes(runtimeReturn.map(val => val.runtime));
   }
-  islayerVersionChanged = !_.isEqual(parameters.runtimes, layerData.runtimes);
-
-  let latestVersion = layerData.getLatestVersion();
-  const latestVersionPushed = layerData.getHash(latestVersion) !== undefined ? latestVersion : 0;
-
-  // get the latest accounts/orgsid
-  const defaultlayerPermissions = layerData.getVersion(latestVersion).permissions.map(permission => permission.type);
-  const defaultorgs = layerData.getVersion(latestVersion).listOrgAccess();
-  const defaultaccounts = layerData.getVersion(latestVersion).listAccoutAccess();
 
   let layerInputParameters: LayerInputParams = {};
 
-  if (await context.amplify.confirmPrompt.run('Do you want to adjust who can access the current & new layer version?', true)) {
-    _.assign(layerInputParameters, await inquirer.prompt(layerPermissionsQuestion(defaultlayerPermissions)));
+  if (await context.amplify.confirmPrompt.run('Do you want to adjust layer version permissions?', true)) {
+    // select layer version
+    const selectedVersion = Number((await inquirer.prompt(layerVersionQuestion(layerState.listVersions()))).layerVersion as string);
 
-    // get the account/orgsID based on the permissions selected and pass defaults in the questions workflow
+    // load defaults
+    const defaultLayerPermissions = layerState.getVersion(selectedVersion).permissions.map(permission => permission.type);
+    const defaultOrgs = layerState.getVersion(selectedVersion).listOrgAccess();
+    const defaultAccounts = layerState.getVersion(selectedVersion).listAccoutAccess();
+
+    // select permission strategy
+    _.assign(layerInputParameters, await inquirer.prompt(layerPermissionsQuestion(defaultLayerPermissions)));
+
+    // get the account and/or org IDs based on the permissions selected and pass defaults in the questions workflow
     for (let permission of layerInputParameters.layerPermissions) {
       switch (permission) {
         case Permission.awsAccounts:
-          _.assign(layerInputParameters, await inquirer.prompt(layerAccountAccessQuestion(defaultaccounts)));
+          _.assign(layerInputParameters, await inquirer.prompt(layerAccountAccessQuestion(defaultAccounts)));
           break;
         case Permission.awsOrg:
-          _.assign(layerInputParameters, await inquirer.prompt(layerOrgAccessQuestion(defaultorgs)));
+          _.assign(layerInputParameters, await inquirer.prompt(layerOrgAccessQuestion(defaultOrgs)));
           break;
       }
     }
-  }
-  if (islayerVersionChanged) {
-    context.print.info('');
-    context.print.warning(
-      'New Lambda layer version created. Any function that wants to use the latest layer version need to configure it by running - "amplify function update"',
-    );
-    if (latestVersion === latestVersionPushed) {
-      latestVersion += 1;
-    }
-    // updating map for a new version
-    const map = createVersionsMap(layerInputParameters, String(latestVersion));
-    parameters.layerVersionMap[Object.keys(map)[0]] = map[Object.keys(map)[0]];
-  } else {
-    // updating map for the selected version
-    const versions = layerData.listVersions();
-    const versionAnswer = await inquirer.prompt(layerVersionQuestion(versions));
-    const selectedVersion = String(versionAnswer.layerVersion);
-    const map = createVersionsMap(layerInputParameters, selectedVersion, parameters.layerVersionMap[selectedVersion].hash);
-    parameters.layerVersionMap[Object.keys(map)[0]] = map[Object.keys(map)[0]];
-  }
-  _.assign(parameters, { layerVersion: String(latestVersion) });
 
-  _.assign(parameters, { build: true });
+    // update layer version based on inputs
+    const layerPermissions = layerInputParamsToLayerPermissionArray(layerInputParameters);
+    layerState.setPermissionsForVersion(selectedVersion, layerPermissions);
+  }
+  _.assign(parameters, layerState.toStoredLayerParameters());
+  parameters.build = true;
   return parameters;
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -60,13 +60,13 @@ export const askLayerSelection = async (
   for (let selection of layerSelections) {
     const currentSelectionDefaults = filterProjectLayers(previousSelections).find(sel => sel.resourceName === selection);
     const currentVersion = currentSelectionDefaults ? currentSelectionDefaults.version.toString() : undefined;
+    const layerState = layerMetadataFactory(selection);
+    await layerState.syncVersions(); // make sure we are reflecting the latest changes;
     const layerVersionPrompt: ListQuestion = {
       type: 'list',
       name: 'versionSelection',
       message: versionSelectionPrompt(selection),
-      choices: layerMetadataFactory(selection)
-        .listVersions()
-        .map(num => num.toString()),
+      choices: layerState.listVersions().map(num => num.toString()),
       default: currentVersion,
       filter: numStr => parseInt(numStr, 10),
     };

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
@@ -25,19 +25,6 @@ function generateLayerCfnObjBase() {
 }
 
 /**
- * generated CFN for Layerpermissions only when updating permisssions
- */
-export function generatePermissionCfnObj(context: any, parameters: LayerParameters): object {
-  const cfnObj = generateLayerCfnObjBase();
-  const layerData = getLayerMetadataFactory(context)(parameters.layerName);
-  Object.entries(parameters.layerVersionMap).forEach(([key]) => {
-    const answer = assignLayerPermissions(layerData, key, parameters.layerName, parameters.build);
-    answer.forEach(permission => (cfnObj.Resources[permission.name] = permission.policy));
-  });
-  return cfnObj;
-}
-
-/**
  * generates CFN for Layer and Layer permissions when updating layerVersion
  */
 export function generateLayerCfnObj(context, parameters: LayerParameters) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -1,6 +1,7 @@
 import uuid from 'uuid';
 import { Permission, LayerPermission } from '../utils/layerParams';
 import _ from 'lodash';
+import { ListQuestion } from 'inquirer';
 
 export interface LayerInputParams {
   layerPermissions?: Permission[];
@@ -8,13 +9,13 @@ export interface LayerInputParams {
   authorizedOrgId?: string;
 }
 
-export function layerVersionQuestion(choices) {
+export function layerVersionQuestion(versions: number[]) {
   return [
     {
       type: 'list',
       name: 'layerVersion',
       message: 'Select the layer version to update:',
-      choices: choices,
+      choices: versions,
     },
   ];
 }
@@ -129,7 +130,7 @@ export function layerOrgAccessQuestion(defaultorgs?: string[]) {
   ];
 }
 
-export function prevPermsQuestion(layerName: string) {
+export function prevPermsQuestion(layerName: string): ListQuestion[] {
   return [
     {
       type: 'list',
@@ -139,12 +140,12 @@ export function prevPermsQuestion(layerName: string) {
         {
           name: 'The same permission as the latest layer version',
           short: 'Previous version permissions',
-          value: 'previous',
+          value: true,
         },
         {
           name: 'Only accessible by the current account. You can always edit this later with: amplify update function',
           short: 'Private',
-          value: 'default',
+          value: false,
         },
       ],
       default: 0,
@@ -152,9 +153,8 @@ export function prevPermsQuestion(layerName: string) {
   ];
 }
 
-export function createVersionsMap(parameters: LayerInputParams, version: string, hash?: string) {
+export function layerInputParamsToLayerPermissionArray(parameters: LayerInputParams): LayerPermission[] {
   const { layerPermissions } = parameters;
-  let versionMap: object = {};
   let permissionObj: Array<LayerPermission> = [];
 
   if (layerPermissions !== undefined && layerPermissions.length > 0) {
@@ -181,11 +181,6 @@ export function createVersionsMap(parameters: LayerInputParams, version: string,
   const privateObj: LayerPermission = {
     type: Permission.private,
   };
-  permissionObj.push(privateObj);
-  // add private as default in versionMap
-  versionMap[version] = { permissions: permissionObj };
-  if (hash) {
-    versionMap[version].hash = hash;
-  }
-  return versionMap;
+  permissionObj.push(privateObj); // layer is always accessible by the aws account of the owner
+  return permissionObj;
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -78,13 +78,14 @@ export function layerPermissionsQuestion(params?: Permission[]) {
   ];
 }
 
-export function layerAccountAccessQuestion(defaultaccounts?: string[]) {
+export function layerAccountAccessQuestion(defaultAccountIds?: string[]) {
+  const hasDefaults = defaultAccountIds && defaultAccountIds.length > 0;
   return [
     {
       type: 'input',
       name: 'authorizedAccountIds',
       message: 'Provide a list of comma-separated AWS account IDs:',
-      validate: input => {
+      validate: (input: string) => {
         const accounts = input.split(',');
         const set = new Set();
         for (let accountID of accounts) {
@@ -99,12 +100,13 @@ export function layerAccountAccessQuestion(defaultaccounts?: string[]) {
         }
         return true;
       },
-      default: defaultaccounts !== undefined ? defaultaccounts.join(',') : '',
+      default: hasDefaults ? defaultAccountIds.join(',') : undefined,
     },
   ];
 }
 
-export function layerOrgAccessQuestion(defaultorgs?: string[]) {
+export function layerOrgAccessQuestion(defaultOrgs?: string[]) {
+  const hasDefaults = defaultOrgs && defaultOrgs.length > 0;
   return [
     {
       type: 'input',
@@ -125,7 +127,7 @@ export function layerOrgAccessQuestion(defaultorgs?: string[]) {
         }
         return true;
       },
-      default: defaultorgs !== undefined ? defaultorgs.join(',') : '',
+      default: hasDefaults ? defaultOrgs.join(',') : undefined,
     },
   ];
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
@@ -3,23 +3,22 @@ import _ from 'lodash';
 import path from 'path';
 import { FunctionRuntime, ProviderContext } from 'amplify-function-plugin-interface';
 import { categoryName, layerParametersFileName } from '../utils/constants';
+import { category } from '../../../constants';
+import { hashLayerDir } from './packageLayer';
 
-export type LayerVersionData = {
-  version: LayerVersionMetadata;
-};
+export type LayerVersionMap = Record<number, Pick<LayerVersionMetadata, 'permissions' | 'hash'>>;
+
+export type LayerRuntime = Pick<FunctionRuntime, 'name' | 'value' | 'layerExecutablePath' | 'cloudTemplateValue'>;
 
 export type LayerParameters = {
   layerName: string;
-  runtimes: FunctionRuntime[];
+  runtimes: LayerRuntime[];
   providerContext: ProviderContext;
-  layerVersionMap?: LayerVersionData;
+  layerVersionMap?: LayerVersionMap;
   build: boolean;
 };
 
-export interface StoredLayerParameters {
-  runtimes: Pick<FunctionRuntime, 'value' | 'layerExecutablePath' | 'cloudTemplateValue'>[];
-  layerVersionMap?: Record<number, Pick<LayerVersionMetadata, 'permissions' | 'hash'>>;
-}
+export type StoredLayerParameters = Pick<LayerParameters, 'runtimes' | 'layerVersionMap'>;
 
 export enum Permission {
   private = 'private',
@@ -31,12 +30,17 @@ export enum Permission {
 export type LayerMetadataFactory = (layerName: string) => LayerMetadata;
 
 export interface LayerMetadata {
-  runtimes: FunctionRuntime[];
-  layerMetaData?: LayerVersionMetadata;
+  layerName: string;
+  runtimes: LayerRuntime[];
   getVersion: (version: number) => LayerVersionMetadata;
   listVersions: () => number[];
   getLatestVersion: () => number;
   getHash: (version: number) => string;
+  syncVersions: () => Promise<boolean>;
+  updateCompatibleRuntimes: (runtimes: LayerRuntime[]) => void;
+  setPermissionsForVersion: (version: number, permissions: LayerPermission[]) => void;
+  setNewVersionHash: () => Promise<void>;
+  toStoredLayerParameters: () => StoredLayerParameters;
 }
 
 export interface LayerVersionMetadata {
@@ -69,14 +73,20 @@ export interface OrgsLayer {
 }
 
 class LayerState implements LayerMetadata {
-  versionMap: Map<number, LayerVersionMetadata> = new Map();
-  runtimes: FunctionRuntime[];
-  layerMetaData: LayerVersionMetadata;
-  constructor(obj) {
-    this.runtimes = obj.runtimes;
-    Object.entries(obj.layerVersionMap).forEach(([versionNumber, versionData]) => {
-      this.layerMetaData = new LayerVersionState(versionData);
-      this.versionMap.set(Number(versionNumber), this.layerMetaData);
+  readonly layerName: string;
+  runtimes: LayerRuntime[];
+  private context;
+  private versionMap: Map<number, LayerVersionState> = new Map();
+
+  private storedParams: StoredLayerParameters;
+  private newVersionHash: string;
+  constructor(context, storedParams: StoredLayerParameters, layerName: string) {
+    this.context = context;
+    this.layerName = layerName;
+    this.storedParams = storedParams;
+    this.runtimes = storedParams.runtimes;
+    Object.entries(storedParams.layerVersionMap).forEach(([versionNumber, versionData]) => {
+      this.versionMap.set(Number(versionNumber), new LayerVersionState(versionData));
     });
   }
 
@@ -95,15 +105,102 @@ class LayerState implements LayerMetadata {
   getHash(version: number): string {
     return this.getVersion(version).hash;
   }
+
+  // sets the hash for a new (not yet pushed) layer version
+  // once a hash is set for a version, this should indicate that the version is "finialized" (ie pushed or about to be pushed)
+  // hashes are immutable once set
+  async setNewVersionHash() {
+    const latestVersion = this.getLatestVersion();
+    // if the latest version doesn't already have a hash
+    if (!this.getHash(latestVersion)) {
+      const newHash = this.newVersionHash || (await this.hashLayer());
+      this.getVersion(latestVersion).hash = newHash;
+      this.storedParams.layerVersionMap[latestVersion].hash = newHash;
+      this.newVersionHash = undefined; // reset the newVersionHash now that the latest one is set
+    }
+  }
+
+  // updates the layer metadata with a new version if changes are detected
+  // if a new version is detected, the permissions from the previous version are carried forward to the new version
+  // returns true if a new version was detected, false otherwise
+  // it does not set a hash for a new version if detected because the version could change more before a push
+  async syncVersions(): Promise<boolean> {
+    const latestVersion = this.getLatestVersion();
+    const currHash = this.getHash(latestVersion);
+    if (!currHash) {
+      return false;
+    }
+    this.newVersionHash = await this.hashLayer();
+    if (currHash !== this.newVersionHash) {
+      this.addNewLayerVersion();
+      return true;
+    }
+    return false;
+  }
+
+  updateCompatibleRuntimes(runtimes: LayerRuntime[]) {
+    let isModified = runtimes.length !== this.runtimes.length;
+    const existingRuntimeVals = this.runtimes.map(runtime => runtime.value);
+    const newRuntimeVals = runtimes.map(runtime => runtime.value);
+    // check that the arrays are different
+    isModified =
+      isModified ||
+      existingRuntimeVals.findIndex(val => !newRuntimeVals.includes(val)) !== -1 ||
+      newRuntimeVals.findIndex(val => !existingRuntimeVals.includes(val)) !== -1;
+    if (isModified) {
+      this.updateRuntimes(runtimes);
+      if (this.isLatestVersionFinalized()) {
+        this.addNewLayerVersion();
+      }
+    }
+  }
+
+  setPermissionsForVersion(version: number, permissions: LayerPermission[]) {
+    this.storedParams.layerVersionMap[version].permissions = permissions;
+    this.versionMap.get(version).setPermissions(permissions);
+  }
+
+  toStoredLayerParameters(): StoredLayerParameters {
+    return _.cloneDeep(this.storedParams);
+  }
+
+  private isLatestVersionFinalized(): boolean {
+    return this.getHash(this.getLatestVersion()) !== undefined;
+  }
+
+  private hashLayer() {
+    const layerPath = path.join(this.context.amplify.pathManager.getBackendDirPath(), category, this.layerName);
+    return hashLayerDir(layerPath);
+  }
+
+  private updateRuntimes(runtimes: LayerRuntime[]) {
+    this.runtimes = runtimes;
+    this.storedParams.runtimes = runtimes;
+  }
+
+  private addNewLayerVersion() {
+    const currVersion = this.getLatestVersion();
+    const newVersion = currVersion + 1;
+    const prevPermissions = this.getVersion(currVersion).permissions;
+    this.storedParams.layerVersionMap[newVersion] = {
+      permissions: _.cloneDeep(prevPermissions),
+    };
+    this.versionMap.set(newVersion, new LayerVersionState(this.storedParams.layerVersionMap[newVersion]));
+  }
 }
 
 class LayerVersionState implements LayerVersionMetadata {
   permissions: LayerPermission[];
   hash: string;
-  constructor(versionData) {
+  constructor(versionData: Pick<LayerVersionMetadata, 'permissions' | 'hash'>) {
     this.permissions = [];
     this.hash = versionData.hash;
-    versionData.permissions.forEach(permission => {
+    this.setPermissions(versionData.permissions);
+  }
+
+  setPermissions(permissions: LayerPermission[]) {
+    this.permissions = [];
+    permissions.forEach(permission => {
       if (permission.type === Permission.public) {
         const permissionPublic: PublicLayer = {
           type: Permission.public,
@@ -171,7 +268,7 @@ export const getLayerMetadataFactory = (context: any): LayerMetadataFactory => {
       return undefined;
     }
     const parametersFilePath = path.join(resourceDirPath, layerParametersFileName);
-    const obj = context.amplify.readJsonFile(parametersFilePath);
-    return new LayerState(obj);
+    const obj = context.amplify.readJsonFile(parametersFilePath) as StoredLayerParameters;
+    return new LayerState(context, obj, layerName);
   };
 };

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -173,7 +173,7 @@ const updateLayerInAmplifyMeta = (context, parameters: LayerParameters) => {
   context.amplify.updateamplifyMetaAfterResourceUpdate(categoryName, parameters.layerName, 'build', metaParams.build);
 };
 
-const createLayerParametersFile = (context, parameters: LayerParameters, layerDirPath: string) => {
+const createLayerParametersFile = (context, parameters: LayerParameters | StoredLayerParameters, layerDirPath: string) => {
   fs.ensureDirSync(layerDirPath);
   const parametersFilePath = path.join(layerDirPath, layerParametersFileName);
   context.amplify.writeObjectAsJson(parametersFilePath, layerParamsToStoredParams(parameters), true);
@@ -189,8 +189,8 @@ const layerParamsToAmplifyMetaParams = (
   });
 };
 
-const layerParamsToStoredParams = (parameters: LayerParameters): StoredLayerParameters => ({
-  runtimes: (parameters.runtimes || []).map(runtime => _.pick(runtime, 'value', 'layerExecutablePath', 'cloudTemplateValue')),
+const layerParamsToStoredParams = (parameters: LayerParameters | StoredLayerParameters): StoredLayerParameters => ({
+  runtimes: (parameters.runtimes || []).map(runtime => _.pick(runtime, 'value', 'name', 'layerExecutablePath', 'cloudTemplateValue')),
   layerVersionMap: parameters.layerVersionMap,
 });
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.js
@@ -8,7 +8,7 @@ const { getEnvInfo } = require('./get-env-info');
 const _ = require('lodash');
 const { CLOUD_INITIALIZED, CLOUD_NOT_INITIALIZED, getCloudInitStatus } = require('./get-cloud-init-status');
 const { readJsonFile } = require('./read-json-file');
-const { ServiceName: FunctionServiceName, hashLayerDir } = require('amplify-category-function');
+const { ServiceName: FunctionServiceName, hashLayerResource } = require('amplify-category-function');
 
 async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPushTimeStamp, isLambdaLayer = false) {
   // Pushing the resource for the first time hence no lastPushTimeStamp
@@ -24,7 +24,7 @@ async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPus
     return false;
   }
 
-  const hashingFunc = isLambdaLayer ? hashLayerDir : getHashForResourceDir;
+  const hashingFunc = isLambdaLayer ? hashLayerResource : getHashForResourceDir;
 
   const localDirHash = await hashingFunc(localBackendDir);
   const cloudDirHash = await hashingFunc(cloudBackendDir);

--- a/packages/amplify-e2e-core/src/utils/selectors.ts
+++ b/packages/amplify-e2e-core/src/utils/selectors.ts
@@ -8,7 +8,7 @@ export const moveUp = (chain: ExecutionContext, nMoves: number) =>
 
 export const singleSelect = <T>(chain: ExecutionContext, item: T, allChoices: T[]) => multiSelect(chain, [item], allChoices);
 
-export const multiSelect = <T>(chain: ExecutionContext, items: T[], allChoices: T[]) =>
+export const multiSelect = <T>(chain: ExecutionContext, items: T[] = [], allChoices: T[]) => {
   items
     .map(item => allChoices.indexOf(item))
     .filter(idx => idx > -1)
@@ -16,5 +16,7 @@ export const multiSelect = <T>(chain: ExecutionContext, items: T[], allChoices: 
     // calculate the diff with the latest, since items are sorted, always positive
     // represents the numbers of moves down we need to make to selection
     .reduce((diffs, move) => (diffs.length > 0 ? [...diffs, move - diffs[diffs.length - 1]] : [move]), [] as number[])
-    .reduce((chain, move) => moveDown(chain, move).send(' '), chain)
-    .sendCarriageReturn();
+    .reduce((chain, move) => moveDown(chain, move).send(' '), chain);
+  chain.sendCarriageReturn();
+  return chain;
+};

--- a/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
@@ -110,16 +110,16 @@ describe('amplify add lambda layer', () => {
 
   it('init a project and add/push and update/push without updating version', async () => {
     const [shortId] = uuid().split('-');
-    const settings = {
+    const settings: any = {
       runtimes: ['nodejs'],
       layerName: `testlayer${shortId}`,
-      versionChanged: false,
       numLayers: 1,
       isPushed: false,
     };
     await initJSProjectWithProfile(projRoot, {});
     await addLayer(projRoot, settings);
     await amplifyPushAuth(projRoot);
+    settings.permissions = ['Public (everyone on AWS can use this layer)'];
     await updateLayer(projRoot, settings);
     await amplifyPushAuth(projRoot);
     await validateMetadata(settings.layerName);


### PR DESCRIPTION
Moved a lot of the logic for maintaining layer state to the layer state class

Call "syncVersions()" when we need to check if a new layer version has been created outside of a CLI flow

also did a significant refactor of the layer update flow

still need to check the  e2e tests -- they probably need to be updated with the new update flow (moved the order of one question)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.