### PR TITLE
fix(graphql-auth-transformer): fix null owner auth assignment

### DIFF
--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -719,7 +719,7 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
       const allowedOwnersVariable = `allowedOwners${ruleNumber}`;
       ownerAuthorizationExpressions = ownerAuthorizationExpressions.concat(
         comment(`Authorization rule: { allow: ${rule.allow}, ownerField: "${ownerAttribute}", identityClaim: "${identityAttribute}" }`),
-        set(ref(allowedOwnersVariable), ref(`${variableToCheck}.${ownerAttribute}`)),
+        set(ref(allowedOwnersVariable), ref(`util.defaultIfNull($${variableToCheck}.${ownerAttribute}, [])`)),
         isUser
           ? // tslint:disable-next-line
             set(

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -410,7 +410,7 @@ groupsField: "${rule.groupsField || DEFAULT_GROUPS_FIELD}", groupClaim: "${rule.
         formatComment
           ? comment(formatComment(rule))
           : comment(`Authorization rule: { allow: ${rule.allow}, ownerField: "${ownerAttribute}", identityClaim: "${identityAttribute}" }`),
-        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, null)`)),
+        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, [])`)),
         isUser
           ? // tslint:disable-next-line
             set(
@@ -487,7 +487,7 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
         formatComment
           ? comment(formatComment(rule))
           : comment(`Authorization rule: { allow: ${rule.allow}, ownerField: "${ownerAttribute}", identityClaim: "${identityAttribute}" }`),
-        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, null)`)),
+        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, [])`)),
         isUser
           ? // tslint:disable-next-line
             set(

--- a/packages/graphql-auth-transformer/src/resources.ts
+++ b/packages/graphql-auth-transformer/src/resources.ts
@@ -410,7 +410,7 @@ groupsField: "${rule.groupsField || DEFAULT_GROUPS_FIELD}", groupClaim: "${rule.
         formatComment
           ? comment(formatComment(rule))
           : comment(`Authorization rule: { allow: ${rule.allow}, ownerField: "${ownerAttribute}", identityClaim: "${identityAttribute}" }`),
-        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, [])`)),
+        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, null)`)),
         isUser
           ? // tslint:disable-next-line
             set(
@@ -487,7 +487,7 @@ identityClaim: "${rule.identityField || rule.identityClaim || DEFAULT_IDENTITY_F
         formatComment
           ? comment(formatComment(rule))
           : comment(`Authorization rule: { allow: ${rule.allow}, ownerField: "${ownerAttribute}", identityClaim: "${identityAttribute}" }`),
-        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, [])`)),
+        set(ref(allowedOwnersVariable), raw(`$util.defaultIfNull($${variableToCheck}.${ownerAttribute}, null)`)),
         isUser
           ? // tslint:disable-next-line
             set(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -30,7 +30,7 @@ import 'isomorphic-fetch';
 
 jest.setTimeout(2000000);
 
-describe(`ModelAuthTests`, async () => {
+describe(`ModelAuthTests`, () => {
   const cf = new CloudFormationClient('us-west-2');
 
   const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
@@ -2600,14 +2600,25 @@ describe(`ModelAuthTests`, async () => {
   test("Test get and list with 'read' operation set", async () => {
     const response = await GRAPHQL_CLIENT_1.query(
       `mutation {
-          createOwnerReadProtected(input: { content: "Hello, World!", owner: "${USERNAME1}" }) {
+          createNoOwner: createOwnerReadProtected(input: { id: "1" content: "Hello, World! - No Owner" }) {
               id
               content
               owner
           }
+          createOwnerReadProtected(input: { id: "2" content: "Hello, World!", owner: "${USERNAME1}" }) {
+              id
+              content
+              owner
+          }
+          createNoOwner2: createOwnerReadProtected(input: { id: "3" content: "Hello, World! - No Owner 2" }) {
+            id
+            content
+            owner
+        }
       }`,
       {},
     );
+
     console.log(response);
     expect(response.data.createOwnerReadProtected.id).toBeDefined();
     expect(response.data.createOwnerReadProtected.content).toEqual('Hello, World!');
@@ -2649,7 +2660,7 @@ describe(`ModelAuthTests`, async () => {
       {},
     );
     console.log(response4);
-    expect(response4.data.listOwnerReadProtecteds.items.length).toBeGreaterThanOrEqual(1);
+    expect(response4.data.listOwnerReadProtecteds.items.length).toEqual(1);
 
     const response5 = await GRAPHQL_CLIENT_2.query(
       `query {


### PR DESCRIPTION
*Issue #, if available:*
resolves #5018

*Description of changes:*
Sets a default owner value of an empty array to compare against when the owner field is null

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.