### PR TITLE
fix: remove env and region from dependsOn

### DIFF
--- a/.circleci/enable_api.exp
+++ b/.circleci/enable_api.exp
@@ -40,6 +40,8 @@ expect "Do you want to access other resources created in this project from your 
 send -- "n\r"
 expect "Do you want to invoke this function on a recurring schedule?"
 send -- "n\r"
+expect "Do you want to configure Lambda layers for this function?"
+send -- "n\r"
 expect "Do you want to edit the local lambda function now?"
 send -- "n\r"
 expect "Restrict API access"

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -32,7 +32,7 @@ export async function addResource(
   service,
   options,
   parameters?: Partial<FunctionParameters> | FunctionTriggerParameters | Partial<LayerParameters>,
-): Promise<void> {
+): Promise<string> {
   // load the service config for this service
   const serviceConfig: ServiceConfig<FunctionParameters> | ServiceConfig<LayerParameters> = supportedServices[service];
   const BAD_SERVICE_ERR = new Error(`amplify-category-function is not configured to provide service type ${service}`);
@@ -55,7 +55,7 @@ export async function addFunctionResource(
   service,
   serviceConfig: ServiceConfig<FunctionParameters>,
   parameters?: Partial<FunctionParameters> | FunctionTriggerParameters,
-): Promise<void> {
+): Promise<string> {
   // Go through the walkthrough if the parameters are incomplete function parameters
   let completeParams: FunctionParameters | FunctionTriggerParameters;
   if (!parameters || (!isComplete(parameters) && !('trigger' in parameters))) {
@@ -115,6 +115,7 @@ export async function addFunctionResource(
   print.info(
     '"amplify publish" builds all of your local backend and front-end resources (if you added hosting category) and provisions them in the cloud',
   );
+  return completeParams.functionName;
 }
 
 export async function addLayerResource(
@@ -122,7 +123,7 @@ export async function addLayerResource(
   service,
   serviceConfig: ServiceConfig<LayerParameters>,
   parameters: Partial<LayerParameters> = {},
-): Promise<void> {
+): Promise<string> {
   parameters.providerContext = {
     provider: provider,
     service: service,
@@ -133,6 +134,7 @@ export async function addLayerResource(
 
   createLayerArtifacts(context, completeParams);
   printLayerSuccessMessages(context, completeParams, 'created');
+  return completeParams.layerName;
 }
 
 export async function updateResource(

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -111,6 +111,8 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
     const dependsOnParams = { env: { Type: 'String' } };
 
     Object.keys(functionParameters.environmentMap)
+      .filter(key => key !== 'ENV')
+      .filter(key => key !== 'REGION')
       .filter(resourceProperty => 'Ref' in functionParameters.environmentMap[resourceProperty])
       .forEach(resourceProperty => {
         dependsOnParams[functionParameters.environmentMap[resourceProperty].Ref] = {


### PR DESCRIPTION
fixes AWS::Region being added as a CFN parameter causing e2e failure

fixes function addResource not returning resourceName

adds lambda layer question to cypress test flow


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.