### PR TITLE
fix: sub * for path parms in CFN policy

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/cloudformation-templates/apigw-cloudformation-template-default.json.ejs
+++ b/packages/amplify-category-api/resources/awscloudformation/cloudformation-templates/apigw-cloudformation-template-default.json.ejs
@@ -84,7 +84,7 @@
                               ]
                             },
                               "<%= props.paths[i].privacy.auth[x] %>",
-                            "<%= props.paths[i].name %>/*"
+                            "<%= props.paths[i].policyResourceName %>/*"
                           ]
                         ]
                       },
@@ -115,7 +115,7 @@
                               ]
                             },
                               "<%= props.paths[i].privacy.auth[x] %>",
-                            "<%= props.paths[i].name %>"
+                            "<%= props.paths[i].policyResourceName %>"
                           ]
                         ]
                       }
@@ -197,7 +197,7 @@
                               ]
                             },
                               "<%= props.paths[i].privacy.userPoolGroups[selectedUserPoolGroupList[j]][x] %>",
-                            "<%= props.paths[i].name %>/*"
+                            "<%= props.paths[i].policyResourceName %>/*"
                           ]
                         ]
                       },
@@ -228,7 +228,7 @@
                               ]
                             },
                               "<%= props.paths[i].privacy.userPoolGroups[selectedUserPoolGroupList[j]][x] %>",
-                            "<%= props.paths[i].name %>"
+                            "<%= props.paths[i].policyResourceName %>"
                           ]
                         ]
                       }
@@ -295,7 +295,7 @@
                               ]
                             },
                               "<%= props.paths[i].privacy.unauth[x] %>",
-                            "<%= props.paths[i].name %>/*"
+                            "<%= props.paths[i].policyResourceName %>/*"
                           ]
                         ]
                       },
@@ -326,7 +326,7 @@
                               ]
                             },
                               "<%= props.paths[i].privacy.unauth[x] %>",
-                            "<%= props.paths[i].name %>"
+                            "<%= props.paths[i].policyResourceName %>"
                           ]
                         ]
                       }

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/__snapshots__/legacy-add-resource.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/__snapshots__/legacy-add-resource.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`legacy add resource sets policy resource name in paths object before copying template 1`] = `
+Object {
+  "paths": Array [
+    Object {
+      "name": "/some/{path}/with/{params}",
+      "policyResourceName": "/some/*/with/*",
+    },
+    Object {
+      "name": "another/path/without/params",
+      "policyResourceName": "another/path/without/params",
+    },
+  ],
+  "resourceName": "mockResourceName",
+}
+`;

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/legacy-add-resource.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/legacy-add-resource.test.ts
@@ -1,0 +1,34 @@
+import { legacyAddResource } from '../../../provider-utils/awscloudformation/legacy-add-resource';
+import { category } from '../../../category-constants';
+
+jest.mock('fs-extra');
+
+describe('legacy add resource', () => {
+  const contextStub = {
+    amplify: {
+      pathManager: {
+        getBackendDirPath: jest.fn(_ => 'mock/backend/path'),
+      },
+      updateamplifyMetaAfterResourceAdd: jest.fn(),
+      copyBatch: jest.fn(),
+    },
+  };
+
+  it('sets policy resource name in paths object before copying template', async () => {
+    const stubWalkthroughPromise: Promise<any> = Promise.resolve({
+      answers: {
+        resourceName: 'mockResourceName',
+        paths: [
+          {
+            name: '/some/{path}/with/{params}',
+          },
+          {
+            name: 'another/path/without/params',
+          },
+        ],
+      },
+    });
+    await legacyAddResource(stubWalkthroughPromise, contextStub, category, 'API Gateway', {});
+    expect(contextStub.amplify.copyBatch.mock.calls[0][2]).toMatchSnapshot();
+  });
+});

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/legacy-add-resource.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/legacy-add-resource.ts
@@ -25,6 +25,7 @@ export const legacyAddResource = async (serviceWalkthroughPromise: Promise<any>,
     if (answers.customCfnFile) {
       cfnFilename = answers.customCfnFile;
     }
+    addPolicyResourceNameToPaths(answers.paths);
     copyCfnTemplate(context, category, answers, cfnFilename);
 
     const parameters = { ...answers };
@@ -66,4 +67,15 @@ export const copyCfnTemplate = (context, category, options, cfnFilename) => {
 
   // copy over the files
   return context.amplify.copyBatch(context, copyJobs, options, true, false);
+};
+
+const addPolicyResourceNameToPaths = paths => {
+  if (Array.isArray(paths)) {
+    paths.forEach(p => {
+      const pathName = p.name;
+      if (typeof pathName === 'string') {
+        p.policyResourceName = pathName.replace(/{[a-zA-Z0-9\-]+}/g, '*');
+      }
+    });
+  }
 };


### PR DESCRIPTION
*Issue #, if available:*
#4492

*Description of changes:*
When a REST API path contained a path parameter (`/path/{param}`) and this API had an IAM policy associated with it, we were putting this path directly in the resource of the policy, meaning it would never match. This PR replaces {param} path components in the policy resource with a wildcard (*).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.