### PR TITLE
feat(amplify-cli-core): visually hide "immutable files" for VSCode users

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
@@ -81,13 +81,13 @@ function hideNoManualEdit(editor) {
       const workspaceSettingsPath = '.vscode/settings.json';
       const exclusionRules = {
         'files.exclude': {
-          'amplify/.config': true,
-          'amplify/**/*-parameters.json': true,
-          'amplify/**/amplify.state': true,
-          'amplify/**/transform.conf.json': true,
-          'amplify/#current-cloud-backend': true,
-          'amplify/backend/amplify-meta.json': true,
-          'amplify/backend/awscloudformation': true,
+          '**/amplify/.config': true,
+          '**/amplify/**/*-parameters.json': true,
+          '**/amplify/**/amplify.state': true,
+          '**/amplify/**/transform.conf.json': true,
+          '**/amplify/#current-cloud-backend': true,
+          '**/amplify/backend/amplify-meta.json': true,
+          '**/amplify/backend/awscloudformation': true,
         },
       };
       try {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
@@ -1,4 +1,6 @@
 import * as inquirer from 'inquirer';
+import { JSONUtilities } from 'amplify-cli-core';
+import { merge } from 'lodash';
 
 export const editors = [
   {
@@ -44,6 +46,8 @@ export async function editorSelection(defaultEditor?) {
 
   const { editorSelected } = await inquirer.prompt(editorQuestion);
 
+  hideNoManualEdit(editorSelected);
+
   return editorSelected;
 }
 
@@ -63,4 +67,43 @@ export function normalizeEditor(editor) {
   }
 
   return editor;
+}
+
+/**
+ * @description Appends the settings file for a given text editor so that state files are visually hidden from the file browser.
+ * @abstract When new users are stuck, many will try to edit these files and often end up creating more state management issues. This is a bad UX. Visually hiding them from their text editor will help mitigate this. Users always have the option of changing this default after project initialization.
+ * @param  {} editor - text editor value code
+ *
+ */
+function hideNoManualEdit(editor) {
+  switch (editor) {
+    case 'vscode':
+      const workspaceSettingsPath = '.vscode/settings.json';
+      const exclusionRules = {
+        'files.exclude': {
+          'amplify/.config': true,
+          'amplify/**/*-parameters.json': true,
+          'amplify/**/amplify.state': true,
+          'amplify/**/build': true,
+          'amplify/**/dist': true,
+          'amplify/**/transform.conf.json': true,
+          'amplify/#current-cloud-backend': true,
+          'amplify/backend/amplify-meta.json': true,
+          'amplify/backend/awscloudformation': true,
+        },
+      };
+      try {
+        // If settings file exists, safely add exclude settings to it.
+        const settings = JSONUtilities.readJson(workspaceSettingsPath);
+        JSONUtilities.writeJson(workspaceSettingsPath, merge(exclusionRules, settings));
+      } catch (error) {
+        // Workspace settings file does not exist.
+      } finally {
+        // So let's create it with exclude settings.
+        JSONUtilities.writeJson(workspaceSettingsPath, exclusionRules);
+      }
+      break;
+    default:
+      break;
+  }
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
@@ -84,8 +84,6 @@ function hideNoManualEdit(editor) {
           'amplify/.config': true,
           'amplify/**/*-parameters.json': true,
           'amplify/**/amplify.state': true,
-          'amplify/**/build': true,
-          'amplify/**/dist': true,
           'amplify/**/transform.conf.json': true,
           'amplify/#current-cloud-backend': true,
           'amplify/backend/amplify-meta.json': true,

--- a/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
@@ -81,13 +81,13 @@ function hideNoManualEdit(editor) {
       const workspaceSettingsPath = '.vscode/settings.json';
       const exclusionRules = {
         'files.exclude': {
-          '**/amplify/.config': true,
-          '**/amplify/**/*-parameters.json': true,
-          '**/amplify/**/amplify.state': true,
-          '**/amplify/**/transform.conf.json': true,
-          '**/amplify/#current-cloud-backend': true,
-          '**/amplify/backend/amplify-meta.json': true,
-          '**/amplify/backend/awscloudformation': true,
+          'amplify/.config': true,
+          'amplify/**/*-parameters.json': true,
+          'amplify/**/amplify.state': true,
+          'amplify/**/transform.conf.json': true,
+          'amplify/#current-cloud-backend': true,
+          'amplify/backend/amplify-meta.json': true,
+          'amplify/backend/awscloudformation': true,
         },
       };
       try {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/editor-selection.ts
@@ -96,8 +96,7 @@ function hideNoManualEdit(editor) {
         JSONUtilities.writeJson(workspaceSettingsPath, merge(exclusionRules, settings));
       } catch (error) {
         // Workspace settings file does not exist.
-      } finally {
-        // So let's create it with exclude settings.
+        // Let's create it with exclude settings.
         JSONUtilities.writeJson(workspaceSettingsPath, exclusionRules);
       }
       break;


### PR DESCRIPTION
I'm proposing a developer experience improvement to Amplify, specifically targeting new users.

Consider the following scenario:

A new user decide is trying out Amplify for the first time.

Forgetting to use the CLI, they attempt to modify the metadata files directly.

They didn't read the docs, and certainly the not the small section at the end explain the Reference > Files and Folders section.

So the only outcome is they get stuck. This causes frustration and a bad new user experience.

Good thing it's totally avoidable. This change visually hides those metadata files so new users aren't tempted to fiddle with them.

With basic workspace configuration settings, we can provide a better user experience for new users by directing their energies and focus towards things in their control, like the templates and source code. 

Of course, these defaults are easily opted out of by updating the settings.json file.

*Issue #, if available:*

*Description of changes:*
If a user selects VSCode during `amplify init`, create or safely update their .vscode/settings.json file to exclude immutable files.
Based on [Files and Folders where manual edits are not allowed](https://docs.amplify.aws/cli/reference/files)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.