### PR TITLE
fix: #4944, #5332

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -684,6 +684,9 @@ test('Schema should compile successfully when subscription is missing from schem
   const subscriptionType = getObjectType(parsed, 'Subscription');
   expect(subscriptionType).toBeDefined();
   expectFields(subscriptionType, ['onCreatePost', 'onUpdatePost', 'onDeletePost']);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  expectFields(mutationType, ['createPost', 'updatePost', 'deletePost']);
 });
 
 function transformerVersionSnapshot(version: number): string {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -152,7 +152,7 @@ type Subscription {
 "
 `;
 
-exports[`DynmoDB transformer should add not default primary key when ID is defined 1`] = `
+exports[`DynamoDB transformer should add not default primary key when ID is defined 1`] = `
 "## [Start] Set default values. **
 #set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **

--- a/packages/graphql-transformer-core/src/TransformerContext.ts
+++ b/packages/graphql-transformer-core/src/TransformerContext.ts
@@ -410,7 +410,24 @@ export class TransformerContext {
    * @param fields The fields to add the mutation type.
    */
   public addMutationFields(fields: FieldDefinitionNode[]) {
-    const mutationTypeName = this.getMutationTypeName();
+    let mutationTypeName = this.getMutationTypeName();
+
+    if (!mutationTypeName) {
+      // It is possible the schema type is manually defined and there is no mutation operation within it
+      // also there is no Mutation type.
+      const mutationNode = this.getMutation();
+      if (!mutationNode) {
+        const schema = this.getSchema();
+        const mutationOperation = makeOperationType('mutation', 'Mutation');
+        const newSchema = {
+          ...schema,
+          operationTypes: [...schema.operationTypes, mutationOperation],
+        };
+        this.putSchema(newSchema);
+        mutationTypeName = 'Mutation';
+      }
+    }
+
     if (mutationTypeName) {
       if (!this.getType(mutationTypeName)) {
         this.addType(blankObject(mutationTypeName));
@@ -428,6 +445,7 @@ export class TransformerContext {
    */
   public addSubscriptionFields(fields: FieldDefinitionNode[]) {
     let subscriptionTypeName = this.getSubscriptionTypeName();
+
     if (!subscriptionTypeName) {
       // It is possible the schema type is manually defined and there is no subscription operation within it
       // also there is no Subscription type.
@@ -440,6 +458,7 @@ export class TransformerContext {
           operationTypes: [...schema.operationTypes, subscriptionOperation],
         };
         this.putSchema(newSchema);
+        subscriptionTypeName = 'Subscription';
       }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

fix #4944
fix #5332 

*Description of changes:*

#4944: If the schema has a `schema` element without `subscription` ensure that we have it when subscription field addition happens.
#5332: Add reserved type name usage validation to @model directive to prevent further errors.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.