### PR TITLE
feat: groundwork for using pkg

### DIFF
--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -2,5 +2,6 @@ export * from './cliContext';
 export * from './cliContextEnvironmentProvider';
 export * from './cliEnvironmentProvider';
 export * from './feature-flags';
+export * from './is-native';
 export * from './jsonUtilities';
 export * from './jsonValidationError';

--- a/packages/amplify-cli-core/src/is-native.ts
+++ b/packages/amplify-cli-core/src/is-native.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns a boolean of whether or not the CLI is running as a native executable.
+ * Uses the fact that the root of __dirname will be the snapshot filesystem created by pkg when packaged natively
+ * See https://github.com/vercel/pkg#snapshot-filesystem
+ *
+ * This function is exported as part of index, but it can also be imported at 'amplify-cli-core/lib/is-native
+ */
+export const isNative = !!['/snapshot', 'C:\\snapshot'].find(prefix => __dirname.startsWith(prefix));

--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -1,3 +1,6 @@
 #!/usr/bin/env node
-require = require('esm')(module, { cache: false });
+if (!require('amplify-cli-core/lib/is-native').isNative) {
+  // eslint-disable-next-line no-global-assign
+  require = require('esm')(module, { cache: false });
+}
 require('../lib/index').run();

--- a/packages/amplify-cli/src/domain/constants.ts
+++ b/packages/amplify-cli/src/domain/constants.ts
@@ -13,6 +13,7 @@ export const constants = {
   Amplify: 'amplify',
   DotAmplifyDirName: '.amplify',
   AmplifyPrefix: 'amplify-',
+  PackagedNodeModules: 'packaged-node-modules',
   LocalNodeModules: 'cli-local-node-modules',
   ParentDirectory: 'cli-parent-directory',
   GlobalNodeModules: 'global-node-modules',

--- a/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
+++ b/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
@@ -12,6 +12,7 @@ import { twoPluginsAreTheSame } from './compare-plugins';
 import { checkPlatformHealth } from './platform-health-check';
 import { readJsonFileSync } from '../utils/readJsonFile';
 import isChildPath from '../utils/is-child-path';
+import { isNative } from 'amplify-cli-core';
 
 export async function scanPluginPlatform(pluginPlatform?: PluginPlatform): Promise<PluginPlatform> {
   pluginPlatform = pluginPlatform || (await readPluginsJsonFile()) || new PluginPlatform();
@@ -35,9 +36,8 @@ export async function scanPluginPlatform(pluginPlatform?: PluginPlatform): Promi
     await sequential(scanUserLocationTasks);
   }
 
-  // check if the CLI is running as a packaged native executable
-  if (['/snapshot', 'C:\\snapshot'].find(prefix => __dirname.startsWith(prefix))) {
-    // if so, add the packaged node modules path to the plugin scan list
+  if (isNative) {
+    // if the cli is running natively, add the packaged node modules path to the plugin scan list
     pluginPlatform!.pluginDirectories.push(constants.PackagedNodeModules);
   }
 

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -2,6 +2,7 @@ const constants = require('./constants');
 const path = require('path');
 const fs = require('fs-extra');
 const graphQLConfig = require('graphql-config');
+const { isNative } = require('amplify-cli-core');
 
 const CUSTOM_CONFIG_BLACK_LIST = [
   'aws_user_files_s3_dangerously_connect_to_http_endpoint_for_testing',
@@ -189,7 +190,17 @@ async function getCurrentAWSExports(context) {
   let awsExports = {};
 
   if (fs.existsSync(targetFilePath)) {
-    awsExports = require(targetFilePath).default;
+    if (isNative) {
+      // if native, we can't load an ES6 module because pkg doesn't support it yet
+      const es5export = 'module.exports = {default: awsmobile};\n';
+      const es6export = 'export default awsmobile;\n';
+      const fileContents = fs.readFileSync(targetFilePath, 'utf-8');
+      fs.writeFileSync(targetFilePath, fileContents.replace(es6export, es5export));
+      awsExports = require(targetFilePath).default;
+      fs.writeFileSync(targetFilePath, fileContents);
+    } else {
+      awsExports = require(targetFilePath).default;
+    }
   }
 
   return awsExports;

--- a/packages/amplify-frontend-javascript/package.json
+++ b/packages/amplify-frontend-javascript/package.json
@@ -16,6 +16,7 @@
     "aws"
   ],
   "dependencies": {
+    "amplify-cli-core": "1.2.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "graphql-config": "^2.2.1",


### PR DESCRIPTION
To package the CLI as a native binary using [pkg](https://www.npmjs.com/package/pkg) we can't use ES6 modules or esm because they are not supported by the library.
To get around this issue we will use Babel to transpile to ES5 (not part of this PR). This PR includes the changes to not use esm if running natively and read aws-exports using ES5 (which is the only file that we import as ES6 that can't be transpiled by Babel because it is part of customer projects.

Also, when packaged, all of the node modules are located alongside the CLI which requires a small addition to the plugin scan directories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.