### PR TITLE
fix(cli): adds a warning when a subcommand of amplify env does not exist

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/env.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/env.test.ts
@@ -1,0 +1,56 @@
+import { run as runEnvCmd } from '../../commands/env';
+
+describe('amplify env: ', () => {
+  it('env run method should exist', () => {
+    expect(runEnvCmd).toBeDefined();
+  });
+
+  const mockContextNoCLArgs = {
+    amplify: {
+      showHelp: jest.fn(),
+    },
+    parameters: {},
+    input: {
+      subCommands: [],
+    },
+    print: {
+      info: jest.fn(),
+    },
+  };
+
+  describe('case: amplify env is run with no additional command line arguments', () => {
+    it('env run method should call context.amplify.showHelp()', async () => {
+      await runEnvCmd(mockContextNoCLArgs);
+      expect(mockContextNoCLArgs.amplify.showHelp).toBeCalled();
+    });
+  });
+
+  const mockContextInvalidSubcommandCLArgs = {
+    amplify: {
+      showHelp: jest.fn(),
+    },
+    parameters: {},
+    input: {
+      argv: [
+        '/Users/userName/.nvm/versions/node/v12.16.1/bin/node',
+        '/Users/userName/.nvm/versions/node/v12.16.1/bin/amplify',
+        'foo',
+        'bar',
+        'piyo',
+      ],
+      subCommands: ['foo', 'bar', 'piyo'],
+    },
+    print: {
+      info: jest.fn(),
+      warning: jest.fn(),
+    },
+  };
+
+  describe('case: amplify env is run with invalid additional command line arguments', () => {
+    it('env run method should call context.amplify.showHelp() and context.print.warning()', async () => {
+      await runEnvCmd(mockContextInvalidSubcommandCLArgs);
+      expect(mockContextInvalidSubcommandCLArgs.amplify.showHelp).toBeCalled();
+      expect(mockContextInvalidSubcommandCLArgs.print.warning).toBeCalled();
+    });
+  });
+});

--- a/packages/amplify-cli/src/commands/env.js
+++ b/packages/amplify-cli/src/commands/env.js
@@ -20,7 +20,9 @@ module.exports = {
       try {
         commandModule = require(path.normalize(path.join(__dirname, 'env', subcommand)));
       } catch (e) {
-        context.print.warning(`The Amplify CLI can NOT find command: env ${subcommand}`);
+        if (subCommands) {
+          context.print.warning(`The Amplify CLI can NOT find command:  env ${subCommands.slice(0, 3).join(' ')}`);
+        }
         displayHelp(context);
       }
 

--- a/packages/amplify-cli/src/commands/env.js
+++ b/packages/amplify-cli/src/commands/env.js
@@ -20,6 +20,7 @@ module.exports = {
       try {
         commandModule = require(path.normalize(path.join(__dirname, 'env', subcommand)));
       } catch (e) {
+        context.print.warning(`The Amplify CLI can NOT find command: env ${subcommand}`);
         displayHelp(context);
       }
 


### PR DESCRIPTION
fix #4969

Description of changes: Add warning log in the catch scope for dynamically executing env.js subcommands
