### PR TITLE
Update Resolver Ver in @model

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -112,7 +112,7 @@ export class VelocityTemplate {
       stash: convertToJavaTypes(stash || {}),
       source: convertToJavaTypes(source),
       result: convertToJavaTypes(result),
-      error,
+      error: error ? { ...error, type: error.extensions.errorType } : error,
     };
 
     if (typeof prevResult !== 'undefined') {

--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -112,6 +112,8 @@ export class VelocityTemplate {
       stash: convertToJavaTypes(stash || {}),
       source: convertToJavaTypes(source),
       result: convertToJavaTypes(result),
+      // surfacing the errorType to ensure the type is included in $ctx.error
+      // Mapping Template Errors: https://docs.aws.amazon.com/appsync/latest/devguide/troubleshooting-and-common-mistakes.html#mapping-template-errors
       error: error ? { ...error, type: error.extensions.errorType } : error,
     };
 

--- a/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
@@ -171,7 +171,7 @@ beforeAll(async () => {
       USERNAME1,
       USERNAME1,
       [ADMIN_GROUP_NAME, PARTICIPANT_GROUP_NAME, WATCHER_GROUP_NAME],
-      'access'
+      'access',
     );
     GRAPHQL_CLIENT_1_ACCESS = new GraphQLClient(GRAPHQL_ENDPOINT, {
       Authorization: accessToken,
@@ -222,7 +222,7 @@ test('Test createPost mutation', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response);
   expect(response.data.createPost.id).toBeDefined();
@@ -242,7 +242,7 @@ test('Test createPost mutation', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response2);
   expect(response2.data.createPost.id).toBeDefined();
@@ -263,7 +263,7 @@ test('Test getPost query when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response);
   expect(response.data.createPost.id).toBeDefined();
@@ -281,7 +281,7 @@ test('Test getPost query when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(getResponse);
   expect(getResponse.data.getPost.id).toBeDefined();
@@ -300,7 +300,7 @@ test('Test getPost query when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(getResponseAccess.data.getPost.id).toBeDefined();
   expect(getResponseAccess.data.getPost.title).toEqual('Hello, World!');
@@ -320,7 +320,7 @@ test('Test getPost query when not authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(response.data.createPost.id).toBeDefined();
   expect(response.data.createPost.title).toEqual('Hello, World!');
@@ -337,7 +337,7 @@ test('Test getPost query when not authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(getResponse.data.getPost).toEqual(null);
   expect(getResponse.errors.length).toEqual(1);
@@ -355,7 +355,7 @@ test('Test updatePost mutation when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(response.data.createPost.id).toBeDefined();
   expect(response.data.createPost.title).toEqual('Hello, World!');
@@ -372,7 +372,7 @@ test('Test updatePost mutation when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(updateResponse.data.updatePost.id).toEqual(response.data.createPost.id);
   expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
@@ -388,7 +388,7 @@ test('Test updatePost mutation when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(updateResponseAccess.data.updatePost.id).toEqual(response.data.createPost.id);
   expect(updateResponseAccess.data.updatePost.title).toEqual('Bye, World!');
@@ -406,7 +406,7 @@ test('Test updatePost mutation when not authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(response.data.createPost.id).toBeDefined();
   expect(response.data.createPost.title).toEqual('Hello, World!');
@@ -423,11 +423,12 @@ test('Test updatePost mutation when not authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(updateResponse.data.updatePost).toEqual(null);
   expect(updateResponse.errors.length).toEqual(1);
   logDebug(updateResponse);
+  expect((updateResponse.errors[0] as any).data).toBeNull();
   expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });
 
@@ -442,7 +443,7 @@ test('Test deletePost mutation when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(response.data.createPost.id).toBeDefined();
   expect(response.data.createPost.title).toEqual('Hello, World!');
@@ -455,7 +456,7 @@ test('Test deletePost mutation when authorized', async () => {
             id
         }
     }`,
-    {}
+    {},
   );
   expect(deleteResponse.data.deletePost.id).toEqual(response.data.createPost.id);
 
@@ -469,7 +470,7 @@ test('Test deletePost mutation when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(responseAccess.data.createPost.id).toBeDefined();
   expect(responseAccess.data.createPost.title).toEqual('Hello, World!');
@@ -482,7 +483,7 @@ test('Test deletePost mutation when authorized', async () => {
             id
         }
     }`,
-    {}
+    {},
   );
   expect(deleteResponseAccess.data.deletePost.id).toEqual(responseAccess.data.createPost.id);
 });
@@ -498,7 +499,7 @@ test('Test deletePost mutation when not authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(response.data.createPost.id).toBeDefined();
   expect(response.data.createPost.title).toEqual('Hello, World!');
@@ -511,10 +512,11 @@ test('Test deletePost mutation when not authorized', async () => {
             id
         }
     }`,
-    {}
+    {},
   );
   expect(deleteResponse.data.deletePost).toEqual(null);
   expect(deleteResponse.errors.length).toEqual(1);
+  expect((deleteResponse.errors[0] as any).data).toBeNull();
   expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });
 
@@ -529,7 +531,7 @@ test('Test listPosts query when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   expect(firstPost.data.createPost.id).toBeDefined();
   expect(firstPost.data.createPost.title).toEqual('testing list');
@@ -546,7 +548,7 @@ test('Test listPosts query when authorized', async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   // There are two posts but only 1 created by me.
   const listResponse = await GRAPHQL_CLIENT_1.query(
@@ -557,7 +559,7 @@ test('Test listPosts query when authorized', async () => {
             }
         }
     }`,
-    {}
+    {},
   );
   logDebug(JSON.stringify(listResponse, null, 4));
   expect(listResponse.data.listPosts.items.length).toEqual(1);
@@ -570,7 +572,7 @@ test('Test listPosts query when authorized', async () => {
             }
         }
     }`,
-    {}
+    {},
   );
   logDebug(JSON.stringify(listResponseAccess, null, 4));
   expect(listResponseAccess.data.listPosts.items.length).toEqual(1);
@@ -662,6 +664,7 @@ test(`Test updating someone else's salary when I am not admin.`, async () => {
     `);
   expect(req2.data.updateSalary).toEqual(null);
   expect(req2.errors.length).toEqual(1);
+  expect((req2.errors[0] as any).data).toBeNull();
   expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });
 
@@ -712,6 +715,7 @@ test(`Test deleteSalary w/ Admin group protection not authorized`, async () => {
     `);
   expect(req2.data.deleteSalary).toEqual(null);
   expect(req2.errors.length).toEqual(1);
+  expect((req2.errors[0] as any).data).toBeNull();
   expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });
 
@@ -2273,6 +2277,7 @@ test(`Test updateAllThree and deleteAllThree as a member of the alternative grou
     `);
   logDebug(JSON.stringify(ownedByAdminsUnauthed, null, 4));
   expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
+  expect((ownedByAdminsUnauthed.errors[0] as any).data).toBeNull();
   expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 
   const ownedByDevs2 = await GRAPHQL_CLIENT_1.query(`
@@ -2377,7 +2382,7 @@ test(`Test createTestIdentity as admin.`, async () => {
             }
         }
     }`,
-    {}
+    {},
   );
   const relevantPost = listResponse.data.listTestIdentitys.items.find(p => p.id === getReq.data.getTestIdentity.id);
   logDebug(JSON.stringify(listResponse, null, 4));
@@ -2415,7 +2420,7 @@ test("Test get and list with 'read' operation set", async () => {
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response);
   expect(response.data.createOwnerReadProtected.id).toBeDefined();
@@ -2428,7 +2433,7 @@ test("Test get and list with 'read' operation set", async () => {
             id content owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response2);
   expect(response2.data.getOwnerReadProtected).toBeNull();
@@ -2440,7 +2445,7 @@ test("Test get and list with 'read' operation set", async () => {
             id content owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response3);
   expect(response3.data.getOwnerReadProtected.id).toBeDefined();
@@ -2455,7 +2460,7 @@ test("Test get and list with 'read' operation set", async () => {
             }
         }
     }`,
-    {}
+    {},
   );
   logDebug(response4);
   expect(response4.data.listOwnerReadProtecteds.items.length).toBeGreaterThanOrEqual(1);
@@ -2468,7 +2473,7 @@ test("Test get and list with 'read' operation set", async () => {
             }
         }
     }`,
-    {}
+    {},
   );
   logDebug(response5);
   expect(response5.data.listOwnerReadProtecteds.items).toHaveLength(0);
@@ -2483,7 +2488,7 @@ test("Test createOwnerCreateUpdateDeleteProtected with 'create' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response);
   expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
@@ -2498,7 +2503,7 @@ test("Test createOwnerCreateUpdateDeleteProtected with 'create' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response2);
   expect(response2.data.createOwnerCreateUpdateDeleteProtected).toBeNull();
@@ -2514,7 +2519,7 @@ test("Test updateOwnerCreateUpdateDeleteProtected with 'update' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response);
   expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
@@ -2534,7 +2539,7 @@ test("Test updateOwnerCreateUpdateDeleteProtected with 'update' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response2);
   expect(response2.data.updateOwnerCreateUpdateDeleteProtected).toBeNull();
@@ -2553,7 +2558,7 @@ test("Test updateOwnerCreateUpdateDeleteProtected with 'update' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response3);
   expect(response3.data.updateOwnerCreateUpdateDeleteProtected.id).toBeDefined();
@@ -2570,7 +2575,7 @@ test("Test deleteOwnerCreateUpdateDeleteProtected with 'update' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response);
   expect(response.data.createOwnerCreateUpdateDeleteProtected.id).toBeDefined();
@@ -2589,7 +2594,7 @@ test("Test deleteOwnerCreateUpdateDeleteProtected with 'update' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response2);
   expect(response2.data.deleteOwnerCreateUpdateDeleteProtected).toBeNull();
@@ -2607,7 +2612,7 @@ test("Test deleteOwnerCreateUpdateDeleteProtected with 'update' operation set", 
             owner
         }
     }`,
-    {}
+    {},
   );
   logDebug(response3);
   expect(response3.data.deleteOwnerCreateUpdateDeleteProtected.id).toBeDefined();

--- a/packages/amplify-util-mock/src/__e2e__/per-field-auth-tests.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/per-field-auth-tests.e2e.test.ts
@@ -190,7 +190,7 @@ test('Test that only Admins can create Employee records.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(createUser1);
   expect(createUser1.data.createEmployee.email).toEqual('user2@test.com');
@@ -204,7 +204,7 @@ test('Test that only Admins can create Employee records.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToCreateAsNonAdmin);
   expect(tryToCreateAsNonAdmin.data.createEmployee).toBeNull();
@@ -218,7 +218,7 @@ test('Test that only Admins can create Employee records.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToCreateAsNonAdmin2);
   expect(tryToCreateAsNonAdmin2.data.createEmployee).toBeNull();
@@ -234,7 +234,7 @@ test('Test that only Admins may update salary & email.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(createUser1);
   const employeeId = createUser1.data.createEmployee.id;
@@ -250,7 +250,7 @@ test('Test that only Admins may update salary & email.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToUpdateAsNonAdmin);
   expect(tryToUpdateAsNonAdmin.data.updateEmployee).toBeNull();
@@ -264,7 +264,7 @@ test('Test that only Admins may update salary & email.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToUpdateAsNonAdmin2);
   expect(tryToUpdateAsNonAdmin2.data.updateEmployee).toBeNull();
@@ -278,7 +278,7 @@ test('Test that only Admins may update salary & email.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToUpdateAsNonAdmin3);
   expect(tryToUpdateAsNonAdmin3.data.updateEmployee).toBeNull();
@@ -292,7 +292,7 @@ test('Test that only Admins may update salary & email.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(updateAsAdmin);
   expect(updateAsAdmin.data.updateEmployee.email).toEqual('someonelese@gmail.com');
@@ -306,7 +306,7 @@ test('Test that only Admins may update salary & email.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(updateAsAdmin2);
   expect(updateAsAdmin2.data.updateEmployee.email).toEqual('someonelese@gmail.com');
@@ -322,7 +322,7 @@ test('Test that owners may update their bio.', async () => {
           salary
       }
   }`,
-    {}
+    {},
   );
   logDebug(createUser1);
   const employeeId = createUser1.data.createEmployee.id;
@@ -339,7 +339,7 @@ test('Test that owners may update their bio.', async () => {
           bio
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToUpdateAsNonAdmin);
   expect(tryToUpdateAsNonAdmin.data.updateEmployee.bio).toEqual('Does cool stuff.');
@@ -357,7 +357,7 @@ test('Test that everyone may view employee bios.', async () => {
           bio
       }
   }`,
-    {}
+    {},
   );
   logDebug(createUser1);
   const employeeId = createUser1.data.createEmployee.id;
@@ -374,7 +374,7 @@ test('Test that everyone may view employee bios.', async () => {
           bio
       }
   }`,
-    {}
+    {},
   );
   logDebug(getAsNonAdmin);
   // Should not be able to view the email as the non owner
@@ -392,7 +392,7 @@ test('Test that everyone may view employee bios.', async () => {
           }
       }
   }`,
-    {}
+    {},
   );
   logDebug(listAsNonAdmin);
   expect(listAsNonAdmin.data.listEmployees.items.length).toBeGreaterThan(1);
@@ -416,7 +416,7 @@ test('Test that only owners may "delete" i.e. update the field to null.', async 
           notes
       }
   }`,
-    {}
+    {},
   );
   logDebug(createUser1);
   const employeeId = createUser1.data.createEmployee.id;
@@ -432,7 +432,7 @@ test('Test that only owners may "delete" i.e. update the field to null.', async 
           notes
       }
   }`,
-    {}
+    {},
   );
   logDebug(tryToDeleteUserNotes);
   expect(tryToDeleteUserNotes.data.updateEmployee).toBeNull();
@@ -445,7 +445,7 @@ test('Test that only owners may "delete" i.e. update the field to null.', async 
           notes
       }
   }`,
-    {}
+    {},
   );
   expect(updateNewsWithNotes.data.updateEmployee.notes).toEqual('something else');
 
@@ -456,7 +456,7 @@ test('Test that only owners may "delete" i.e. update the field to null.', async 
           notes
       }
   }`,
-    {}
+    {},
   );
   expect(updateAsAdmin.data.updateEmployee).toBeNull();
   expect(updateAsAdmin.errors).toHaveLength(1);
@@ -468,7 +468,7 @@ test('Test that only owners may "delete" i.e. update the field to null.', async 
           notes
       }
   }`,
-    {}
+    {},
   );
   expect(deleteNotes.data.updateEmployee.notes).toBeNull();
 });
@@ -489,7 +489,7 @@ test('Test with auth with subscriptions on default behavior', async () => {
           owner
       }
   }`,
-    {}
+    {},
   );
   logDebug(createStudent2);
   expect(createStudent2.data.createStudent.id).toBeDefined();
@@ -507,7 +507,7 @@ test('Test with auth with subscriptions on default behavior', async () => {
           owner
       }
   }`,
-    {}
+    {},
   );
   logDebug(queryForStudent2);
   expect(queryForStudent2.data.getStudent.notes).toEqual(secureNote1);
@@ -523,7 +523,7 @@ test('Test with auth with subscriptions on default behavior', async () => {
           owner
       }
   }`,
-    {}
+    {},
   );
   console.log(JSON.stringify(queryAsStudent1));
   expect(queryAsStudent1.data.getStudent.notes).toBeNull();
@@ -552,6 +552,7 @@ test('AND per-field dynamic auth rule test', async () => {
     }
     `);
   logDebug(badUpdatePostResponse);
+  expect(badUpdatePostResponse.errors[0].data).toBeNull();
   expect(badUpdatePostResponse.errors[0].errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 
   const correctUpdatePostResponse = await GRAPHQL_CLIENT_1.query(`mutation UpdatePost {

--- a/packages/amplify-util-mock/src/__e2e__/versioned-model-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/versioned-model-transformer.e2e.test.ts
@@ -73,7 +73,7 @@ test('Test createPost mutation', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(response.data.createPost.id).toBeDefined();
   expect(response.data.createPost.title).toEqual('Hello, World!');
@@ -93,7 +93,7 @@ test('Test updatePost mutation', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual('Test Update');
@@ -110,7 +110,7 @@ test('Test updatePost mutation', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
   expect(updateResponse.data.updatePost.version).toEqual(2);
@@ -127,7 +127,7 @@ test('Test failed updatePost mutation with wrong version', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual('Test Update');
@@ -144,9 +144,10 @@ test('Test failed updatePost mutation with wrong version', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(updateResponse.errors.length).toEqual(1);
+  expect((updateResponse.errors[0] as any).data).toBeNull();
   expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });
 
@@ -161,7 +162,7 @@ test('Test deletePost mutation', async () => {
             updatedAt
         }
     }`,
-    {}
+    {},
   );
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual('Test Delete');
@@ -174,7 +175,7 @@ test('Test deletePost mutation', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(deleteResponse.data.deletePost.title).toEqual('Test Delete');
   expect(deleteResponse.data.deletePost.version).toEqual(createResponse.data.createPost.version);
@@ -191,7 +192,7 @@ test('Test deletePost mutation with wrong version', async () => {
             updatedAt
         }
     }`,
-    {}
+    {},
   );
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual('Test Delete');
@@ -204,8 +205,9 @@ test('Test deletePost mutation with wrong version', async () => {
             version
         }
     }`,
-    {}
+    {},
   );
   expect(deleteResponse.errors.length).toEqual(1);
+  expect((deleteResponse.errors[0] as any).data).toBeNull();
   expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });

--- a/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
+++ b/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts
@@ -2276,7 +2276,7 @@ found '${rule.provider}' assigned.`,
   }
 
   private isOperationExpressionSet(operationTypeName: string, template: string): boolean {
-    return template.includes(`$context.result.operation = "${operationTypeName}"`);
+    return template.includes(`$ctx.result.put("operation", "${operationTypeName}")`);
   }
 
   private updateMutationConditionInput(ctx: TransformerContext, type: ObjectTypeDefinitionNode, rules: Array<AuthRule>): void {

--- a/packages/graphql-auth-transformer/src/__tests__/PerFieldAuthArgument.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/PerFieldAuthArgument.test.ts
@@ -40,13 +40,13 @@ test('Test that subscriptions are only generated if the respective mutation oper
   expect(out.resolvers['Salary.secret.res.vtl']).toContain('#if( $operation == "Mutation" )');
   expect(out.resolvers['Salary.secret.res.vtl']).toMatchSnapshot();
 
-  expect(out.resolvers['Mutation.createSalary.res.vtl']).toContain('#set( $context.result.operation = "Mutation" )');
+  expect(out.resolvers['Mutation.createSalary.res.vtl']).toContain('$util.qr($ctx.result.put("operation", "Mutation"))');
   expect(out.resolvers['Mutation.createSalary.res.vtl']).toMatchSnapshot();
 
-  expect(out.resolvers['Mutation.updateSalary.res.vtl']).toContain('#set( $context.result.operation = "Mutation" )');
+  expect(out.resolvers['Mutation.updateSalary.res.vtl']).toContain('$util.qr($ctx.result.put("operation", "Mutation"))');
   expect(out.resolvers['Mutation.updateSalary.res.vtl']).toMatchSnapshot();
 
-  expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toContain('#set( $context.result.operation = "Mutation" )');
+  expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toContain('$util.qr($ctx.result.put("operation", "Mutation"))');
   expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toMatchSnapshot();
 });
 

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -1,8 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test "create", "update", "delete" auth operations 1`] = `"$util.toJson($ctx.result)"`;
+exports[`Test "create", "update", "delete" auth operations 1`] = `
+"#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
+`;
 
