### PR TITLE
chore: fix state management for pull

### DIFF
--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -81,6 +81,8 @@ export class StateManager {
     return this.getData<$TSAny>(filePath, mergedOptions);
   };
 
+  backendConfigFileExists = (projectPath?: string): boolean => fs.existsSync(pathManager.getBackendConfigFilePath(projectPath));
+
   getBackendConfig = (projectPath?: string, options?: GetOptions<$TSAny>): $TSAny => {
     const filePath = pathManager.getBackendConfigFilePath(projectPath);
     const mergedOptions = {

--- a/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
@@ -94,7 +94,9 @@ function generateTeamProviderInfoFile(context: $TSContext) {
 function generateBackendConfigFile(context: $TSContext) {
   const { projectPath } = context.exeInfo.localEnvInfo;
 
-  stateManager.setBackendConfig(projectPath, {});
+  if (!stateManager.backendConfigFileExists(projectPath)) {
+    stateManager.setBackendConfig(projectPath, {});
+  }
 }
 
 function generateGitIgnoreFile(context: $TSContext) {

--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -6,12 +6,12 @@ import { stateManager } from 'amplify-cli-core';
 
 export const run = async context => {
   const inputParams = constructInputParams(context);
-  const projcetPath = process.cwd();
+  const projectPath = process.cwd();
 
-  if (stateManager.currentMetaFileExists(projcetPath)) {
+  if (stateManager.currentMetaFileExists(projectPath)) {
     const { appId: inputAppId, envName: inputEnvName } = inputParams.amplify;
-    const teamProviderInfo = stateManager.getTeamProviderInfo(projcetPath);
-    const { envName } = stateManager.getLocalEnvInfo(projcetPath);
+    const teamProviderInfo = stateManager.getTeamProviderInfo(projectPath);
+    const { envName } = stateManager.getLocalEnvInfo(projectPath);
 
     const { AmplifyAppId } = teamProviderInfo[envName].awscloudformation;
     const localEnvNames = Object.keys(teamProviderInfo);

--- a/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
@@ -175,8 +175,8 @@ describe('amplify app console tests', () => {
   });
   afterEach(async () => {
     if (!fs.existsSync(getAmplifyDirPath(projRoot)) && stackName && AmplifyAppID) {
-      deleteAmplifyStack(stackName);
-      deleteConsoleApp(AmplifyAppID);
+      await deleteAmplifyStack(stackName);
+      await deleteConsoleApp(AmplifyAppID);
     } else {
       await deleteProject(projRoot, getConfigFromProfile());
     }


### PR DESCRIPTION
*Description of changes:*

This PR fixes the 2 failing nightly console integration tests, which caused by a missing condition during attach backend. 

- add missing condition check during attach backend
- add missing awaits to console test cleanup
- fix typo in `projectPath`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.