### PR TITLE
fix: update function not loading previous selections

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
@@ -38,8 +38,11 @@ export const addLayersToFunctionWalkthrough = async (
 
   if (lambdaLayers.length === 0) {
     context.print.info('No Lambda layers were selected');
-    const removeMessage = `Removing ${previousSelections.length} previously added Lambda layer`;
-    context.print.info(removeMessage + (previousSelections.length === 1 ? '' : 's') + ' from Lambda function');
+    if (previousSelections.length > 0) {
+      const plural = previousSelections.length > 1 ? 's' : '';
+      const removeMessage = `Removing ${previousSelections.length} previously added Lambda layer${plural} from Lambda function`;
+      context.print.info(removeMessage);
+    }
   }
 
   lambdaLayers = await askLayerOrderQuestion(lambdaLayers, previousSelections);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
@@ -21,7 +21,7 @@ export const addLayersToFunctionWalkthrough = async (
 
   // ask initial confirmation
   if (!(await context.amplify.confirmPrompt.run(confirmationPrompt, false))) {
-    return { lambdaLayers, dependsOn };
+    return { lambdaLayers: previousSelections, dependsOn };
   }
 
   let askArnQuestion: boolean;
@@ -38,6 +38,8 @@ export const addLayersToFunctionWalkthrough = async (
 
   if (lambdaLayers.length === 0) {
     context.print.info('No Lambda layers were selected');
+    const removeMessage = `Removing ${previousSelections.length} previously added Lambda layer`;
+    context.print.info(removeMessage + (previousSelections.length === 1 ? '' : 's') + ' from Lambda function');
   }
 
   lambdaLayers = await askLayerOrderQuestion(lambdaLayers, previousSelections);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -40,7 +40,7 @@ export async function createWalkthrough(
   templateParameters = merge(templateParameters, await templateWalkthrough(context, templateParameters));
 
   if (await context.amplify.confirmPrompt.run('Do you want to access other resources in this project from your Lambda function?')) {
-    templateParameters = merge(templateParameters, await askExecRolePermissionsQuestions(context));
+    templateParameters = merge(templateParameters, await askExecRolePermissionsQuestions(context, templateParameters.functionName));
   }
 
   // ask scheduling Lambda questions and merge in results
@@ -103,7 +103,10 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
       'Do you want to update the Lambda function permissions to access other resources in this project?',
     )
   ) {
-    merge(functionParameters, await askExecRolePermissionsQuestions(context, currentParameters.permissions));
+    merge(
+      functionParameters,
+      await askExecRolePermissionsQuestions(context, lambdaToUpdate, _.get(currentParameters, ['mutableParametersState', 'permissions'])),
+    );
 
     const cfnFileName = `${functionParameters.resourceName}-cloudformation-template.json`;
     const cfnFilePath = path.join(resourceDirPath, cfnFileName);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/permissionMapUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/permissionMapUtils.ts
@@ -1,13 +1,13 @@
-import _ from "lodash"
+import _ from 'lodash';
 
-export const fetchPermissionCategories = (permissionMap) => {
+export const fetchPermissionCategories = permissionMap => {
   return _.keys(permissionMap);
-}
+};
 
 export const fetchPermissionResourcesForCategory = (permissionMap, category: string) => {
   return _.keys(_.get(permissionMap, [category]));
-}
+};
 
 export const fetchPermissionsForResourceInCategory = (permissionMap, category: string, resourceName: string) => {
   return _.get(permissionMap, [category, resourceName]);
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -20031,6 +20031,11 @@ uuid@^8.1.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
   integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
 
+uuid@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
+  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
+
 v8-compile-cache@^2.0.3:
   version "2.1.1"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"


### PR DESCRIPTION
`amplify update function` was not correctly loading previously selected values and would overwrite
other values as a result

Added filter selecting permissions to prevent adding layers or a function to itself

#4785


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.