### PR TITLE
fix: translate include oAuthMetadata and fix hostedUI meta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,110 +769,6 @@ jobs:
           when: always
       - store_artifacts:
           path: ../uitest_android_results
-  schema-key-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-key.test.ts
-      CLI_REGION: us-east-2
-  tags-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/tags.test.ts
-      CLI_REGION: us-west-2
-  api_2-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/api_2.test.ts
-      CLI_REGION: eu-west-2
-  auth_1-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/auth_1.test.ts
-      CLI_REGION: eu-central-1
-  auth_2-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/auth_2.test.ts
-      CLI_REGION: ap-northeast-1
-  schema-versioned-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-versioned.test.ts
-      CLI_REGION: ap-southeast-1
-  schema-searchable-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: ap-southeast-2
-  env-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/env.test.ts
-      CLI_REGION: us-east-2
-  function_1-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/function_1.test.ts
-      CLI_REGION: us-west-2
-  function_2-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: eu-west-2
-  schema-predictions-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-predictions.test.ts
-      CLI_REGION: eu-central-1
-  schema-model-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/schema-model.test.ts
-      CLI_REGION: ap-northeast-1
-  init-special-case-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/init-special-case.test.ts
-      CLI_REGION: ap-southeast-1
   api_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -880,14 +776,62 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/api_1.test.ts
-      CLI_REGION: ap-southeast-2
-  schema-function-amplify_e2e_tests:
+      CLI_REGION: us-east-2
+  api_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-function.test.ts
+      TEST_SUITE: src/__tests__/api_2.test.ts
+      CLI_REGION: us-west-2
+  auth_1-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/auth_1.test.ts
+      CLI_REGION: eu-west-2
+  auth_2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/auth_2.test.ts
+      CLI_REGION: eu-central-1
+  env-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/env.test.ts
+      CLI_REGION: ap-northeast-1
+  function_1-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/function_1.test.ts
+      CLI_REGION: ap-southeast-1
+  function_2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/function_2.test.ts
+      CLI_REGION: ap-southeast-2
+  init-special-case-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/init-special-case.test.ts
       CLI_REGION: us-east-2
   layer-amplify_e2e_tests:
     working_directory: ~/repo
@@ -897,13 +841,69 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/layer.test.ts
       CLI_REGION: us-west-2
-  schema-data-access-patterns-amplify_e2e_tests:
+  schema-auth-1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
+      TEST_SUITE: src/__tests__/schema-auth-1.test.ts
+      CLI_REGION: eu-west-2
+  schema-auth-2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-2.test.ts
+      CLI_REGION: eu-central-1
+  schema-auth-3-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-3.test.ts
+      CLI_REGION: ap-northeast-1
+  schema-auth-4-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-4.test.ts
+      CLI_REGION: ap-southeast-1
+  schema-auth-5-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-5.test.ts
+      CLI_REGION: ap-southeast-2
+  schema-auth-6-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-6.test.ts
+      CLI_REGION: us-east-2
+  schema-auth-7-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-7.test.ts
+      CLI_REGION: us-west-2
+  schema-auth-8-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/schema-auth-8.test.ts
       CLI_REGION: eu-west-2
   schema-connection-amplify_e2e_tests:
     working_directory: ~/repo
@@ -913,69 +913,69 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/schema-connection.test.ts
       CLI_REGION: eu-central-1
-  schema-auth-8-amplify_e2e_tests:
+  schema-data-access-patterns-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-8.test.ts
+      TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
       CLI_REGION: ap-northeast-1
-  schema-auth-7-amplify_e2e_tests:
+  schema-function-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-7.test.ts
+      TEST_SUITE: src/__tests__/schema-function.test.ts
       CLI_REGION: ap-southeast-1
-  schema-auth-1-amplify_e2e_tests:
+  schema-key-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-1.test.ts
+      TEST_SUITE: src/__tests__/schema-key.test.ts
       CLI_REGION: ap-southeast-2
