### PR TITLE
fix: use _.uniqWith instead of _.uniqBy to remove duplicates

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/funcParamsUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/funcParamsUtils.ts
@@ -11,7 +11,7 @@ export function merge(existing: Partial<FunctionParameters>, other: Partial<Func
       return oldVal;
     }
     if (_.isArray(oldVal)) {
-      return _.uniqBy(oldVal.concat(newVal), _.isEqual);
+      return _.uniqWith(oldVal.concat(newVal), _.isEqual);
     }
   };
   return _.mergeWith(existing, other, mergeFunc);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.