### PR TITLE
Add the ability to list Amazon Cognito groups

### DIFF
--- a/packages/amplify-category-auth/resources/adminAuth/admin-auth-app.js
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-auth-app.js
@@ -23,6 +23,7 @@ const {
   enableUser,
   getUser,
   listUsers,
+  listGroups,
   listGroupsForUser,
   listUsersInGroup,
   signUserOut,
@@ -168,6 +169,22 @@ app.get('/listUsers', async (req, res, next) => {
       response = await listUsers((Limit = req.query.limit));
     } else {
       response = await listUsers();
+    }
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/listGroups', async (req, res, next) => {
+  try {
+    let response;
+    if (req.query.token) {
+      response = await listGroups(req.query.limit || 25, req.query.token);
+    } else if (req.query.limit) {
+      response = await listGroups((Limit = req.query.limit));
+    } else {
+      response = await listGroups();
     }
     res.status(200).json(response);
   } catch (err) {

--- a/packages/amplify-category-auth/resources/adminAuth/admin-auth-cognitoActions.js
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-auth-cognitoActions.js
@@ -154,6 +154,29 @@ async function listUsers(Limit, PaginationToken) {
   }
 }
 
+async function listGroups(Limit, PaginationToken) {
+  const params = {
+    UserPoolId: userPoolId,
+    ...(Limit && { Limit }),
+    ...(PaginationToken && { PaginationToken }),
+  };
+
+  console.log('Attempting to list groups');
+
+  try {
+    const result = await cognitoIdentityServiceProvider.listGroups(params).promise();
+
+    // Rename to NextToken for consistency with other Cognito APIs
+    result.NextToken = result.PaginationToken;
+    delete result.PaginationToken;
+
+    return result;
+  } catch (err) {
+    console.log(err);
+    throw err;
+  }
+}
+
 async function listGroupsForUser(username, Limit, NextToken) {
   const params = {
     UserPoolId: userPoolId,
@@ -229,6 +252,7 @@ module.exports = {
   enableUser,
   getUser,
   listUsers,
+  listGroups,
   listGroupsForUser,
   listUsersInGroup,
   signUserOut,

--- a/packages/amplify-category-auth/resources/adminAuth/admin-queries-function-template.json.ejs
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-queries-function-template.json.ejs
@@ -137,7 +137,8 @@
 								"cognito-idp:AdminListGroupsForUser",
 								"cognito-idp:AdminGetUser",
 								"cognito-idp:AdminConfirmSignUp",
-								"cognito-idp:ListUsers"
+								"cognito-idp:ListUsers",
+								"cognito-idp:ListGroups"
 							],
 							"Resource": {
 								"Fn::Join": [


### PR DESCRIPTION
Select the type of change that you're committing: feature
Write a short, imperative tense description of the change: Add the ability to list Amazon Cognito groups
Provide a longer description of the change: If someone wants to dynamically display a list of Amazon Cognito groups in an application, that is not currently possible.  This change opens up that use case.
Are there any breaking changes? N
Does this change affect any open issues? N