-exports[`Test "create", "update", "delete" auth operations 2`] = `"$util.toJson($ctx.result)"`;
+exports[`Test "create", "update", "delete" auth operations 2`] = `
+"#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
+`;
 
 exports[`Test "create", "update", "delete" auth operations 3`] = `
 "## [Start] Set default values. **
@@ -71,7 +83,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -294,7 +306,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {
@@ -453,7 +465,7 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"DeleteItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -633,9 +645,21 @@ exports[`Test that checks subscription resolvers are generated with auth logic 3
 $util.toJson(null)"
 `;
 
-exports[`Test that operation overwrites queries in auth operations 1`] = `"$util.toJson($ctx.result)"`;
+exports[`Test that operation overwrites queries in auth operations 1`] = `
+"#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
+`;
 
-exports[`Test that operation overwrites queries in auth operations 2`] = `"$util.toJson($ctx.result)"`;
+exports[`Test that operation overwrites queries in auth operations 2`] = `
+"#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
+`;
 
 exports[`Test that operation overwrites queries in auth operations 3`] = `
 "## [Start] Set default values. **
@@ -704,7 +728,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -927,7 +951,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {
@@ -1086,7 +1110,7 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"DeleteItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/PerFieldAuthArgument.test.ts.snap
@@ -36,24 +36,36 @@ $util.toJson($context.source.secret)
 
 exports[`Test that subscriptions are only generated if the respective mutation operation exists 2`] = `
 "## [Start] Setting the operation **
-#set( $context.result.operation = \\"Mutation\\" )
+$util.qr($ctx.result.put(\\"operation\\", \\"Mutation\\"))
 ## [End] Setting the operation **
 
-$util.toJson($ctx.result)"
+#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
 `;
 
 exports[`Test that subscriptions are only generated if the respective mutation operation exists 3`] = `
 "## [Start] Setting the operation **
-#set( $context.result.operation = \\"Mutation\\" )
+$util.qr($ctx.result.put(\\"operation\\", \\"Mutation\\"))
 ## [End] Setting the operation **
 
-$util.toJson($ctx.result)"
+#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
 `;
 
 exports[`Test that subscriptions are only generated if the respective mutation operation exists 4`] = `
 "## [Start] Setting the operation **
-#set( $context.result.operation = \\"Mutation\\" )
+$util.qr($ctx.result.put(\\"operation\\", \\"Mutation\\"))
 ## [End] Setting the operation **
 
-$util.toJson($ctx.result)"
+#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end"
 `;

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -25,6 +25,7 @@ import {
   ifElse,
   newline,
   methodCall,
+  RESOLVER_VERSION_ID,
 } from 'graphql-mapping-template';
 import { ResourceConstants, NONE_VALUE } from 'graphql-transformer-common';
 import GraphQLApi, {
@@ -226,7 +227,7 @@ export class ResourceFactory {
       TypeName: type,
       RequestMappingTemplate: print(
         obj({
-          version: str('2017-02-28'),
+          version: str(RESOLVER_VERSION_ID),
           payload: obj({}),
         }),
       ),
@@ -900,7 +901,7 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
       TypeName: subscriptionTypeName,
       RequestMappingTemplate: print(
         raw(`{
-    "version": "2018-05-29",
+    "version": "${RESOLVER_VERSION_ID}",
     "payload": {}
 }`),
       ),
@@ -916,7 +917,7 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
   }
 
   public setOperationExpression(operation: string): string {
-    return print(block('Setting the operation', [set(ref('context.result.operation'), str(operation))]));
+    return print(block('Setting the operation', [qref(print(methodCall(ref('ctx.result.put'), str('operation'), str(operation))))]));
   }
 
   public getAuthModeCheckWrappedExpression(expectedAuthModes: Set<AuthProvider>, expression: Expression): Expression {

--- a/packages/graphql-connection-transformer/src/resources.ts
+++ b/packages/graphql-connection-transformer/src/resources.ts
@@ -164,7 +164,7 @@ export class ResourceFactory {
           key: keyObj,
         }),
       ),
-      ResponseMappingTemplate: print(ref('util.toJson($context.result)')),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(false)),
     }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
   }
 