-  schema-auth-2-amplify_e2e_tests:
+  schema-model-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-2.test.ts
+      TEST_SUITE: src/__tests__/schema-model.test.ts
       CLI_REGION: us-east-2
-  schema-auth-3-amplify_e2e_tests:
+  schema-predictions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-3.test.ts
+      TEST_SUITE: src/__tests__/schema-predictions.test.ts
       CLI_REGION: us-west-2
-  schema-auth-4-amplify_e2e_tests:
+  schema-searchable-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-4.test.ts
+      TEST_SUITE: src/__tests__/schema-searchable.test.ts
       CLI_REGION: eu-west-2
-  schema-auth-5-amplify_e2e_tests:
+  schema-versioned-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-5.test.ts
+      TEST_SUITE: src/__tests__/schema-versioned.test.ts
       CLI_REGION: eu-central-1
-  schema-auth-6-amplify_e2e_tests:
+  tags-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
     resource_class: large
     steps: *ref_1
     environment:
-      TEST_SUITE: src/__tests__/schema-auth-6.test.ts
+      TEST_SUITE: src/__tests__/tags.test.ts
       CLI_REGION: ap-northeast-1
   plugin-amplify_e2e_tests:
     working_directory: ~/repo
@@ -1173,25 +1173,25 @@ workflows:
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4
-            - schema-auth-2-amplify_e2e_tests
+            - schema-model-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - delete-amplify_e2e_tests
-            - schema-auth-3-amplify_e2e_tests
+            - schema-predictions-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - storage-amplify_e2e_tests
-            - schema-auth-4-amplify_e2e_tests
+            - schema-searchable-amplify_e2e_tests
             - init-amplify_e2e_tests
             - migration-api-key-migration-amplify_e2e_tests
-            - schema-auth-5-amplify_e2e_tests
+            - schema-versioned-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - migration-api-connection-migration-amplify_e2e_tests
-            - schema-auth-8-amplify_e2e_tests
-            - schema-auth-6-amplify_e2e_tests
+            - schema-data-access-patterns-amplify_e2e_tests
+            - tags-amplify_e2e_tests
             - analytics-amplify_e2e_tests
-            - schema-auth-7-amplify_e2e_tests
+            - schema-function-amplify_e2e_tests
             - plugin-amplify_e2e_tests
             - hostingPROD-amplify_e2e_tests
-            - schema-auth-1-amplify_e2e_tests
+            - schema-key-amplify_e2e_tests
             - datastore-modegen-amplify_e2e_tests
             - predictions-amplify_e2e_tests
           filters:
@@ -1200,7 +1200,7 @@ workflows:
                 - release
                 - master
                 - beta
-      - schema-key-amplify_e2e_tests:
+      - api_1-amplify_e2e_tests:
           filters: &ref_2
             branches:
               only:
@@ -1208,119 +1208,7 @@ workflows:
                 - graphqlschemae2e
           requires:
             - publish_to_local_registry
