### PR TITLE
fix: #4222 - mock S3 list returns undefined keys under Windows

### DIFF
--- a/packages/amplify-storage-simulator/src/server/S3server.ts
+++ b/packages/amplify-storage-simulator/src/server/S3server.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import cors from 'cors';
-import { join, normalize } from 'path';
-import { readFile, unlink, statSync, ensureFileSync, writeFileSync, existsSync } from 'fs-extra';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import xml from 'xml';
 import * as bodyParser from 'body-parser';
 import * as convert from 'xml-js';
@@ -108,15 +108,22 @@ export class StorageServer extends EventEmitter {
   }
 
   private async handleRequestGet(request, response) {
-    const filePath = normalize(join(this.localDirectoryPath, request.params.path));
-    if (existsSync(filePath)) {
-      readFile(filePath, (err, data) => {
+    const filePath = path.normalize(path.join(this.localDirectoryPath, request.params.path));
+    if (fs.existsSync(filePath) && !fs.statSync(filePath).isDirectory()) {
+      fs.readFile(filePath, (err, data) => {
         if (err) {
           console.log('error');
         }
         response.send(data);
       });
     } else {
+      // fixup the keyname for proper error message since it is normalized for the given platform
+      // remove the leading path separator and replace the remaining ones.
+      let keyName = request.params.path.replace('\\', '/');
+      if (keyName.startsWith('/')) {
+        keyName = keyName.slice(1);
+      }
+      response.set('Content-Type', 'text/xml');
       response.status(404);
       response.send(
         o2x({
@@ -124,7 +131,7 @@ export class StorageServer extends EventEmitter {
           Error: {
             Code: 'NoSuchKey',
             Message: 'The specified key does not exist.',
-            Key: request.params.path,
+            Key: keyName,
             RequestId: '',
             HostId: '',
           },
@@ -149,24 +156,39 @@ export class StorageServer extends EventEmitter {
     let startAfter = request.query.startAfter || '';
     let keyCount = 0;
     // getting folders recursively
-    const dirPath = normalize(join(this.localDirectoryPath, request.params.path) + '/');
+    const dirPath = path.normalize(path.join(this.localDirectoryPath, request.params.path));
 
-    const files = glob.sync(dirPath + '/**/*');
+    const files = glob.sync('**/*', {
+      cwd: dirPath,
+      absolute: true,
+    });
     for (const file of files) {
+      // We have to normalize glob returned filenames to make sure deriving the keyname will work under every OS.
+      const normalizedFile = path.normalize(file);
+      // Remove directory portion, cut starting slash, replace backslash with slash.
+      let keyName = normalizedFile.replace(dirPath, '').replace('\\', '/');
+      if (keyName.startsWith('/')) {
+        keyName = keyName.slice(1);
+      }
+
       if (delimiter !== '' && util.checkfile(file, prefix, delimiter)) {
         ListBucketResult[LIST_COMMOM_PREFIXES].push({
-          prefix: request.params.path + file.split(dirPath)[1],
+          prefix: request.params.path + keyName,
         });
       }
-      if (!statSync(file).isDirectory()) {
+      if (!fs.statSync(file).isDirectory()) {
         if (keyCount === maxKeys) {
           break;
         }
 
         ListBucketResult[LIST_CONTENT].push({
-          Key: request.params.path + file.split(dirPath)[1],
-          LastModified: new Date(statSync(file).mtime).toISOString(),
-          Size: statSync(file).size,
+          //   paramsPath: request.params.path,
+          // file: file,
+          // originalDir: originalDir,
+          // dirPath: dirPath,
+          Key: request.params.path + keyName,
+          LastModified: new Date(fs.statSync(file).mtime).toISOString(),
+          Size: fs.statSync(file).size,
           ETag: etag(file),
           StorageClass: 'STANDARD',
         });
@@ -193,10 +215,11 @@ export class StorageServer extends EventEmitter {
   }
 
   private async handleRequestDelete(request, response) {
-    const filePath = join(this.localDirectoryPath, request.params.path);
-    if (existsSync(filePath)) {
-      unlink(filePath, err => {
+    const filePath = path.join(this.localDirectoryPath, request.params.path);
+    if (fs.existsSync(filePath)) {
+      fs.unlink(filePath, err => {
         if (err) throw err;
+        response.set('Content-Type', 'text/xml');
         response.send(xml(convert.json2xml(JSON.stringify(request.params.id + 'was deleted'))));
       });
     } else {
@@ -205,28 +228,30 @@ export class StorageServer extends EventEmitter {
   }
 
   private async handleRequestPut(request, response) {
-    const directoryPath = normalize(join(String(this.localDirectoryPath), String(request.params.path)));
-    ensureFileSync(directoryPath);
+    const directoryPath = path.normalize(path.join(String(this.localDirectoryPath), String(request.params.path)));
+    fs.ensureFileSync(directoryPath);
     // strip signature in android , returns same buffer for other clients
     var new_data = util.stripChunkSignature(request.body);
     // loading data in map for each part
     if (request.query.partNumber !== undefined) {
       this.upload_bufferMap[request.query.uploadId][request.query.partNumber] = request.body;
     } else {
-      writeFileSync(directoryPath, new_data);
+      fs.writeFileSync(directoryPath, new_data);
       // event trigger  to differentitiate between multipart and normal put
       let eventObj = this.createEvent(request);
       this.emit('event', eventObj);
     }
+    response.set('Content-Type', 'text/xml');
     response.send(xml(convert.json2xml(JSON.stringify('upload success'))));
   }
 
   private async handleRequestPost(request, response) {
-    const directoryPath = normalize(join(String(this.localDirectoryPath), String(request.params.path)));
+    const directoryPath = path.normalize(path.join(String(this.localDirectoryPath), String(request.params.path)));
     if (request.query.uploads !== undefined) {
       let id = uuid();
       this.uploadIds.push(id);
       this.upload_bufferMap[id] = {};
+      response.set('Content-Type', 'text/xml');
       response.send(
         o2x({
           '?xml version="1.0" encoding="utf-8"?': null,
@@ -257,18 +282,19 @@ export class StorageServer extends EventEmitter {
         }),
       );
       let buf = Buffer.concat(arr);
-      writeFileSync(directoryPath, buf);
+      fs.writeFileSync(directoryPath, buf);
       // event trigger for multipart post
       let eventObj = this.createEvent(request);
       this.emit('event', eventObj);
     } else {
-      const directoryPath = normalize(join(String(this.localDirectoryPath), String(request.params.path)));
-      ensureFileSync(directoryPath);
+      const directoryPath = path.normalize(path.join(String(this.localDirectoryPath), String(request.params.path)));
+      fs.ensureFileSync(directoryPath);
       var new_data = util.stripChunkSignature(request.body);
-      writeFileSync(directoryPath, new_data);
+      fs.writeFileSync(directoryPath, new_data);
       // event trigger for normal post
       let eventObj = this.createEvent(request);
       this.emit('event', eventObj);
+      response.set('Content-Type', 'text/xml');
       response.send(
         o2x({
           '?xml version="1.0" encoding="utf-8"?': null,
@@ -284,7 +310,7 @@ export class StorageServer extends EventEmitter {
   }
   // build eevent obj for s3 trigger
   private createEvent(request) {
-    const filePath = normalize(join(this.localDirectoryPath, request.params.path));
+    const filePath = path.normalize(path.join(this.localDirectoryPath, request.params.path));
     let eventObj = {};
     eventObj[EVENT_RECORDS] = [];
 
@@ -308,7 +334,7 @@ export class StorageServer extends EventEmitter {
       },
       object: {
         key: request.params.path,
-        size: statSync(filePath).size,
+        size: fs.statSync(filePath).size,
         eTag: etag(filePath),
         versionId: '096fKKXTRTtl3on89fVO.nfljtsv6qko',
       },

--- a/packages/amplify-storage-simulator/src/server/S3server.ts
+++ b/packages/amplify-storage-simulator/src/server/S3server.ts
@@ -119,7 +119,7 @@ export class StorageServer extends EventEmitter {
     } else {
       // fixup the keyname for proper error message since it is normalized for the given platform
       // remove the leading path separator and replace the remaining ones.
-      let keyName = request.params.path.replace('\\', '/');
+      let keyName = request.params.path.replaceAll('\\', '/');
       if (keyName.startsWith('/')) {
         keyName = keyName.slice(1);
       }
@@ -166,7 +166,7 @@ export class StorageServer extends EventEmitter {
       // We have to normalize glob returned filenames to make sure deriving the keyname will work under every OS.
       const normalizedFile = path.normalize(file);
       // Remove directory portion, cut starting slash, replace backslash with slash.
-      let keyName = normalizedFile.replace(dirPath, '').replace('\\', '/');
+      let keyName = normalizedFile.replace(dirPath, '').replaceAll('\\', '/');
       if (keyName.startsWith('/')) {
         keyName = keyName.slice(1);
       }

--- a/packages/amplify-storage-simulator/src/server/S3server.ts
+++ b/packages/amplify-storage-simulator/src/server/S3server.ts
@@ -182,10 +182,6 @@ export class StorageServer extends EventEmitter {
         }
 
         ListBucketResult[LIST_CONTENT].push({
-          //   paramsPath: request.params.path,
-          // file: file,
-          // originalDir: originalDir,
-          // dirPath: dirPath,
           Key: request.params.path + keyName,
           LastModified: new Date(fs.statSync(file).mtime).toISOString(),
           Size: fs.statSync(file).size,

--- a/packages/amplify-storage-simulator/src/server/S3server.ts
+++ b/packages/amplify-storage-simulator/src/server/S3server.ts
@@ -119,7 +119,7 @@ export class StorageServer extends EventEmitter {
     } else {
       // fixup the keyname for proper error message since it is normalized for the given platform
       // remove the leading path separator and replace the remaining ones.
-      let keyName = request.params.path.replaceAll('\\', '/');
+      let keyName = request.params.path.replace(/\\/g, '/');
       if (keyName.startsWith('/')) {
         keyName = keyName.slice(1);
       }
@@ -166,7 +166,7 @@ export class StorageServer extends EventEmitter {
       // We have to normalize glob returned filenames to make sure deriving the keyname will work under every OS.
       const normalizedFile = path.normalize(file);
       // Remove directory portion, cut starting slash, replace backslash with slash.
-      let keyName = normalizedFile.replace(dirPath, '').replaceAll('\\', '/');
+      let keyName = normalizedFile.replace(dirPath, '').replace(/\\/g, '/');
       if (keyName.startsWith('/')) {
         keyName = keyName.slice(1);
       }

--- a/packages/amplify-storage-simulator/src/server/utils.ts
+++ b/packages/amplify-storage-simulator/src/server/utils.ts
@@ -28,7 +28,7 @@ export function parseUrl(request, route: String) {
   }
 
   if (request.method === 'GET') {
-    if (request.query.prefix !== undefined || (temp[1] === '' && temp[0] === '')) {
+    if (request.query.prefix !== undefined || (temp[1] === '' && temp[0] === '') || (temp[1] === '/' && temp[0] === '')) {
       request.method = 'LIST';
     }
   }

--- a/packages/amplify-storage-simulator/src/server/utils.ts
+++ b/packages/amplify-storage-simulator/src/server/utils.ts
@@ -1,17 +1,22 @@
-import { join, normalize } from 'path';
+import * as path from 'path';
 
 // parse the request url to get the path and storing in the request.params.path  with the prefix if present
 
 export function parseUrl(request, route: String) {
-  request.url = normalize(decodeURIComponent(request.url));
+  request.url = path.normalize(decodeURIComponent(request.url));
   const temp = request.url.split(route);
   request.params.path = '';
 
-  if (request.query.prefix !== undefined) request.params.path = request.query.prefix + '/';
+  if (request.query.prefix !== undefined) {
+    request.params.path = request.query.prefix + '/';
+  }
 
-  if (temp[1] !== undefined) request.params.path = normalize(join(request.params.path, temp[1].split('?')[0]));
-  // change for IOS as no bucket name is present in the original url
-  else request.params.path = normalize(join(request.params.path, temp[0].split('?')[0]));
+  if (temp[1] !== undefined) {
+    request.params.path = path.normalize(path.join(request.params.path, temp[1].split('?')[0]));
+  } else {
+    // change for IOS as no bucket name is present in the original url
+    request.params.path = path.normalize(path.join(request.params.path, temp[0].split('?')[0]));
+  }
 
   if (request.params.path[0] == '/' || request.params.path[0] == '.') {
     request.params.path = request.params.path.substring(1);


### PR DESCRIPTION
*Issue #, if available:*

#4222 

*Description of changes:*

- return correct keys for objects
- fix slash/backslash in returned keys for objects when it has them
- handle 404 for folders to return correctly instead of 'error' message in console and no response on the wire
- add `text/xml` content type for all responses where XML is being returned
- change `fs` and `path` imports to `* as` syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.