### PR TITLE
fix: enable building multiple go files, .exe extension for local invoke on Windows only

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -84,7 +84,6 @@ export const buildResourceInternal = async (
 
   if (force === true || !timestampToCheck || isBuildStale(request.srcRoot, timestampToCheck, outDir)) {
     const srcDir = path.join(request.srcRoot, SRC);
-    const entryFile = MAIN_SOURCE;
 
     // Clean and/or create the output directory
     if (fs.existsSync(outDir)) {

--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -105,7 +105,7 @@ export const buildResourceInternal = async (
     }
 
     // Execute the build command, cwd must be the source file directory (Windows requires it)
-    executeCommand(['build', '-o', executablePath, entryFile], true, envVars, srcDir);
+    executeCommand(['build', '-o', executablePath, '*.go'], true, envVars, srcDir);
 
     rebuilt = true;
   }

--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -105,7 +105,7 @@ export const buildResourceInternal = async (
     }
 
     // Execute the build command, cwd must be the source file directory (Windows requires it)
-    executeCommand(['build', '-o', executablePath, '*.go'], true, envVars, srcDir);
+    executeCommand(['build', '-o', executablePath, '.'], true, envVars, srcDir);
 
     rebuilt = true;
   }

--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -68,7 +68,7 @@ export const buildResourceInternal = async (
   const outDir = path.join(request.srcRoot, buildDir);
 
   const isWindows = /^win/.test(process.platform);
-  const executableName = isWindows === true ? MAIN_BINARY_WIN : MAIN_BINARY;
+  const executableName = isWindows && forLocalInvoke ? MAIN_BINARY_WIN : MAIN_BINARY;
   const executablePath = path.join(outDir, executableName);
 
   // For local invoke we've to use the build timestamp of the binary built

--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 import glob from 'glob';
 import path from 'path';
 import { SemVer, coerce, gte, lt } from 'semver';
-import { BIN_LOCAL, BIN, SRC, MAIN_BINARY, DIST, MAIN_SOURCE, MAIN_BINARY_WIN } from './constants';
+import { BIN_LOCAL, BIN, SRC, MAIN_BINARY, DIST, MAIN_BINARY_WIN } from './constants';
 
 const executableName = 'go';
 const minimumVersion = <SemVer>coerce('1.0');


### PR DESCRIPTION
*Issue #, if available:*
#5209 #5269

*Description of changes:*
Only output executables with a `.exe` suffix for local invocation on windows.
Change build target from `main.go` to `.` to enable building multiple go source files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.