### PR TITLE
fix: publish returns with exitcode 1

### DIFF
--- a/packages/amplify-cli-core/src/errors/index.ts
+++ b/packages/amplify-cli-core/src/errors/index.ts
@@ -9,3 +9,4 @@ export class MissingParametersError extends Error {}
 export class NonEmptyDirectoryError extends Error {}
 export class InvalidEnvironmentNameError extends Error {}
 export class InvalidSubCommandError extends Error {}
+export class FrontendBuildError extends Error {}

--- a/packages/amplify-cli/src/commands/publish.ts
+++ b/packages/amplify-cli/src/commands/publish.ts
@@ -1,4 +1,5 @@
 import { run as push } from './push';
+import { FrontendBuildError } from 'amplify-cli-core';
 
 export const run = async context => {
   context.amplify.constructExeInfo(context);
@@ -34,9 +35,15 @@ export const run = async context => {
     continueToPublish = await context.amplify.confirmPrompt('Do you still want to publish the frontend?');
   }
 
-  if (continueToPublish) {
-    const frontendPlugins = context.amplify.getFrontendPlugins(context);
-    const frontendHandlerModule = require(frontendPlugins[context.exeInfo.projectConfig.frontend]);
-    await frontendHandlerModule.publish(context);
+  try {
+    if (continueToPublish) {
+      const frontendPlugins = context.amplify.getFrontendPlugins(context);
+      const frontendHandlerModule = require(frontendPlugins[context.exeInfo.projectConfig.frontend]);
+      await frontendHandlerModule.publish(context);
+    }
+  } catch (e) {
+    context.print.error(`An error occurred during the publish operation`);
+    context.usageData.emitError(new FrontendBuildError());
+    process.exit(1);
   }
 };


### PR DESCRIPTION
*Issue #2809

*Description of changes:*

* Added try/catch block when angular build fails and return with exitcode 1 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.