### PR TITLE
fix: lambda resolver CFN syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,22 +769,14 @@ jobs:
           when: always
       - store_artifacts:
           path: ../uitest_android_results
-  layer-amplify_e2e_tests:
+  api_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/layer.test.ts
+      TEST_SUITE: src/__tests__/api_1.test.ts
       CLI_REGION: us-east-2
-  schema-data-access-patterns-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
-      CLI_REGION: us-west-2
   api_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -792,7 +784,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/api_2.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: us-west-2
   auth_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -800,7 +792,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/auth_1.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: eu-west-2
   auth_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -808,23 +800,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/auth_2.test.ts
-      CLI_REGION: ap-northeast-1
-  schema-connection-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-connection.test.ts
-      CLI_REGION: ap-southeast-1
-  schema-versioned-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-versioned.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-central-1
   env-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -832,7 +808,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/env.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-northeast-1
   function_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -840,7 +816,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/function_1.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-southeast-1
   function_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -848,23 +824,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: eu-west-2
-  schema-auth-8-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-      CLI_REGION: eu-central-1
-  schema-searchable-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-2
   init-special-case-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -872,14 +832,54 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/init-special-case.test.ts
-      CLI_REGION: ap-southeast-1
-  schema-auth-7-amplify_e2e_tests:
+      CLI_REGION: us-east-2
+  layer-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-7.test.ts
+      TEST_SUITE: src/__tests__/layer.test.ts
+      CLI_REGION: us-west-2
+  schema-auth-1-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-1.test.ts
+      CLI_REGION: eu-west-2
+  schema-auth-2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-2.test.ts
+      CLI_REGION: eu-central-1
+  schema-auth-3-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-3.test.ts
+      CLI_REGION: ap-northeast-1
+  schema-auth-4-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-4.test.ts
+      CLI_REGION: ap-southeast-1
+  schema-auth-5-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-5.test.ts
       CLI_REGION: ap-southeast-2
   schema-auth-6-amplify_e2e_tests:
     working_directory: ~/repo
@@ -889,37 +889,37 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
       CLI_REGION: us-east-2
-  api_1-amplify_e2e_tests:
+  schema-auth-7-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/api_1.test.ts
+      TEST_SUITE: src/__tests__/schema-auth-7.test.ts
       CLI_REGION: us-west-2
-  schema-predictions-amplify_e2e_tests:
+  schema-auth-8-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-predictions.test.ts
+      TEST_SUITE: src/__tests__/schema-auth-8.test.ts
       CLI_REGION: eu-west-2
-  schema-model-amplify_e2e_tests:
+  schema-connection-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-model.test.ts
+      TEST_SUITE: src/__tests__/schema-connection.test.ts
       CLI_REGION: eu-central-1
-  schema-key-amplify_e2e_tests:
+  schema-data-access-patterns-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-key.test.ts
+      TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
       CLI_REGION: ap-northeast-1
   schema-function-amplify_e2e_tests:
     working_directory: ~/repo
@@ -929,45 +929,45 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/schema-function.test.ts
       CLI_REGION: ap-southeast-1
-  schema-auth-1-amplify_e2e_tests:
+  schema-key-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-1.test.ts
+      TEST_SUITE: src/__tests__/schema-key.test.ts
       CLI_REGION: ap-southeast-2
-  schema-auth-2-amplify_e2e_tests:
+  schema-model-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-2.test.ts
+      TEST_SUITE: src/__tests__/schema-model.test.ts
       CLI_REGION: us-east-2
-  schema-auth-3-amplify_e2e_tests:
+  schema-predictions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-3.test.ts
+      TEST_SUITE: src/__tests__/schema-predictions.test.ts
       CLI_REGION: us-west-2
-  schema-auth-4-amplify_e2e_tests:
+  schema-searchable-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-4.test.ts
+      TEST_SUITE: src/__tests__/schema-searchable.test.ts
       CLI_REGION: eu-west-2
-  schema-auth-5-amplify_e2e_tests:
+  schema-versioned-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-5.test.ts
+      TEST_SUITE: src/__tests__/schema-versioned.test.ts
       CLI_REGION: eu-central-1
   plugin-amplify_e2e_tests:
     working_directory: ~/repo
@@ -1165,25 +1165,25 @@ workflows:
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4
-            - schema-auth-2-amplify_e2e_tests
+            - schema-model-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - storage-amplify_e2e_tests
-            - schema-auth-3-amplify_e2e_tests
+            - schema-predictions-amplify_e2e_tests
             - init-amplify_e2e_tests
             - migration-api-key-migration-amplify_e2e_tests
-            - schema-auth-4-amplify_e2e_tests
+            - schema-searchable-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - migration-api-connection-migration-amplify_e2e_tests
-            - schema-model-amplify_e2e_tests
-            - schema-auth-5-amplify_e2e_tests
+            - schema-connection-amplify_e2e_tests
+            - schema-versioned-amplify_e2e_tests
             - analytics-amplify_e2e_tests
