### PR TITLE
fixes  functions mock  when dependsOn resource

### DIFF
--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/loadMinimal.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/loadMinimal.test.ts
@@ -95,5 +95,6 @@ describe('load minimal lambda Config', () => {
       },
     };
     expect(loadMinimalLambdaConfig(contextStub, resourceName, params)).toBeDefined();
+    expect(loadMinimalLambdaConfig(contextStub, resourceName, params)).toEqual(config);
   });
 });

--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/loadMinimal.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/loadMinimal.test.ts
@@ -1,0 +1,99 @@
+import { loadMinimalLambdaConfig } from '../../../utils/lambda/loadMinimal';
+import { processResources, LambdaFunctionConfig } from '../../../CFNParser/lambda-resource-processor';
+import * as path from 'path';
+
+jest.mock('../../../CFNParser/lambda-resource-processor');
+jest.mock('path');
+
+const processResources_mock = processResources as jest.MockedFunction<typeof processResources>;
+
+const path_mock = {
+  path: {
+    join: jest.fn(),
+  },
+};
+
+const config: LambdaFunctionConfig = {
+  name: 'demo',
+  handler: 'handler',
+  basePath: 'path',
+  environment: { env: 'dev' },
+};
+
+processResources_mock.mockImplementation(() => config);
+
+describe('load minimal lambda Config', () => {
+  it('successfully return lambda config', () => {
+    const resourceName = 'mockfunction';
+    const params = { env: 'dev' };
+    const contextStub = {
+      amplify: {
+        readJsonFile: () => ({
+          Resources: 'demo',
+        }),
+        pathManager: {
+          getBackendDirPath: () => {
+            'demoPath';
+          },
+        },
+        getProjectMeta: () => ({
+          function: {
+            mockfunction: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [
+                {
+                  category: 'auth',
+                  resourceName: 'issue4992901fd08f',
+                  attributes: ['UserPoolId'],
+                },
+                {
+                  category: 'storage',
+                  resourceName: 's33c7946f3',
+                  attributes: ['BucketName'],
+                },
+                {
+                  category: 'function',
+                  resourceName: 'demofunction1',
+                  attributes: ['Name'],
+                },
+                {
+                  category: 'function',
+                  resourceName: 'demofunction2',
+                  attributes: ['Name'],
+                },
+              ],
+            },
+            demofunction1: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'Lambda',
+              dependsOn: [],
+            },
+            demofunction2: {
+              build: true,
+              providerPlugin: 'awscloudformation',
+              service: 'LambdaLayer',
+              dependsOn: [],
+            },
+          },
+          auth: {
+            issue4992901fd08f: {
+              service: 'Cognito',
+              providerPlugin: 'awscloudformation',
+              dependsOn: [],
+            },
+          },
+          storage: {
+            s33c7946f3: {
+              service: 'S3',
+              providerPlugin: 'awscloudformation',
+            },
+          },
+        }),
+      },
+    };
+    expect(loadMinimalLambdaConfig(contextStub, resourceName, params)).toBeDefined();
+  });
+});

--- a/packages/amplify-util-mock/src/utils/lambda/loadMinimal.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/loadMinimal.ts
@@ -10,8 +10,11 @@ export function loadMinimalLambdaConfig(context: any, resourceName: string, para
   if (projectMeta.function[resourceName].dependsOn) {
     extendedParams = projectMeta.function[resourceName].dependsOn.reduce((ini, depend) => {
       depend.attributes.forEach(attribute => {
-        const val = projectMeta[depend.category][depend.resourceName].output[attribute];
-        ini[depend.category + depend.resourceName + attribute] = val;
+        const dependsOnResourceMeta = projectMeta[depend.category][depend.resourceName];
+        if (dependsOnResourceMeta.output !== undefined) {
+          const val = dependsOnResourceMeta.output[attribute];
+          ini[depend.category + depend.resourceName + attribute] = val;
+        }
       });
       return ini;
     }, {});


### PR DESCRIPTION
*Issue

Amplify mock function fails when it depends on another resources and resources not pushed yet.

*Description of changes:*

* Added a condition to check if the resources pushed yet.

* Added tests for the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.