### PR TITLE
fix: add owner field if owner auth is included in auth rules

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/package.json
+++ b/packages/amplify-codegen-appsync-model-plugin/package.json
@@ -27,6 +27,7 @@
     "@graphql-tools/utils": "^6.0.18",
     "chalk": "^3.0.0",
     "change-case": "^4.1.1",
+    "lint-fix": "^0.24.0",
     "lower-case-first": "^2.0.1",
     "pluralize": "^8.0.0",
     "strip-indent": "^3.0.0",

--- a/packages/amplify-codegen-appsync-model-plugin/package.json
+++ b/packages/amplify-codegen-appsync-model-plugin/package.json
@@ -27,7 +27,6 @@
     "@graphql-tools/utils": "^6.0.18",
     "chalk": "^3.0.0",
     "change-case": "^4.1.1",
-    "lint-fix": "^0.24.0",
     "lower-case-first": "^2.0.1",
     "pluralize": "^8.0.0",
     "strip-indent": "^3.0.0",

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -233,8 +233,6 @@ export declare class SimpleModel {
 
 });
 
-
-
 describe('Javascript visitor with custom owner field auth', () => {
   const schema = /* GraphQL */ `
     type SimpleModel @model @auth(rules: [{ allow: owner, ownerField: "customOwnerField", operations: [create, update, delete, read] }]) {
@@ -269,7 +267,6 @@ describe('Javascript visitor with custom owner field auth', () => {
       const generateModelDeclarationSpy = jest.spyOn(declarationVisitor as any, 'generateModelDeclaration');
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
-      console.log(declarations)
       expect(declarations).toMatchInlineSnapshot(`
 "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
@@ -289,6 +286,78 @@ export declare class SimpleModel {
   readonly name?: string;
   readonly bar?: string;
   readonly customOwnerField?: String;
+  constructor(init: ModelInit<SimpleModel>);
+  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+}"
+`);
+      expect(generateImportSpy).toBeCalledTimes(1);
+      expect(generateImportSpy).toBeCalledWith();
+
+      expect(generateEnumDeclarationsSpy).toBeCalledTimes(1);
+      expect(generateEnumDeclarationsSpy).toBeCalledWith((declarationVisitor as any).enumMap['SimpleEnum'], true);
+
+      expect(generateModelDeclarationSpy).toBeCalledTimes(2);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+    });
+  });
+
+});
+
+describe('Javascript visitor with multiple owner field auth', () => {
+  const schema = /* GraphQL */ `
+    type SimpleModel @model @auth(rules: [{ allow: owner, ownerField: "customOwnerField"}, { allow: owner, ownerField: "customOwnerField2"}]) {
+      id: ID!
+      name: String
+      bar: String
+    }
+    enum SimpleEnum {
+      enumVal1
+      enumVal2
+    }
+
+    type SimpleNonModelType {
+      id: ID!
+      names: [String]
+    }
+  `;
+  let visitor: AppSyncModelJavascriptVisitor;
+  beforeEach(() => {
+    visitor = getVisitor(schema);
+  });
+
+  describe('generate', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should add custom both owner fields to Javascript declaration', () => {
+      const declarationVisitor = getVisitor(schema, true);
+      const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
+      const generateEnumDeclarationsSpy = jest.spyOn(declarationVisitor as any, 'generateEnumDeclarations');
+      const generateModelDeclarationSpy = jest.spyOn(declarationVisitor as any, 'generateModelDeclaration');
+      const declarations = declarationVisitor.generate();
+      validateTs(declarations);
+      expect(declarations).toMatchInlineSnapshot(`
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+
+export enum SimpleEnum {
+  ENUM_VAL1 = \\"enumVal1\\",
+  ENUM_VAL2 = \\"enumVal2\\"
+}
+
+export declare class SimpleNonModelType {
+  readonly id: string;
+  readonly names?: string[];
+  constructor(init: ModelInit<SimpleNonModelType>);
+}
+
+export declare class SimpleModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly bar?: string;
+  readonly customOwnerField?: String;
+  readonly customOwnerField2?: String;
   constructor(init: ModelInit<SimpleModel>);
   static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
 }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -162,7 +162,7 @@ export {
   });
 });
 
