### PR TITLE
fix(amplify-nodejs-function-runtime-provider): restore console.log

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
@@ -15,6 +15,10 @@ export function invoke(options: InvokeOptions): Promise<any> {
       });
       lambdaFn.on('close', () => {
         const lines = data.split('\n');
+        if (lines.length > 1) {
+          const logs = lines.slice(0, -1).join('\n');
+          console.log(logs);
+        }
         const lastLine = lines[lines.length - 1];
         const result = JSON.parse(lastLine);
         if (result.error) {


### PR DESCRIPTION
*Description of changes:*

I usually print out some logs in my Lambda functions for debugging purpose.
Since https://github.com/aws-amplify/amplify-cli/pull/4906, the logs are gone in the terminal.

This PR restores them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.