-            - schema-key-amplify_e2e_tests
+            - schema-data-access-patterns-amplify_e2e_tests
             - plugin-amplify_e2e_tests
             - hostingPROD-amplify_e2e_tests
             - schema-function-amplify_e2e_tests
             - datastore-modegen-amplify_e2e_tests
             - predictions-amplify_e2e_tests
-            - schema-auth-1-amplify_e2e_tests
+            - schema-key-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - delete-amplify_e2e_tests
           filters:
@@ -1192,7 +1192,7 @@ workflows:
                 - release
                 - master
                 - beta
-      - layer-amplify_e2e_tests:
+      - api_1-amplify_e2e_tests:
           filters: &ref_2
             branches:
               only:
@@ -1200,7 +1200,7 @@ workflows:
                 - graphqlschemae2e
           requires:
             - publish_to_local_registry
-      - env-amplify_e2e_tests:
+      - init-special-case-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1208,53 +1208,30 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-2-amplify_e2e_tests:
+      - schema-model-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - layer-amplify_e2e_tests
+            - api_1-amplify_e2e_tests
       - hosting-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - env-amplify_e2e_tests
+            - init-special-case-amplify_e2e_tests
       - storage-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
             - schema-auth-6-amplify_e2e_tests
-      - schema-data-access-patterns-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - function_1-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - api_1-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-3-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - schema-data-access-patterns-amplify_e2e_tests
-      - init-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - function_1-amplify_e2e_tests
-      - migration-api-key-migration-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - api_1-amplify_e2e_tests
       - api_2-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - function_2-amplify_e2e_tests:
+      - layer-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-7-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1262,22 +1239,22 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-4-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
             - api_2-amplify_e2e_tests
-      - amplify-app-amplify_e2e_tests:
+      - init-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - function_2-amplify_e2e_tests
-      - migration-api-connection-migration-amplify_e2e_tests:
+            - layer-amplify_e2e_tests
+      - migration-api-key-migration-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-predictions-amplify_e2e_tests
+            - schema-auth-7-amplify_e2e_tests
       - auth_1-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-1-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1285,16 +1262,17 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-model-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-5-amplify_e2e_tests:
+      - schema-searchable-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
             - auth_1-amplify_e2e_tests
-      - analytics-amplify_e2e_tests:
+      - amplify-app-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-1-amplify_e2e_tests
+      - migration-api-connection-migration-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1303,11 +1281,33 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-searchable-amplify_e2e_tests:
+      - schema-auth-2-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-key-amplify_e2e_tests:
+      - schema-connection-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-versioned-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - auth_2-amplify_e2e_tests
+      - analytics-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-2-amplify_e2e_tests
+      - env-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-3-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-data-access-patterns-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1315,17 +1315,17 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - auth_2-amplify_e2e_tests
+            - env-amplify_e2e_tests
       - hostingPROD-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-searchable-amplify_e2e_tests
-      - schema-connection-amplify_e2e_tests:
+            - schema-auth-3-amplify_e2e_tests
+      - function_1-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - init-special-case-amplify_e2e_tests:
+      - schema-auth-4-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1337,21 +1337,21 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-connection-amplify_e2e_tests
+            - function_1-amplify_e2e_tests
       - predictions-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - init-special-case-amplify_e2e_tests
-      - schema-versioned-amplify_e2e_tests:
+            - schema-auth-4-amplify_e2e_tests
+      - function_2-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-7-amplify_e2e_tests:
+      - schema-auth-5-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-1-amplify_e2e_tests:
+      - schema-key-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1359,9 +1359,9 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-versioned-amplify_e2e_tests
+            - function_2-amplify_e2e_tests
       - delete-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-auth-7-amplify_e2e_tests
+            - schema-auth-5-amplify_e2e_tests

