### PR TITLE
chore: fix #3282, update autocomplete, remove chalkpipe

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/question-factories/core-questions.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/question-factories/core-questions.js
@@ -1,7 +1,6 @@
 const inquirer = require('inquirer');
 const { uniq, flatten } = require('lodash');
 const chalk = require('chalk');
-const chalkpipe = require('chalk-pipe');
 
 function parseInputs(input, amplify, defaultValuesFilename, stringMapsFilename, currentAnswers, context) {
   // eslint-disable-line max-len
@@ -14,9 +13,8 @@ function parseInputs(input, amplify, defaultValuesFilename, stringMapsFilename, 
   // Can also have some validations here based on the input json
   // Uncool implementation here
 
-  const prefix = input.prefix
-    ? `${'\n'} ${chalkpipe(null, input.prefixColor ? chalk[input.prefixColor] : chalk.green)(input.prefix)} ${'\n'}`
-    : '';
+  const questionChalk = input.prefixColor ? chalk[input.prefixColor] : chalk.green;
+  const prefix = input.prefix ? `${'\n'} ${questionChalk(input.prefix)} ${'\n'}` : '';
 
   let question = {
     name: input.key,

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -1,6 +1,5 @@
 const inquirer = require('inquirer');
 const chalk = require('chalk');
-const chalkpipe = require('chalk-pipe');
 const { uniq, pullAll } = require('lodash');
 const path = require('path');
 const { Sort } = require('enquirer');
@@ -68,7 +67,7 @@ async function serviceWalkthrough(context, defaultValuesFilename, stringMapsFile
     // LEARN MORE BLOCK
     if (new RegExp(/learn/i).test(answer[questionObj.key]) && questionObj.learnMore) {
       const helpText = `\n${questionObj.learnMore.replace(new RegExp('[\\n]', 'g'), '\n\n')}\n\n`;
-      questionObj.prefix = chalkpipe(null, chalk.green)(helpText);
+      questionObj.prefix = chalk.green(helpText);
       // ITERATOR BLOCK
     } else if (
       /*

--- a/packages/amplify-category-interactions/package.json
+++ b/packages/amplify-category-interactions/package.json
@@ -19,7 +19,7 @@
     "fs-extra": "^8.1.0",
     "fuzzy": "^0.1.3",
     "inquirer": "^7.0.3",
-    "inquirer-autocomplete-prompt": "^1.0.1",
+    "inquirer-autocomplete-prompt": "^1.1.0",
     "uuid": "^3.4.0"
   }
 }

--- a/packages/amplify-category-predictions/package.json
+++ b/packages/amplify-category-predictions/package.json
@@ -20,7 +20,6 @@
     "amplify-provider-awscloudformation": "4.26.1",
     "aws-sdk": "^2.608.0",
     "chalk": "^3.0.0",
-    "chalk-pipe": "^3.0.0",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.0.3",
     "open": "^7.0.0",

--- a/packages/amplify-category-predictions/provider-utils/supportedPredictions.js
+++ b/packages/amplify-category-predictions/provider-utils/supportedPredictions.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-multi-str */
-import chalkpipe from 'chalk-pipe';
 import chalk from 'chalk';
 
 const inquirer = require('inquirer');
@@ -42,7 +41,7 @@ Interpret allows you to analyze text for language, entities (places, people), ke
 Infer allows you to perform inference against a cloud endpoint. It’s an advanced feature using Amazon SageMaker, where you have more control over your models.\n\
 Learn More: https://docs.amplify.aws/lib/predictions/intro/q/platform/js';
     helpText = `\n${helpText.replace(new RegExp('[\\n]', 'g'), '\n\n')}\n\n`;
-    questions[0].prefix = chalkpipe(null, chalk.green)(helpText);
+    questions[0].prefix = chalk.green(helpText);
   }
   return questions;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5497,7 +5497,7 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   version "4.3.1"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
@@ -10575,7 +10575,7 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-figures@^3.0.0:
+figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -12409,15 +12409,16 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-inquirer-autocomplete-prompt@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.2.tgz#3f2548f73dd12f0a541be055ea9c8c7aedeb42bf"
-  integrity sha512-vNmAhhrOQwPnUm4B9kz1UB7P98rVF1z8txnjp53r40N0PBCuqoRWqjg3Tl0yz0UkDg7rEUtZ2OZpNc7jnOU9Zw==
+inquirer-autocomplete-prompt@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.1.0.tgz#e7745b49122e56b483659c91328a2c3fca33ffd6"
+  integrity sha512-mrSeUSFGnTSid/DCKG+E+IcN4MaOnT2bW7NuSagZAguD4k3hZ0UladdYNP4EstZOwgeqv0C3M1zYa1QIIf0Oyg==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
-    figures "^2.0.0"
-    run-async "^2.3.0"
+    ansi-escapes "^4.3.1"
+    chalk "^4.0.0"
+    figures "^3.2.0"
+    run-async "^2.4.0"
+    rxjs "^6.6.2"
 
 inquirer-datepicker@^1.1.0:
   version "1.1.1"
@@ -19036,7 +19037,7 @@ rsvp@^4.8.4:
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-async@^2.2.0, run-async@^2.3.0, run-async@^2.4.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -19062,6 +19063,13 @@ rxjs@^6.1.0, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0:
   version "6.6.2"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
   integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.2:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
*Issue #, if available:*

#3284

*Description of changes:*

- Update `inquirer-auto-complete` dependency explicitly to solve peer-dependency issue.
- Remove `chalkpipe` as a dependency, replace with standard `chalk` functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.