### PR TITLE
fix: internal add auth entry point

### DIFF
--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -45,21 +45,6 @@ async function add(context) {
       }
       return providerController.addResource(context, result.service);
     })
-    .then(resourceName => {
-      const options = {
-        service: resultMetadata.service,
-        providerPlugin: resultMetadata.providerName,
-      };
-      const resourceDirPath = path.join(amplify.pathManager.getBackendDirPath(), 'auth', resourceName, 'parameters.json');
-      const authParameters = amplify.readJsonFile(resourceDirPath);
-
-      if (authParameters.dependsOn) {
-        options.dependsOn = authParameters.dependsOn;
-      }
-      amplify.updateamplifyMetaAfterResourceAdd(category, resourceName, options);
-      context.print.success('Successfully added auth resource');
-      return resourceName;
-    })
     .catch(err => {
       context.print.info(err.stack);
       context.print.error('There was an error adding the auth resource');

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/post-add-auth-message-printer.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/post-add-auth-message-printer.ts
@@ -4,7 +4,7 @@
  */
 export const getPostAddAuthMessagePrinter = (context: any) => (resourceName: string) => {
   const { print } = context;
-  print.success(`Successfully added resource ${resourceName} locally`);
+  print.success(`Successfully added auth resource ${resourceName} locally`);
   print.info('');
   print.success('Some next steps:');
   print.info('"amplify push" will build all your local backend resources and provision it in the cloud');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Internal calls to add auth use a different entry point into the category which had some logic that was duplicated since the refactor

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.