### PR TITLE
feat(graphql-key-transformer): change default to add GSIs when using @key

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -139,9 +139,12 @@ export function addApiWithSchemaAndConflictDetection(cwd: string, schemaFile: st
   });
 }
 
-export function updateApiSchema(cwd: string, projectName: string, schemaName: string) {
+export function updateApiSchema(cwd: string, projectName: string, schemaName: string, forceUpdate: boolean = false) {
   const testSchemaPath = getSchemaPath(schemaName);
-  const schemaText = fs.readFileSync(testSchemaPath).toString();
+  let schemaText = fs.readFileSync(testSchemaPath).toString();
+  if (forceUpdate) {
+    schemaText += '  ';
+  }
   updateSchema(cwd, projectName, schemaText);
 }
 

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -1,6 +1,16 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 
+function getFeatureFlagConfig(projRoot: string) {
+  const featureFlagPath = path.join(projRoot, 'amplify.json');
+  return JSON.parse(fs.readFileSync(featureFlagPath, 'utf8'));
+}
+
+function updateFeatureFlagConfig(projRoot: string, config: Object) {
+  const featureFlagPath = path.join(projRoot, 'amplify.json');
+  fs.writeFileSync(featureFlagPath, config);
+}
+
 function getAWSConfigAndroidPath(projRoot: string): string {
   return path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'awsconfiguration.json');
 }
