### PR TITLE
fix: codegen statements spelling mistake

### DIFF
--- a/packages/amplify-codegen/commands/codegen/codegen.js
+++ b/packages/amplify-codegen/commands/codegen/codegen.js
@@ -16,7 +16,7 @@ module.exports = {
           description: constants.CMD_DESCRIPTION_GENERATE_TYPES,
         },
         {
-          name: 'statments [--nodownload] [--max-depth]',
+          name: 'statements [--nodownload] [--max-depth]',
           description: constants.CMD_DESCRIPTION_GENERATE_STATEMENTS,
         },
         {


### PR DESCRIPTION
*Description of changes:*
fix spelling mistake in `amplify codegen --help` output

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.