### PR TITLE
fix: trim process stdout in python runtime provider

### DIFF
--- a/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
@@ -32,7 +32,13 @@ export function majMinPyVersion(pyVersion: string): string {
 // opts are passed directly to the exec command
 export async function execAsStringPromise(command: string, opts?: ExecOptions): Promise<string> {
   try {
-    return (await execa.command(command, opts)).stdout;
+    let stdout = (await execa.command(command, opts)).stdout;
+
+    if (stdout) {
+      stdout = stdout.trim();
+    }
+
+    return stdout;
   } catch (err) {
     throw new Error(`Recieved error [${err}] running command [${command}]`);
   }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

`getPipenvDir` failed under Windows since process output had a `\r` appended so `path.join` generated some obscure path which made python functions fail. This regression was introduced in 4.24.1 by this [PR](https://github.com/aws-amplify/amplify-cli/pull/4673) and only affected Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.