### PR TITLE
fix wrong Java version check

### DIFF
--- a/packages/amplify-util-mock/src/__tests__/utils/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/index.test.ts
@@ -1,0 +1,85 @@
+import { describe } from 'jest-circus';
+import { _isUnsupportedJavaVersion } from '../../utils';
+import { fail } from 'assert';
+
+type JavaCondition = {
+  name: string;
+  unsupported: boolean;
+  javaOpts: string | null;
+  versionString: string | null;
+};
+
+describe('isUnsupportedJavaVersion', () => {
+  const javas: Array<JavaCondition> = [
+    {
+      javaOpts: null,
+      name: '7u79',
+      unsupported: true,
+      versionString: `java version "1.7.0_79"
+Java(TM) SE Runtime Environment (build 1.7.0_79-b15)
+Java HotSpot(TM) 64-Bit Server VM (build 24.79-b02, mixed mode)`,
+    },
+    {
+      javaOpts: null,
+      name: '8u131',
+      unsupported: false,
+      versionString: `java version "1.8.0_131"
+Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
+Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)`,
+    },
+    {
+      javaOpts: 'Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8',
+      name: '8u131',
+      unsupported: false,
+      versionString: `java version "1.8.0_131"
+Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
+Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)`,
+    },
+    {
+      javaOpts: null,
+      name: '8.0.265-amzn',
+      unsupported: false,
+      versionString: `openjdk version "1.8.0_265"
+OpenJDK Runtime Environment Corretto-8.265.01.1 (build 1.8.0_265-b01)
+OpenJDK 64-Bit Server VM Corretto-8.265.01.1 (build 25.265-b01, mixed mode)`,
+    },
+    {
+      javaOpts: null,
+      name: '11.0.0-open',
+      unsupported: false,
+      versionString: `openjdk version "11" 2018-09-25
+OpenJDK Runtime Environment 18.9 (build 11+28)
+OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)`,
+    },
+    {
+      javaOpts: 'Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8',
+      name: '11.0.0-open',
+      unsupported: false,
+      versionString: `openjdk version "11" 2018-09-25
+OpenJDK Runtime Environment 18.9 (build 11+28)
+OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)`,
+    },
+    {
+      javaOpts: null,
+      name: '11.0.3-librca',
+      unsupported: false,
+      versionString: `openjdk version "11.0.3-BellSoft" 2019-04-16
+LibericaJDK Runtime Environment (build 11.0.3-BellSoft+12)
+LibericaJDK 64-Bit Server VM (build 11.0.3-BellSoft+12, mixed mode)`,
+    },
+    {
+      javaOpts: null,
+      name: 'uninstalled',
+      unsupported: true,
+      versionString: null,
+    },
+  ];
+
+  javas.forEach(java => {
+    it(`should return ${java.unsupported} on java ${java.name} with JAVA_OPTS: ${java.javaOpts != null}`, () => {
+      const stderr: string = [java.javaOpts, java.versionString].filter(text => text != null).join('\n');
+      const actual = _isUnsupportedJavaVersion(stderr === '' ? null : stderr);
+      expect(actual).toBe(java.unsupported);
+    });
+  });
+});

--- a/packages/amplify-util-mock/src/__tests__/utils/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/index.test.ts
@@ -1,6 +1,7 @@
 import { describe } from 'jest-circus';
 import { _isUnsupportedJavaVersion } from '../../utils';
 import { fail } from 'assert';
+import semver = require('semver/preload');
 
 type JavaCondition = {
   name: string;
@@ -58,6 +59,14 @@ OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)`,
       versionString: `openjdk version "11" 2018-09-25
 OpenJDK Runtime Environment 18.9 (build 11+28)
 OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)`,
+    },
+    {
+      javaOpts: null,
+      name: '11.0.0-librca',
+      unsupported: false,
+      versionString: `openjdk version "11-BellSoft" 2018-09-25
+OpenJDK Runtime Environment (build 11-BellSoft+0)
+OpenJDK 64-Bit Server VM (build 11-BellSoft+0, mixed mode)`,
     },
     {
       javaOpts: null,

--- a/packages/amplify-util-mock/src/utils/index.ts
+++ b/packages/amplify-util-mock/src/utils/index.ts
@@ -35,10 +35,15 @@ export const checkJavaVersion = async context => {
 };
 
 function isUnsupportedJavaVersion(stderr: string | null): boolean {
-  const regex = /(\d+\.)(\d+\.)(\d)/g;
-  const versionString: string = stderr ? stderr.split(/\r?\n/)[0] : '';
-  const version = versionString.match(regex);
-  return version == null && !semver.satisfies(version[0], minJavaVersion);
+  const regex = /version "(\d+)(\.(\d+\.)(\d))?/g;
+  const versionStrings: Array<string> = stderr ? stderr.split(/\r?\n/) : [''];
+  const mayVersion = versionStrings.map(line => line.match(regex)).find(v => v != null);
+  if (mayVersion === undefined) {
+    return true;
+  }
+  const version = mayVersion[0].replace('version "', '');
+  const semVer = version.match(/^\d+$/g) === null ? version : `${version}.0.0`;
+  return !semver.satisfies(semVer, minJavaVersion);
 }
 
 export const _isUnsupportedJavaVersion: (stderr: string | null) => boolean = isUnsupportedJavaVersion;


### PR DESCRIPTION
*Issue #, if available:*

#5044 

*Description of changes:*

- Change regexp to make a Java's first major version(it is only number `14` if it is `openjdk 14.0.0`) able to run mock server.
- Fix the check expression in `checkJavaVersion`, for Java 7 not to pass, and for Java N and Java A.B.C to pass.
- Add tests for these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
