### PR TITLE
enhance(mock): print dynamodb-local endpoint url when running mock

### DIFF
--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -60,6 +60,7 @@ export class APITest {
       await this.generateTestFrontendExports(context);
       await this.generateCode(context, appSyncConfig);
 
+      context.print.info(`DynamoDB Local endpoint is running at ${this.ddbClient.endpoint.href}`);
       context.print.info(`AppSync Mock endpoint is running at ${this.appSyncSimulator.url}`);
     } catch (e) {
       context.print.error(`Failed to start API Mock endpoint ${e}`);


### PR DESCRIPTION
*Issue:*
NA

*Description of changes:*
Adds a line to the `mock` command output, printing the address of the dynamodb-local endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.