### PR TITLE
fix(amplify-codegen-appsync-model-plugin): DataStore Array Support

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -932,7 +932,7 @@ describe('AppSyncSwiftVisitor', () => {
           Class: Class
           nonNullClass: Class!
           classes: [Class]
-          nonNullClasses: [Class]!
+          nonNullClasses: [Class!]!
         }
       `;
       const visitor = getVisitor(schema, 'Class');

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/get-type-info.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/get-type-info.ts
@@ -23,7 +23,6 @@ export function getTypeInfo(typeNode: TypeNode, schema: GraphQLSchema): TypeInfo
     return {
       ...getTypeInfo(typeNode.type, schema),
       isList: true,
-      isListNullable: true,
     };
   }
   return {

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/get-type-info.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/get-type-info.ts
@@ -8,6 +8,12 @@ export function getTypeInfo(typeNode: TypeNode, schema: GraphQLSchema): TypeInfo
       isList: false,
       baseType: schema.getType(typeNode.name.value),
     };
+  } else if (typeNode.kind === 'NonNullType' && typeNode.type.kind === 'ListType') {
+    return {
+      ...getTypeInfo(typeNode.type.type, schema),
+      isList: true,
+      isListNullable: false,
+    };
   } else if (typeNode.kind === 'NonNullType') {
     return {
       ...getTypeInfo(typeNode.type, schema),
@@ -17,7 +23,7 @@ export function getTypeInfo(typeNode: TypeNode, schema: GraphQLSchema): TypeInfo
     return {
       ...getTypeInfo(typeNode.type, schema),
       isList: true,
-      isNullable: true,
+      isListNullable: true,
     };
   }
   return {

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -205,7 +205,7 @@ export class AppSyncJSONVisitor<
         };
 
         if (field.isListNullable !== undefined) {
-          fieldMeta.isArrayNullable = !field.isListNullable;
+          fieldMeta.isArrayNullable = field.isListNullable;
         }
 
         const association: AssociationType | void = this.getFieldAssociation(field);

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -201,9 +201,13 @@ export class AppSyncJSONVisitor<
           isArray: field.isList,
           type: this.getType(field.type),
           isRequired: !field.isNullable,
-          isArrayRequired: field.isListNullable !== undefined ? !field.isListNullable : undefined,
           attributes: [],
         };
+
+        if (field.isListNullable !== undefined) {
+          fieldMeta.isArrayRequired = !field.isListNullable;
+        }
+
         const association: AssociationType | void = this.getFieldAssociation(field);
         if (association) {
           fieldMeta.association = association;

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -62,6 +62,7 @@ type JSONModelField = {
   type: JSONModelFieldType;
   isArray: boolean;
   isRequired?: boolean;
+  isArrayRequired?: boolean;
   attributes?: JSONModelFieldAttributes;
   association?: AssociationType;
 };
@@ -200,6 +201,7 @@ export class AppSyncJSONVisitor<
           isArray: field.isList,
           type: this.getType(field.type),
           isRequired: !field.isNullable,
+          isArrayRequired: field.isListNullable !== undefined ? !field.isListNullable : undefined,
           attributes: [],
         };
         const association: AssociationType | void = this.getFieldAssociation(field);

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -62,7 +62,7 @@ type JSONModelField = {
   type: JSONModelFieldType;
   isArray: boolean;
   isRequired?: boolean;
-  isArrayRequired?: boolean;
+  isArrayNullable?: boolean;
   attributes?: JSONModelFieldAttributes;
   association?: AssociationType;
 };
@@ -205,7 +205,7 @@ export class AppSyncJSONVisitor<
         };
 
         if (field.isListNullable !== undefined) {
-          fieldMeta.isArrayRequired = !field.isListNullable;
+          fieldMeta.isArrayNullable = !field.isListNullable;
         }
 
         const association: AssociationType | void = this.getFieldAssociation(field);

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -120,6 +120,7 @@ export type TypeInfo = {
   type: string;
   isList: boolean;
   isNullable: boolean;
+  isListNullable?: boolean;
   baseType?: GraphQLNamedType | null;
 };
 export type CodeGenModel = {


### PR DESCRIPTION
Issue #, if available: #5139

*Description of changes:*
I added a check to getTypeInfo to check if the current node is NonNullType and its' child node is ListType to set isListNullable, new attribute in TypeInfo, to to true.
The metadata-visitor then sets isArrayRequired to true whe isListNullable is not allowed.
To add support in DataStore, this PR should do: https://github.com/aws-amplify/amplify-js/pull/6784

This PR should support the table below:

declaration | null | [] | [null] | [{ foo: 'BAR' }]
-- | -- | -- | -- | --
[Type!]! | no | yes | no | yes
[Type]! | no | yes | yes | yes
[Type!] | yes | yes | no | yes
[Type] | yes | yes | yes | yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.