### PR TITLE
[minor UX fix] insert prompt to run `amplify codegen`

### DIFF
--- a/packages/amplify-codegen/src/commands/configure.js
+++ b/packages/amplify-codegen/src/commands/configure.js
@@ -17,7 +17,7 @@ async function configure(context) {
   const project = await configureProjectWalkThrough(context, config.getProjects(), withoutInit);
   config.addProject(project);
   config.save();
-  console.log('Amplify codegen configured. Remember to run `amplify codegen` to rerun the codegen.')
+  console.log('Codegen configured. Remember to run "amplify codegen" to generate your types and statements.')
 }
 
 module.exports = configure;

--- a/packages/amplify-codegen/src/commands/configure.js
+++ b/packages/amplify-codegen/src/commands/configure.js
@@ -17,6 +17,7 @@ async function configure(context) {
   const project = await configureProjectWalkThrough(context, config.getProjects(), withoutInit);
   config.addProject(project);
   config.save();
+  console.log('Amplify codegen configured. Remember to run `amplify codegen` to rerun the codegen.')
 }
 
 module.exports = configure;


### PR DESCRIPTION
insert prompt to run `amplify codegen` - partially addressing the core confusion in https://github.com/aws-amplify/amplify-cli/issues/4858

*Issue #, if available:* https://github.com/aws-amplify/amplify-cli/issues/4858

*Description of changes:* inserting a small log message to prevent confusion, in place of actually running the command for them.