### PR TITLE
fix: #4950 amplify cli fails with checked in local settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1099,7 +1099,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
                 - graphql_e2e_testing
           requires:
@@ -1110,7 +1109,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
                 - beta
           requires:
@@ -1121,7 +1119,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
                 - beta
           requires:
@@ -1131,7 +1128,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
           requires:
             - build
@@ -1140,7 +1136,6 @@ workflows:
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
           requires:
             - build
@@ -1188,14 +1183,12 @@ workflows:
               only:
                 - release
                 - master
-                - headless-staging
                 - beta
       - api_1-amplify_e2e_tests:
           filters: &ref_2
             branches:
               only:
                 - master
-                - headless-staging
                 - graphqlschemae2e
           requires:
             - publish_to_local_registry

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs-extra';
 import * as path from 'path';
 import { CLIContextEnvironmentProvider, FeatureFlags } from 'amplify-cli-core';
 import { Input } from './domain/input';
@@ -62,7 +63,14 @@ export async function run() {
 
     const getProjectPath = (): string => {
       try {
-        const { projectPath } = context.amplify.getEnvInfo();
+        let { projectPath } = context.amplify.getEnvInfo();
+
+        // Check if the returned path exists, because it is possible that
+        // local-env-info.json is checked in and contains an invalid path
+        // https://github.com/aws-amplify/amplify-cli/issues/4950
+        if (projectPath && !fs.pathExistsSync(projectPath)) {
+          projectPath = '';
+        }
 
         return projectPath;
       } catch {

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -226,3 +226,19 @@ export function initNewEnvWithProfile(cwd: string, s: { envName: string }) {
       });
   });
 }
+
+export function amplifyStatus(cwd: string, expectedStatus: string) {
+  return new Promise((resolve, reject) => {
+    let regex = new RegExp(`.*${expectedStatus}*`);
+    spawn(getCLIPath(), ['status'], { cwd, stripColors: true })
+      .wait(regex)
+      .sendLine('\r')
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #4950

*Description of changes:*

When `.gitignore` does not have the `amplify/.config/local-*` files excluded - which is added by the CLI during init - and it gets checked into source control, then Amplify CLI can fail when the persisted project path is not matching the current one. This easily happens in CI/CD scenarios. This fix makes an additional check on the existence of the project directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.