-describe('Javascript visitor with auth', () => {
+describe('Javascript visitor with default owner auth', () => {
   const schema = /* GraphQL */ `
     type SimpleModel @model @auth(rules: [{ allow: owner }]) {
       id: ID!
@@ -215,6 +215,80 @@ export declare class SimpleModel {
   readonly name?: string;
   readonly bar?: string;
   readonly owner?: String;
+  constructor(init: ModelInit<SimpleModel>);
+  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+}"
+`);
+      expect(generateImportSpy).toBeCalledTimes(1);
+      expect(generateImportSpy).toBeCalledWith();
+
+      expect(generateEnumDeclarationsSpy).toBeCalledTimes(1);
+      expect(generateEnumDeclarationsSpy).toBeCalledWith((declarationVisitor as any).enumMap['SimpleEnum'], true);
+
+      expect(generateModelDeclarationSpy).toBeCalledTimes(2);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+    });
+  });
+
+});
+
+
+
+describe('Javascript visitor with custom owner field auth', () => {
+  const schema = /* GraphQL */ `
+    type SimpleModel @model @auth(rules: [{ allow: owner, ownerField: "customOwnerField", operations: [create, update, delete, read] }]) {
+      id: ID!
+      name: String
+      bar: String
+    }
+    enum SimpleEnum {
+      enumVal1
+      enumVal2
+    }
+
+    type SimpleNonModelType {
+      id: ID!
+      names: [String]
+    }
+  `;
+  let visitor: AppSyncModelJavascriptVisitor;
+  beforeEach(() => {
+    visitor = getVisitor(schema);
+  });
+
+  describe('generate', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should add custom owner field to Javascript declaration', () => {
+      const declarationVisitor = getVisitor(schema, true);
+      const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
+      const generateEnumDeclarationsSpy = jest.spyOn(declarationVisitor as any, 'generateEnumDeclarations');
+      const generateModelDeclarationSpy = jest.spyOn(declarationVisitor as any, 'generateModelDeclaration');
+      const declarations = declarationVisitor.generate();
+      validateTs(declarations);
+      console.log(declarations)
+      expect(declarations).toMatchInlineSnapshot(`
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+
+export enum SimpleEnum {
+  ENUM_VAL1 = \\"enumVal1\\",
+  ENUM_VAL2 = \\"enumVal2\\"
+}
+
+export declare class SimpleNonModelType {
+  readonly id: string;
+  readonly names?: string[];
+  constructor(init: ModelInit<SimpleNonModelType>);
+}
+
+export declare class SimpleModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly bar?: string;
+  readonly customOwnerField?: String;
   constructor(init: ModelInit<SimpleModel>);
   static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
 }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -508,3 +508,271 @@ export declare const schema: Schema;"
     });
   });
 });
+
+
+describe('Metadata visitor', () => {
+  const schema = /* GraphQL */ `
+  type SimpleModel @model @auth(rules: [{ allow: owner, ownerField: "customOwnerField"}, { allow: owner, ownerField: "customOwnerField2"}]) {
+    id: ID!
+    name: String
+    bar: String
+  }
+  enum SimpleEnum {
+    enumVal1
+    enumVal2
+  }
+
+  type SimpleNonModelType {
+    id: ID!
+    names: [String]
+  }
+  `;
+  let visitor: AppSyncJSONVisitor;
+  beforeEach(() => {
+    visitor = getVisitor(schema);
+  });
+
+  describe('metadata snapshots', () => {
+    it('should generate for Javascript', () => {
+      const jsVisitor = getVisitor(schema, 'javascript');
+      expect(jsVisitor.generate()).toMatchInlineSnapshot(`
+        "export const schema = {
+            \\"models\\": {
+                \\"SimpleModel\\": {
+                    \\"name\\": \\"SimpleModel\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"name\\": {
+                            \\"name\\": \\"name\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"bar\\": {
+                            \\"name\\": \\"bar\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"customOwnerField\\": {
+                            \\"name\\": \\"customOwnerField\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"customOwnerField2\\": {
+                            \\"name\\": \\"customOwnerField2\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    },
+                    \\"syncable\\": true,
+                    \\"pluralName\\": \\"SimpleModels\\",
+                    \\"attributes\\": [
+                        {
+                            \\"type\\": \\"model\\",
+                            \\"properties\\": {}
+                        },
+                        {
+                            \\"type\\": \\"auth\\",
+                            \\"properties\\": {
+                                \\"rules\\": [
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"customOwnerField\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    },
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"customOwnerField2\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            \\"enums\\": {
+                \\"SimpleEnum\\": {
+                    \\"name\\": \\"SimpleEnum\\",
+                    \\"values\\": [
+                        \\"enumVal1\\",
+                        \\"enumVal2\\"
+                    ]
+                }
+            },
+            \\"nonModels\\": {
+                \\"SimpleNonModelType\\": {
+                    \\"name\\": \\"SimpleNonModelType\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"names\\": {
+                            \\"name\\": \\"names\\",
+                            \\"isArray\\": true,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    }
+                }
+            },
+            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+        };"
+      `);
+    });
+    it('should generate for typescript', () => {
+      const tsVisitor = getVisitor(schema, 'typescript');
+      expect(tsVisitor.generate()).toMatchInlineSnapshot(`
+        "import { Schema } from \\"@aws-amplify/datastore\\";
+
+        export const schema: Schema = {
+            \\"models\\": {
+                \\"SimpleModel\\": {
+                    \\"name\\": \\"SimpleModel\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"name\\": {
+                            \\"name\\": \\"name\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"bar\\": {
+                            \\"name\\": \\"bar\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"customOwnerField\\": {
+                            \\"name\\": \\"customOwnerField\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"customOwnerField2\\": {
+                            \\"name\\": \\"customOwnerField2\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    },
+                    \\"syncable\\": true,
+                    \\"pluralName\\": \\"SimpleModels\\",
+                    \\"attributes\\": [
+                        {
+                            \\"type\\": \\"model\\",
+                            \\"properties\\": {}
+                        },
+                        {
+                            \\"type\\": \\"auth\\",
+                            \\"properties\\": {
+                                \\"rules\\": [
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"customOwnerField\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    },
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"customOwnerField2\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            \\"enums\\": {
+                \\"SimpleEnum\\": {
+                    \\"name\\": \\"SimpleEnum\\",
+                    \\"values\\": [
+                        \\"enumVal1\\",
+                        \\"enumVal2\\"
+                    ]
+                }
+            },
+            \\"nonModels\\": {
+                \\"SimpleNonModelType\\": {
+                    \\"name\\": \\"SimpleNonModelType\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"names\\": {
+                            \\"name\\": \\"names\\",
+                            \\"isArray\\": true,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    }
+                }
+            },
+            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+        };"
+      `);
+    });
+
+  });
+});

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
@@ -1,4 +1,4 @@
-import { CodeGenDirectives, CodeGenDirective } from '../visitors/appsync-visitor';
+import { CodeGenDirectives, CodeGenDirective, CodeGenModel, CodeGenField } from '../visitors/appsync-visitor';
 export enum AuthProvider {
   apiKey = 'apiKey',
   iam = 'iam',
@@ -92,4 +92,31 @@ export function processAuthDirective(directives: CodeGenDirectives): AuthDirecti
       },
     };
   });
+}
+
+export function getOwnerAuthRules(modelObj: CodeGenModel): any {
+  let rules = Array<any>();
+  for (let directive of modelObj.directives) {
+    if ("auth" === directive.name) {
+      for (let rule of directive.arguments.rules) {
+        if (rule.allow === AuthStrategy.owner) {
+          rules.push(rule);
+        }
+      }
+    }
+  }
+  return rules;
+}
+
+export function getOwnerFieldName(rule: any): string | undefined {
+  if (rule.ownerField === undefined) {
+    return "owner";
+  } else {
+    return rule.ownerField
+  }
+}
+
+export function hasOwnerField(fields: CodeGenField[], ownerField: string): boolean {
+  let ownerFields = fields.filter(field => field.name === ownerField);
+  return ownerFields && ownerFields.length !== 0
 }

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
@@ -94,8 +94,8 @@ export function processAuthDirective(directives: CodeGenDirectives): AuthDirecti
   });
 }
 
-export function getOwnerAuthRules(modelObj: CodeGenModel): any {
-  let rules = Array<any>();
+export function getOwnerAuthRules(modelObj: CodeGenModel): AuthRule[] {
+  let rules = Array<AuthRule>();
   for (let directive of modelObj.directives) {
     if ("auth" === directive.name) {
       for (let rule of directive.arguments.rules) {
@@ -108,7 +108,7 @@ export function getOwnerAuthRules(modelObj: CodeGenModel): any {
   return rules;
 }
 
-export function getOwnerFieldName(rule: any): string | undefined {
+export function getOwnerFieldName(rule: AuthRule): string | undefined {
   if (rule.ownerField === undefined) {
     return "owner";
   } else {

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -95,10 +95,11 @@ export class AppSyncModelTypeScriptVisitor<
       for (let rule of ownerAuthRules) {
         let ownerFieldName = getOwnerFieldName(rule);
         if (ownerFieldName !== undefined && !hasOwnerField(modelObj.fields, ownerFieldName)) {
-        modelDeclarations.addProperty(ownerFieldName, "String", undefined, 'DEFAULT', {
-          readonly: true,
-          optional: true,
-        });
+          modelDeclarations.addProperty(ownerFieldName, "String", undefined, 'DEFAULT', {
+            readonly: true,
+            optional: true,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/5687

*Description of changes:*
Add owner field to generated schema if it does not exist in the original schema but owner auth is included in auth rules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.