### PR TITLE
feat: headless add api working e2e

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "amplify-category-auth": "2.15.8",
     "amplify-category-function": "2.20.7",
+    "amplify-util-headless-input": "1.0.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "graphql": "^14.5.8",

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -1,6 +1,8 @@
 import { run } from './commands/api/console';
 import fs from 'fs-extra';
 import path from 'path';
+import { getCfnApiArtifactHandler } from './provider-utils/awscloudformation/cfn-api-artifact-handler';
+import { validateAddApiRequest } from 'amplify-util-headless-input';
 
 const category = 'api';
 
@@ -175,6 +177,16 @@ export async function executeAmplifyCommand(context) {
   const commandModule = require(commandPath);
   await commandModule.run(context);
 }
+
+export const executeAmplifyHeadlessCommand = async (context, headlessPayload: string) => {
+  switch (context.input.command) {
+    case 'add':
+      await getCfnApiArtifactHandler(context).createArtifacts(await validateAddApiRequest(headlessPayload));
+      break;
+    default:
+      context.print.error(`Headless mode for ${context.input.command} api is not implemented yet`);
+  }
+};
 
 export async function handleAmplifyEvent(context, args) {
   context.print.info(`${category} handleAmplifyEvent to be implemented`);

--- a/packages/amplify-category-api/tsconfig.json
+++ b/packages/amplify-category-api/tsconfig.json
@@ -13,6 +13,7 @@
   ],
   "references": [
     {"path": "../amplify-headless-interface"},
-    {"path": "../graphql-transformer-core"}
+    {"path": "../graphql-transformer-core"},
+    {"path": "../amplify-util-headless-input"},
   ]
 }

--- a/packages/amplify-cli/src/domain/constants.ts
+++ b/packages/amplify-cli/src/domain/constants.ts
@@ -17,5 +17,6 @@ export const constants = {
   ParentDirectory: 'cli-parent-directory',
   GlobalNodeModules: 'global-node-modules',
   ExecuteAmplifyCommand: 'executeAmplifyCommand',
+  ExecuteAmplifyHeadlessCommand: 'executeAmplifyHeadlessCommand',
   HandleAmplifyEvent: 'handleAmplifyEvent',
 };

--- a/packages/amplify-cli/src/utils/headless-input-utils.ts
+++ b/packages/amplify-cli/src/utils/headless-input-utils.ts
@@ -1,0 +1,25 @@
+import readline from 'readline';
+
+const headlessPayloadReadTimeoutMillis = 2000;
+
+export const isHeadlessCommand = (context: any): boolean => context.input.options && context.input.options.stdin;
+
+export const readHeadlessPayload = async (): Promise<string> => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+  const readTimeout = new Promise((_, reject) => {
+    const id = setTimeout(() => {
+      clearTimeout(id);
+      reject(new Error('No input received on stdin'));
+    }, headlessPayloadReadTimeoutMillis);
+  });
+
+  const readPromise: Promise<string> = new Promise(resolve => {
+    rl.on('line', line => resolve(line));
+  });
+
+  return Promise.race([readTimeout, readPromise]) as Promise<string>;
+};

--- a/packages/amplify-cli/src/utils/headless-input-utils.ts
+++ b/packages/amplify-cli/src/utils/headless-input-utils.ts
@@ -2,14 +2,20 @@ import readline from 'readline';
 
 const headlessPayloadReadTimeoutMillis = 2000;
 
-export const isHeadlessCommand = (context: any): boolean => context.input.options && context.input.options.stdin;
+// checks if the --stdin flag is set on the amplify command;
+export const isHeadlessCommand = (context: any): boolean => context.input.options && context.input.options.yes;
 
+// waits for a line on stdin.
+// times out after the time specified above if no input received.
+// this prevents the CLI from hanging forever if a customer forgets to pipe the headless payload into the command.
 export const readHeadlessPayload = async (): Promise<string> => {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
     terminal: false,
   });
+
+  // rejects a promise after an amount of time
   const readTimeout = new Promise((_, reject) => {
     const id = setTimeout(() => {
       clearTimeout(id);
@@ -17,9 +23,11 @@ export const readHeadlessPayload = async (): Promise<string> => {
     }, headlessPayloadReadTimeoutMillis);
   });
 
+  // resolves a promise on the 'line' event
   const readPromise: Promise<string> = new Promise(resolve => {
     rl.on('line', line => resolve(line));
   });
 
+  // wait for a line or timeout, whichever comes first
   return Promise.race([readTimeout, readPromise]) as Promise<string>;
 };


### PR DESCRIPTION
includes a small refactor of the executeAmplifyHeadlessCommand in the CLI to eliminate code duplication between the existing method of invoking plugins and invoking them in headless mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.