-      - env-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-function-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-2-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - schema-key-amplify_e2e_tests
-      - interactions-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - env-amplify_e2e_tests
-      - delete-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - schema-function-amplify_e2e_tests
-      - tags-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - function_1-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - layer-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-3-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - tags-amplify_e2e_tests
-      - hosting-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - function_1-amplify_e2e_tests
-      - storage-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - layer-amplify_e2e_tests
-      - api_2-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - function_2-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-data-access-patterns-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-4-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - api_2-amplify_e2e_tests
-      - init-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - function_2-amplify_e2e_tests
-      - migration-api-key-migration-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - schema-data-access-patterns-amplify_e2e_tests
-      - auth_1-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-predictions-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-connection-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-5-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - auth_1-amplify_e2e_tests
-      - amplify-app-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - schema-predictions-amplify_e2e_tests
-      - migration-api-connection-migration-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-            - schema-connection-amplify_e2e_tests
-      - auth_2-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-model-amplify_e2e_tests:
-          filters: *ref_2
-          requires:
-            - publish_to_local_registry
-      - schema-auth-8-amplify_e2e_tests:
+      - init-special-case-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1328,17 +1216,26 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - auth_2-amplify_e2e_tests
-      - analytics-amplify_e2e_tests:
+      - schema-model-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-model-amplify_e2e_tests
-      - schema-versioned-amplify_e2e_tests:
+            - api_1-amplify_e2e_tests
+      - interactions-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - init-special-case-amplify_e2e_tests:
+            - init-special-case-amplify_e2e_tests
+      - delete-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-6-amplify_e2e_tests
+      - api_2-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - layer-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1346,21 +1243,22 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - plugin-amplify_e2e_tests:
+      - schema-predictions-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-versioned-amplify_e2e_tests
-      - hostingPROD-amplify_e2e_tests:
+            - api_2-amplify_e2e_tests
+      - hosting-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - init-special-case-amplify_e2e_tests
-      - schema-searchable-amplify_e2e_tests:
+            - layer-amplify_e2e_tests
+      - storage-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - api_1-amplify_e2e_tests:
+            - schema-auth-7-amplify_e2e_tests
+      - auth_1-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1368,13 +1266,115 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
+      - schema-auth-8-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-searchable-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - auth_1-amplify_e2e_tests
+      - init-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-1-amplify_e2e_tests
+      - migration-api-key-migration-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-8-amplify_e2e_tests
+      - auth_2-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-2-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-connection-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-versioned-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - auth_2-amplify_e2e_tests
+      - amplify-app-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-2-amplify_e2e_tests
+      - migration-api-connection-migration-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-connection-amplify_e2e_tests
+      - env-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-3-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-data-access-patterns-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - tags-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - env-amplify_e2e_tests
+      - analytics-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-3-amplify_e2e_tests
+      - function_1-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-4-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-function-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - plugin-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - function_1-amplify_e2e_tests
+      - hostingPROD-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+            - schema-auth-4-amplify_e2e_tests
+      - function_2-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-auth-5-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
+      - schema-key-amplify_e2e_tests:
+          filters: *ref_2
+          requires:
+            - publish_to_local_registry
       - datastore-modegen-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-searchable-amplify_e2e_tests
+            - function_2-amplify_e2e_tests
       - predictions-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - api_1-amplify_e2e_tests
