### PR TITLE
fix: env vars comment on func update

### DIFF
--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -13,7 +13,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf ./lib",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
     "test": "jest"
   },
   "keywords": [

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -80,7 +80,18 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
     lambdaToUpdate = (await inquirer.prompt(resourceQuestion)).resourceName as string;
   }
 
-  const functionParameters: Partial<FunctionParameters> = { resourceName: lambdaToUpdate };
+  // initialize function parameters for update
+  const functionParameters: Partial<FunctionParameters> = {
+    resourceName: lambdaToUpdate,
+    environmentMap: {
+      ENV: {
+        Ref: 'env',
+      },
+      REGION: {
+        Ref: 'AWS::Region',
+      },
+    },
+  };
 
   const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
   const resourceDirPath = path.join(projectBackendDirPath, category, functionParameters.resourceName);
@@ -148,7 +159,7 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
     );
 
     context.amplify.writeObjectAsJson(cfnFilePath, cfnContent, true);
-    tryUpdateTopLevelComment(resourceDirPath, functionParameters.topLevelComment);
+    tryUpdateTopLevelComment(resourceDirPath, _.keys(functionParameters.environmentMap));
   }
   // ask scheduling Lambda questions and merge in results
   const cfnParameters = context.amplify.readJsonFile(path.join(resourceDirPath, parametersFileName), undefined, false) || {};

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
@@ -6,7 +6,8 @@ import _ from 'lodash';
  * This is legacy code that has been copied here.
  * In the future we either need to get rid of the top level comment entirely, or create a template hook to modify it
  */
-export const tryUpdateTopLevelComment = (resourceDirPath: string, newComment: string) => {
+export const tryUpdateTopLevelComment = (resourceDirPath: string, envVars: string[]) => {
+  const newComment = createTopLevelComment(envVars);
   const appJSFilePath = path.join(resourceDirPath, 'src', 'app.js');
   const indexJSFilePath = path.join(resourceDirPath, 'src', 'index.js');
   if (fs.existsSync(appJSFilePath)) {
@@ -15,6 +16,8 @@ export const tryUpdateTopLevelComment = (resourceDirPath: string, newComment: st
     updateTopLevelComment(indexJSFilePath, newComment);
   }
 };
+
+const createTopLevelComment = (envVars: string[]) => `${topLevelCommentPrefix}${envVars.sort().join('\n\t')}${topLevelCommentSuffix}`;
 
 const updateTopLevelComment = (filePath, newComment) => {
   const commentRegex = new RegExp(`${_.escapeRegExp(topLevelCommentPrefix)}[a-zA-Z0-9\\-\\s._=]+${_.escapeRegExp(topLevelCommentSuffix)}`);


### PR DESCRIPTION
Fixes functions e2e test "environment vars comment should update on permission update"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.