### PR TITLE
chore: bump min cli to latest for stacktrace removal

### DIFF
--- a/packages/amplify-app/package.json
+++ b/packages/amplify-app/package.json
@@ -25,7 +25,7 @@
   },
   "engines": {
     "node": ">=10.0.0",
-    "@aws-amplify/cli": ">=4.21.0"
+    "@aws-amplify/cli": ">=4.27.2"
   },
   "dependencies": {
     "amplify-frontend-android": "2.13.4",


### PR DESCRIPTION
fix #4272

*Issue #, if available:*
#4272

*Description of changes:*
When running amplify status on a project created with amplify-app with the latest CLI a stacktrace will no longer be shown and a message will be shown that init must be run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.