### PR TITLE
fix: function update no longer removes dependsOn array implicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1099,7 +1099,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
                 - graphql_e2e_testing
           requires:
@@ -1110,7 +1109,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
                 - beta
           requires:
@@ -1121,7 +1119,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
                 - beta
           requires:
@@ -1131,7 +1128,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
           requires:
             - build
@@ -1140,7 +1136,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
           requires:
             - build
@@ -1188,14 +1183,12 @@ workflows:
               only:
                 - release
                 - master
-                - headless-staging
                 - beta
       - api_1-amplify_e2e_tests:
           filters: &ref_2
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
           requires:
             - publish_to_local_registry

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -64,8 +64,7 @@ export async function migrate(context) {
 }
 
 export async function getPermissionPolicies(context, resourceOpsMapping) {
-  const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
-  const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
+  const amplifyMeta = context.amplify.getProjectMeta();
   const permissionPolicies = [];
   const resourceAttributes = [];
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -225,7 +225,7 @@ export const askExecRolePermissionsQuestions = async (
       envVars.add(envName);
     });
 
-    if (dependsOn.filter(dep => dep.resourceName === resourceName).length === 0) {
+    if (!dependsOn.find(dep => dep.resourceName === resourceName)) {
       dependsOn.push({
         category: resource.category,
         resourceName: resource.resourceName,
@@ -237,6 +237,7 @@ export const askExecRolePermissionsQuestions = async (
   const envVarStringList = Array.from(envVars)
     .sort()
     .join('\n\t');
+
   context.print.info(`${envVarPrintoutPrefix}${envVarStringList}`);
 
   return {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -225,14 +225,7 @@ export const askExecRolePermissionsQuestions = async (
       envVars.add(envName);
     });
 
-    let resourceExists = false;
-    dependsOn.forEach(amplifyResource => {
-      if (amplifyResource.resourceName === resourceName) {
-        resourceExists = true;
-      }
-    });
-
-    if (!resourceExists) {
+    if (dependsOn.filter(dep => dep.resourceName === resourceName).length === 0) {
       dependsOn.push({
         category: resource.category,
         resourceName: resource.resourceName,
@@ -244,7 +237,6 @@ export const askExecRolePermissionsQuestions = async (
   const envVarStringList = Array.from(envVars)
     .sort()
     .join('\n\t');
-
   context.print.info(`${envVarPrintoutPrefix}${envVarStringList}`);
 
   return {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -162,7 +162,11 @@ export async function updateWalkthrough(context, lambdaToUpdate?: string) {
 
     context.amplify.writeObjectAsJson(cfnFilePath, cfnContent, true);
     tryUpdateTopLevelComment(resourceDirPath, _.keys(functionParameters.environmentMap));
+  } else {
+    // Need to load previous dependsOn
+    functionParameters.dependsOn = _.get(context.amplify.getProjectMeta(), ['function', lambdaToUpdate, 'dependsOn'], []);
   }
+
   // ask scheduling Lambda questions and merge in results
   const cfnParameters = context.amplify.readJsonFile(path.join(resourceDirPath, parametersFileName), undefined, false) || {};
   const scheduleParameters = {

--- a/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
@@ -465,6 +465,21 @@ describe('nodejs', () => {
         path.join(projRoot, 'amplify', 'backend', 'function', fnName, `${fnName}-cloudformation-template.json`),
       );
       expect(lambdaCFN.Resources.AmplifyResourcesPolicy.Properties.PolicyDocument.Statement.length).toBe(3);
+
+      const configPath = path.join(projRoot, 'amplify', 'backend', 'backend-config.json');
+      const metaPath = path.join(projRoot, 'amplify', 'backend', 'amplify-meta.json');
+      const functionConfig = readJsonFile(configPath).function[fnName];
+      const functionMeta = readJsonFile(metaPath).function[fnName];
+      delete functionMeta.lastPushTimeStamp;
+
+      // Don't update anything, sends 'n' to the question:
+      // Do you want to update the Lambda function permissions to access...?
+      await updateFunction(projRoot, {}, 'nodejs');
+      const updatedFunctionConfig = readJsonFile(configPath).function[fnName];
+      const updatedFunctionMeta = readJsonFile(metaPath).function[fnName];
+      delete updatedFunctionMeta.lastPushTimeStamp;
+      expect(functionConfig).toStrictEqual(updatedFunctionConfig);
+      expect(functionMeta).toStrictEqual(updatedFunctionMeta);
     });
 
     it('should add api key from api to env vars', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
@@ -465,6 +465,32 @@ describe('nodejs', () => {
         path.join(projRoot, 'amplify', 'backend', 'function', fnName, `${fnName}-cloudformation-template.json`),
       );
       expect(lambdaCFN.Resources.AmplifyResourcesPolicy.Properties.PolicyDocument.Statement.length).toBe(3);
+    });
+
+    it('function dependencies should be preserved when not editing permissions during `amplify update function`', async () => {
+      await initJSProjectWithProfile(projRoot, {});
+      await addApiWithSchema(projRoot, 'two-model-schema.graphql');
+
+      const random = Math.floor(Math.random() * 10000);
+      const fnName = `integtestfn${random}`;
+      const ddbName = `ddbTable${random}`;
+
+      await addSimpleDDB(projRoot, { name: ddbName });
+      await addFunction(
+        projRoot,
+        {
+          name: fnName,
+          functionTemplate: 'Hello World',
+          additionalPermissions: {
+            permissions: ['storage'],
+            choices: ['api', 'storage'],
+            resources: [ddbName, 'Post:@model(appsync)', 'Comment:@model(appsync)'],
+            resourceChoices: [ddbName, 'Post:@model(appsync)', 'Comment:@model(appsync)'],
+            operations: ['read'],
+          },
+        },
+        'nodejs',
+      );
 
       const configPath = path.join(projRoot, 'amplify', 'backend', 'backend-config.json');
       const metaPath = path.join(projRoot, 'amplify', 'backend', 'amplify-meta.json');

--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -26,8 +26,7 @@
     "archiver": "^3.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",
-    "glob": "^7.1.6",
-    "execa": "^4.0.0"
+    "glob": "^7.1.6"
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",

--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -26,7 +26,8 @@
     "archiver": "^3.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",
-    "glob": "^7.1.6"
+    "glob": "^7.1.6",
+    "execa": "^4.0.0"
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",


### PR DESCRIPTION
Previously, if answering 'no' to "Do you want to update the Lambda function permissions to access
other resources in this project?", the function's dependencies would be removed. Now, permissions
must be removed explicitly by answering 'yes' to the question and the relevant permissions have to
be deselected.

#4932, #4852, #4892


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.