### PR TITLE
fix: add custom user agent for amplify client

### DIFF
--- a/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
@@ -5,6 +5,7 @@ import { getConfigFromProfile } from '../profile-helper';
 
 export function getConfiguredAmplifyClient() {
   const config = getConfigFromProfile();
+  config["customUserAgent"] = "amplify-cli";
   return new Amplify(config);
 }
 

--- a/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/amplifyConsoleOperations.ts
@@ -5,7 +5,11 @@ import { getConfigFromProfile } from '../profile-helper';
 
 export function getConfiguredAmplifyClient() {
   const config = getConfigFromProfile();
-  config["customUserAgent"] = "amplify-cli";
+  if(config["customUserAgent"]) {
+    config["customUserAgent"] += " amplify-cli";
+  } else {
+    config["customUserAgent"] = "amplify-cli";
+  }
   return new Amplify(config);
 }
 

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js
@@ -44,6 +44,7 @@ async function getConfiguredAmplifyClient(context, options = {}) {
   }
 
   const config = { ...cred, ...defaultOptions, ...options };
+  config["customUserAgent"] = "amplify-cli";
 
   // this is the "project" config level case, creds and region are explicitly set or retrieved from a profile
   if (config.region) {


### PR DESCRIPTION
*Issue #, if available:*
AWS Amplify Console needs a way to tell how many user's made list calls via amplify cli. So we want to append a custom user agent.

*Description of changes:*
Add 'amplify-cli' when init amplify console client

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.