### PR TITLE
feat(graphql-elasticsearch-transformer): add 'from' query parameter

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -80,7 +80,7 @@ input ModelPostFilterInput {
 }
 
 type Query {
-  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String): SearchablePostConnection @aws_api_key @aws_iam
+  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String, from: Int): SearchablePostConnection @aws_api_key @aws_iam
   getPost(id: ID!): Post @aws_api_key @aws_iam
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection @aws_api_key @aws_iam
 }

--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -137,6 +137,7 @@ export class SearchableModelTransformer extends Transformer {
             makeInputValueDefinition('sort', makeNamedType(`Searchable${def.name.value}SortInput`)),
             makeInputValueDefinition('limit', makeNamedType('Int')),
             makeInputValueDefinition('nextToken', makeNamedType('String')),
+            makeInputValueDefinition('from', makeNamedType('Int')),
           ],
           makeNamedType(`Searchable${def.name.value}Connection`),
         ),

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
@@ -22,6 +22,7 @@ exports[`SearchableModelTransformer with external versioning 1`] = `
   \\"params\\": {
       \\"body\\":     {
                 #if( $context.args.nextToken )\\"search_after\\": [$util.toJson($context.args.nextToken)], #end
+                #if( $context.args.from )\\"from\\": $context.args.from, #end
                 \\"size\\": #if( $context.args.limit ) $context.args.limit #else 100 #end,
                 \\"sort\\": [{$sortField0: { \\"order\\" : $util.toJson($sortDirection) }}],
                 \\"version\\": true,
@@ -136,7 +137,7 @@ input ModelPostFilterInput {
 type Query {
   getPost(id: ID!): Post
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
-  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String): SearchablePostConnection
+  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String, from: Int): SearchablePostConnection
 }
 
 input CreatePostInput {
@@ -352,8 +353,8 @@ type Query {
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
   getUser(id: ID!): User
   listUsers(filter: ModelUserFilterInput, limit: Int, nextToken: String): ModelUserConnection
-  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String): SearchablePostConnection
-  searchUsers(filter: SearchableUserFilterInput, sort: SearchableUserSortInput, limit: Int, nextToken: String): SearchableUserConnection
+  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String, from: Int): SearchablePostConnection
+  searchUsers(filter: SearchableUserFilterInput, sort: SearchableUserSortInput, limit: Int, nextToken: String, from: Int): SearchableUserConnection
 }
 
 input CreatePostInput {
@@ -617,7 +618,7 @@ input ModelPostFilterInput {
 type Query {
   getPost(id: ID!): Post
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
-  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String): SearchablePostConnection
+  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String, from: Int): SearchablePostConnection
 }
 
 input CreatePostInput {
@@ -809,7 +810,7 @@ input ModelPostFilterInput {
 type Query {
   getPost(id: ID!): Post
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
-  customSearchPost(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String): SearchablePostConnection
+  customSearchPost(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String, from: Int): SearchablePostConnection
 }
 
 input CreatePostInput {
@@ -1016,7 +1017,7 @@ input ModelPostFilterInput {
 type Query {
   getPost(id: ID!): Post
   listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection
-  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String): SearchablePostConnection
+  searchPosts(filter: SearchablePostFilterInput, sort: SearchablePostSortInput, limit: Int, nextToken: String, from: Int): SearchablePostConnection
 }
 
 input CreatePostInput {

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -467,6 +467,7 @@ export class ResourceFactory {
             path: str('$indexPath'),
             size: ifElse(ref('context.args.limit'), ref('context.args.limit'), int(ResourceConstants.DEFAULT_SEARCHABLE_PAGE_LIMIT), true),
             search_after: list([ref('util.toJson($context.args.nextToken)')]),
+            from: ref('context.args.from'),
             version: bool(includeVersion),
             query: ifElse(
               ref('context.args.filter'),

--- a/packages/graphql-mapping-template/src/elasticsearch.ts
+++ b/packages/graphql-mapping-template/src/elasticsearch.ts
@@ -27,13 +27,15 @@ export class ElasticsearchMappingTemplate {
   /**
    * Create a search item resolver template.
    * @param size the size limit
-   * @param from the next token
+   * @param search_after the next token
+   * @param from the pagination offset
    * @param query the query
    */
   public static searchItem({
     query,
     size,
     search_after,
+    from,
     path,
     sort,
     version = bool(false),
@@ -43,6 +45,7 @@ export class ElasticsearchMappingTemplate {
     query?: ObjectNode | Expression;
     size?: Expression;
     search_after?: Expression | ListNode;
+    from?: Expression;
     version?: BooleanNode;
   }): ObjectNode {
     return obj({
@@ -52,6 +55,7 @@ export class ElasticsearchMappingTemplate {
       params: obj({
         body: raw(`{
                 #if( $context.args.nextToken )"search_after": ${print(search_after)}, #end
+                #if( $context.args.from )"from": ${print(from)}, #end
                 "size": ${print(size)},
                 "sort": ${print(sort)},
                 "version": ${print(version)},

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
@@ -276,6 +276,49 @@ test('Test searchPosts with sort field on a string field', async () => {
   expect(firstItemOfThirdQuery).toEqual(fourthItemOfFirstQuery);
 });
 
+test('Test searchPosts with offset pagination', async () => {
+  const firstQuery = await runQuery(
+    `query {
+        searchPosts(from: 0, limit: 999, sort: {
+            field: id
+            direction: desc
+        }){
+            items{
+              ...FullPost
+            }
+            nextToken
+            total
+          }
+    }`,
+    'Test searchPosts with offset pagination ',
+  );
+  expect(firstQuery).toBeDefined();
+  expect(firstQuery.data.searchPosts).toBeDefined();
+  const firstLength = firstQuery.data.searchPosts.items.length;
+  const secondQuery = await runQuery(
+    `query {
+        searchPosts(from: 2, limit: 999, sort: {
+            field: id
+            direction: desc
+        }){
+            items{
+              ...FullPost
+            }
+            nextToken
+            total
+          }
+    }`,
+    'Test searchPosts with offset pagination 2 ',
+  );
+  expect(secondQuery).toBeDefined();
+  expect(secondQuery.data.searchPosts).toBeDefined();
+  const secondLength = secondQuery.data.searchPosts.items.length;
+  expect(secondLength).toEqual(firstLength - 2);
+  const firstItem = firstQuery.data.searchPosts.items[0];
+  const secondItems = secondQuery.data.searchPosts.items;
+  expect(secondItems.find(i => i.id === firstItem.id)).not.toBeDefined();
+});
+
 test('Test searchPosts with sort on date type', async () => {
   const query = await runQuery(
     `query {


### PR DESCRIPTION
*Issue #, if available:* closes #5086 

*Description of changes:*
adds offset pagination for searchable queries. Uses the elasticsearch parameter 'from'.
adds test for new feature to verify offset.
updates snapshots for searchable template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.