### PR TITLE
fix(graphql-elasticsearch-transformer): to support non string key in es

### DIFF
--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -132,7 +132,7 @@ def compute_doc_index(keys_raw, deserializer, formatIndex=False):
                 key, deserializer.deserialize(keys_raw[key])))
         else:
             index.append(deserializer.deserialize(keys_raw[key]))
-    return '|'.join(index)
+    return '|'.join(map(str,index))
 
 def _lambda_handler(event, context):
     logger.debug('Event: %s', event)


### PR DESCRIPTION
Updated the streaming lambda function support to handle non string type in key directive fields

fix #5140

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.