--- a/packages/graphql-transformer-core/src/__tests__/util/__snapshots__/syncUtils.test.ts.snap
+++ b/packages/graphql-transformer-core/src/__tests__/util/__snapshots__/syncUtils.test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sync lambda arn resource creates the correct lambda arn substitution 1`] = `
+Object {
+  "Fn::If": Array [
+    "HasEnvironmentParameter",
+    Object {
+      "Fn::Sub": Array [
+        "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:myLambda-\${env}",
+        Object {
+          "env": Object {
+            "Ref": "env",
+          },
+        },
+      ],
+    },
+    Object {
+      "Fn::Sub": Array [
+        "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:myLambda",
+        Object {},
+      ],
+    },
+  ],
+}
+`;
+
+exports[`sync resolver config creates the correct lambda resolver config 1`] = `
+Object {
+  "ConflictDetection": "VERSION",
+  "ConflictHandler": "LAMBDA",
+  "LambdaConflictHandlerConfig": Object {
+    "LambdaConflictHandlerArn": Object {
+      "Fn::If": Array [
+        "HasEnvironmentParameter",
+        Object {
+          "Fn::Sub": Array [
+            "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:myLambda-\${env}",
+            Object {
+              "env": Object {
+                "Ref": "env",
+              },
+            },
+          ],
+        },
+        Object {
+          "Fn::Sub": Array [
+            "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:myLambda",
+            Object {},
+          ],
+        },
+      ],
+    },
+  },
+}
+`;

--- a/packages/graphql-transformer-core/src/__tests__/util/syncUtils.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/util/syncUtils.test.ts
@@ -1,0 +1,26 @@
+import { SyncConfigLAMBDA, ConflictHandlerType } from '../../util/transformConfig';
+import { SyncUtils } from '../../util/syncUtils';
+
+describe('sync resolver config', () => {
+  it('creates the correct lambda resolver config', () => {
+    const syncConfig: SyncConfigLAMBDA = {
+      ConflictDetection: 'VERSION',
+      ConflictHandler: ConflictHandlerType.LAMBDA,
+      LambdaConflictHandler: {
+        name: 'myLambda-${env}',
+      },
+    };
+
+    expect(SyncUtils.syncResolverConfig(syncConfig)).toMatchSnapshot();
+  });
+});
+
+describe('sync lambda arn resource', () => {
+  it('creates the correct lambda arn substitution', () => {
+    const partialSyncConfig = {
+      name: 'myLambda-${env}',
+    };
+
+    expect(SyncUtils.syncLambdaArnResource(partialSyncConfig)).toMatchSnapshot();
+  });
+});

--- a/packages/graphql-transformer-core/src/util/syncUtils.ts
+++ b/packages/graphql-transformer-core/src/util/syncUtils.ts
@@ -6,7 +6,9 @@ import { SyncConfigLAMBDA, SyncConfigOPTIMISTIC, SyncConfigSERVER } from './tran
 type SyncConfig = {
   ConflictDetection: string;
   ConflictHandler: string;
-  LambdaConflictHandlerArn?: any;
+  LambdaConflictHandlerConfig?: {
+    LambdaConflictHandlerArn?: any;
+  };
 };
 type DeltaSyncConfig = {
   DeltaSyncTableName: any;
@@ -93,7 +95,7 @@ export module SyncUtils {
     });
   }
   export function syncLambdaArnResource({ name, region }: { name: string; region?: string }) {
-    const env = 'env;';
+    const env = 'env';
     const substitutions = {};
     if (referencesEnv(name)) {
       substitutions[env] = Fn.Ref(ResourceConstants.PARAMETERS.Env);
@@ -101,7 +103,7 @@ export module SyncUtils {
     return Fn.If(
       ResourceConstants.CONDITIONS.HasEnvironmentParameter,
       Fn.Sub(lambdaArnKey(name, region), substitutions),
-      Fn.Sub(lambdaArnKey(removeEnvReference(name), region), {})
+      Fn.Sub(lambdaArnKey(removeEnvReference(name), region), {}),
     );
   }
   export function lambdaArnKey(name: string, region?: string) {
@@ -119,7 +121,7 @@ export module SyncUtils {
     return Fn.If(
       ResourceConstants.CONDITIONS.HasEnvironmentParameter,
       Fn.Join(separator, [...listToJoin, Fn.Ref(ResourceConstants.PARAMETERS.Env)]),
-      Fn.Join(separator, listToJoin)
+      Fn.Join(separator, listToJoin),
     );
   }
   export function syncLambdaIAMRole({ name, region }: { name: string; region?: string }) {
@@ -135,7 +137,7 @@ export module SyncUtils {
           // tslint:disable-next-line: no-magic-numbers
           name.slice(0, 37), // max of 64. 64-26-38 = 0
           Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'), // 26
-        ])
+        ]),
       ),
       AssumeRolePolicyDocument: {
         Version: '2012-10-17',
@@ -205,7 +207,9 @@ export module SyncUtils {
       ConflictHandler: syncConfig.ConflictHandler,
     };
     if (isLambdaSyncConfig(syncConfig)) {
-      resolverObj.LambdaConflictHandlerArn = syncLambdaArnResource(syncConfig.LambdaConflictHandler);
+      resolverObj.LambdaConflictHandlerConfig = {
+        LambdaConflictHandlerArn: syncLambdaArnResource(syncConfig.LambdaConflictHandler),
+      };
     }
     return resolverObj;
   }


### PR DESCRIPTION
There were 2 issues with the generated lambda resolver CFN. 1. the env map had an ";" in the key causing a CFN error and the SyncConfig of the AWS::AppSync::Resolver was malformed. see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-resolver-syncconfig.html#cfn-appsync-resolver-syncconfig-lambdaconflicthandlerconfig

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.