### PR TITLE
refactor(amplify-category-auth): stop loading module at runtime

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/function-template-dir/trigger-index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/function-template-dir/trigger-index.js
@@ -3,11 +3,15 @@
   provided that the file names (without extension) are included in the "MODULES" env variable.
   "MODULES" is a comma-delimmited string.
 */
+const moduleNames = process.env.MODULES.split(',');
+const modules = [];
+for (let i = 0; i < moduleNames.length; i += 1) {
+  modules.push(require(`./${moduleNames[i]}`));
+}
 
 exports.handler = (event, context, callback) => {
-  const modules = process.env.MODULES.split(',');
   for (let i = 0; i < modules.length; i += 1) {
-    const { handler } = require(`./${modules[i]}`);
+    const { handler } = modules[i];
     handler(event, context, callback);
   }
 };

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/function-template-dir/trigger-index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/function-template-dir/trigger-index.js
@@ -4,10 +4,7 @@
   "MODULES" is a comma-delimmited string.
 */
 const moduleNames = process.env.MODULES.split(',');
-const modules = [];
-for (let i = 0; i < moduleNames.length; i += 1) {
-  modules.push(require(`./${moduleNames[i]}`));
-}
+const modules = moduleNames.map(name => require(`./${name}`));
 
 exports.handler = (event, context, callback) => {
   for (let i = 0; i < modules.length; i += 1) {


### PR DESCRIPTION
*Issue #, if available:*
fix #3212

*Description of changes:*
This change extracts the module loading outside the handler function to don't load the modules at
every runtime execution. It also reduces a lot the cold start duration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.