@@ -226,7 +226,10 @@ export class ResourceFactory {
         ]),
       ),
       ResponseMappingTemplate: print(
-        compoundExpression([iff(raw('!$result'), set(ref('result'), ref('ctx.result'))), raw('$util.toJson($result)')]),
+        DynamoDBMappingTemplate.dynamoDBResponse(
+          false,
+          compoundExpression([iff(raw('!$result'), set(ref('result'), ref('ctx.result'))), raw('$util.toJson($result)')]),
+        ),
       ),
     }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
   }
@@ -286,7 +289,7 @@ export class ResourceFactory {
           }),
         ]),
       ),
-      ResponseMappingTemplate: print(ref('util.toJson($context.result)')),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(false)),
     }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
   }
 
@@ -360,7 +363,10 @@ export class ResourceFactory {
       TypeName: type,
       RequestMappingTemplate: print(compoundExpression([...setup, queryObj])),
       ResponseMappingTemplate: print(
-        compoundExpression([iff(raw('!$result'), set(ref('result'), ref('ctx.result'))), raw('$util.toJson($result)')]),
+        DynamoDBMappingTemplate.dynamoDBResponse(
+          false,
+          compoundExpression([iff(raw('!$result'), set(ref('result'), ref('ctx.result'))), raw('$util.toJson($result)')]),
+        ),
       ),
     }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
   }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -299,7 +299,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -433,7 +433,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {
@@ -579,7 +579,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -711,7 +711,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {
@@ -879,7 +879,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -1011,7 +1011,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {
@@ -1283,7 +1283,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -1417,7 +1417,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -19,6 +19,7 @@ import {
   comment,
   forEach,
   and,
+  RESOLVER_VERSION_ID,
 } from 'graphql-mapping-template';
 import {
   ResourceConstants,
@@ -713,7 +714,7 @@ export class ResourceFactory {
           set(
             ref(requestVariable),
             obj({
-              version: isSyncEnabled ? str('2018-05-29') : str('2017-02-28'),
+              version: str(RESOLVER_VERSION_ID),
               limit: ref('limit'),
             }),
           ),

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -17,6 +17,7 @@ import {
   forEach,
   list,
   and,
+  RESOLVER_VERSION_ID,
 } from 'graphql-mapping-template';
 import {
   ResolverResourceIDs,
@@ -820,7 +821,7 @@ function makeQueryResolver(definition: ObjectTypeDefinitionNode, directive: Dire
         set(
           ref(requestVariable),
           obj({
-            version: str('2017-02-28'),
+            version: str(RESOLVER_VERSION_ID),
             operation: str('Query'),
             limit: ref('limit'),
             query: ref(ResourceConstants.SNIPPETS.ModelQueryExpression),
@@ -842,7 +843,12 @@ function makeQueryResolver(definition: ObjectTypeDefinitionNode, directive: Dire
         raw(`$util.toJson($${requestVariable})`),
       ]),
     ),
-    ResponseMappingTemplate: print(raw('$util.toJson($ctx.result)')),
+    ResponseMappingTemplate: print(
+      compoundExpression([
+        iff(ref('ctx.error'), raw('$util.error($ctx.error.message, $ctx.error.type)')),
+        raw('$util.toJson($ctx.result)'),
+      ]),
+    ),
   });
 }
 

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -49,7 +49,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"PutItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
@@ -58,7 +58,11 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
   \\"condition\\": $util.toJson($condition)
 }
 ## [End] Prepare DynamoDB PutItem Request. **",
-  "Mutation.createItem.res.vtl": "$util.toJson($ctx.result)",
+  "Mutation.createItem.res.vtl": "#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end",
   "Mutation.deleteItem.req.vtl": "
 
 ## [Start] Set the primary @key. **
@@ -124,14 +128,18 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 } )
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"DeleteItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
 } #end,
   \\"condition\\": $util.toJson($condition)
 }",
