### PR TITLE
fix: #5354 .net core lambda project file naming

### DIFF
--- a/packages/amplify-dotnet-function-template-provider/src/providers/crudProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/crudProvider.ts
@@ -34,7 +34,7 @@ export async function provideCrud(request: TemplateContributionRequest, context:
       destMap: {
         ...getDstMap(commonFiles),
         'Crud/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
-        'Crud/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
+        'Crud/Function.csproj.ejs': path.join('src', `${request.contributionContext.resourceName}.csproj`),
         'Crud/FunctionHandler.cs.ejs': handlerSource,
         'Crud/event.json.ejs': path.join('src', 'event.json'),
       },

--- a/packages/amplify-dotnet-function-template-provider/src/providers/helloWorldProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/helloWorldProvider.ts
@@ -22,7 +22,7 @@ export async function provideHelloWorld(request: TemplateContributionRequest): P
       destMap: {
         ...getDstMap(commonFiles),
         'HelloWorld/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
-        'HelloWorld/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
+        'HelloWorld/Function.csproj.ejs': path.join('src', `${request.contributionContext.resourceName}.csproj`),
         'HelloWorld/FunctionHandler.cs.ejs': handlerSource,
         'HelloWorld/event.json': path.join('src', 'event.json'),
       },

--- a/packages/amplify-dotnet-function-template-provider/src/providers/serverlessProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/serverlessProvider.ts
@@ -26,7 +26,7 @@ export function provideServerless(request: TemplateContributionRequest): Promise
       destMap: {
         ...getDstMap(commonFiles),
         'Serverless/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
-        'Serverless/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
+        'Serverless/Function.csproj.ejs': path.join('src', `${request.contributionContext.resourceName}.csproj`),
         'Serverless/FunctionHandler.cs.ejs': handlerSource,
         'Serverless/event.json.ejs': path.join('src', 'event.json'),
       },

--- a/packages/amplify-dotnet-function-template-provider/src/providers/triggerProvider.ts
+++ b/packages/amplify-dotnet-function-template-provider/src/providers/triggerProvider.ts
@@ -33,7 +33,7 @@ export async function provideTrigger(request: TemplateContributionRequest, conte
         ...getDstMap(commonFiles),
         [templateFile]: handlerSource,
         'Trigger/aws-lambda-tools-defaults.json.ejs': path.join('src', 'aws-lambda-tools-defaults.json'),
-        'Trigger/Function.csproj.ejs': path.join('src', `${request.contributionContext.functionName}.csproj`),
+        'Trigger/Function.csproj.ejs': path.join('src', `${request.contributionContext.resourceName}.csproj`),
         [eventFile]: path.join('src', 'event.json'),
       },
       defaultEditorFile: handlerSource,

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -50,7 +50,7 @@ const coreFunction = (
         .wait('Select which capability you want to add:')
         .sendCarriageReturn() // lambda function
         .wait('Provide a friendly name for your resource to be used as a label')
-        .sendLine(settings.name || '')
+        .sendLine(settings.friendlyName || settings.name || '')
         .wait('Provide the AWS Lambda function name:')
         .sendLine(settings.name || '');
 

--- a/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
@@ -110,11 +110,13 @@ describe('dotnet function tests', () => {
     await initJSProjectWithProfile(projRoot, {});
 
     const random = Math.floor(Math.random() * 10000);
+    const friendlyName = `dotnettestfriendlyfn${random}`;
     funcName = `dotnettestfn${random}`;
 
     await addFunction(
       projRoot,
       {
+        friendlyName,
         name: funcName,
         functionTemplate: 'Hello World',
       },


### PR DESCRIPTION
*Issue #, if available:*

fix #5354 

*Description of changes:*

for .NET Core templates the friendly name will be used for the project file name which will default to be the compiled assembly name as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.