### PR TITLE
fix: match Fn::GetAtt and Fn::Sub when initializing lambda resolvers

### DIFF
--- a/packages/amplify-util-mock/src/__tests__/api/lambda-arn-to-config.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-arn-to-config.test.ts
@@ -1,0 +1,52 @@
+import { LambdaFunctionConfig } from '../../CFNParser/lambda-resource-processor';
+import { lambdaArnToConfig } from '../../api/lambda-arn-to-config';
+
+describe('lambda arn to config', () => {
+  const provisionedLambdasStub: LambdaFunctionConfig[] = [
+    {
+      name: 'lambda1',
+      handler: 'index.handle1',
+    },
+    {
+      name: 'lambda2',
+      handler: 'index.handle2',
+    },
+  ];
+  it('resolves string arns', () => {
+    const result = lambdaArnToConfig('aws::arn::something::region::lambda1::otherstuff', provisionedLambdasStub);
+    expect(result).toEqual(provisionedLambdasStub[0]);
+  });
+
+  it('resolves Fn::Sub with params when lambda name is in template string', () => {
+    const result = lambdaArnToConfig(
+      { 'Fn::Sub': ['some::arn::lambda2::{withsubs}::stuff', { withsubs: 'a value' }] },
+      provisionedLambdasStub,
+    );
+    expect(result).toEqual(provisionedLambdasStub[1]);
+  });
+
+  it('resolves Fn::Sub strings when lambda name is in template string', () => {
+    const result = lambdaArnToConfig({ 'Fn::Sub': 'some::{sub}::string::with::lambda1::name' }, provisionedLambdasStub);
+    expect(result).toEqual(provisionedLambdasStub[0]);
+  });
+
+  it('resolves Fn::GetAtt arns when lambda name is in resource name', () => {
+    const result = lambdaArnToConfig({ 'Fn::GetAtt': ['functionlambda1resourcename', 'arn'] }, provisionedLambdasStub);
+    expect(result).toEqual(provisionedLambdasStub[0]);
+  });
+
+  it('throws on malformed arn refs', () => {
+    const ex = () => lambdaArnToConfig({ 'Fn::Sub': { key: 'cant interpret this' } }, provisionedLambdasStub);
+    expect(ex).toThrowError();
+  });
+
+  it('throws on unknown arn formats', () => {
+    const ex = () => lambdaArnToConfig(['dont know', 'what this is'], provisionedLambdasStub);
+    expect(ex).toThrowError();
+  });
+
+  it('throws when arn is valid but no matching lambda found in the project', () => {
+    const ex = () => lambdaArnToConfig('validformat::but::no::matchinglambda', provisionedLambdasStub);
+    expect(ex).toThrowError();
+  });
+});

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -17,6 +17,7 @@ import { getAllLambdaFunctions } from '../utils/lambda/load';
 import { getInvoker } from 'amplify-category-function';
 import { keys } from 'lodash';
 import { LambdaFunctionConfig } from '../CFNParser/lambda-resource-processor';
+import { lambdaArnToConfig } from './lambda-arn-to-config';
 
 export class APITest {
   private apiName: string;
@@ -195,7 +196,7 @@ export class APITest {
           if (d.type !== 'AWS_LAMBDA') {
             return d;
           }
-          const lambdaConfig = this.lambdaArnToConfig(d.LambdaFunctionArn, provisionedLambdas);
+          const lambdaConfig = lambdaArnToConfig(d.LambdaFunctionArn, provisionedLambdas);
           const envVars = await this.hydrateLambdaEnvVars(context, lambdaConfig.environment, config);
           const invoker = await getInvoker(context, {
             resourceName: lambdaConfig.name,
@@ -347,34 +348,4 @@ export class APITest {
       dataSources: config.dataSources,
     });
   }
-
-  /**
-   * Attempts to match an arn object against the array of lambdas configured in the project
-   */
-  private lambdaArnToConfig = (arn: any, provisionedLambdas: LambdaFunctionConfig[]): LambdaFunctionConfig => {
-    const errorSuffix =
-      '\nSee https://docs.amplify.aws/cli/graphql-transformer/directives#function for information on how to configure Lambda resolvers.';
-    let searchString = '';
-    if (typeof arn === 'string') {
-      searchString = arn;
-    } else if (typeof arn === 'object' && keys(arn).length === 1) {
-      const funcArr = arn['Fn::GetAtt'] || arn['Fn::Sub'];
-      if (Array.isArray(funcArr) && funcArr.length > 0) {
-        searchString = funcArr[0];
-      } else {
-        throw new Error(`Malformed Lambda ARN [${JSON.stringify(arn)}]${errorSuffix}`);
-      }
-    } else {
-      throw new Error(`Cannot interpret Lambda ARN [${JSON.stringify(arn)}]${errorSuffix}`);
-    }
-    const lambdaConfig = provisionedLambdas.find(funcConfig => searchString.includes(funcConfig.name));
-    if (!lambdaConfig) {
-      throw new Error(
-        `Did not find a Lambda matching ARN [${JSON.stringify(
-          arn,
-        )}] in the project. Local mocking only supports Lambdas that are configured in the project.${errorSuffix}`,
-      );
-    }
-    return lambdaConfig;
-  };
 }

--- a/packages/amplify-util-mock/src/api/lambda-arn-to-config.ts
+++ b/packages/amplify-util-mock/src/api/lambda-arn-to-config.ts
@@ -1,0 +1,34 @@
+import { LambdaFunctionConfig } from '../CFNParser/lambda-resource-processor';
+import { keys } from 'lodash';
+
+/**
+ * Attempts to match an arn object against the array of lambdas configured in the project
+ */
+export const lambdaArnToConfig = (arn: any, provisionedLambdas: LambdaFunctionConfig[]): LambdaFunctionConfig => {
+  const errorSuffix =
+    '\nSee https://docs.amplify.aws/cli/graphql-transformer/directives#function for information on how to configure Lambda resolvers.';
+  let searchString = '';
+  if (typeof arn === 'string') {
+    searchString = arn;
+  } else if (typeof arn === 'object' && keys(arn).length === 1) {
+    const value = arn['Fn::GetAtt'] || arn['Fn::Sub'];
+    if (Array.isArray(value) && value.length > 0) {
+      searchString = value[0];
+    } else if (typeof value === 'string') {
+      searchString = value;
+    } else {
+      throw new Error(`Malformed Lambda ARN [${JSON.stringify(arn)}]${errorSuffix}`);
+    }
+  } else {
+    throw new Error(`Cannot interpret Lambda ARN [${JSON.stringify(arn)}]${errorSuffix}`);
+  }
+  const lambdaConfig = provisionedLambdas.find(funcConfig => searchString.includes(funcConfig.name));
+  if (!lambdaConfig) {
+    throw new Error(
+      `Did not find a Lambda matching ARN [${JSON.stringify(
+        arn,
+      )}] in the project. Local mocking only supports Lambdas that are configured in the project.${errorSuffix}`,
+    );
+  }
+  return lambdaConfig;
+};


### PR DESCRIPTION
*Issue #, if available:*
#4438 

*Description of changes:*
Before we were assuming that the lambda ARN was a string of a certain format and extracting the lambda name from it.
Now there is some logic to account for strings as well as Fn::Sub and Fn::GetAtt references to lambdas when initializing the lambda resolvers in mock. It is probably not comprehensive, but it should cover most cases


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.