-  "Mutation.deleteItem.res.vtl": "$util.toJson($ctx.result)",
+  "Mutation.deleteItem.res.vtl": "#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end",
   "Mutation.updateItem.req.vtl": "
 
 
@@ -272,7 +280,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($update.put(\\"expressionValues\\", $expValues))
 #end
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"UpdateItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": {
@@ -282,7 +290,11 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   \\"update\\": $util.toJson($update),
   \\"condition\\": $util.toJson($condition)
 }",
-  "Mutation.updateItem.res.vtl": "$util.toJson($ctx.result)",
+  "Mutation.updateItem.res.vtl": "#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end",
   "Query.getItem.req.vtl": "## [Start] Set the primary @key. **
 #set( $modelObjectKey = {
   \\"orderId\\": $util.dynamodb.toDynamoDB($ctx.args.orderId),
@@ -290,13 +302,17 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 } )
 ## [End] Set the primary @key. **
 {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"GetItem\\",
   \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   \\"id\\": $util.dynamodb.toDynamoDBJson($ctx.args.id)
 } #end
 }",
-  "Query.getItem.res.vtl": "$util.toJson($ctx.result)",
+  "Query.getItem.res.vtl": "#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end",
   "Query.itemsByCreatedAt.req.vtl": "## [Start] Set query expression for @key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -356,7 +372,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 ## [End] Set query expression for @key **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $QueryRequest = {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Query\\",
   \\"limit\\": $limit,
   \\"query\\": $modelQueryExpression,
