### PR TITLE
fix(amplify-appsync-simulator): fix returning null on nonexistent fields in util.toJson

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -30,7 +30,7 @@ export const generalUtils = {
     return JSON.parse(value);
   },
   toJson(value) {
-    return JSON.stringify(value);
+    return value ? JSON.stringify(value) : JSON.stringify(null);
   },
   autoId() {
     return autoId();

--- a/packages/amplify-util-mock/src/__e2e__/dynamo-db-model-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/dynamo-db-model-transformer.e2e.test.ts
@@ -178,6 +178,36 @@ test('Test createPost mutation', async () => {
   }
 });
 
+test('Test query on get query with null field', async () => {
+  const createResponse = await GRAPHQL_CLIENT.query(`
+    mutation {
+      createPost(input: { title: "Cool Post" }) {
+        id
+        title
+        createdAt
+        updatedAt
+      }
+    }`, {});
+  expect(createResponse.data.createPost.id).toBeDefined();
+  expect(createResponse.data.createPost.title).toEqual('Cool Post');
+  const postID = createResponse.data.createPost.id;
+  try {
+    const queryResponse = await GRAPHQL_CLIENT.query(`
+    query {
+      getPost(id: "${postID}") {
+        id
+        title
+        episode
+      }
+    }`, {});
+    expect(queryResponse.data.getPost.id).toEqual(postID);
+    expect(queryResponse.data.getPost.episode).toBeNull();
+  } catch (err) {
+    logDebug(err);
+    expect(err).toBeUndefined();
+  }
+});
+
 test('Test updatePost mutation', async () => {
   try {
     const createResponse = await GRAPHQL_CLIENT.query(


### PR DESCRIPTION
return null if on util.toJson if the value does not exist

re #5003

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.