### PR TITLE
feat: implement headless remove resource

### DIFF
--- a/packages/amplify-cli/src/utils/headless-input-utils.ts
+++ b/packages/amplify-cli/src/utils/headless-input-utils.ts
@@ -3,7 +3,7 @@ import readline from 'readline';
 const headlessPayloadReadTimeoutMillis = 2000;
 
 // checks if the --stdin flag is set on the amplify command;
-export const isHeadlessCommand = (context: any): boolean => context.input.options && context.input.options.yes;
+export const isHeadlessCommand = (context: any): boolean => context.input.options && context.input.options.headless;
 
 // waits for a line on stdin.
 // times out after the time specified above if no input received.


### PR DESCRIPTION
Implement headless mode for remove resource. Just implemented a --yes check on the removal confirmation prompt

Also, had to change the headless flag from --yes to --headless because overloading --yes causes the headless plugin entry to execute regardless of the command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.