### PR TITLE
fix: timeout mock function invocation

### DIFF
--- a/packages/amplify-util-mock/src/__tests__/func/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-util-mock/src/__tests__/func/__snapshots__/index.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function start times out function execution at the default time 2`] = `
+[Error: Lambda execution timed out after 10 seconds. Press ctrl + C to exit the process.
+    To increase the lambda timeout use the --timeout parameter to set a value in seconds.
+    Note that the maximum Lambda execution time is 15 minutes:
+    https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
+]
+`;
+
+exports[`function start times out function execution at the specified time 1`] = `
+[Error: Lambda execution timed out after 12 seconds. Press ctrl + C to exit the process.
+    To increase the lambda timeout use the --timeout parameter to set a value in seconds.
+    Note that the maximum Lambda execution time is 15 minutes:
+    https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
+]
+`;

--- a/packages/amplify-util-mock/src/__tests__/func/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/func/index.test.ts
@@ -1,0 +1,59 @@
+import { start } from '../../func';
+
+jest.mock('../../utils/lambda/loadMinimal', () => ({
+  loadMinimalLambdaConfig: jest.fn(() => ({ handler: 'index.testHandle' })),
+}));
+jest.mock('../../utils', () => ({
+  hydrateAllEnvVars: jest.fn(),
+}));
+jest.mock('amplify-category-function', () => ({
+  getInvoker: () => () => new Promise(resolve => setTimeout(() => resolve('lambda value'), 1000 * 19)),
+  isMockable: () => ({ isMockable: true }),
+  category: 'function',
+}));
+
+describe('function start', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const context_stub = {
+    input: {
+      subCommands: ['funcName'],
+      options: {
+        event: 'event.json',
+        timeout: undefined,
+      },
+    },
+    amplify: {
+      pathManager: {
+        getBackendDirPath: jest.fn(() => 'backend-path'),
+      },
+      inputValidation: () => () => true,
+      readJsonFile: jest.fn(),
+      getResourceStatus: () => ({ allResources: [] }),
+      getEnvInfo: () => ({ envName: 'testing' }),
+    },
+    print: {
+      success: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+
+  jest.setTimeout(1000 * 20);
+
+  // NOTE: A warning from jest saying that async operations weren't stopped in the test is expected here
+  // because the mock function is designed to keep running after the timeout to ense that the timeout works
+  it('times out function execution at the default time', async () => {
+    await start(context_stub);
+    expect(context_stub.print.error.mock.calls[0][0]).toMatchInlineSnapshot(`"funcName failed with the following error:"`);
+    expect(context_stub.print.info.mock.calls[0][0]).toMatchSnapshot();
+  });
+
+  it('times out function execution at the specified time', async () => {
+    context_stub.input.options.timeout = '12';
+    await start(context_stub);
+    expect(context_stub.print.info.mock.calls[0][0]).toMatchSnapshot();
+  });
+});

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -18,6 +18,7 @@ import { getInvoker } from 'amplify-category-function';
 import { keys } from 'lodash';
 import { LambdaFunctionConfig } from '../CFNParser/lambda-resource-processor';
 import { lambdaArnToConfig } from './lambda-arn-to-config';
+import { timeConstrainedInvoker } from '../func';
 
 export class APITest {
   private apiName: string;
@@ -206,9 +207,12 @@ export class APITest {
           return {
             ...d,
             invoke: payload => {
-              return invoker({
-                event: payload,
-              });
+              return timeConstrainedInvoker(
+                invoker({
+                  event: payload,
+                }),
+                context.input.options,
+              );
             },
           };
         }),

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -4,6 +4,8 @@ import * as inquirer from 'inquirer';
 import { loadMinimalLambdaConfig } from '../utils/lambda/loadMinimal';
 import { hydrateAllEnvVars } from '../utils';
 
+const DEFAULT_TIMEOUT_SECONDS = 10;
+
 export async function start(context) {
   if (!context.input.subCommands || context.input.subCommands.length < 1) {
     throw new Error('Specify the function name to invoke with "amplify mock function <function name>"');
@@ -59,7 +61,7 @@ export async function start(context) {
   const envVars = hydrateAllEnvVars(allResources, lambdaConfig.environment);
   const invoker = await getInvoker(context, { resourceName, handler: lambdaConfig.handler, envVars });
   context.print.success('Starting execution...');
-  await invoker({ event })
+  await timeConstrainedInvoker(invoker({ event }), context.input.options)
     .then(result => {
       const msg = typeof result === 'object' ? JSON.stringify(result) : result;
       context.print.success('Result:');
@@ -71,3 +73,19 @@ export async function start(context) {
     })
     .then(() => context.print.success('Finished execution.'));
 }
+
+interface InvokerOptions {
+  timeout?: string;
+}
+export const timeConstrainedInvoker: <T>(p: Promise<T>, opts: InvokerOptions) => Promise<T> = (promise, options): Promise<any> =>
+  Promise.race([promise, getTimer(options)]);
+
+const getTimer = (options: { timeout?: string }) => {
+  const inputTimeout = Number.parseInt(options?.timeout, 10);
+  const lambdaTimeoutSeconds = !!inputTimeout && inputTimeout > 0 ? inputTimeout : DEFAULT_TIMEOUT_SECONDS;
+  const timeoutErrorMessage = `Lambda execution timed out after ${lambdaTimeoutSeconds} seconds. Press ctrl + C to exit the process.
+    To increase the lambda timeout use the --timeout parameter to set a value in seconds.
+    Note that the maximum Lambda execution time is 15 minutes:
+    https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/\n`;
+  return new Promise((_, reject) => setTimeout(() => reject(new Error(timeoutErrorMessage)), lambdaTimeoutSeconds * 1000));
+};


### PR DESCRIPTION
*Issue #, if available:*
#5159

*Description of changes:*
Add a Promise.race() against a timeout when invoking a function
Also added a --timeout parameter that can be used to configure the timeout
By default set to 10 seconds. Don't really have a reason for that number other than it will timeout quickly if a developer is expecting a quick response and if they know it should take a while, the error message specifies how to use the --timeout option

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.