### PR TITLE
fix(cli): throw error on attach backend

### DIFF
--- a/packages/amplify-cli/src/attach-backend.js
+++ b/packages/amplify-cli/src/attach-backend.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra');
 const path = require('path');
-const util = require('util');
 const queryProvider = require('./attach-backend-steps/a10-queryProvider');
 const analyzeProject = require('./attach-backend-steps/a20-analyzeProject');
 const initFrontend = require('./attach-backend-steps/a30-initFrontend');
@@ -24,8 +23,8 @@ async function attachBackend(context, inputParams) {
       removeFolderStructure(context);
       restoreOriginalAmplifyFolder(context);
       context.print.error('Failed to pull the backend.');
-      context.print.info(util.inspect(e));
       context.usageData.emitError(e);
+      throw e;
     });
 }
 

--- a/packages/amplify-cli/src/initialize-env.js
+++ b/packages/amplify-cli/src/initialize-env.js
@@ -62,14 +62,15 @@ async function initializeEnv(context, currentAmplifyMeta) {
       isPulling ? `Fetching updates to backend environment: ${currentEnv} from the cloud.` : `Initializing your environment: ${currentEnv}`,
     );
     await sequential(initializationTasks);
-    spinner.succeed(
-      isPulling ? `Successfully pulled backend environment ${currentEnv} from the cloud.` : 'Initialized provider successfully.',
-    );
 
     const projectDetails = context.amplify.getProjectDetails();
     context.exeInfo = context.exeInfo || {};
     Object.assign(context.exeInfo, projectDetails);
     await sequential(categoryInitializationTasks);
+
+    spinner.succeed(
+      isPulling ? `Successfully pulled backend environment ${currentEnv} from the cloud.` : 'Initialized provider successfully.',
+    );
 
     if (context.exeInfo.forcePush === undefined) {
       context.exeInfo.forcePush = await context.amplify.confirmPrompt.run(


### PR DESCRIPTION
throw pull error when running into issues on attaching backend and move spinner back until
categories are initialized to show success message

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.