### PR TITLE
fix: remove mutableParametersState from stored function-params

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -143,26 +143,28 @@ export async function getPermissionPolicies(context, resourceOpsMapping) {
   const permissionPolicies = [];
   const resourceAttributes = [];
 
-  Object.keys(resourceOpsMapping).forEach(resourceName => {
-    try {
-      const providerController = require(`./provider-utils/${amplifyMeta[category][resourceName].providerPlugin}/index`);
-      if (providerController) {
-        const { policy, attributes } = providerController.getPermissionPolicies(
-          context,
-          amplifyMeta[category][resourceName].service,
-          resourceName,
-          resourceOpsMapping[resourceName],
-        );
-        permissionPolicies.push(policy);
-        resourceAttributes.push({ resourceName, attributes, category });
-      } else {
-        context.print.error(`Provider not configured for ${category}: ${resourceName}`);
+  await Promise.all(
+    Object.keys(resourceOpsMapping).map(async resourceName => {
+      try {
+        const providerController = require(`./provider-utils/${amplifyMeta[category][resourceName].providerPlugin}/index`);
+        if (providerController) {
+          const { policy, attributes } = await providerController.getPermissionPolicies(
+            context,
+            amplifyMeta[category][resourceName].service,
+            resourceName,
+            resourceOpsMapping[resourceName],
+          );
+          permissionPolicies.push(policy);
+          resourceAttributes.push({ resourceName, attributes, category });
+        } else {
+          context.print.error(`Provider not configured for ${category}: ${resourceName}`);
+        }
+      } catch (e) {
+        context.print.warning(`Could not get policies for ${category}: ${resourceName}`);
+        throw e;
       }
-    } catch (e) {
-      context.print.warning(`Could not get policies for ${category}: ${resourceName}`);
-      throw e;
-    }
-  });
+    }),
+  );
   return { permissionPolicies, resourceAttributes };
 }
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/storeResources.test.ts.snap
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/storeResources.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`save mutable state destructures mutableParametersState in the stored object 1`] = `
+Object {
+  "lambdaLayers": Array [],
+  "permissions": Object {
+    "something": "a value",
+  },
+}
+`;
+
+exports[`save mutable state removes mutableParametersState from the existing file if present 1`] = `
+Object {
+  "lambdaLayers": Array [],
+  "permissions": Object {
+    "something": "the latest value",
+    "somethingElse": "other value",
+  },
+}
+`;

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/loadFunctionParameters.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/loadFunctionParameters.test.ts
@@ -1,0 +1,38 @@
+import { loadFunctionParameters } from '../../../../provider-utils/awscloudformation/utils/loadFunctionParameters';
+
+describe('load function parameters', () => {
+  const permissionsBase = {
+    permissions: {
+      api: {
+        myapiname: ['create', 'read'],
+      },
+    },
+  };
+  const funcParamsBase = {
+    lambdaLayers: [],
+  };
+
+  const mutableParametersStub = {
+    mutableParametersState: {
+      permissions: {
+        api: {
+          myapiname: ['create', 'read', 'update'],
+        },
+        auth: {
+          myauth: ['read'],
+        },
+      },
+    },
+  };
+  const context_stub = {
+    amplify: {
+      readJsonFile: jest.fn(() => ({ ...funcParamsBase, ...permissionsBase, ...mutableParametersStub })),
+    },
+  };
+  it('destructures mutableParametersState if it exists', () => {
+    expect(loadFunctionParameters(context_stub, 'resourcePath')).toEqual({
+      ...funcParamsBase,
+      ...mutableParametersStub.mutableParametersState,
+    });
+  });
+});

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/storeResources.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/storeResources.test.ts
@@ -1,0 +1,60 @@
+import { LambdaLayer } from 'amplify-function-plugin-interface';
+import { saveMutableState } from '../../../../provider-utils/awscloudformation/utils/storeResources';
+
+describe('save mutable state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const context_stub = {
+    amplify: {
+      pathManager: {
+        getBackendDirPath: () => 'backendDir',
+      },
+      writeObjectAsJson: jest.fn(),
+      readJsonFile: jest.fn(() => ({})),
+    },
+  };
+
+  it('destructures mutableParametersState in the stored object', () => {
+    const mutableParametersStateContents = {
+      permissions: {
+        something: 'a value',
+      },
+    };
+    const input = {
+      mutableParametersState: mutableParametersStateContents,
+      resourceName: 'testResourceName',
+      lambdaLayers: [] as LambdaLayer[],
+    };
+
+    saveMutableState(context_stub, input);
+    expect(context_stub.amplify.writeObjectAsJson.mock.calls[0][1]).toMatchSnapshot();
+  });
+
+  it('removes mutableParametersState from the existing file if present', () => {
+    context_stub.amplify.readJsonFile.mockImplementationOnce(() => ({
+      lambdaLayers: [],
+      permissions: {
+        something: 'a value',
+      },
+      mutableParametersState: {
+        permissions: {
+          something: 'a new value',
+        },
+      },
+    }));
+    const input = {
+      mutableParametersState: {
+        permissions: {
+          something: 'the latest value',
+          somethingElse: 'other value',
+        },
+      },
+      lambdaLayers: [],
+      resourceName: 'testResourceName',
+    };
+    saveMutableState(context_stub, input);
+    expect(context_stub.amplify.writeObjectAsJson.mock.calls[0][1]).toMatchSnapshot();
+  });
+});

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/loadFunctionParameters.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/loadFunctionParameters.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { functionParametersFileName } from './constants';
+import _ from 'lodash';
+
+export const loadFunctionParameters = (context, resourcePath: string) => {
+  const funcParams = context.amplify.readJsonFile(path.join(resourcePath, functionParametersFileName), undefined, false) || {};
+
+  // there was a bug where permissions were nested within "mutableParametersState" in the file so the following is necessary to ensure
+  // forward compatability with functions whose permissions were updated with a version of the CLI where the bug existed
+  if (funcParams.mutableParametersState) {
+    _.assign(funcParams, { ...funcParams.mutableParametersState });
+    delete funcParams.mutableParametersState;
+  }
+  return funcParams;
+};


### PR DESCRIPTION
*Issue #, if available:*
#4849

*Description of changes:*
Remove "mutableParametersState" from the JSON object that is stored in function-parameters.json
When reading the file, check for that field and flatten the contents into the root object if present

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.