### PR TITLE
chore: implement workaround for fs copy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 packages/amplify-headless-interface/**/*.schema.json
 packages/*/CHANGELOG.md
 packages/amplify-cli-core/src/__tests__/testFiles
+packages/**/lib

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "amplify-category-auth": "2.18.1",
     "amplify-category-function": "2.23.1",
+    "amplify-cli-core":"1.2.0",
     "amplify-util-headless-input": "1.2.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
@@ -6,6 +6,7 @@ import { AddApiRequest, UpdateApiRequest } from 'amplify-headless-interface';
 import { category } from '../../../category-constants';
 import { writeTransformerConfiguration } from 'graphql-transformer-core';
 import { rootAssetDir } from '../../../provider-utils/awscloudformation/aws-constants';
+import { copy } from 'amplify-cli-core';
 import {
   getAppSyncResourceName,
   getAppSyncAuthConfig,
@@ -14,6 +15,9 @@ import {
 import _ from 'lodash';
 
 jest.mock('fs-extra');
+jest.mock('amplify-cli-core', () => ({
+  copy: jest.fn(),
+}));
 
 jest.mock('graphql-transformer-core', () => ({
   readTransformerConfiguration: jest.fn(async () => ({})),
@@ -28,6 +32,7 @@ jest.mock('../../../provider-utils/awscloudformation/utils/amplify-meta-utils', 
 }));
 
 const fs_mock = (fs as unknown) as jest.Mocked<typeof fs>;
+const copy_mock = copy as jest.MockedFunction<typeof copy>;
 const writeTransformerConfiguration_mock = writeTransformerConfiguration as jest.MockedFunction<typeof writeTransformerConfiguration>;
 const getAppSyncResourceName_mock = getAppSyncResourceName as jest.MockedFunction<typeof getAppSyncResourceName>;
 const getAppSyncAuthConfig_mock = getAppSyncAuthConfig as jest.MockedFunction<typeof getAppSyncAuthConfig>;
@@ -104,8 +109,8 @@ describe('create artifacts', () => {
 
   it('writes the default custom resources stack', async () => {
     await cfnApiArtifactHandler.createArtifacts(addRequestStub);
-    expect(fs_mock.copyFileSync.mock.calls.length).toBe(1);
-    expect(fs_mock.copyFileSync.mock.calls[0]).toEqual([
+    expect(copy_mock.mock.calls.length).toBe(1);
+    expect(copy_mock.mock.calls[0]).toEqual([
       path.join(rootAssetDir, 'cloudformation-templates', 'defaultCustomResources.json'),
       path.join(backendDirPathStub, category, addRequestStub.serviceConfiguration.apiName, 'stacks', 'CustomResources.json'),
     ]);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -18,6 +18,7 @@ import _ from 'lodash';
 import { ServiceName as FunctionServiceName } from 'amplify-category-function';
 import { getAppSyncResourceName, getAppSyncAuthConfig, checkIfAuthExists, authConfigHasApiKey } from './utils/amplify-meta-utils';
 import { printApiKeyWarnings } from './utils/print-api-key-warnings';
+import { copy } from 'amplify-cli-core';
 
 export const getCfnApiArtifactHandler = (context): ApiArtifactHandler => {
   return new CfnApiArtifactHandler(context);
@@ -67,7 +68,7 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
     await writeResolverConfig(serviceConfig.conflictResolution, resourceDir);
 
     // Write the default custom resources stack out to disk.
-    fs.copyFileSync(
+    await copy(
       path.join(rootAssetDir, 'cloudformation-templates', 'defaultCustomResources.json'),
       path.join(resourceDir, stacksDirName, defaultStackName),
     );

--- a/packages/amplify-category-api/tsconfig.json
+++ b/packages/amplify-category-api/tsconfig.json
@@ -12,6 +12,7 @@
     "src/__tests__"
   ],
   "references": [
+    {"path": "../amplify-cli-core"},
     {"path": "../amplify-headless-interface"},
     {"path": "../graphql-transformer-core"},
     {"path": "../amplify-util-headless-input"},

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "amplify-category-function": "2.23.1",
+    "amplify-cli-core": "1.2.0",
     "aws-sdk": "^2.608.0",
     "chalk": "^3.0.0",
     "chalk-pipe": "^3.0.0",

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/index.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra');
 const _ = require('lodash');
 const uuid = require('uuid');
 const { existsSync } = require('fs');
-const { copySync } = require('fs-extra');
+const { copy } = require('amplify-cli-core');
 const { getAuthResourceName } = require('../../utils/getAuthResourceName');
 const { ServiceName: FunctionServiceName } = require('amplify-category-function');
 
@@ -641,7 +641,7 @@ async function copyS3Assets(context, props) {
   if (confirmationFileNeeded) {
     if (!existsSync(targetDir)) {
       const source = `${__dirname}/triggers/CustomMessage/assets`;
-      copySync(source, `${targetDir}`);
+      await copy(source, `${targetDir}`);
     }
   }
 }

--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -28,13 +28,15 @@
     "dotenv": "^8.2.0",
     "fs-extra": "^8.1.0",
     "hjson": "^3.2.1",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "ncp": "^2.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
     "@types/hjson": "^2.4.2",
     "@types/json-schema": "^7.0.5",
     "@types/lodash": "^4.14.149",
+    "@types/ncp":"^2.0.4",
     "@types/node": "^10.17.13",
     "@types/rimraf": "^3.0.0",
     "@types/uuid": "^8.0.0",

--- a/packages/amplify-cli-core/src/fsUtilities.ts
+++ b/packages/amplify-cli-core/src/fsUtilities.ts
@@ -1,0 +1,20 @@
+import ncp from 'ncp';
+import { CopyOptions } from 'fs-extra';
+
+/**
+ * Uses ncp to copy files because it doesn't use fs.copyFile under the hood. fs.copyFile does not work with pkg: https://github.com/vercel/pkg/issues/420
+ * Once that issue is resolved, we should be able to use fs.copy() here
+ *
+ * To allow this to be a drop-in replacement for fs.copy operations, this function takes in fs CopyOptions and translates them to ncp options
+ * (currently just translating the 'overwrite' flag because that's all that we use)
+ * @param source source directory or file
+ * @param destination destination directory or file
+ */
+export const copy = (source: string, destination: string, options: Pick<CopyOptions, 'overwrite'> = {}) =>
+  new Promise<void>((resolve, reject) => {
+    ncp(source, destination, translateOptions(options), err => (err ? reject(err) : resolve()));
+  });
+
+const translateOptions = (options: CopyOptions): ncp.Options => ({
+  clobber: options.overwrite,
+});

--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -2,5 +2,6 @@ export * from './cliContext';
 export * from './cliContextEnvironmentProvider';
 export * from './cliEnvironmentProvider';
 export * from './feature-flags';
+export * from './fsUtilities';
 export * from './jsonUtilities';
 export * from './jsonValidationError';

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -6,6 +6,7 @@ import { initFrontend } from './attach-backend-steps/a30-initFrontend';
 import { generateFiles } from './attach-backend-steps/a40-generateFiles';
 import { postPullCodeGenCheck } from './amplify-service-helper';
 import { initializeEnv } from './initialize-env';
+import { copy } from 'amplify-cli-core';
 
 const backupAmplifyDirName = 'amplify-backup';
 
@@ -37,7 +38,7 @@ async function onSuccess(context) {
     if (fs.existsSync(backupBackendDirPath)) {
       const backendDirPath = context.amplify.pathManager.getBackendDirPath(projectPath);
       fs.removeSync(backendDirPath);
-      fs.copySync(backupBackendDirPath, backendDirPath);
+      await copy(backupBackendDirPath, backendDirPath);
     }
   }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { readJsonFile } from './read-json-file';
 import { ServiceName as FunctionServiceName } from 'amplify-category-function';
 import Separator from 'inquirer/lib/objects/separator';
+import { copy } from 'amplify-cli-core';
 
 /** ADD A TRIGGER
  * @function addTrigger
@@ -397,7 +398,7 @@ export const copyFunctions = async (key, value, category, context, targetPath) =
       } else {
         source = `${pluginPath}/provider-utils/awscloudformation/triggers/${key}/${value}.js`;
       }
-      fs.copySync(source, `${targetPath}/${value}.js`);
+      await copy(source, `${targetPath}/${value}.js`);
       await openEditor(context, targetPath, value);
     }
   } catch (e) {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
@@ -11,6 +11,7 @@ import {
   getBackendDirPath,
   getCurrentCloudBackendDirPath,
 } from './path-manager';
+import { copy } from 'amplify-cli-core';
 
 export function updateAwsMetaFile(filePath, category, resourceName, attribute, value, timeStamp) {
   const amplifyMeta = readJsonFile(filePath);
@@ -43,7 +44,7 @@ export function updateAwsMetaFile(filePath, category, resourceName, attribute, v
   return amplifyMeta;
 }
 
-function moveBackendResourcesToCurrentCloudBackend(resources) {
+async function moveBackendResourcesToCurrentCloudBackend(resources) {
   const amplifyMetaFilePath = getAmplifyMetaFilePath();
   const amplifyCloudMetaFilePath = getCurrentAmplifyMetaFilePath();
   const backendConfigFilePath = getBackendConfigFilePath();
@@ -60,11 +61,11 @@ function moveBackendResourcesToCurrentCloudBackend(resources) {
 
     fs.ensureDirSync(targetDir);
 
-    fs.copySync(sourceDir, targetDir);
+    await copy(sourceDir, targetDir);
   }
 
-  fs.copySync(amplifyMetaFilePath, amplifyCloudMetaFilePath, { overwrite: true });
-  fs.copySync(backendConfigFilePath, backendConfigCloudFilePath, { overwrite: true });
+  await copy(amplifyMetaFilePath, amplifyCloudMetaFilePath, { overwrite: true });
+  await copy(backendConfigFilePath, backendConfigCloudFilePath, { overwrite: true });
 }
 
 export function updateamplifyMetaAfterResourceAdd(category, resourceName, options: { dependsOn? } = {}) {
@@ -142,7 +143,7 @@ export async function updateamplifyMetaAfterPush(resources) {
   const jsonString = JSON.stringify(amplifyMeta, null, '\t');
   fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
 
-  moveBackendResourcesToCurrentCloudBackend(resources);
+  await moveBackendResourcesToCurrentCloudBackend(resources);
 }
 
 function getHashForResourceDir(dirPath) {

--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -6,6 +6,7 @@ import { getPackageManager } from '../packageManagerHelpers';
 import { normalizePackageManagerForOS } from '../packageManagerHelpers';
 import { generateLocalEnvInfoFile } from './s9-onSuccess';
 import { insertAmplifyIgnore } from '../extensions/amplify-helpers/git-manager';
+import { copy } from 'amplify-cli-core';
 
 export async function preInitSetup(context) {
   if (context.parameters.options.app) {
@@ -99,5 +100,5 @@ async function createAmplifySkeleton() {
   insertAmplifyIgnore(path.join(process.cwd(), '.gitignore'));
   const skeletonLocalDir = path.join(__dirname, '../../templates/amplify-skeleton');
   const skeletonProjectDir = path.join(process.cwd(), '/amplify');
-  await fs.copySync(skeletonLocalDir, skeletonProjectDir);
+  await copy(skeletonLocalDir, skeletonProjectDir);
 }

--- a/packages/amplify-cli/src/migrate-project.ts
+++ b/packages/amplify-cli/src/migrate-project.ts
@@ -24,6 +24,7 @@ import {
   getAmplifyRcFilePath,
 } from './extensions/amplify-helpers/path-manager';
 import { $TSObject } from '.';
+import { copy } from 'amplify-cli-core';
 
 const confirmMigrateMessage =
   'We detected the project was initialized using an older version of the CLI. Do you want to migrate the project, so that it is compatible with the latest version of the CLI?';
@@ -79,7 +80,7 @@ async function migrateFrom0To1(context, projectPath, projectConfig) {
   let backupAmplifyDirPath;
   try {
     amplifyDirPath = getAmplifyDirPath(projectPath);
-    backupAmplifyDirPath = backup(amplifyDirPath, projectPath);
+    backupAmplifyDirPath = await backup(amplifyDirPath, projectPath);
     context.migrationInfo = generateMigrationInfo(projectConfig, projectPath);
 
     // Give each category a chance to migrate their respective files
@@ -142,7 +143,7 @@ async function migrateFrom0To1(context, projectPath, projectConfig) {
   }
 }
 
-function backup(amplifyDirPath, projectPath) {
+async function backup(amplifyDirPath, projectPath) {
   const backupAmplifyDirName = `${amplifyCLIConstants.AmplifyCLIDirName}-${makeId(5)}`;
   const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
 
@@ -155,7 +156,7 @@ function backup(amplifyDirPath, projectPath) {
     throw error;
   }
 
-  fs.copySync(amplifyDirPath, backupAmplifyDirPath);
+  await copy(amplifyDirPath, backupAmplifyDirPath);
 
   return backupAmplifyDirPath;
 }

--- a/packages/amplify-cli/src/plugin-helpers/create-new-plugin.ts
+++ b/packages/amplify-cli/src/plugin-helpers/create-new-plugin.ts
@@ -9,6 +9,7 @@ import { readJsonFileSync } from '../utils/readJsonFile';
 import { validPluginName } from './verify-plugin';
 import { createIndentation } from './display-plugin-platform';
 import { InputQuestion, ConfirmQuestion } from 'inquirer';
+import { copy } from 'amplify-cli-core';
 
 const INDENTATIONSPACE = 4;
 
@@ -78,7 +79,7 @@ async function copyAndUpdateTemplateFiles(context: Context, pluginParentDirPath:
   } else if (pluginType === AmplifyPluginType.provider.toString()) {
     srcDirPath = path.join(__dirname, '../../templates/plugin-template-provider');
   }
-  fs.copySync(srcDirPath, pluginDirPath);
+  await copy(srcDirPath, pluginDirPath);
 
   updatePackageJson(pluginDirPath, pluginName);
   updateAmplifyPluginJson(pluginDirPath, pluginName, pluginType, eventHandlers);

--- a/packages/amplify-provider-awscloudformation/lib/attach-backend.js
+++ b/packages/amplify-provider-awscloudformation/lib/attach-backend.js
@@ -7,6 +7,7 @@ const configurationManager = require('./configuration-manager');
 const { getConfiguredAmplifyClient } = require('../src/aws-utils/aws-amplify');
 const { checkAmplifyServiceIAMPermission } = require('./amplify-service-permission-check');
 const constants = require('./constants');
+const { copy } = require('amplify-cli-core');
 
 async function run(context) {
   await configurationManager.init(context);
@@ -245,8 +246,8 @@ async function downloadBackend(context, backendEnv, awsConfig) {
     });
   });
 
-  fs.copySync(unzippedDirPath, currentCloudBackendDir);
-  fs.copySync(unzippedDirPath, backendDir);
+  await copy(unzippedDirPath, currentCloudBackendDir);
+  await copy(unzippedDirPath, backendDir);
   fs.removeSync(tempDirPath);
 }
 

--- a/packages/amplify-provider-awscloudformation/lib/download-api-models.js
+++ b/packages/amplify-provider-awscloudformation/lib/download-api-models.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const extract = require('extract-zip');
 const sequential = require('promise-sequential');
 const APIGateway = require('../src/aws-utils/aws-apigw');
+const { copy } = require('amplify-cli-core');
 
 function downloadAPIModels(context, allResources) {
   const { amplify } = context;
@@ -51,12 +52,12 @@ function extractAPIModel(context, resource, framework) {
             if (err) {
               reject(err);
             }
-            extract(`${tempDir}/${apiName}.zip`, { dir: tempDir }, err => {
+            extract(`${tempDir}/${apiName}.zip`, { dir: tempDir }, async err => {
               if (err) {
                 reject(err);
               }
               // Copy files to src
-              copyFilesToSrc(context, apiName, framework);
+              await copyFilesToSrc(context, apiName, framework);
               fs.removeSync(tempDir);
               resolve();
             });
@@ -66,7 +67,7 @@ function extractAPIModel(context, resource, framework) {
   });
 }
 
-function copyFilesToSrc(context, apiName, framework) {
+async function copyFilesToSrc(context, apiName, framework) {
   const backendDir = context.amplify.pathManager.getBackendDirPath();
   const tempDir = `${backendDir}/.temp`;
 
@@ -79,7 +80,7 @@ function copyFilesToSrc(context, apiName, framework) {
 
         fs.ensureDirSync(target);
 
-        fs.copySync(generatedSrc, target);
+        await copy(generatedSrc, target);
       }
       break;
     case 'ios':
@@ -90,7 +91,7 @@ function copyFilesToSrc(context, apiName, framework) {
 
         fs.ensureDirSync(target);
 
-        fs.copySync(generatedSrc, target);
+        await copy(generatedSrc, target);
       }
       break;
     default:

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "amplify-category-auth": "2.18.1",
     "amplify-category-predictions": "2.4.9",
+    "amplify-cli-core": "1.2.0",
     "amplify-codegen": "2.15.16",
     "archiver": "^3.1.1",
     "aws-sdk": "^2.608.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,6 +4836,13 @@
   dependencies:
     moment ">=2.14.0"
 
+"@types/ncp@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.4.tgz#16c9e7fa2c849d429a1b142648987164b06bf490"
+  integrity sha512-erpimpT1pH8QfeNg77ypnjwz6CGMqrnL4DewVbqFzD9FXzSULjmG3KzjZnLNe7bzTSZm2W9DpkHyqop1g1KmgQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/nexpect@0.4.30":
   version "0.4.30"
   resolved "https://registry.npmjs.org/@types/nexpect/-/nexpect-0.4.30.tgz#08919064509d78b2b75e7150b07d718597bff9ab"
@@ -15719,6 +15726,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 negotiator@0.6.2:
   version "0.6.2"


### PR DESCRIPTION
[pkg](https://www.npmjs.com/package/pkg) does not support fs.copyFile/fs.copyFileSync operations (which includes fs-extra copy operations). This PR replaces all usages of these copy functions with a copy() utility function that is a wrapper around [ncp](https://www.npmjs.com/package/ncp) which does not use fs.copyFile so that the copy operations will work even when the CLI is packaged as a native binary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.