### PR TITLE
feat(graphql-key-transformer): add type arg to specify @key type

### DIFF
--- a/packages/amplify-e2e-tests/schemas/migrations_key/cant_remove_lsi.graphql
+++ b/packages/amplify-e2e-tests/schemas/migrations_key/cant_remove_lsi.graphql
@@ -1,0 +1,11 @@
+type Todo
+  @model
+  @key(fields: ["id", "version"])
+  @key(name: "SomeLSI", fields: ["id", "name"], type: GSI)
+  @key(name: "SomeGSI", fields: ["name", "id"]) {
+  id: ID!
+  id2: ID!
+  name: String!
+  name2: String!
+  version: String!
+}

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -1,12 +1,13 @@
-import { amplifyPush, amplifyPushUpdate, deleteProject, initJSProjectWithProfile } from 'amplify-e2e-core';
 import * as path from 'path';
 import { existsSync } from 'fs';
 import {
+  amplifyPush,
+  amplifyPushUpdate,
+  deleteProject,
+  initJSProjectWithProfile,
   addApiWithSchema,
   addApiWithSchemaAndConflictDetection,
   addRestApi,
-  updateApiSchema,
-  updateApiWithMultiAuth,
   updateAPIWithResolutionStrategy,
   apiUpdateToggleDataStore,
   addFunction,
@@ -18,7 +19,7 @@ import {
   getProjectMeta,
   getTransformConfig,
 } from 'amplify-e2e-core';
-import { TRANSFORM_CURRENT_VERSION, TRANSFORM_BASE_VERSION, writeTransformerConfiguration } from 'graphql-transformer-core';
+import { TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
 import _ from 'lodash';
 
 describe('amplify add api (GraphQL)', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration.test.ts
@@ -78,4 +78,17 @@ describe('amplify add api', () => {
     updateApiSchema(projRoot, projectName, nextSchema1);
     await amplifyPushUpdate(projRoot, /GraphQL endpoint:.*/);
   });
+
+  it('init project, run invalid migration when trying to remove an lsi, and check for error', async () => {
+    const projectName = 'removinglsi';
+    const initialSchema = 'migrations_key/initial_schema.graphql';
+    const nextSchema1 = 'migrations/cant_remove_lsi.graphql';
+    await initJSProjectWithProfile(projRoot, { name: projectName });
+    await addApiWithSchema(projRoot, initialSchema);
+    await amplifyPush(projRoot);
+    updateApiSchema(projRoot, projectName, nextSchema1);
+    await expect(
+      amplifyPushUpdate(projRoot, /Attempting to remove the local secondary index SomeLSI on the TodoTable table in the Todo stack.*/),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
+  });
 });

--- a/packages/graphql-connection-transformer/src/__tests__/NewConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/NewConnectionTransformer.test.ts
@@ -229,7 +229,7 @@ test('ModelConnectionTransformer should fail if partial sort key is passed in co
 
     type Test1
         @model
-        @key(name: "testIndex", fields: ["id", "friendID", "name"])
+        @key(name: "testIndex", fields: ["id", "friendID", "name"], type: GSI)
     {
         id: ID!
         friendID: ID!
@@ -256,7 +256,7 @@ test('ModelConnectionTransformer should accept connection without sort key', () 
 
     type Test1
         @model
-        @key(name: "testIndex", fields: ["id", "friendID", "name"])
+        @key(name: "testIndex", fields: ["id", "friendID", "name"], type: GSI)
     {
         id: ID!
         friendID: ID!
@@ -281,7 +281,7 @@ test('ModelConnectionTransformer should fail if sort key type passed in does not
 
     type Test1
         @model
-        @key(name: "testIndex", fields: ["id", "friendID"])
+        @key(name: "testIndex", fields: ["id", "friendID"], type: GSI)
     {
         id: ID!
         friendID: ID!
@@ -306,7 +306,7 @@ test('ModelConnectionTransformer should fail if partition key type passed in doe
 
     type Test1
         @model
-        @key(name: "testIndex", fields: ["id", "friendID"])
+        @key(name: "testIndex", fields: ["id", "friendID"], type: GSI)
     {
         id: ID!
         friendID: ID!

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -33,6 +33,7 @@ export async function check(
     cantAddLSILater,
     cantEditGSIKeySchema,
     cantEditLSIKeySchema,
+    cantRemoveLSILater,
     cantAddAndRemoveGSIAtSameTime,
   ];
   // Project rules run on the full set of diffs, the current build, and the next build.
@@ -249,6 +250,29 @@ export function cantEditLSIKeySchema(diff: Diff, currentBuild: DiffableProject, 
           'The key schema of a local secondary index cannot be changed after being deployed.',
           'When enabling new access patterns you should: 1. Add a new @key 2. run amplify push ' +
             '3. Verify the new access pattern and remove the old @key.',
+        );
+      }
+    }
+  }
+}
+
+export function cantRemoveLSILater(diff: Diff, currentBuild: DiffableProject, nextBuild: DiffableProject) {
+  if (diff.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'LocalSecondaryIndexes') {
+    // Run logic to check that an LSI is being removed in favor of creating a GSI
+    const pathToTable = diff.path.slice(0, 5);
+    const oldTable = get(currentBuild, pathToTable);
+    const newTable = get(nextBuild, pathToTable);
+    const innerDiffs = getDiffs(oldTable, newTable);
+
+    for (const innerDiff of innerDiffs) {
+      if (innerDiff.kind === 'D' && innerDiff.path.length === 1 && innerDiff.path[0] === 'LocalSecondaryIndexes') {
+        const tableName = diff.path[3];
+        const indexName = innerDiff.lhs[0].IndexName;
+        const stackName = basename(diff.path[1], '.json');
+        throw new InvalidMigrationError(
+          `Attempting to remove the local secondary index ${indexName} on the ${tableName} table in the ${stackName} stack.`,
+          'A local secondary index cannot be removed once after being deployed.',
+          'In order to remove the local secondary index you would need to either delete or rename the table.',
         );
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
re #2702
*Description of changes:*
 - added a type argument to `@key` to toggle the behavior to indicate whether a secondary index is local or
global
- Added sanity check when removing an LSI from an already existing table
- `@key` Validations
  - check that an LSI can only be added when when a primary composite key is defined
  - check that an LSI has the same field length as the primary composite key
- Removed unused imports from amplify e2e
- Updated `@connection` unit tests since the schema provided would fail if actually deployed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.