### PR TITLE
fix: display relative paths on success output for layers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1024,12 +1024,12 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - layer-amplify_e2e_tests
+            - hostingPROD-amplify_e2e_tests
       - hosting-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - hostingPROD-amplify_e2e_tests
+            - layer-amplify_e2e_tests
       - init-amplify_e2e_tests:
           filters: *ref_2
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1024,12 +1024,12 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - hostingPROD-amplify_e2e_tests
+            - layer-amplify_e2e_tests
       - hosting-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - layer-amplify_e2e_tests
+            - hostingPROD-amplify_e2e_tests
       - init-amplify_e2e_tests:
           filters: *ref_2
           requires:

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -135,27 +135,8 @@ export async function addLayerResource(
 
   const completeParams = (await serviceConfig.walkthroughs.createWalkthrough(context, parameters)) as LayerParameters;
 
-  const layerDirPath = createLayerArtifacts(context, completeParams);
-
-  const { print } = context;
-  print.info('✅ Lambda layer folders & files created:');
-  print.info(layerDirPath);
-  print.info('');
-  print.success('Next steps:');
-
-  if (parameters.runtimes.length !== 0) {
-    print.info('Move your libraries in the following folder:');
-    for (let runtime of parameters.runtimes) {
-      print.info(`[${runtime.name}]: ${layerDirPath}/lib/${runtime.layerExecutablePath}`);
-    }
-    print.info('');
-  }
-
-  print.info('Include any files you want to share across runtimes in this folder:');
-  print.info(`amplify/backend/function/${parameters.layerName}/opt`);
-  print.info('');
-  print.info('"amplify function update <function-name>" - configure a function with this Lambda layer');
-  print.info('"amplify push" - builds all of your local backend resources and provisions them in the cloud');
+  createLayerArtifacts(context, completeParams);
+  printLayerSuccessMessages(context, completeParams, 'created');
 }
 
 export async function updateResource(
@@ -202,27 +183,8 @@ export async function updateLayerResource(
   const completeParams = (await serviceConfig.walkthroughs.updateWalkthrough(context, undefined, parameters)) as LayerParameters;
 
   // write out updated resources
-  const layerDirPath = updateLayerArtifacts(context, completeParams);
-
-  const { print } = context;
-  print.info('✅ Lambda layer folders & files created:');
-  print.info(layerDirPath);
-  print.info('');
-  print.success('Next steps:');
-
-  if (parameters.runtimes.length !== 0) {
-    print.info('Move your libraries in the following folder:');
-    for (let runtime of parameters.runtimes) {
-      print.info(`[${runtime.name}]: ${layerDirPath}/lib/${runtime.layerExecutablePath}`);
-    }
-    print.info('');
-  }
-
-  print.info('Include any files you want to share across runtimes in this folder:');
-  print.info(`amplify/backend/function/${parameters.layerName}/opt`);
-  print.info('');
-  print.info('"amplify function update <function-name>" - configure a function with this Lambda layer');
-  print.info('"amplify push" - builds all of your local backend resources and provisions them in the cloud');
+  updateLayerArtifacts(context, completeParams);
+  printLayerSuccessMessages(context, completeParams, 'updated');
 }
 
 export async function updateFunctionResource(context, category, service, parameters, resourceToUpdate) {
@@ -259,6 +221,31 @@ export async function updateFunctionResource(context, category, service, paramet
   }
 
   return parameters.resourceName;
+}
+
+function printLayerSuccessMessages(context: any, parameters: LayerParameters, action: string): void {
+  const { print } = context;
+  const { layerName } = parameters;
+  const relativeDirPath = path.join('amplify', 'backend', 'function', layerName);
+  print.info(`✅ Lambda layer folders & files ${action}:`);
+  print.info(relativeDirPath);
+  print.info('');
+  print.success('Next steps:');
+
+  if (parameters.runtimes.length !== 0) {
+    print.info('Move your libraries in the following folder:');
+    for (let runtime of parameters.runtimes) {
+      let runtimePath = path.join(relativeDirPath, 'lib', runtime.layerExecutablePath);
+      print.info(`[${runtime.name}]: ${runtimePath}`);
+    }
+    print.info('');
+  }
+
+  print.info('Include any files you want to share across runtimes in this folder:');
+  print.info(path.join(relativeDirPath, 'opt'));
+  print.info('');
+  print.info('"amplify function update <function-name>" - configure a function with this Lambda layer');
+  print.info('"amplify push" - builds all of your local backend resources and provisions them in the cloud');
 }
 
 async function openEditor(context, category: string, resourceName: string, template: Partial<FunctionTemplate>, displayName = 'local') {

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -56,10 +56,8 @@ export function addLayer(cwd: string, settings?: any) {
     multiSelect(chain, runtimeDisplayNames, layerRuntimeChoices);
     chain.wait('The current AWS account will always have access to this layer.');
     multiSelect(chain, settings.permissions, permissionChoices);
+    waitForLayerSuccessPrintout(chain, settings, 'created');
 
-    const layerDirRegex = new RegExp('.*/amplify/backend/function/' + settings.layerName);
-
-    waitForLayerSuccessPrintout(chain, settings, layerDirRegex);
     chain.run((err: Error) => {
       if (!err) {
         resolve();
@@ -117,8 +115,7 @@ export function updateLayer(cwd: string, settings?: any) {
       .wait('The current AWS account will always have access to this layer.');
     multiSelect(chain, settings.permissions, permissionChoices);
 
-    const layerDirRegex = new RegExp('.*/amplify/backend/function/' + settings.layerName);
-    waitForLayerSuccessPrintout(chain, settings, layerDirRegex);
+    waitForLayerSuccessPrintout(chain, settings, 'updated');
     chain.run((err: Error) => {
       if (!err) {
         resolve();
@@ -150,17 +147,17 @@ function getLayerRuntimeInfo(runtime: LayerRuntimes) {
   }
 }
 
-function waitForLayerSuccessPrintout(chain: ExecutionContext, settings: any, layerDirRegex) {
+function waitForLayerSuccessPrintout(chain: ExecutionContext, settings: any, action: string) {
   chain
-    .wait('✅ Lambda layer folders & files created:')
-    .wait(layerDirRegex)
+    .wait(`✅ Lambda layer folders & files ${action}:`)
+    .wait(path.join('amplify', 'backend', 'function', settings.layerName))
     .wait('Next steps:')
     .wait('Move your libraries in the following folder:');
 
   for (let i = 0; i < settings.runtimes.length; ++i) {
     const { displayName, path } = getLayerRuntimeInfo(settings.runtimes[i]);
-    const layerRuntimeDirRegex = new RegExp(`\\[${displayName}\\]: .*/amplify/backend/function/${settings.layerName}/${path}`);
-    chain.wait(layerRuntimeDirRegex);
+    const layerRuntimeDir = `[${displayName}]: amplify/backend/function/${settings.layerName}/${path}`;
+    chain.wait(layerRuntimeDir);
   }
 
   chain

--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -17,7 +17,6 @@ const { loadResourceParameters } = require('../src/resourceParams');
 const { uploadAuthTriggerFiles } = require('./upload-auth-trigger-files');
 const archiver = require('../src/utils/archiver');
 const amplifyServiceManager = require('./amplify-service-manager');
-const ziparchiver = require('archiver');
 const { packageLayer, ServiceName: FunctionServiceName } = require('amplify-category-function');
 
 const spinner = ora('Updating resources in the cloud. This may take a few minutes...');


### PR DESCRIPTION
Also remove unused import, show "updated" on `amplify update function`, updated relevant e2e helper functions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.