### PR TITLE
added new error message

### DIFF
--- a/packages/amplify-provider-awscloudformation/lib/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/lib/push-resources.js
@@ -249,9 +249,12 @@ function packageResources(context, resources) {
         });
 
         if (cfnFiles.length !== 1) {
-          context.print.error('Only one CloudFormation template is allowed in the resource directory');
+          const errorMessage = cfnFiles.length > 1 
+            ? 'Only one CloudFormation template is allowed in the resource directory'
+            : 'CloudFormation template is missing in the resource directory'
+          context.print.error(errorMessage);
           context.print.error(resourceDir);
-          throw new Error('Only one CloudFormation template is allowed in the resource directory');
+          throw new Error(errorMessage);
         }
 
         const cfnFile = cfnFiles[0];


### PR DESCRIPTION
*Issue #, if available:*
Given it is pretty trivial, there is no issue # associated with it.

*Description of changes:*
Something short and sweet. 

When I do amplify push with either zero or two or more CloudFormation Template, the error message stays the same which is confusing and misleading for me.

On my team, due to someone mistakenly removing one of the cloudformation template, our amplify push did not work and the error messages was very misleading and suggested there might be more hidden Cloudformation template somewhere getting used until I realized it was just missing the template instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.