### PR TITLE
fix: isMockable() handles Lambda functions without dependsOn array

### DIFF
--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -138,7 +138,9 @@ export async function getInvoker(context: any, params: InvokerParameters): Promi
 export function isMockable(context: any, resourceName: string): IsMockableResponse {
   const { service, dependsOn } = context.amplify.getProjectMeta()[category][resourceName];
   const hasLayer =
-    service === ServiceName.LambdaFunction && dependsOn && dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
+    service === ServiceName.LambdaFunction &&
+    Array.isArray(dependsOn) &&
+    dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
   if (hasLayer) {
     return {
       isMockable: false,

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -138,7 +138,7 @@ export async function getInvoker(context: any, params: InvokerParameters): Promi
 export function isMockable(context: any, resourceName: string): IsMockableResponse {
   const { service, dependsOn } = context.amplify.getProjectMeta()[category][resourceName];
   const hasLayer =
-    service === ServiceName.LambdaFunction && dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
+    service === ServiceName.LambdaFunction && dependsOn && dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
   if (hasLayer) {
     return {
       isMockable: false,


### PR DESCRIPTION
*Issue #, if available:*
fixes  #4761

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.