### PR TITLE
fix(amplify-category-function): allow response object when runnning go local invoke

### DIFF
--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -139,7 +139,14 @@ export async function getInvoker(context: any, params: InvokerParameters): Promi
 }
 
 export function isMockable(context: any, resourceName: string): IsMockableResponse {
-  const { service, dependsOn } = context.amplify.getProjectMeta()[category][resourceName];
+  const resourceValue = _.get(context.amplify.getProjectMeta(), [category, resourceName]);
+  if (!resourceValue) {
+    return {
+      isMockable: false,
+      reason: `Could not find the specified ${category}: ${resourceName}`,
+    };
+  }
+  const { service, dependsOn } = resourceValue;
   const hasLayer =
     service === ServiceName.LambdaFunction &&
     Array.isArray(dependsOn) &&

--- a/packages/amplify-go-function-runtime-provider/resources/localinvoke/main.go
+++ b/packages/amplify-go-function-runtime-provider/resources/localinvoke/main.go
@@ -161,7 +161,7 @@ func main() {
 			Payload: payload,
 		})
 
-		json.Unmarshal(response, &responseString)
+		responseString = string(response)
 
 		if err != nil {
 			errorString = fmt.Sprintf(":%s", err)

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@hapi/topo": "^5.0.0",
     "amplify-appsync-simulator": "1.21.1",
-    "amplify-category-function": "2.21.1",
+    "amplify-category-function": "2.21.5",
     "amplify-codegen": "2.15.13",
     "amplify-dynamodb-simulator": "1.14.0",
     "amplify-storage-simulator": "1.4.0",


### PR DESCRIPTION
*Issue #, if available:*
re aws-amplify#4487

*Description of changes:*
- Changed go local invoke function
- Added check to see if resourceName exists when checking if function is mockable


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.