### PR TITLE
fix: fix appsync permission assignment from functions

### DIFF
--- a/packages/amplify-category-function/src/constants.ts
+++ b/packages/amplify-category-function/src/constants.ts
@@ -12,3 +12,9 @@ export enum CRUDOperation {
   UPDATE = 'update',
   DELETE = 'delete',
 }
+
+export enum GraphQLOperation {
+  QUERY = 'Query',
+  MUTATION = 'Mutation',
+  SUBSCRIPTION = 'Subscription',
+}

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -1,9 +1,9 @@
 import { constructCFModelTableNameComponent, constructCFModelTableArnComponent } from '../utils/cloudformationHelpers';
-import inquirer from 'inquirer';
+import inquirer, { CheckboxQuestion, DistinctChoice } from 'inquirer';
 import path from 'path';
 import * as TransformPackage from 'graphql-transformer-core';
 import _ from 'lodash';
-import { topLevelCommentPrefix, topLevelCommentSuffix, envVarPrintoutPrefix, CRUDOperation } from '../../../constants';
+import { topLevelCommentPrefix, topLevelCommentSuffix, envVarPrintoutPrefix, CRUDOperation, GraphQLOperation } from '../../../constants';
 import { ServiceName } from '../utils/constants';
 import {
   fetchPermissionCategories,
@@ -14,6 +14,10 @@ import { FunctionParameters, FunctionDependency } from 'amplify-function-plugin-
 import { appsyncTableSuffix } from '../utils/constants';
 import { getAppSyncResourceName } from '../utils/appSyncHelper';
 import { stateManager } from 'amplify-cli-core';
+import { FeatureFlags } from 'amplify-cli-core';
+
+const generateGraphQLPermissions = () => FeatureFlags.getBoolean('generateGraphQLPermissions');
+
 /**
  * This whole file desperately needs to be refactored
  */
@@ -32,25 +36,21 @@ export const askExecRolePermissionsQuestions = async (
   // retrieve api's AppSync resource name for conditional logic
   // in blending appsync @model-backed dynamoDB tables into storage category flow
   const appsyncResourceName = getAppSyncResourceName();
+
   // if there is api category AppSync resource and no storage category, add it back to selection
   // since storage category is responsible for managing appsync @model-backed dynamoDB table permissions
   if (!categories.includes('storage') && appsyncResourceName !== undefined) {
     categories.push('storage');
   }
 
-  const categoryPermissionQuestion = {
-    type: 'checkbox',
-    name: 'categories',
-    message: 'Select the category',
-    choices: categories,
-    default: fetchPermissionCategories(currentPermissionMap),
-  };
-  const capitalizeFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
-  const categoryPermissionAnswer = await inquirer.prompt([categoryPermissionQuestion]);
-  const selectedCategories = categoryPermissionAnswer.categories as any[];
+  const categoryPermissionQuestion = selectCategories(categories, currentPermissionMap);
+  const categoryPermissionAnswer = await inquirer.prompt(categoryPermissionQuestion);
+  const selectedCategories = categoryPermissionAnswer.categories as string[];
+
   let categoryPolicies = [];
   let resources = [];
   const crudOptions = _.values(CRUDOperation);
+  const graphqlOperations = _.values(GraphQLOperation);
   const permissions = {};
 
   const backendDir = context.amplify.pathManager.getBackendDirPath();
@@ -72,73 +72,60 @@ export const askExecRolePermissionsQuestions = async (
       // Lambda layer dependencies are handled seperately
       if (serviceName === ServiceName.LambdaFunction) {
         resourcesList = resourcesList.filter(
-          resourceName => resourceName !== resourceNameToUpdate && amplifyMeta[selectedCategory][resourceName].service === serviceName);
+          resourceName => resourceName !== resourceNameToUpdate && amplifyMeta[selectedCategory][resourceName].service === serviceName,
+        );
       } else {
-        resourcesList = resourcesList.filter(resourceName => resourceName !== resourceNameToUpdate &&
-          !(amplifyMeta[selectedCategory][resourceName].iamAccessUnavailable));
+        resourcesList = resourcesList.filter(
+          resourceName => resourceName !== resourceNameToUpdate && !amplifyMeta[selectedCategory][resourceName].iamAccessUnavailable,
+        );
       }
     }
 
-    if (resourcesList.length === 0) {
-      context.print.warning(`No resources found for ${selectedCategory}`);
+    if (_.isEmpty(resourcesList)) {
+      context.print.warning(`No resources found for ${category}`);
       continue;
     }
 
     try {
-      let selectedResources: any = [];
-
-      if (resourcesList.length === 1) {
-        context.print.info(`${capitalizeFirstLetter(selectedCategory)} category has a resource called ${resourcesList[0]}`);
-        selectedResources = [resourcesList[0]];
-      } else {
-        const resourceQuestion = {
-          type: 'checkbox',
-          name: 'resources',
-          message: `${capitalizeFirstLetter(selectedCategory)} has ${resourcesList.length
-            } resources in this project. Select the one you would like your Lambda to access`,
-          choices: resourcesList,
-          validate: value => {
-            if (value.length === 0) {
-              return 'You must select at least resource';
-            }
-            return true;
-          },
-          default: fetchPermissionResourcesForCategory(currentPermissionMap, selectedCategory),
-        };
-
+      let selectedResources = [];
+      if (resourcesList.length > 1) {
+        // There's a few resources in this category. Let's pick some.
+        const resourceQuestion = selectResourcesInCategory(resourcesList, currentPermissionMap, category);
         const resourceAnswer = await inquirer.prompt([resourceQuestion]);
-        selectedResources = resourceAnswer.resources;
+        selectedResources = _.concat(resourceAnswer.resources);
+      } else {
+        // There's only one resource in the category. Let's use that.
+        selectedResources = _.concat(resourcesList);
       }
 
       for (let resourceName of selectedResources) {
-        if (
-          // In case of some resources they are not in the meta file so check for resource existence as well
-          amplifyMeta[selectedCategory] &&
-          amplifyMeta[selectedCategory][resourceName] &&
-          amplifyMeta[selectedCategory][resourceName].mobileHubMigrated === true
-        ) {
-          context.print.warning(`Policies cannot be added for ${selectedCategory}/${resourceName}, since it is a MobileHub imported resource.`);
+        // PR-5342
+        // If the resource is AppSync, use GraphQL operations for permission policies.
+        // Otherwise, default to CRUD permissions.
+        const serviceType = _.get(amplifyMeta, [category, resourceName, 'service']);
+        let options;
+        switch (serviceType) {
+          case 'AppSync':
+            options = generateGraphQLPermissions() ? graphqlOperations : crudOptions;
+            break;
+          default:
+            options = crudOptions;
+            break;
+        }
+
+        // In case of some resources they are not in the meta file so check for resource existence as well
+        const isMobileHubImportedResource = _.get(amplifyMeta, [category, resourceName, 'mobileHubMigrated'], false);
+        if (isMobileHubImportedResource) {
+          context.print.warning(`Policies cannot be added for ${category}/${resourceName}, since it is a MobileHub imported resource.`);
           continue;
         } else {
-          const crudPermissionQuestion = {
-            type: 'checkbox',
-            name: 'crudOptions',
-            message: `Select the operations you want to permit for ${resourceName}`,
-            choices: crudOptions,
-            validate: value => {
-              if (value.length === 0) {
-                return 'You must select at least one operation';
-              }
+          const resourceType = _.get(amplifyMeta, [category, resourceName, 'service']);
+          const currentPermissions = fetchPermissionsForResourceInCategory(currentPermissionMap, category, resourceName);
+          const permissionQuestion = selectPermissions(options, currentPermissions, resourceType);
+          const permissionAnswer = await inquirer.prompt([permissionQuestion]);
+          const resourcePolicy: any = permissionAnswer.options;
 
-              return true;
-            },
-            default: fetchPermissionsForResourceInCategory(currentPermissionMap, selectedCategory, resourceName),
-          };
-
-          const crudPermissionAnswer = await inquirer.prompt([crudPermissionQuestion]);
-
-          const resourcePolicy: any = crudPermissionAnswer.crudOptions;
-          // overload crudOptions when user selects graphql @model-backing DynamoDB table
+          // overload options when user selects graphql @model-backing DynamoDB table
           // as there is no actual storage category resource where getPermissionPolicies can derive service and provider
           if (resourceName.endsWith(appsyncTableSuffix)) {
             resourcePolicy.providerPlugin = 'awscloudformation';
@@ -176,23 +163,23 @@ export const askExecRolePermissionsQuestions = async (
             resourceAttributes.map(attributes =>
               attributes.resourceName && attributes.resourceName.endsWith(appsyncTableSuffix)
                 ? {
-                  resourceName: appsyncResourceName,
-                  category: 'api',
-                  attributes: ['GraphQLAPIIdOutput'],
-                  needsAdditionalDynamoDBResourceProps: true,
-                  // data to pass so we construct additional resourceProps for lambda envvar for @model back dynamoDB tables
-                  _modelName: attributes.resourceName.replace(`:${appsyncTableSuffix}`, 'Table'),
-                  _cfJoinComponentTableName: constructCFModelTableNameComponent(
-                    appsyncResourceName,
-                    attributes.resourceName,
-                    appsyncTableSuffix,
-                  ),
-                  _cfJoinComponentTableArn: constructCFModelTableArnComponent(
-                    appsyncResourceName,
-                    attributes.resourceName,
-                    appsyncTableSuffix,
-                  ),
-                }
+                    resourceName: appsyncResourceName,
+                    category: 'api',
+                    attributes: ['GraphQLAPIIdOutput'],
+                    needsAdditionalDynamoDBResourceProps: true,
+                    // data to pass so we construct additional resourceProps for lambda envvar for @model back dynamoDB tables
+                    _modelName: attributes.resourceName.replace(`:${appsyncTableSuffix}`, 'Table'),
+                    _cfJoinComponentTableName: constructCFModelTableNameComponent(
+                      appsyncResourceName,
+                      attributes.resourceName,
+                      appsyncTableSuffix,
+                    ),
+                    _cfJoinComponentTableArn: constructCFModelTableArnComponent(
+                      appsyncResourceName,
+                      attributes.resourceName,
+                      appsyncTableSuffix,
+                    ),
+                  }
                 : attributes,
             ),
           );
@@ -272,3 +259,32 @@ export const askExecRolePermissionsQuestions = async (
 export type ExecRolePermissionsResponse = Required<
   Pick<FunctionParameters, 'categoryPolicies' | 'environmentMap' | 'topLevelComment' | 'dependsOn' | 'mutableParametersState'>
 >;
+
+// Inquirer Questions
+
+const selectResourcesInCategory = (choices: DistinctChoice<any>[], currentPermissionMap: any, category: any): CheckboxQuestion => ({
+  type: 'checkbox',
+  name: 'resources',
+  message: `${_.capitalize(category)} has ${choices.length} resources in this project. Select the one you would like your Lambda to access`,
+  choices,
+  validate: answers => (_.isEmpty(answers) ? 'You must select at least one resource' : true),
+  default: fetchPermissionResourcesForCategory(currentPermissionMap, category),
+});
+
+const selectCategories = (choices: DistinctChoice<any>[], currentPermissionMap: object): CheckboxQuestion => ({
+  type: 'checkbox',
+  name: 'categories',
+  message: 'Select the categories you want this function to have access to.',
+  choices,
+  validate: answers => (_.isEmpty(answers) ? 'You must select at least one category' : true),
+  default: fetchPermissionCategories(currentPermissionMap),
+});
+
+const selectPermissions = (choices: DistinctChoice<any>[], currentPermissions: any, resourceType: any) => ({
+  type: 'checkbox',
+  name: 'options',
+  message: `Select the operations you want to permit for ${resourceType}`,
+  choices,
+  validate: answers => (_.isEmpty(answers) ? 'You must select at least one operation' : true),
+  default: currentPermissions,
+});

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/permissionMapUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/permissionMapUtils.ts
@@ -8,6 +8,6 @@ export const fetchPermissionResourcesForCategory = (permissionMap, category: str
   return _.keys(_.get(permissionMap, [category]));
 };
 
-export const fetchPermissionsForResourceInCategory = (permissionMap, category: string, resourceName: string) => {
+export const fetchPermissionsForResourceInCategory = (permissionMap: object = {}, category: string, resourceName: string) => {
   return _.get(permissionMap, [category, resourceName]);
 };

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -561,5 +561,14 @@ export class FeatureFlags {
         defaultValueForNewProjects: true,
       },
     ]);
+
+    this.registerFlag('appSync', [
+      {
+        name: 'generateGraphQLPermissions',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
+    ]);
   };
 }

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -34,7 +34,7 @@ const pythonTemplateChoices = ['Hello World'];
 
 const additionalPermissions = (chain: ExecutionContext, settings: any) => {
   multiSelect(
-    chain.sendLine('y').wait('Select the category'),
+    chain.sendLine('y').wait('Select the categories you want this function to have access to'),
     settings.additionalPermissions.permissions,
     settings.additionalPermissions.choices,
   );


### PR DESCRIPTION
fix #4306

*Issue #, if available:*
4306

*Description of changes:*
The current implementation of appsync permissions is using an incorrect understanding of [IAM policies for AppSync](https://docs.aws.amazon.com/appsync/latest/devguide/security.html). This PR updates the IAM Policy generation process for lambdas from `amplify function create/update` walkthroughs.

This PR is ready for merging. :rocket: 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.