### PR TITLE
feat(amplify-codegen): add schema compile process in codegen commands

### DIFF
--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -47,9 +47,11 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
     ({ projectPath } = context.amplify.getEnvInfo());
   }
 
-  await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-    forceCompile: true,
-  });
+  if (!project.schema.endsWith('.json') && fs.existsSync(path.join(projectPath, project.schema))){
+    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+      forceCompile: true,
+    });
+  }
 
   let downloadPromises;
   if (!withoutInit) {

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -7,6 +7,7 @@ const constants = require('../constants');
 const { ensureIntrospectionSchema, getAppSyncAPIDetails } = require('../utils');
 const path = require('path');
 const fs = require('fs-extra');
+const ensureSchemaCompiled = require('../utils/ensureSchemaCompiled');
 
 async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth) {
   let withoutInit = false;
@@ -47,11 +48,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
     ({ projectPath } = context.amplify.getEnvInfo());
   }
 
-  if (!project.schema.endsWith('.json') && fs.existsSync(path.join(projectPath, project.schema))){
-    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-      forceCompile: true,
-    });
-  }
+  await ensureSchemaCompiled(context, path.join(projectPath, project.schema));
 
   let downloadPromises;
   if (!withoutInit) {

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -47,6 +47,10 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
     ({ projectPath } = context.amplify.getEnvInfo());
   }
 
+  await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+    forceCompile: true,
+  });
+
   let downloadPromises;
   if (!withoutInit) {
     downloadPromises = projects.map(

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -5,7 +5,7 @@ const { generate } = require('amplify-graphql-docs-generator');
 
 const loadConfig = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
+const { ensureIntrospectionSchema, ensureSchemaCompiled, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 
 async function generateStatements(context, forceDownloadSchema, maxDepth, withoutInit = false, decoupleFrontend = '') {
   try {
@@ -42,10 +42,8 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     const schemaPath = path.join(projectPath, cfg.schema);
     let region;
     let frontend;
-    if (context.input.command === 'statements' && !schemaPath.endsWith('.json') && fs.existsSync(schemaPath)) {
-      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-        forceCompile: true,
-      });
+    if (context.input.command === 'statements') {
+      await ensureSchemaCompiled(context, schemaPath);
     }
     if (!withoutInit) {
       ({ region } = cfg.amplifyExtension);

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -33,6 +33,13 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
     return;
   }
+
+  if (context.input.command === 'statements') {
+    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+      forceCompile: true,
+    });
+  }
+
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -34,12 +34,6 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     return;
   }
 
-  if (context.input.command === 'statements') {
-    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-      forceCompile: true,
-    });
-  }
-
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath
@@ -48,6 +42,11 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     const schemaPath = path.join(projectPath, cfg.schema);
     let region;
     let frontend;
+    if (context.input.command === 'statements' && !schemaPath.endsWith('.json') && fs.existsSync(schemaPath)) {
+      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+        forceCompile: true,
+      });
+    }
     if (!withoutInit) {
       ({ region } = cfg.amplifyExtension);
       await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra');
 
 const constants = require('../constants');
 const loadConfig = require('../codegen-config');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
+const { ensureIntrospectionSchema, ensureSchemaCompiled, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 
 async function generateTypes(context, forceDownloadSchema, withoutInit = false, decoupleFrontend = '') {
   let frontend = decoupleFrontend;
@@ -53,10 +53,8 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
         const schemaPath = path.join(projectPath, cfg.schema);
         const target = cfg.amplifyExtension.codeGenTarget;
 
-        if (context.input.command === 'types' && !schemaPath.endsWith('.json') && fs.existsSync(schemaPath)) {
-          await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-            forceCompile: true,
-          });
+        if (context.input.command === 'types') {
+          await ensureSchemaCompiled(context, schemaPath);
         }
 
         const outputPath = path.join(projectPath, generatedFileName);

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -2,7 +2,6 @@ const glob = require('glob-all');
 const path = require('path');
 const { generate } = require('amplify-graphql-types-generator');
 const Ora = require('ora');
-const fs = require('fs-extra');
 
 const constants = require('../constants');
 const loadConfig = require('../codegen-config');

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -36,6 +36,12 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
       ({ projectPath } = context.amplify.getEnvInfo());
     }
 
+    if (context.input.command === 'types') {
+      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+        forceCompile: true,
+      });
+    }
+
     try {
       projects.forEach(async cfg => {
         const { generatedFileName } = cfg.amplifyExtension || {};

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -2,6 +2,7 @@ const glob = require('glob-all');
 const path = require('path');
 const { generate } = require('amplify-graphql-types-generator');
 const Ora = require('ora');
+const fs = require('fs-extra');
 
 const constants = require('../constants');
 const loadConfig = require('../codegen-config');
@@ -36,12 +37,6 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
       ({ projectPath } = context.amplify.getEnvInfo());
     }
 
-    if (context.input.command === 'types') {
-      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-        forceCompile: true,
-      });
-    }
-
     try {
       projects.forEach(async cfg => {
         const { generatedFileName } = cfg.amplifyExtension || {};
@@ -57,6 +52,12 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
         });
         const schemaPath = path.join(projectPath, cfg.schema);
         const target = cfg.amplifyExtension.codeGenTarget;
+
+        if (context.input.command === 'types' && !schemaPath.endsWith('.json') && fs.existsSync(schemaPath)) {
+          await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+            forceCompile: true,
+          });
+        }
 
         const outputPath = path.join(projectPath, generatedFileName);
         let region;

