### PR TITLE
fix: migration issue with layers created before 4.29.0

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerParams.ts
@@ -86,7 +86,9 @@ class LayerState implements LayerMetadata {
     this.context = context;
     this.layerName = layerName;
     this.storedParams = getStoredLayerState(context, layerName);
-    this.runtimes = getLayerRuntimes(context.amplify.pathManager.getBackendDirPath(), layerName);
+    this.runtimes = isMultiEnvLayer(context, layerName)
+      ? getLayerRuntimes(context.amplify.pathManager.getBackendDirPath(), layerName)
+      : this.storedParams.runtimes;
     Object.entries(this.storedParams.layerVersionMap).forEach(([versionNumber, versionData]) => {
       this.versionMap.set(Number(versionNumber), new LayerVersionState(versionData));
     });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -5,6 +5,7 @@ import { prompt } from 'inquirer';
 import path from 'path';
 import _ from 'lodash';
 import { hashElement } from 'folder-hash';
+import { pathManager } from 'amplify-cli-core';
 import { FunctionDependency } from 'amplify-function-plugin-interface';
 import { ServiceName, provider } from './constants';
 import { previousPermissionsQuestion } from './layerHelpers';
@@ -30,7 +31,7 @@ export async function packageLayer(context, resource: Resource) {
 async function zipLayer(context, resource: Resource) {
   const zipFilename = 'latest-build.zip';
   const layerName = resource.resourceName;
-  const layerDirPath = path.join(context.amplify.pathManager.getBackendDirPath(), resource.category, layerName);
+  const layerDirPath = path.join(pathManager.getBackendDirPath(), resource.category, layerName);
   const distDir = path.join(layerDirPath, 'dist');
   fs.ensureDirSync(distDir);
   const destination = path.join(distDir, zipFilename);
@@ -116,7 +117,7 @@ async function ensureLayerVersion(context: any, layerName: string) {
   };
 
   if (isMultiEnvLayer(context, layerName)) {
-    additionalLayerParams.runtimes = getLayerRuntimes(context.amplify.pathManager.getBackendDirPath(), layerName);
+    additionalLayerParams.runtimes = getLayerRuntimes(pathManager.getBackendDirPath(), layerName);
   }
 
   const layerParameters = { ...storedParams, ...additionalLayerParams } as LayerParameters;


### PR DESCRIPTION
*Description of changes:*
The CLI was incorrectly looking for layer-runtimes.json when layer-parameters.json was present

*Issue #, if available:*
#5250 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.