### PR TITLE
test: early return on function flow expect failure

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -73,6 +73,7 @@ const coreFunction = (
 
     if (settings.expectFailure) {
       runChain(chain, resolve, reject);
+      return;
     }
 
     // other permissions flow


### PR DESCRIPTION
fixes e2e test failure in "should fail with approp message when adding lambda triggers to unexisting resources" test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.