### PR TITLE
Fixed 'SyntaxError: Unexpected end of JSON input' error when lambda r…

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
@@ -30,6 +30,9 @@ export function invoke(options: InvokeOptions): Promise<any> {
           resolve(lastLine)
         }
       });
+      lambdaFn.catch((err) => {
+        reject(err.message);
+      });
       lambdaFn.send(JSON.stringify(options));
     } catch (e) {
       reject(e);

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
@@ -20,11 +20,15 @@ export function invoke(options: InvokeOptions): Promise<any> {
           console.log(logs);
         }
         const lastLine = lines[lines.length - 1];
-        const result = JSON.parse(lastLine);
-        if (result.error) {
-          reject(result.error);
+        try {
+          const result = JSON.parse(lastLine);
+          if (result.error) {
+            reject(result.error);
+          }
+          resolve(result.result);
+        } catch {
+          resolve(lastLine)
         }
-        resolve(result.result);
       });
       lambdaFn.send(JSON.stringify(options));
     } catch (e) {


### PR DESCRIPTION
…esult is not valid json

*Issue #, if available:*

*Description of changes:*
Currently if a lambda fails when running `amplify mock function <lambda>` and returns a non valid JSON response (such as null or string or Error) then the nodejs lambda invoke fails with this error message:
```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at ChildProcess.<anonymous> (/usr/local/lib/node_modules/@aws-amplify/cli/node_modules/amplify-nodejs-function-runtime-provider/lib/utils/invoke.js:45:37)
    at ChildProcess.emit (events.js:315:20)
    at ChildProcess.EventEmitter.emit (domain.js:485:12)
    at maybeClose (internal/child_process.js:1051:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
```

This change catches this issue and outputs the value instead without an attempt to parse to JSON

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.