@@ -431,7 +447,7 @@ $util.toJson($QueryRequest)",
 ## [End] Set query expression for @key **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $QueryRequest = {
-  \\"version\\": \\"2017-02-28\\",
+  \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Query\\",
   \\"limit\\": $limit,
   \\"query\\": $modelQueryExpression,
@@ -577,7 +593,11 @@ $util.toJson($QueryRequest)",
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 $util.toJson($ListRequest)",
-  "Query.listItems.res.vtl": "$util.toJson($ctx.result)",
+  "Query.listItems.res.vtl": "#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end",
 }
 `;
 

--- a/packages/graphql-mapping-template/src/dynamodb.ts
+++ b/packages/graphql-mapping-template/src/dynamodb.ts
@@ -164,10 +164,8 @@ export class DynamoDBMappingTemplate {
     condition: ObjectNode | ReferenceNode;
     isSyncEnabled: boolean;
   }): ObjectNode {
-    const version: string = isSyncEnabled ? '2018-05-29' : RESOLVER_VERSION_ID;
-
     return obj({
-      version: str(version),
+      version: str(RESOLVER_VERSION_ID),
       operation: str('DeleteItem'),
       key,
       condition,
@@ -288,7 +286,9 @@ export class DynamoDBMappingTemplate {
     const errorExpresion = isSyncEnabled
       ? ref('util.error($ctx.error.message, $ctx.error.type, $ctx.result)')
       : ref('util.error($ctx.error.message, $ctx.error.type)');
-    const resultExpression = returnExpression ? returnExpression : ref('util.toJson($ctx.result)');
+    const resultExpression = returnExpression
+      ? returnExpression
+      : ref('util.toJson($ctx.result)');
     return compoundExpression([ifElse(ref('ctx.error'), errorExpresion, resultExpression)]);
   }
 

--- a/packages/graphql-mapping-template/src/dynamodb.ts
+++ b/packages/graphql-mapping-template/src/dynamodb.ts
@@ -17,7 +17,7 @@ import {
   CompoundExpressionNode,
 } from './ast';
 
-const RESOLVER_VERSION_ID = '2018-05-29';
+export const RESOLVER_VERSION_ID = '2018-05-29';
 
 export class DynamoDBMappingTemplate {
   /**

--- a/packages/graphql-mapping-template/src/dynamodb.ts
+++ b/packages/graphql-mapping-template/src/dynamodb.ts
@@ -17,7 +17,7 @@ import {
   CompoundExpressionNode,
 } from './ast';
 
-const RESOLVER_VERSION_ID = '2017-02-28';
+const RESOLVER_VERSION_ID = '2018-05-29';
 
 export class DynamoDBMappingTemplate {
   /**
@@ -34,7 +34,7 @@ export class DynamoDBMappingTemplate {
       attributeValues: Expression;
       condition?: ObjectNode | ReferenceNode;
     },
-    version: string = RESOLVER_VERSION_ID
+    version: string = RESOLVER_VERSION_ID,
   ): ObjectNode {
     return obj({
       version: str(version),
@@ -72,7 +72,6 @@ export class DynamoDBMappingTemplate {
     limit,
     nextToken,
     index,
-    isSyncEnabled,
   }: {
     query: ObjectNode | Expression;
     scanIndexForward: Expression;
@@ -80,12 +79,9 @@ export class DynamoDBMappingTemplate {
     limit: Expression;
     nextToken?: Expression;
     index?: StringNode;
-    isSyncEnabled?: boolean;
   }): ObjectNode {
-    const version = isSyncEnabled ? '2018-05-29' : RESOLVER_VERSION_ID;
-
     return obj({
-      version: str(version),
+      version: str(RESOLVER_VERSION_ID),
       operation: str('Query'),
       query,
       scanIndexForward,
@@ -116,7 +112,7 @@ export class DynamoDBMappingTemplate {
       query?: ObjectNode | Expression;
       index?: StringNode;
     },
-    version: string = RESOLVER_VERSION_ID
+    version: string = RESOLVER_VERSION_ID,
   ): ObjectNode {
     return obj({
       version: str(version),
@@ -211,7 +207,7 @@ export class DynamoDBMappingTemplate {
       ifElse(
         raw(`!$util.isNull($${nameOverrideMap}) && $${nameOverrideMap}.containsKey("${keyVar}")`),
         set(ref(entryKeyAttributeNameVar), raw(`$${nameOverrideMap}.get("${keyVar}")`)),
-        set(ref(entryKeyAttributeNameVar), raw(keyVar))
+        set(ref(entryKeyAttributeNameVar), raw(keyVar)),
       );
     return compoundExpression([
       set(ref('expNames'), obj({})),
@@ -225,7 +221,7 @@ export class DynamoDBMappingTemplate {
           set(ref('keyFields'), list([])),
           forEach(ref('entry'), ref(`${objectKeyVariable}.entrySet()`), [qref('$keyFields.add("$entry.key")')]),
         ]),
-        set(ref('keyFields'), list(keyFields))
+        set(ref('keyFields'), list(keyFields)),
       ),
       forEach(ref('entry'), ref(`util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet()`), [
         handleRename('$entry.key'),
@@ -239,7 +235,7 @@ export class DynamoDBMappingTemplate {
             qref(`$expSet.put("#$${entryKeyAttributeNameVar}", ":$${entryKeyAttributeNameVar}")`),
             qref(`$expNames.put("#$${entryKeyAttributeNameVar}", "$entry.key")`),
             qref(`$expValues.put(":$${entryKeyAttributeNameVar}", $util.dynamodb.toDynamoDB($entry.value))`),
-          ])
+          ]),
         ),
       ]),
       set(ref('expression'), str('')),
@@ -251,7 +247,7 @@ export class DynamoDBMappingTemplate {
             set(ref('expression'), str('$expression $entry.key = $entry.value')),
             iff(ref('foreach.hasNext()'), set(ref('expression'), str('$expression,'))),
           ]),
-        ])
+        ]),
       ),
       iff(
         raw('!$expAdd.isEmpty()'),
@@ -261,7 +257,7 @@ export class DynamoDBMappingTemplate {
             set(ref('expression'), str('$expression $entry.key $entry.value')),
             iff(ref('foreach.hasNext()'), set(ref('expression'), str('$expression,'))),
           ]),
-        ])
+        ]),
       ),
       iff(
         raw('!$expRemove.isEmpty()'),
@@ -271,7 +267,7 @@ export class DynamoDBMappingTemplate {
             set(ref('expression'), str('$expression $entry')),
             iff(ref('foreach.hasNext()'), set(ref('expression'), str('$expression,'))),
           ]),
-        ])
+        ]),
       ),
       set(ref('update'), obj({})),
       qref('$update.put("expression", "$expression")'),
@@ -288,10 +284,12 @@ export class DynamoDBMappingTemplate {
     ]);
   }
 
-  public static dynamoDBResponse(
-    expression: Expression = ref('util.error($ctx.error.message, $ctx.error.type, $ctx.result)')
-  ): CompoundExpressionNode {
-    return compoundExpression([ifElse(ref('ctx.error'), expression, ref('util.toJson($ctx.result)'))]);
+  public static dynamoDBResponse(isSyncEnabled: boolean, returnExpression?: Expression): CompoundExpressionNode {
+    const errorExpresion = isSyncEnabled
+      ? ref('util.error($ctx.error.message, $ctx.error.type, $ctx.result)')
+      : ref('util.error($ctx.error.message, $ctx.error.type)');
+    const resultExpression = returnExpression ? returnExpression : ref('util.toJson($ctx.result)');
+    return compoundExpression([ifElse(ref('ctx.error'), errorExpresion, resultExpression)]);
   }
 
   public static stringAttributeValue(value: Expression): ObjectNode {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -528,6 +528,7 @@ describe(`ModelAuthTests`, async () => {
     );
     expect(updateResponse.data.updatePost).toEqual(null);
     expect(updateResponse.errors.length).toEqual(1);
+    expect((updateResponse.errors[0] as any).data).toBeNull();
     expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
   });
 
@@ -615,6 +616,7 @@ describe(`ModelAuthTests`, async () => {
     );
     expect(deleteResponse.data.deletePost).toEqual(null);
     expect(deleteResponse.errors.length).toEqual(1);
+    expect((deleteResponse.errors[0] as any).data).toBeNull();
     expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
   });
 
@@ -762,6 +764,7 @@ describe(`ModelAuthTests`, async () => {
       `);
     expect(req2.data.updateSalary).toEqual(null);
     expect(req2.errors.length).toEqual(1);
