### PR TITLE
chore: fix test-ci script to run all unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test-changed": "lerna run test --since master",
     "test": "lerna run test",
-    "test-ci": "lerna run test-ci --concurrency 1",
+    "test-ci": "lerna run test --concurrency 1 -- --ci -i",
     "e2e": "lerna run e2e",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --quiet",
     "lint-fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",

--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -22,8 +22,7 @@
     "clean": "rimraf ./lib",
     "watch": "tsc -w",
     "start": "node ./lib/index.js",
-    "test": "jest",
-    "test-ci": "jest"
+    "test": "jest"
   },
   "dependencies": {
     "amplify-velocity-template": "1.1.10",

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
-    "test": "jest",
-    "test-ci": "jest --ci -i"
+    "test": "jest"
   },
   "dependencies": {
     "amplify-category-auth": "2.16.5",

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -16,8 +16,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-watch": "jest --watch",
-    "test-ci": "jest --ci -i"
+    "test-watch": "jest --watch"
   },
   "dependencies": {
     "amplify-category-function": "2.21.5",

--- a/packages/amplify-category-hosting/package.json
+++ b/packages/amplify-category-hosting/package.json
@@ -15,8 +15,7 @@
     "aws"
   ],
   "scripts": {
-    "test": "jest --coverage",
-    "test-ci": "jest --ci -i"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "chalk": "^3.0.0",

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -15,8 +15,7 @@
     "aws"
   ],
   "scripts": {
-    "test": "jest --coverage",
-    "test-ci": "jest --ci -i"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "amplify-category-auth": "2.16.5",

--- a/packages/amplify-category-xr/package.json
+++ b/packages/amplify-category-xr/package.json
@@ -16,8 +16,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-watch": "jest --watch",
-    "test-ci": "jest --ci -i"
+    "test-watch": "jest --watch"
   },
   "dependencies": {
     "amplify-category-auth": "2.16.5",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -24,7 +24,6 @@
   },
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "postinstall": "node scripts/post-install.js",
     "build": "tsc",
     "start": "tsc -w",

--- a/packages/amplify-codegen-appsync-model-plugin/package.json
+++ b/packages/amplify-codegen-appsync-model-plugin/package.json
@@ -19,8 +19,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test-watch": "jest --watch",
-    "test": "jest",
-    "test-ci": "jest --ci"
+    "test": "jest"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^1.12.2",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -17,7 +17,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -17,8 +17,7 @@
   ],
   "scripts": {
     "build": "download --extract -o emulator https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip",
-    "test": "jest",
-    "test-ci": "jest"
+    "test": "jest"
   },
   "dependencies": {
     "aws-sdk": "^2.608.0",

--- a/packages/amplify-frontend-ios/package.json
+++ b/packages/amplify-frontend-ios/package.json
@@ -17,8 +17,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-watch": "jest --watch",
-    "test-ci": "jest --ci -i"
+    "test-watch": "jest --watch"
   },
   "dependencies": {
     "fs-extra": "^8.1.0",

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -26,7 +26,6 @@
   },
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "test-watch": "jest --watch",
     "build": "tsc",
     "watch": "tsc -w",

--- a/packages/amplify-graphql-types-generator/package.json
+++ b/packages/amplify-graphql-types-generator/package.json
@@ -30,7 +30,6 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "test:smoke": "npm install && npm run build && rimraf node_modules && npm install --prod && node ./lib/cli.js && echo 'Smoke Test Passed'"
   },
   "dependencies": {

--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
-    "test": "jest",
-    "test-ci": "jest"
+    "test": "jest"
   },
   "dependencies": {
     "amplify-function-plugin-interface": "1.4.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -17,9 +17,8 @@
   ],
   "scripts": {
     "e2e": "jest --runInBand  --forceExit src/__e2e__/*.test.ts",
-    "test": "jest  src/__tests__/**/*.test.ts",
+    "test": "jest src/__tests__/**/*.test.ts",
     "test-watch": "jest --watch",
-    "test-ci": "jest src/__tests__/",
     "build": "tsc",
     "build-tests": "tsc --build tsconfig.tests.json",
     "watch": "tsc -w",

--- a/packages/amplify-velocity-template/package.json
+++ b/packages/amplify-velocity-template/package.json
@@ -23,7 +23,8 @@
     "Eward Song"
   ],
   "scripts": {
-    "test": "mocha tests --require should",
+    "test": "npm run test-sub",
+    "test-sub": "mocha tests --require should",
     "pub": "npm version patch && npm publish && git push origin master && git push origin --tag",
     "build": "jison src/parse/velocity.yy src/parse/velocity.l -o src/parse/index.js"
   },

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rimraf ./lib",
     "watch": "tsc -w"

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rimraf ./lib"
   },

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rimraf ./lib",
     "watch": "tsc -w"

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rimraf ./lib"
   },

--- a/packages/graphql-mapping-template/package.json
+++ b/packages/graphql-mapping-template/package.json
@@ -19,7 +19,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib"

--- a/packages/graphql-relational-schema-transformer/package.json
+++ b/packages/graphql-relational-schema-transformer/package.json
@@ -17,7 +17,6 @@
     "aws"
   ],
   "scripts": {
-    "test-ci": "jest --ci --coverage",
     "test": "jest --coverage",
     "build": "tsc",
     "clean": "rimraf ./lib"

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib"

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib"

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci -i",
     "build": "tsc",
     "clean": "rimraf ./lib"
   },


### PR DESCRIPTION
Our current method of running "test-ci" to run unit tests in circle ci was missing many packages because not all of them define a "test-ci" script. Updated the root "test-ci" lerna command to run "test" with the [--ci](https://jestjs.io/docs/en/cli#--ci) jest option. This will ensure that as we add new packages we don't have to remember to add a "test-ci" command in order to have them picked up on circle ci runs.

Also removed the "test-ci" script in the packages where it was defined because it's no longer needed


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.