### PR TITLE
fix(amplify-appsync-simulator): forward stash to responseMappingTemplate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1116,9 +1116,9 @@ workflows:
           filters:
             branches:
               only:
-                # - master
+                - master
                 - graphqlschemae2e
-                # - beta
+                - beta
           requires:
             - build
             - mock_e2e_tests
@@ -1161,7 +1161,7 @@ workflows:
             - test
             - mock_e2e_tests
             - graphql_e2e_tests
-            # - integration_test
+            - integration_test
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4

--- a/packages/amplify-appsync-simulator/src/__tests__/resolvers/unit-resolver.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/resolvers/unit-resolver.test.ts
@@ -172,5 +172,20 @@ describe('Unit resolver', () => {
       expect(result).toEqual(REQUEST_TEMPLATE_RESULT.result);
       expect(context.appsyncErrors).toEqual(['request error', 'response error']);
     });
+
+    it('should forward stash from request template to response template', async () => {
+      templates.request.render.mockReturnValue({
+        ...REQUEST_TEMPLATE_RESULT,
+        errors: [],
+        stash: 'TEST STASH',
+      });
+      const result = await resolver.resolve(source, args, context, info);
+      expect(result).toEqual(RESPONSE_TEMPLATE_RESULT);
+      expect(templates.response.render).toHaveBeenCalledWith(
+        { source, arguments: args, result: DATA_FROM_DATA_SOURCE, stash: 'TEST STASH' },
+        context,
+        info,
+      );
+    });
   });
 });

--- a/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
@@ -22,7 +22,7 @@ export class AppSyncUnitResolver extends AppSyncBaseResolver {
     const requestMappingTemplate = this.getRequestMappingTemplate();
     const responseMappingTemplate = this.getResponseMappingTemplate();
     const dataLoader = this.simulatorContext.getDataLoader(this.config.dataSourceName);
-    const { result: requestPayload, errors: requestTemplateErrors, isReturn } = requestMappingTemplate.render(
+    const { result: requestPayload, errors: requestTemplateErrors, isReturn, stash } = requestMappingTemplate.render(
       { source, arguments: args },
       context,
       info,
@@ -49,7 +49,7 @@ export class AppSyncUnitResolver extends AppSyncBaseResolver {
     }
 
     const { result: responseTemplateResult, errors: responseTemplateErrors } = responseMappingTemplate.render(
-      { source, arguments: args, result, error },
+      { source, arguments: args, result, error, stash },
       context,
       info,
     );


### PR DESCRIPTION
stash from requestMappingTemplate should be available in responseMappingTemplate

*Description of changes:*
https://github.com/aws-amplify/amplify-cli/pull/3387 fixed this for pipeline resolvers, but the same applies to unit resolvers as well on real AWS. See stash documentation at https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.