### PR TITLE
[minor fix] add link to login with Amazon

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -231,7 +231,7 @@ export const supportedServices = {
       {
         key: 'amazonAppId',
         prefix:
-          " \n You've opted to allow users to authenticate via Amazon.  If you haven't already, you'll need to create an Amazon App ID. \n",
+          " \n You've opted to allow users to authenticate via Amazon.  If you haven't already, you'll need to create an Amazon App ID. Head to https://developer.amazon.com/docs/login-with-amazon/documentation-overview.html to learn more. \n",
         question: 'Enter your Amazon App ID for your identity pool: ',
         required: true,
         andConditions: [


### PR DESCRIPTION
this fixes a hole compared to the other login options in that we dont offer instructions to our own docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.