### PR TITLE
fix(amplify-category-api): skip writing resolver config

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/resolver-config-to-conflict-resolution-bi-di-mapper.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/resolver-config-to-conflict-resolution-bi-di-mapper.test.ts
@@ -41,7 +41,7 @@ describe('transform ConflictResolution to ResolverConfig', () => {
   });
 
   it('returns an empty object when ConflictResolution is not present', () => {
-    expect(conflictResolutionToResolverConfig(undefined)).toEqual({});
+    expect(conflictResolutionToResolverConfig(undefined)).toEqual(undefined);
   });
 });
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/resolver-config-to-conflict-resolution-bi-di-mapper.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/resolver-config-to-conflict-resolution-bi-di-mapper.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 export const conflictResolutionToResolverConfig = (conflictResolution: ConflictResolution = {}): ResolverConfig => {
   const result: ResolverConfig = {};
+  if (_.isEmpty(conflictResolution)) return undefined;
   if (conflictResolution.defaultResolutionStrategy) {
     result.project = resolutionStrategyToSyncConfig(conflictResolution.defaultResolutionStrategy);
   }


### PR DESCRIPTION
Skip writing resolver config to transform.conf if return object is empty

*Issue #, if available:*
#4965
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.