### PR TITLE
Fix truncated results

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -25,11 +25,13 @@
     "amplify-function-plugin-interface": "1.4.0",
     "archiver": "^3.1.1",
     "execa": "^4.0.0",
+    "exit": "^0.1.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6"
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",
+    "@types/exit": "^0.1.31",
     "@types/node": "^10.17.13"
   },
   "jest": {

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs-extra';
 import { InvokeOptions } from './invokeOptions';
 import path from 'path';
 import _ from 'lodash';
+import exit from 'exit';
 
 //  copied from amplify-util-mock with slight modifications
 
@@ -104,5 +105,5 @@ process.on('message', async options => {
       }),
     );
   }
-  process.exit(1);
+  exit(1);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,6 +4685,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/exit@^0.1.31":
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/@types/exit/-/exit-0.1.31.tgz#681387d7724b42b91c29c7822da7967e05db5255"
+  integrity sha512-ghT0E6Bw64RXc6lM30ExMNlYbUCsyR8oucl/q+ESGGhNOXOmBPpZHYGXCH2T/yTFq9YtudNCnZEQ4puX6aq87A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/express-serve-static-core@*":
   version "4.17.9"
   resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz#2d7b34dcfd25ec663c25c85d76608f8b249667f1"
@@ -10201,7 +10208,7 @@ exenv@^1.2.2:
 
 exit@^0.1.2:
   version "0.1.2"
-  resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-brackets@^0.1.4:


### PR DESCRIPTION
*Issue #, if available:*
#4439

*Description of changes:*
As per NodeJs doc: 
> Calling process.exit() will force the process to exit as quickly as possible even if there are still asynchronous operations pending that have not yet completed fully, including I/O operations to process.stdout and process.stderr.

This causes sometimes [the output](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts#L23) to be truncated, making `JSON.parse` fail, when the output has not been completely processed.

I changed `process.exit` for https://github.com/cowboy/node-exit which ensures that stdout is fully drained.

After testing it, this solution seems to work.

Credits: This comment helped: 
https://github.com/sindresorhus/execa/issues/130#issuecomment-405259383

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.