### PR TITLE
feat(amplify-category-auth): Add support for PreventUserExistenceErrors

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -304,6 +304,7 @@ Resources:
       WriteAttributes: !Ref userpoolClientWriteAttributes
       <% } %>
       RefreshTokenValidity: !Ref userpoolClientRefreshTokenValidity
+      PreventUserExistenceErrors: !Ref userpoolClientPreventUserExistenceErrors
       UserPoolId: !Ref UserPool
     DependsOn: UserPool
   UserPoolClient:
@@ -318,6 +319,7 @@ Resources:
       <% } %>
       GenerateSecret: !Ref userpoolClientGenerateSecret
       RefreshTokenValidity: !Ref userpoolClientRefreshTokenValidity
+      PreventUserExistenceErrors: !Ref userpoolClientPreventUserExistenceErrors
       UserPoolId: !Ref UserPool
     DependsOn: UserPool
   # BEGIN USER POOL LAMBDA RESOURCES

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -42,6 +42,7 @@ const userPoolDefaults = projectName => {
     userpoolClientReadAttributes: ['email'],
     userpoolClientLambdaRole: `${projectNameTruncated}_userpoolclient_lambda_role`,
     userpoolClientSetAttributes: false,
+    userpoolClientPreventUserExistenceErrors: 'ENABLED',
   };
 };
 

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/string-maps.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/string-maps.js
@@ -556,6 +556,17 @@ const additonalConfigMap = [
   },
 ];
 
+const preventUserExistenceErrorsMap = [
+  {
+    name: 'Enabled(recommended)',
+    value: 'ENABLED',
+  },
+  {
+    name: 'Legacy',
+    value: 'LEGACY',
+  },
+];
+
 const disableOptionsOnEdit = () => {
   mfaOptions.find(i => i.value === 'ON').disabled = true;
 };
@@ -584,6 +595,7 @@ const getAllMaps = edit => {
     updateFlowMap,
     capabilities,
     additonalConfigMap,
+    preventUserExistenceErrorsMap,
   };
 };
 

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
@@ -32,6 +32,7 @@ export const safeDefaults = [
   'passwordPolicyMinLength',
   'passwordPolicyCharacters',
   'userpoolClientRefreshTokenValidity',
+  'userpoolClientPreventUserExistenceErrors',
 ];
 
 // These attributes cannot be modified once the auth resource is created

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
@@ -24,6 +24,7 @@ export interface ServiceQuestionsBaseResult {
   userpoolClientRefreshTokenValidity?: number;
   userpoolClientReadAttributes: string[];
   userpoolClientWriteAttributes: string[];
+  userpoolClientPreventUserExistenceErrors?: 'ENABLED' | 'LEGACY';
 }
 
 export interface OAuthResult {

--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -704,6 +704,21 @@ export const supportedServices = {
         ],
       },
       {
+        key: 'userpoolClientPreventUserExistenceErrors',
+        question: 'Do you want to prevent user existence errors?',
+        required: true,
+        type: 'list',
+        default: true,
+        map: 'preventUserExistenceErrorsMap',
+        andConditions: [
+          {
+            key: 'authSelections',
+            value: 'identityPoolOnly',
+            operator: '!=',
+          }
+        ],
+      },
+      {
         key: 'triggers',
         question: 'Do you want to enable any of the following capabilities?',
         required: true,


### PR DESCRIPTION
*Issue #, if available:* #4214 

*Description of changes:*
Added in the `userpoolClientPreventUserExistenceErrors` option for User Pool creation. This defaults to `ENABLED` as this is the recommended value by AWS. If the user chooses to go through the advanced configuration of Cognito in the cli there is a promprt added around this key as well for Enabled or Legacy.

Tested by bootstrapping a project using the `amplify-dev` setup and was able to configure via `amplify add api` and `amplify add auth` and confirm in the Cognito User Pool that this was now enabled instead of defaulting to the Legacy option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.