### PR TITLE
fix: change logic to separate functions from layers in mock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1116,9 +1116,9 @@ workflows:
           filters:
             branches:
               only:
-                # - master
+                - master
                 - graphqlschemae2e
-                # - beta
+                - beta
           requires:
             - build
             - mock_e2e_tests
@@ -1161,7 +1161,7 @@ workflows:
             - test
             - mock_e2e_tests
             - graphql_e2e_tests
-            # - integration_test
+            - integration_test
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4

--- a/packages/amplify-category-function/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-category-function/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mock function mock function with functions 1`] = `
+Object {
+  "isMockable": true,
+  "reason": "Lambda layers cannot be mocked locally",
+}
+`;
+
+exports[`mock function mock function with layers 1`] = `
+Object {
+  "isMockable": false,
+  "reason": "Mocking a function with layers is not supported. To test in the cloud: run \\"amplify push\\" to deploy your function to the cloud and then run \\"amplify console function\\" to test your function in the Lambda console.",
+}
+`;

--- a/packages/amplify-category-function/src/__tests__/index.test.ts
+++ b/packages/amplify-category-function/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { initEnv } from '../../src';
+import { initEnv, isMockable } from '../../src';
 import sequential from 'promise-sequential';
 
 jest.mock('promise-sequential');
@@ -50,5 +50,87 @@ describe('function category provider', () => {
       expect(sequential_mock.mock.calls.length).toBe(1);
       expect(sequential_mock.mock.calls[0][0].length).toBe(2);
     });
+  });
+});
+
+describe('mock function', () => {
+  it('mock function with layers', async () => {
+    const contextStub = {
+      amplify: {
+        getProjectMeta: () => ({
+          function: {
+            issue4992d7983625: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [
+                {
+                  category: 'function',
+                  resourceName: 'demofunction',
+                },
+                {
+                  category: 'function',
+                  resourceName: 'demolayer',
+                },
+              ],
+            },
+            demofunction: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [],
+            },
+            demolayer: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'LambdaLayer',
+              dependsOn: [],
+            },
+          },
+        }),
+      },
+    };
+    const resourceName = 'issue4992d7983625';
+    expect(isMockable(contextStub, resourceName)).toMatchSnapshot();
+  });
+
+  it('mock function with functions', async () => {
+    const contextStub = {
+      amplify: {
+        getProjectMeta: () => ({
+          function: {
+            issue4992d7983625: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [
+                {
+                  category: 'function',
+                  resourceName: 'demofunction',
+                },
+                {
+                  category: 'function',
+                  resourceName: 'demolayer',
+                },
+              ],
+            },
+            demofunction: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [],
+            },
+            demolayer: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [],
+            },
+          },
+        }),
+      },
+    };
+    const resourceName = 'issue4992d7983625';
+    expect(isMockable(contextStub, resourceName)).toMatchSnapshot();
   });
 });

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -146,10 +146,12 @@ export function isMockable(context: any, resourceName: string): IsMockableRespon
     };
   }
   const { service, dependsOn } = resourceValue;
-  const hasLayer =
-    service === ServiceName.LambdaFunction &&
-    Array.isArray(dependsOn) &&
-    dependsOn.filter(dependency => dependency.category === 'function').length !== 0;
+  const dependsOnLayers = dependsOn
+    .filter(dependency => dependency.category === 'function')
+    .map(val => _.get(context.amplify.getProjectMeta(), [val.category, val.resourceName]))
+    .filter(val => val.service === ServiceName.LambdaLayer);
+
+  const hasLayer = service === ServiceName.LambdaFunction && Array.isArray(dependsOnLayers) && dependsOnLayers.length !== 0;
   if (hasLayer) {
     return {
       isMockable: false,


### PR DESCRIPTION
*Issue #4992 *

*Description of changes:*

* Changed the logic to mock functions with layers when dependency on a function

* Added tests for the same


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.