### PR TITLE
enhance(amplify-provider-awscloudformation): multiple lambdas per resource

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.js
@@ -349,17 +349,19 @@ function packageResources(context, resources) {
             };
           }
         } else {
-          if (cfnMeta.Resources.LambdaFunction.Type === 'AWS::Serverless::Function') {
-            cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
-              Bucket: s3Bucket,
-              Key: s3Key,
-            };
-          } else {
-            cfnMeta.Resources.LambdaFunction.Properties.Code = {
-              S3Bucket: s3Bucket,
-              S3Key: s3Key,
-            };
-          }
+          Object.values(cfnMeta.Resources).forEach(value => {
+            if (value.Type === 'AWS::Serverless::Function' && typeof value.Properties.CodeUri === 'object') {
+              value.Properties.CodeUri = {
+                Bucket: s3Bucket,
+                Key: s3Key,
+              };
+            } else if (value.Type === 'AWS::Lambda::Function' && typeof value.Properties.Code === 'object') {
+              value.Properties.Code = {
+                S3Bucket: s3Bucket,
+                S3Key: s3Key,
+              };
+            }
+          });
         }
         context.amplify.writeObjectAsJson(cfnFilePath, cfnMeta, true);
       });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There may be reasons to have a multiple lambda function resources inside a single function resource. This may be because the function is doing one-off deployment tasks as a custom resource, or handling other processing duties related to the main lambda. For example, one lambda may handle domain logic and handle CRUD for a dynamodb table, another Lambda may do the stream processing of the dynamodb table, and another might setup dynamodb ttl properties, or perform a data migration. At the same time, the details of these functions do not need to be exposed as a top level function and are best served by being encapsulated in another resource. Having the top level resources littered with tiny lambdas can lead to messy code.

This PR changes the push resources code to update all resources in a template that are a lambda and have a Code property. Previously, only the resource named LambdaFunction would have its Code property updated.

Users would not set a Code property in a resource template that they do not expect to have overwritten, but it is technically possible.

There are no better alternatives to handle this use case as the cloudformation provider is in control of the bucket and key names. Users could inline their functions inside the template, but that excludes a lot of nice tooling.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.