--- a/packages/amplify-codegen/src/utils/ensureSchemaCompiled.js
+++ b/packages/amplify-codegen/src/utils/ensureSchemaCompiled.js
@@ -1,0 +1,12 @@
+const fs = require('fs-extra');
+const existsAppSyncAPIResourse = require('./existsAppSyncAPIResource');
+
+async function ensureSchemaCompiled(context, schemaPath) {
+    if (!schemaPath.endsWith('.json') && existsAppSyncAPIResourse(context) && fs.existsSync(schemaPath)) {
+        await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+          forceCompile: true,
+        });
+      }
+}
+
+module.exports = ensureSchemaCompiled;

--- a/packages/amplify-codegen/src/utils/existsAppSyncAPIResource.js
+++ b/packages/amplify-codegen/src/utils/existsAppSyncAPIResource.js
@@ -1,0 +1,13 @@
+function existsAppSyncAPIResource(context) {
+    const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
+    const amplifyMeta = context.amplify.readJsonFile(amplifyMetaFilePath);
+    const { api: apis = {} } = amplifyMeta;
+    return Object.values(apis).some((value) => {
+        if(value.service === 'AppSync' && value.providerPlugin === 'awscloudformation') {
+            return true;
+        }
+    });
+
+}
+
+module.exports = existsAppSyncAPIResource;

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -15,6 +15,8 @@ const isCodegenConfigured = require('./isCodegenConfigured');
 const getSDLSchemaLocation = require('./getSDLSchemaLocation');
 const switchToSDLSchema = require('./switchToSDLSchema');
 const ensureIntrospectionSchema = require('./ensureIntrospectionSchema');
+const ensureSchemaCompiled = require('./ensureSchemaCompiled');
+const existsAppSyncAPIResource = require('./existsAppSyncAPIResource');
 
 module.exports = {
   getAppSyncAPIDetails,
@@ -34,4 +36,6 @@ module.exports = {
   getSDLSchemaLocation,
   switchToSDLSchema,
   ensureIntrospectionSchema,
+  ensureSchemaCompiled,
+  existsAppSyncAPIResource,
 };

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -15,6 +15,10 @@ const MOCK_CONTEXT = {
     getEnvInfo: jest.fn(),
     getProjectMeta: jest.fn(),
     executeProviderUtils: jest.fn(),
+    readJsonFile: jest.fn(),
+    pathManager: {
+      getAmplifyMetaFilePath: jest.fn(),
+    },
   },
   input: {},
 };
@@ -57,6 +61,7 @@ describe('command - generateStatementsAndTypes', () => {
       getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
     });
     MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    MOCK_CONTEXT.amplify.readJsonFile.mockReturnValue({});
     getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
   });
 

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -14,7 +14,9 @@ const MOCK_CONTEXT = {
   amplify: {
     getEnvInfo: jest.fn(),
     getProjectMeta: jest.fn(),
+    executeProviderUtils: jest.fn(),
   },
+  input: {},
 };
 
 jest.mock('../../src/commands/types');

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -14,7 +14,9 @@ const MOCK_CONTEXT = {
   amplify: {
     getEnvInfo: jest.fn(),
     getProjectMeta: jest.fn(),
+    executeProviderUtils: jest.fn(),
   },
+  input: {},
 };
 
 jest.mock('amplify-graphql-docs-generator');

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -15,7 +15,9 @@ const MOCK_CONTEXT = {
   amplify: {
     getEnvInfo: jest.fn(),
     getProjectMeta: jest.fn(),
+    executeProviderUtils: jest.fn(),
   },
+  input: {},
 };
 
 jest.mock('glob-all');


### PR DESCRIPTION
*Issue #, if available:*
fix #4882 
*Description of changes:*
Added graphql schema compiling in command `amplify codegen`, `amplify codegen statements` and `amplify codegen types`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.