### PR TITLE
fix: added sharedId in manual auth flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1116,9 +1116,9 @@ workflows:
           filters:
             branches:
               only:
-                # - master
+                - master
                 - graphqlschemae2e
-                # - beta
+                - beta
           requires:
             - build
             - mock_e2e_tests
@@ -1161,7 +1161,7 @@ workflows:
             - test
             - mock_e2e_tests
             - graphql_e2e_tests
-            # - integration_test
+            - integration_test
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -20,6 +20,10 @@ const generalDefaults = projectName => ({
   ...roles,
 });
 
+const sharedIdManual = () => ({
+  sharedId: sharedId,
+});
+
 const userPoolDefaults = projectName => {
   const projectNameTruncated = `${projectName.substring(0, 6)}${sharedId}`;
   return {
@@ -96,4 +100,5 @@ module.exports = {
   withSocialDefaults,
   entityKeys,
   roles,
+  sharedIdManual,
 };

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -122,7 +122,7 @@ async function addResource(context, category, service) {
   return serviceQuestions(context, defaultValuesFilename, stringMapFilename, serviceWalkthroughFilename)
     .then(async result => {
       const defaultValuesSrc = `${__dirname}/assets/${defaultValuesFilename}`;
-      const { functionMap, generalDefaults, roles } = require(defaultValuesSrc);
+      const { functionMap, generalDefaults, roles, sharedIdManual } = require(defaultValuesSrc);
 
       /* if user has used the default configuration,
        * we populate base choices like authSelections and resourceName for them */
@@ -134,7 +134,7 @@ async function addResource(context, category, service) {
 
       /* merge actual answers object into props object,
        * ensuring that manual entries override defaults */
-      props = Object.assign(functionMap[result.authSelections](result.resourceName), result, roles);
+      props = Object.assign(functionMap[result.authSelections](result.resourceName), result, roles, sharedIdManual());
 
       await lambdaTriggers(props, context, null);
 


### PR DESCRIPTION
*Description of changes:*

When adding auth manually configure everything, two IAM roles are created that have 'undefined' in their name.This PR adds SharedId to the props , so that IAM roles generated has proper Id instead of undefined


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.