### PR TITLE
fix: filter init env resources by function category

### DIFF
--- a/packages/amplify-category-function/src/__tests__/index.test.ts
+++ b/packages/amplify-category-function/src/__tests__/index.test.ts
@@ -1,0 +1,54 @@
+import { initEnv } from '../../src';
+import sequential from 'promise-sequential';
+
+jest.mock('promise-sequential');
+
+const sequential_mock = sequential as jest.MockedFunction<typeof sequential>;
+
+describe('function category provider', () => {
+  describe('initialize environment', () => {
+    it('only initializes function category resources', async () => {
+      const contextStub = {
+        amplify: {
+          removeResourceParameters: jest.fn(),
+          getResourceStatus: () => ({
+            resourcesToBeCreated: [
+              {
+                category: 'function',
+                resourceName: 'someResource',
+              },
+              {
+                category: 'other',
+                resourceName: 'dontIncludeMe',
+              },
+            ],
+            resourcesToBeDeleted: [
+              {
+                category: 'something',
+                resourceName: 'dontDeleteMe',
+              },
+              {
+                category: 'function',
+                resourceName: 'doDeleteThis',
+              },
+            ],
+            resourcesToBeUpdated: [
+              {
+                category: 'function',
+                resourceName: 'updateMe',
+              },
+              {
+                category: 'different',
+                resourceName: 'leaveThisOut',
+              },
+            ],
+          }),
+        },
+      };
+      await initEnv(contextStub);
+      expect(contextStub.amplify.removeResourceParameters.mock.calls.length).toBe(1);
+      expect(sequential_mock.mock.calls.length).toBe(1);
+      expect(sequential_mock.mock.calls[0][0].length).toBe(2);
+    });
+  });
+});

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -96,11 +96,14 @@ export async function initEnv(context) {
   const { amplify } = context;
   const { resourcesToBeCreated, resourcesToBeDeleted, resourcesToBeUpdated } = await amplify.getResourceStatus(category);
 
-  resourcesToBeDeleted.forEach(authResource => {
-    amplify.removeResourceParameters(context, category, authResource.resourceName);
+  // getResourceStatus will add dependencies of other types even when filtering by category, so we need to filter them out here
+  const resourceCategoryFilter = resource => resource.category === category;
+
+  resourcesToBeDeleted.filter(resourceCategoryFilter).forEach(functionResource => {
+    amplify.removeResourceParameters(context, category, functionResource.resourceName);
   });
 
-  const tasks = resourcesToBeCreated.concat(resourcesToBeUpdated);
+  const tasks = resourcesToBeCreated.concat(resourcesToBeUpdated).filter(resourceCategoryFilter);
 
   const functionTasks = tasks.map(functionResource => {
     const { resourceName, service } = functionResource;


### PR DESCRIPTION
*Issue #, if available:*
#4770, #4774

*Description of changes:*
Filter result of `amplify.getResourceStatus` to only include function resources

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.