+    expect((req2.errors[0] as any).data).toBeNull();
     expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
   });
 
@@ -812,6 +815,7 @@ describe(`ModelAuthTests`, async () => {
       `);
     expect(req2.data.deleteSalary).toEqual(null);
     expect(req2.errors.length).toEqual(1);
+    expect((req2.errors[0] as any).data).toBeNull();
     expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
   });
 
@@ -1012,6 +1016,7 @@ describe(`ModelAuthTests`, async () => {
     console.log(JSON.stringify(req3, null, 4));
     expect(req.data.createSingleGroupProtected.value).toEqual(11);
     expect(req.data.createSingleGroupProtected.value).toEqual(req3.data.getSingleGroupProtected.value);
+    expect((req2.errors[0] as any).data).toBeNull();
     expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
   });
 
@@ -2458,6 +2463,7 @@ describe(`ModelAuthTests`, async () => {
       `);
     console.log(JSON.stringify(ownedByAdminsUnauthed, null, 4));
     expect(ownedByAdminsUnauthed.errors.length).toEqual(1);
+    expect((ownedByAdminsUnauthed.errors[0] as any).data).toBeNull();
     expect((ownedByAdminsUnauthed.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 
     const ownedByDevs2 = await GRAPHQL_CLIENT_1.query(`

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
@@ -644,7 +644,7 @@ test('AND per-field dynamic auth rule test', async () => {
       }
       `);
   console.log(badUpdatePostResponse);
-  expect(badUpdatePostResponse.errors[0].errorType).toBeNull();
+  expect(badUpdatePostResponse.errors[0].data).toBeNull();
   expect(badUpdatePostResponse.errors[0].errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 
   const correctUpdatePostResponse = await GRAPHQL_CLIENT_1.query(`mutation UpdatePost {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
@@ -644,6 +644,7 @@ test('AND per-field dynamic auth rule test', async () => {
       }
       `);
   console.log(badUpdatePostResponse);
+  expect(badUpdatePostResponse.errors[0].errorType).toBeNull();
   expect(badUpdatePostResponse.errors[0].errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 
   const correctUpdatePostResponse = await GRAPHQL_CLIENT_1.query(`mutation UpdatePost {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/VersionedModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/VersionedModelTransformer.e2e.test.ts
@@ -208,6 +208,7 @@ test('Test failed updatePost mutation with wrong version', async () => {
     {},
   );
   expect(updateResponse.errors.length).toEqual(1);
+  expect((updateResponse.errors[0] as any).data).toBeNull();
   expect((updateResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });
 
@@ -268,5 +269,6 @@ test('Test deletePost mutation with wrong version', async () => {
     {},
   );
   expect(deleteResponse.errors.length).toEqual(1);
+  expect((deleteResponse.errors[0] as any).data).toBeNull();
   expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
 });

--- a/packages/graphql-transformers-e2e-tests/src/stringSetMutations.ts
+++ b/packages/graphql-transformers-e2e-tests/src/stringSetMutations.ts
@@ -33,7 +33,7 @@ $util.qr($context.args.input.put("__typename", "Class"))
 } )
 #end
 {
-  "version": "2017-02-28",
+  "version": "2018-05-29",
   "operation": "PutItem",
   "key": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   "id":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))
@@ -172,7 +172,7 @@ $util.qr($update.put("expression", "$expression"))
   $util.qr($update.put("expressionValues", $expValues))
 #end
 {
-  "version": "2017-02-28",
+  "version": "2018-05-29",
   "operation": "UpdateItem",
   "key": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
   "id": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update resolver config to 2018 for better error handling on failed operations
- return errorType for ver 2018 resolvers
  - previously for 2018 the error type was null
- additive update on e2e and mock e2e tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.