+            - schema-auth-5-amplify_e2e_tests

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/get-add-auth-handler.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/get-add-auth-handler.ts
@@ -15,7 +15,7 @@ export const getAddAuthHandler = (context: any) => async (request: ServiceQuesti
   let projectName = context.amplify.getProjectConfig().projectName.toLowerCase();
   const disallowedChars = /[^A-Za-z0-9]+/g;
   projectName = projectName.replace(disallowedChars, '');
-  const requestWithDefaults = await getAddAuthDefaultsApplier(defaultValuesFilename, projectName)(request);
+  const requestWithDefaults = await getAddAuthDefaultsApplier(context, defaultValuesFilename, projectName)(request);
   await getResourceSynthesizer(
     context,
     cfnFilename,

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -184,7 +184,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, stringMapsFile
   }
 
   // formatting oAuthMetaData
-  structureoAuthMetaData(coreAnswers, context, getAllDefaults, amplify);
+  structureOAuthMetadata(coreAnswers, context, getAllDefaults, amplify);
 
   if (coreAnswers.usernameAttributes && !Array.isArray(coreAnswers.usernameAttributes)) {
     if (coreAnswers.usernameAttributes === 'username') {
@@ -453,7 +453,7 @@ function userPoolProviders(oAuthProviders, coreAnswers, prevAnswers) {
 /*
   Format hosted UI oAuth data per lambda spec
 */
-function structureoAuthMetaData(coreAnswers, context, defaults, amplify) {
+function structureOAuthMetadata(coreAnswers, context, defaults, amplify) {
   if (coreAnswers.useDefault === 'default' && context.updatingAuth) {
     delete context.updatingAuth.oAuthMetadata;
     return null;
@@ -706,7 +706,7 @@ module.exports = {
   serviceWalkthrough,
   userPoolProviders,
   parseOAuthCreds,
-  structureoAuthMetaData,
+  structureOAuthMetadata,
   getIAMPolicies,
   identityPoolProviders,
 };

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/add-auth-defaults-applier.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/add-auth-defaults-applier.ts
@@ -1,6 +1,7 @@
 import { ServiceQuestionsResult } from '../service-walkthrough-types';
 import { verificationBucketName } from './verification-bucket-name';
 import { merge } from 'lodash';
+import { structureOAuthMetadata } from '../service-walkthroughs/auth-questions';
 
 /**
  * Factory function that returns a function that applies default values to a ServiceQuestionsResult request.
@@ -10,13 +11,15 @@ import { merge } from 'lodash';
  * @param defaultValuesFilename The filename to fetch defaults from
  * @param projectName The name of the current project (used to generate some default values)
  */
-export const getAddAuthDefaultsApplier = (defaultValuesFilename: string, projectName: string) => async (
+export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: string, projectName: string) => async (
   result: ServiceQuestionsResult,
 ): Promise<ServiceQuestionsResult> => {
-  const { functionMap, generalDefaults, roles } = require(`../assets/${defaultValuesFilename}`);
+  const { functionMap, generalDefaults, roles, getAllDefaults } = await import(`../assets/${defaultValuesFilename}`);
   result = merge(generalDefaults(projectName), result);
 
   await verificationBucketName(result);
+
+  structureOAuthMetadata(result, context, getAllDefaults, context.amplify); // adds "oauthMetadata" to result
 
   /* merge actual answers object into props object,
    * ensuring that manual entries override defaults */

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/add-auth-request-adaptor.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/add-auth-request-adaptor.ts
@@ -83,26 +83,28 @@ const socialProviderMap = (
   requiredAttributes: string[] = [],
 ): SocialProviderResult => {
   const authProvidersUserPool = socialConfig.map(sc => sc.provider).map(provider => pascalCase(provider));
-  const result: ReturnType<typeof socialProviderMap> = {
-    authProvidersUserPool,
-    ...userPoolProviders(authProvidersUserPool, { requiredAttributes }),
-  };
-  socialConfig.forEach(sc => {
-    switch (sc.provider) {
+  const socialConfigMap = socialConfig.reduce((acc, it) => {
+    switch (it.provider) {
       case 'FACEBOOK':
-        result.facebookAppIdUserPool = sc.clientId;
-        result.facebookAppSecretUserPool = sc.clientSecret;
+        acc.facebookAppIdUserPool = it.clientId;
+        acc.facebookAppSecretUserPool = it.clientSecret;
         break;
       case 'GOOGLE':
-        result.googleAppIdUserPool = sc.clientId;
-        result.googleAppSecretUserPool = sc.clientSecret;
+        acc.googleAppIdUserPool = it.clientId;
+        acc.googleAppSecretUserPool = it.clientSecret;
         break;
       case 'LOGIN_WITH_AMAZON':
-        result.loginwithamazonAppIdUserPool = sc.clientId;
-        result.loginwithamazonAppSecretUserPool = sc.clientSecret;
+        acc.loginwithamazonAppIdUserPool = it.clientId;
+        acc.loginwithamazonAppSecretUserPool = it.clientSecret;
         break;
     }
-  });
+    return acc;
+  }, {} as any) as SocialProviderResult;
+  const result: SocialProviderResult = {
+    authProvidersUserPool,
+    ...socialConfigMap,
+    ...userPoolProviders(authProvidersUserPool, { requiredAttributes, ...socialConfigMap }),
+  };
   return result;
 };
 


### PR DESCRIPTION
*Issue #, if available:*
I don't think anyone has reported it yet
*Description of changes:*
When refactoring auth for headless mode, the new logic did not properly add "oAuthMetadata" to the props passed into the CFN template. It also didn't add the client id and client secret in the hostedUIProviderCreds stored in team provider info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.