### PR TITLE
test(cli): add maxWorkers parameter to the unit tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -53,7 +53,7 @@ jobs:
           command: yarn lint
       - run:
           name: Run tests
-          command: yarn test-ci
+          command: yarn test-ci --maxWorkers=3
       - run:
           name: Collect code coverage
           command: yarn coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: yarn lint
       - run:
           name: Run tests
-          command: yarn test-ci
+          command: yarn test-ci --maxWorkers=3
       - run:
           name: Collect code coverage
           command: yarn coverage


### PR DESCRIPTION
add maxWorkers parameter to the unit tests to avoid Not Enough Memory errors in the CirclCI test job

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.