### PR TITLE
fix(graphql-elasticsearch-transformer): fix script to use keyschema

### DIFF
--- a/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
+++ b/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
@@ -44,7 +44,7 @@ def import_dynamodb_items_to_es(table_name, aws_secret, aws_access, aws_region, 
   ddb_table_name = table_name
   table = dynamodb.Table(ddb_table_name)
   logger.info('table: %s', table)
-  ddb_keys_name = [a['AttributeName'] for a in table.attribute_definitions]
+  ddb_keys_name = [a['AttributeName'] for a in table.key_schema]
   logger.info('ddb_keys_name: %s', ddb_keys_name)
   response = None
 


### PR DESCRIPTION
fix migration script to use key schema over attribute definitions

re #3786

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.