@@ -60,4 +70,6 @@ export {
   getAWSConfigIOSPath,
   getS3StorageBucketName,
   getAmplifyDirPath,
+  getFeatureFlagConfig,
+  updateFeatureFlagConfig
 };

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts
@@ -1,6 +1,7 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushForce } from 'amplify-e2e-core';
-import { addApiWithSchema, apiGqlCompile } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import { 
+  initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushForce,
+  addApiWithSchema, updateApiSchema, apiGqlCompile, createNewProjectDir, deleteProjectDir,
+  getFeatureFlagConfig, updateFeatureFlagConfig, amplifyPushUpdate } from 'amplify-e2e-core';
 
 describe('amplify key force push', () => {
   let projRoot: string;
@@ -23,5 +24,25 @@ describe('amplify key force push', () => {
     // gql-compile and force push with codebase cli
     await apiGqlCompile(projRoot, true);
     await amplifyPushForce(projRoot, true);
+  });
+
+  it('init project, add lsi key and force push expect error', async () => {
+    const projectName = 'keyforce';
+    const initialSchema = 'migrations_key/initial_schema.graphql';
+    // init, add api and push with installed cli
+    await initJSProjectWithProfile(projRoot, { name: projectName });
+    await addApiWithSchema(projRoot, initialSchema);
+    await amplifyPush(projRoot);
+    // update feature flag
+    let featureFlagConfig = getFeatureFlagConfig(projRoot);
+    featureFlagConfig.features.keytransformer['defaultSecondaryIndex'] = true
+    // write back to config
+    updateFeatureFlagConfig(projRoot, featureFlagConfig);
+    // forceUpdateSchema
+    updateApiSchema(projRoot, projectName, initialSchema, true);
+    // gql-compile and force push with codebase cli
+    await expect(
+      amplifyPushUpdate(projRoot, /Attempting to remove the local secondary index SomeLSI on the TodoTable table in the Todo stack.*/, true),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 });

--- a/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
+++ b/packages/amplify-provider-awscloudformation/lib/transform-graphql-schema.js
@@ -182,7 +182,7 @@ async function transformerVersionCheck(context, resourceDir, cloudBackendDirecto
     writeToConfig = true;
   }
   // Add the warning as noted in the elasticsearch
-  if (!localTransformerConfig.warningESMessage) {
+  if (!localTransformerConfig.ElasticsearchWarning) {
     localTransformerConfig.ElasticsearchWarning = true;
     writeToConfig = true;
   }

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -210,7 +210,6 @@ export class GraphQLTransform {
     this.transformers = options.transformers;
     this.stackMappingOverrides = options.stackMapping || {};
     this.transformConfig = options.transformConfig || {};
-    // check if this is an sync enabled project
   }
 
   /**
@@ -250,6 +249,7 @@ export class GraphQLTransform {
 
     // Transformer version is populated, store it in the transformer context, to make it accessible to transformers
     context.setTransformerVersion(this.transformConfig.Version!);
+    context.setTransfromerFeatureFlags(this.transformConfig.FeatureFlags!);
 
     for (const transformer of this.transformers) {
       if (isFunction(transformer.before)) {

--- a/packages/graphql-transformer-core/src/GraphQLTransform.ts
+++ b/packages/graphql-transformer-core/src/GraphQLTransform.ts
@@ -249,7 +249,7 @@ export class GraphQLTransform {
 
     // Transformer version is populated, store it in the transformer context, to make it accessible to transformers
     context.setTransformerVersion(this.transformConfig.Version!);
-    context.setTransfromerFeatureFlags(this.transformConfig.FeatureFlags!);
+    context.setTransfromerFeatureFlags(this.transformConfig.FeatureFlags || {});
 
     for (const transformer of this.transformers) {
       if (isFunction(transformer.before)) {

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -113,6 +113,8 @@ export class TransformerContext {
 
   private transformerVersion: Number;
 
+  private featureFlags: Record<string, string | number | boolean>;
+
   constructor(inputSDL: string) {
     const doc: DocumentNode = parse(inputSDL);
     for (const def of doc.definitions) {
@@ -719,6 +721,15 @@ export class TransformerContext {
 
   public getTransformerVersion(): Number {
     return this.transformerVersion;
+  }
+
+  public setTransfromerFeatureFlags(featureFlags: Record<string, string | number | boolean>) {
+    this.featureFlags = featureFlags;
+  }
+
+  public getTransformerFeatureFlag(key: string): string | number | boolean | null {
+    if (!(key in this.featureFlags)) return null;
+    return this.featureFlags[key];
   }
 
   public isProjectUsingDataStore(): boolean {

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -15,6 +15,7 @@ const PARAMETERS_FILE_NAME = 'parameters.json';
 export interface ProjectOptions {
   projectDirectory?: string;
   transformersFactory: Function;
+  featureFlags?: Record<string, string | number | boolean>;
   transformersFactoryArgs: object[];
   currentCloudBackendDirectory: string;
   rootStackFileName?: string;

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -33,6 +33,7 @@ export async function check(
     cantAddLSILater,
     cantEditGSIKeySchema,
     cantEditLSIKeySchema,
+    cantRemoveLSILater,
     cantAddAndRemoveGSIAtSameTime,
   ];
   // Project rules run on the full set of diffs, the current build, and the next build.
@@ -249,6 +250,29 @@ export function cantEditLSIKeySchema(diff: Diff, currentBuild: DiffableProject, 
           'The key schema of a local secondary index cannot be changed after being deployed.',
           'When enabling new access patterns you should: 1. Add a new @key 2. run amplify push ' +
             '3. Verify the new access pattern and remove the old @key.',
+        );
+      }
+    }
+  }
+}
+
+export function cantRemoveLSILater(diff: Diff, currentBuild: DiffableProject, nextBuild: DiffableProject) {
+  if (diff.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'LocalSecondaryIndexes') {
+    // Run logic to check that an LSI is being removed in favor of creating a GSI
+    const pathToTable = diff.path.slice(0, 5);
+    const oldTable = get(currentBuild, pathToTable);
+    const newTable = get(nextBuild, pathToTable);
+    const innerDiffs = getDiffs(oldTable, newTable);
+
+    for (const innerDiff of innerDiffs) {
+      if (innerDiff.kind === 'D' && innerDiff.path.length === 1 && innerDiff.path[0] === 'LocalSecondaryIndexes') {
+        const tableName = diff.path[3];
+        const indexName = innerDiff.lhs[0].IndexName;
+        const stackName = basename(diff.path[1], '.json');
+        throw new InvalidMigrationError(
+          `Attempting to remove the local secondary index ${indexName} on the ${tableName} table in the ${stackName} stack.`,
+          'A local secondary index cannot be removed once after being deployed.',
+          'In order to remove the local secondary index you would need to either delete or rename the table.',
         );
       }
     }

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -91,6 +91,10 @@ export interface TransformConfig {
    */
   Version?: number;
   /**
+   * A record flags so the transformer can determine which features to enable/disable
+   */
+  FeatureFlags?: Record<string, string | number | boolean>
+  /**
    * A flag added to keep a track of a change noted in elasticsearch
    */
   ElasticsearchWarning?: boolean;
@@ -226,7 +230,14 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
     }
   }
 
-  const config = await loadConfig(projectDirectory);
+  let config = await loadConfig(projectDirectory);
+  // add feature flags if they exist
+  if (opts?.featureFlags) {
+    config = {
+      ...config,
+      FeatureFlags: opts.featureFlags
+    };
+  }
   return {
     functions,
     pipelineFunctions,

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -353,6 +353,48 @@ test('Test that a secondary @key with a multiple field adds an LSI.', () => {
   expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
 });
 
+test('Test that a secondary @key with a multiple field adds an GSI based on enabled feature flag.', () => {
+  const validSchema = `
+    type Test
+        @model @key(fields: ["email", "createdAt"])
+        @key(name: "GSI_Email_UpdatedAt", fields: ["email", "updatedAt"], queryField: "testsByEmailByUpdatedAt") {
+        email: String!
+        createdAt: AWSDateTime!
+        updatedAt: AWSDateTime!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
+    transformConfig: {
+      FeatureFlags: {
+        defaultSecondaryIndex: true
+      }
+    }
+  });
+
+  const out = transformer.transform(validSchema);
+  let tableResource = out.stacks.Test.Resources.TestTable;
+  expect(tableResource).toBeDefined();
+  expect(tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].AttributeName).toEqual('email');
+  expect(tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[0].KeyType).toEqual('HASH');
+  expect(tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].AttributeName).toEqual('updatedAt');
+  expect(tableResource.Properties.GlobalSecondaryIndexes[0].KeySchema[1].KeyType).toEqual('RANGE');
+  expect(tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'email').AttributeType).toEqual('S');
+  expect(tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'updatedAt').AttributeType).toEqual('S');
+  expect(tableResource.Properties.AttributeDefinitions.find(ad => ad.AttributeName === 'createdAt').AttributeType).toEqual('S');
+  const schema = parse(out.schema);
+  const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as ObjectTypeDefinitionNode;
+  const queryIndexField = queryType.fields.find(f => f.name && f.name.value === 'testsByEmailByUpdatedAt') as FieldDefinitionNode;
+  expect(queryIndexField.arguments).toHaveLength(6);
+  expectArguments(queryIndexField, ['email', 'updatedAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
+
+  // When using a complex primary key args are added to the list field. They are optional and if provided, will use a Query instead of a Scan.
+  const listTestsField = queryType.fields.find(f => f.name && f.name.value === 'listTests') as FieldDefinitionNode;
+  expect(listTestsField.arguments).toHaveLength(6);
+  expectArguments(listTestsField, ['email', 'createdAt', 'filter', 'nextToken', 'limit', 'sortDirection']);
+});
+
 test('Test that a primary @key with complex fields will update the input objects.', () => {
   const validSchema = `
     type Test @model @key(fields: ["email"]) {


### PR DESCRIPTION
*Description of changes:*
- changed the default to adding GSI when creating a secondary index
- Added sanity check when removing an LSI from an already existing table
- Passed down feature flag config into graphql transformer
- Will maintain previous behavior via a feature flag
```json
{
  "features":
  {
    "keytransformer":
    {
      "defaultSecondaryIndex": true
    }
  }
}
```

*Issue #, if available:*
- re #2702 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.