### PR TITLE
feat(amplify-codegen): add inquiries for user input to configure modelgen output

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/preset.ts
@@ -110,7 +110,7 @@ const generateTypeScriptPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
-  const modelFolder = join(options.baseOutputDir, 'models');
+  const modelFolder = options.baseOutputDir;
   config.push({
     ...options,
     filename: join(modelFolder, 'index.ts'),
@@ -139,7 +139,7 @@ const generateJavasScriptPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
-  const modelFolder = join(options.baseOutputDir, 'models');
+  const modelFolder = options.baseOutputDir;
   config.push({
     ...options,
     filename: join(modelFolder, 'index.js'),

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -20,8 +20,8 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@graphql-codegen/core": "1.17.8",
-    "amplify-codegen-appsync-model-plugin": "1.20.3",
+    "@graphql-codegen/core": "1.8.3",
+    "amplify-codegen-appsync-model-plugin": "1.20.4",
     "amplify-graphql-docs-generator": "2.1.16",
     "amplify-graphql-types-generator": "2.5.0",
     "chalk": "^3.0.0",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@graphql-codegen/core": "1.8.3",
-    "amplify-codegen-appsync-model-plugin": "1.20.4",
+    "amplify-codegen-appsync-model-plugin": "1.20.5",
     "amplify-graphql-docs-generator": "2.1.16",
     "amplify-graphql-types-generator": "2.5.0",
     "chalk": "^3.0.0",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -20,7 +20,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@graphql-codegen/core": "1.8.3",
+    "@graphql-codegen/core": "1.17.8",
     "amplify-codegen-appsync-model-plugin": "1.20.3",
     "amplify-graphql-docs-generator": "2.1.16",
     "amplify-graphql-types-generator": "2.5.0",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@graphql-codegen/core": "1.8.3",
-    "amplify-codegen-appsync-model-plugin": "1.20.5",
+    "amplify-codegen-appsync-model-plugin": "1.20.8",
     "amplify-graphql-docs-generator": "2.1.16",
     "amplify-graphql-types-generator": "2.5.0",
     "chalk": "^3.0.0",

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -104,8 +104,8 @@ function loadSchema(apiResourcePath) {
 async function getModelOutputPath(context) {
   const projectConfig = context.amplify.getProjectConfig();
 
-  if(projectConfig.modelgen && projectConfig.modelgen.outputPath && !context.parameters.options.configpath) {
-    context.print.success('\nThe output path for modelgen is already setup. You can edit the path in .config/project-config.json\n');
+  if(projectConfig.modelgen && projectConfig.modelgen.outputPath && !context.parameters.options.configPath) {
+    context.print.success('\nThe output path for modelgen is already configured. You can edit the path in .config/project-config.json\n');
     return projectConfig.modelgen.outputPath;
   }
 
@@ -125,7 +125,7 @@ async function getModelOutputPath(context) {
   }
 
   let outputPath = defaultPath;
-  if(context.parameters.options.configpath) {
+  if(context.parameters.options.configPath) {
     const answer = await askForModelOutputPath(defaultPath);
     outputPath = answer.outputPath;
   }
@@ -147,7 +147,7 @@ async function askForModelOutputPath(defaultPath) {
   const answer = await inquirer.prompt({
     type: 'input',
     name: 'outputPath',
-    message: 'Please type your relative output path for model',
+    message: 'Enter the path to the directory where models will be output. The path should be relative to the project root',
     default: defaultPath
   });
   return answer;

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -103,11 +103,11 @@ function loadSchema(apiResourcePath) {
 
 async function getModelOutputPath(context) {
   const projectConfig = context.amplify.getProjectConfig();
-  if(!projectConfig.frontend){
+  if(!projectConfig.frontend) {
     throw new Error('Frontend type is not configured.');
   }
 
-  if(projectConfig.modelgen && projectConfig.modelgen.outputPath){
+  if(projectConfig.modelgen && projectConfig.modelgen.outputPath) {
     context.print.success('\nThe output path for modelgen is already setup. You can edit the path in .config/project-config.json\n');
     return projectConfig.modelgen.outputPath;
   }
@@ -128,7 +128,7 @@ async function getModelOutputPath(context) {
   }
 
   let outputPath = defaultPath;
-  if(!context.parameters.options.yes){
+  if(!context.parameters.options.yes) {
     const answer = await askForModelOutputPath(defaultPath);
     outputPath = answer.outputPath;
   }
@@ -136,7 +136,7 @@ async function getModelOutputPath(context) {
   return outputPath;
 }
 
-async function askForModelOutputPath(defaultPath){
+async function askForModelOutputPath(defaultPath) {
   const answer = await inquirer.prompt({
     type: 'input',
     name: 'outputPath',

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -112,8 +112,9 @@ async function getModelOutputPath(context) {
   let defaultPath = '.';
   switch (projectConfig.frontend) {
     case 'javascript':
-      defaultPath = 'src/models';
-      break;
+      return projectConfig.javascript && projectConfig.javascript.config && projectConfig.javascript.config.SourceDir
+        ? path.normalize(projectConfig.javascript.config.SourceDir)
+        : 'src';
     case 'android':
       defaultPath = projectConfig.android && projectConfig.android.config && projectConfig.android.config.ResDir
         ? path.normalize(path.join(projectConfig.android.config.ResDir, '..', 'java'))

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -103,9 +103,6 @@ function loadSchema(apiResourcePath) {
 
 async function getModelOutputPath(context) {
   const projectConfig = context.amplify.getProjectConfig();
-  if(!projectConfig.frontend) {
-    throw new Error('Frontend type is not configured.');
-  }
 
   if(projectConfig.modelgen && projectConfig.modelgen.outputPath && !context.parameters.options.configpath) {
     context.print.success('\nThe output path for modelgen is already setup. You can edit the path in .config/project-config.json\n');

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -132,7 +132,17 @@ async function getModelOutputPath(context) {
     const answer = await askForModelOutputPath(defaultPath);
     outputPath = answer.outputPath;
   }
-  context.amplify.updateProjectConfig(context.amplify.getEnvInfo().projectPath, 'modelgen', {outputPath: outputPath});
+
+  //Get the project root directory
+  let projectRoot;
+  try {
+    context.amplify.getProjectMeta();
+    projectRoot = context.amplify.getEnvInfo().projectPath;
+  } catch (e) {
+    projectRoot = process.cwd();
+  }
+  context.amplify.updateProjectConfig(projectRoot, 'modelgen', {outputPath: outputPath});
+
   return outputPath;
 }
 

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -107,7 +107,7 @@ async function getModelOutputPath(context) {
     throw new Error('Frontend type is not configured.');
   }
 
-  if(projectConfig.modelgen && projectConfig.modelgen.outputPath) {
+  if(projectConfig.modelgen && projectConfig.modelgen.outputPath && !context.parameters.options.configpath) {
     context.print.success('\nThe output path for modelgen is already setup. You can edit the path in .config/project-config.json\n');
     return projectConfig.modelgen.outputPath;
   }
@@ -128,7 +128,7 @@ async function getModelOutputPath(context) {
   }
 
   let outputPath = defaultPath;
-  if(!context.parameters.options.yes) {
+  if(context.parameters.options.configpath) {
     const answer = await askForModelOutputPath(defaultPath);
     outputPath = answer.outputPath;
   }
@@ -140,7 +140,7 @@ async function askForModelOutputPath(defaultPath) {
   const answer = await inquirer.prompt({
     type: 'input',
     name: 'outputPath',
-    message: 'Please type your output path for model',
+    message: 'Please type your relative output path for model',
     default: defaultPath
   });
   return answer;

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -1,0 +1,122 @@
+const generateModels = require("../../src/commands/models");
+const { codegen } = require('@graphql-codegen/core');
+const { preset } = require('amplify-codegen-appsync-model-plugin');
+const { parse } = require('graphql');
+const fs = require('fs-extra');
+const path = require('path');
+const inquirer = require('inquirer');
+
+const MOCK_CONTEXT = {
+    amplify: {
+        getProjectMeta: jest.fn(),
+        getEnvInfo: jest.fn(),
+        getResourceStatus: jest.fn(),
+        getProjectConfig: jest.fn(),
+        executeProviderUtils: jest.fn(),
+        updateProjectConfig: jest.fn(),
+        pathManager: {
+            getBackendDirPath: jest.fn(),
+        },
+    },
+    parameters: {
+        options: {},
+    },
+    print: {
+        info: jest.fn(),
+    }
+}
+
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+const MOCK_SCHEMA = 'SCHEMA.GRAPHQL';
+const MOCK_RESOURCE_NAME = 'MOCK_RESOURCE_NAME';
+const MOCK_BACKEND_PATH = 'MOCK_BACKEND_PATH';
+const MOCK_RESOURCES = {
+    allResources:[
+        {
+            service: 'AppSync',
+            providerPlugin: 'awscloudformation',
+            resourceName: MOCK_RESOURCE_NAME
+        }
+    ]
+}
+
+const MOCK_SDK = 'MOCK_SDK';
+const MOCK_OUTPUT_PATH = 'MOCK_OUTPUT_PATH';
+const DEFAULT_SDK_PATH = {
+    javascript: 'src/models',
+    android: 'app/src/main/java',
+    ios: 'amplify/generated/models',
+}
+
+
+jest.mock('amplify-codegen-appsync-model-plugin');
+jest.mock('@graphql-codegen/core');
+jest.mock('graphql');
+jest.mock('fs-extra');
+jest.mock('inquirer');
+
+describe('command - models', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({projectPath: MOCK_PROJECT_ROOT});
+        MOCK_CONTEXT.amplify.getResourceStatus.mockReturnValue(MOCK_RESOURCES);
+        MOCK_CONTEXT.amplify.pathManager.getBackendDirPath.mockReturnValue(MOCK_BACKEND_PATH);
+        MOCK_CONTEXT.parameters.options.configpath = false;
+        parse.mockReturnValue(MOCK_SCHEMA);
+        preset.buildGeneratesSection.mockReturnValue([{}]);
+        fs.pathExistsSync.mockReturnValue(true);
+    });
+
+    it('should generate models in root if no frontend type is found', async () => {
+        MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({});
+        await generateModels(MOCK_CONTEXT);
+        expect(inquirer.prompt).not.toHaveBeenCalled();
+        expect(preset.buildGeneratesSection).toHaveBeenCalledWith({
+            baseOutputDir: MOCK_PROJECT_ROOT,
+            config: {
+                directives: undefined,
+                target: undefined
+            },
+            schema: MOCK_SCHEMA,
+        });
+        expect(codegen).toHaveBeenCalled();
+    });
+
+    describe('should generate models in default path if frontend is defined and no flags are passed', () => {
+        Object.entries(DEFAULT_SDK_PATH).forEach(([sdk, outputPath]) => {
+            it(`should generate models in ${sdk} by default path ${outputPath}`, async () => {
+                MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: sdk});
+                await generateModels(MOCK_CONTEXT);
+                expect(inquirer.prompt).not.toHaveBeenCalled();
+                expect(preset.buildGeneratesSection).toHaveBeenCalledWith({
+                    baseOutputDir: path.join(MOCK_PROJECT_ROOT, outputPath),
+                    config: {
+                        directives: undefined,
+                        target: sdk
+                    },
+                    schema: MOCK_SCHEMA,
+                });
+                expect(codegen).toHaveBeenCalled();
+            })
+        });
+    });
+
+    it('should ask for the output path if configpath flag is passed', async () => {
+        MOCK_CONTEXT.parameters.options.configpath = true;
+        MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: MOCK_SDK});
+        inquirer.prompt.mockReturnValue({outputPath: MOCK_OUTPUT_PATH});
+        await generateModels(MOCK_CONTEXT);
+        const question = inquirer.prompt.mock.calls[0][0];
+        expect(question.name).toEqual('outputPath');
+        expect(question.type).toEqual('input');
+        expect(preset.buildGeneratesSection).toHaveBeenCalledWith({
+            baseOutputDir: path.join(MOCK_PROJECT_ROOT, MOCK_OUTPUT_PATH),
+            config: {
+                directives: undefined,
+                target: MOCK_SDK
+            },
+            schema: MOCK_SCHEMA,
+        });
+        expect(codegen).toHaveBeenCalled();
+    });
+})

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -102,7 +102,7 @@ describe('command - models', () => {
     });
 
     it('should ask for the output path if configpath flag is passed', async () => {
-        MOCK_CONTEXT.parameters.options.configpath = true;
+        MOCK_CONTEXT.parameters.options.configPath = true;
         MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: MOCK_SDK});
         inquirer.prompt.mockReturnValue({outputPath: MOCK_OUTPUT_PATH});
         await generateModels(MOCK_CONTEXT);

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -31,7 +31,7 @@ const MOCK_SCHEMA = 'SCHEMA.GRAPHQL';
 const MOCK_RESOURCE_NAME = 'MOCK_RESOURCE_NAME';
 const MOCK_BACKEND_PATH = 'MOCK_BACKEND_PATH';
 const MOCK_RESOURCES = {
-    allResources:[
+    allResources: [
         {
             service: 'AppSync',
             providerPlugin: 'awscloudformation',


### PR DESCRIPTION
*Issue #, if available:*
fix #3585 fix #4548
*Description of changes:*

- Running `amplify codegen models` will first read from `amplify/.config/project-config.json` to get the output path. If it does not exist, the default output path will be used.

- Added an inquiry option when you run `amplify codegen models --configPath`, which will provide a customized output path for users.

- The path is stored in `amplify/.config/project-config.json` with the entry `modelgen.outputPath` after the first time modelgen runs. You can change the value either directly in this file or add `--configPath` flag in cmd. The first approach is recommended for iOS/Android developer using amplify tool plugins.

## Testing Done

- [x] passed API test in android studio gradle plugin

- [x] passed API test in xcode build process

- [x] added and passed unit tests for modelgen

## Examples

- `amplify codegen models`
<img width="1071" alt="Screen Shot 2020-08-24 at 5 43 31 PM" src="https://user-images.githubusercontent.com/20614187/91110060-9ec94d00-e631-11ea-896c-699808c7de77.png">

- `amplify codegen models --configPath`
<img width="1078" alt="Screen Shot 2020-08-24 at 5 44 51 PM" src="https://user-images.githubusercontent.com/20614187/91110074-a4bf2e00-e631-11ea-858c-7c37a6e9328e.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.