### PR TITLE
fix(amplify-codegen-appsync-model-plugin): add ownerField to modelgen…

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -30,9 +30,11 @@ public final class customClaim implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField BAR = field(\\"bar\\");
+  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -45,10 +47,15 @@ public final class customClaim implements Model {
       return bar;
   }
   
-  private customClaim(String id, String name, String bar) {
+  public String getOwner() {
+      return owner;
+  }
+  
+  private customClaim(String id, String name, String bar, String owner) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.owner = owner;
   }
   
   @Override
@@ -61,7 +68,8 @@ public final class customClaim implements Model {
       customClaim customClaim = (customClaim) obj;
       return ObjectsCompat.equals(getId(), customClaim.getId()) &&
               ObjectsCompat.equals(getName(), customClaim.getName()) &&
-              ObjectsCompat.equals(getBar(), customClaim.getBar());
+              ObjectsCompat.equals(getBar(), customClaim.getBar()) &&
+              ObjectsCompat.equals(getOwner(), customClaim.getOwner());
       }
   }
   
@@ -71,6 +79,7 @@ public final class customClaim implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -81,7 +90,8 @@ public final class customClaim implements Model {
       .append(\\"customClaim {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"owner=\\" + String.valueOf(getOwner()))
       .append(\\"}\\")
       .toString();
   }
@@ -112,6 +122,7 @@ public final class customClaim implements Model {
     return new customClaim(
       id,
       null,
+      null,
       null
     );
   }
@@ -119,13 +130,15 @@ public final class customClaim implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      owner);
   }
   public interface BuildStep {
     customClaim build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep owner(String owner);
   }
   
 
@@ -133,6 +146,7 @@ public final class customClaim implements Model {
     private String id;
     private String name;
     private String bar;
+    private String owner;
     @Override
      public customClaim build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -140,7 +154,8 @@ public final class customClaim implements Model {
         return new customClaim(
           id,
           name,
-          bar);
+          bar,
+          owner);
     }
     
     @Override
@@ -152,6 +167,12 @@ public final class customClaim implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep owner(String owner) {
+        this.owner = owner;
         return this;
     }
     
@@ -178,10 +199,11 @@ public final class customClaim implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, String owner) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .owner(owner);
     }
     
     @Override
@@ -192,6 +214,11 @@ public final class customClaim implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder owner(String owner) {
+      return (CopyOfBuilder) super.owner(owner);
     }
   }
   
@@ -627,9 +654,11 @@ public final class simpleOwnerAuth implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField BAR = field(\\"bar\\");
+  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -642,10 +671,15 @@ public final class simpleOwnerAuth implements Model {
       return bar;
   }
   
-  private simpleOwnerAuth(String id, String name, String bar) {
+  public String getOwner() {
+      return owner;
+  }
+  
+  private simpleOwnerAuth(String id, String name, String bar, String owner) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.owner = owner;
   }
   
   @Override
@@ -658,7 +692,8 @@ public final class simpleOwnerAuth implements Model {
       simpleOwnerAuth simpleOwnerAuth = (simpleOwnerAuth) obj;
       return ObjectsCompat.equals(getId(), simpleOwnerAuth.getId()) &&
               ObjectsCompat.equals(getName(), simpleOwnerAuth.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleOwnerAuth.getBar());
+              ObjectsCompat.equals(getBar(), simpleOwnerAuth.getBar()) &&
+              ObjectsCompat.equals(getOwner(), simpleOwnerAuth.getOwner());
       }
   }
   
@@ -668,6 +703,7 @@ public final class simpleOwnerAuth implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -678,7 +714,8 @@ public final class simpleOwnerAuth implements Model {
       .append(\\"simpleOwnerAuth {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"owner=\\" + String.valueOf(getOwner()))
       .append(\\"}\\")
       .toString();
   }
@@ -709,6 +746,7 @@ public final class simpleOwnerAuth implements Model {
     return new simpleOwnerAuth(
       id,
       null,
+      null,
       null
     );
   }
@@ -716,13 +754,15 @@ public final class simpleOwnerAuth implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      owner);
   }
   public interface BuildStep {
     simpleOwnerAuth build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep owner(String owner);
   }
   
 
@@ -730,6 +770,7 @@ public final class simpleOwnerAuth implements Model {
     private String id;
     private String name;
     private String bar;
+    private String owner;
     @Override
      public simpleOwnerAuth build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -737,7 +778,8 @@ public final class simpleOwnerAuth implements Model {
         return new simpleOwnerAuth(
           id,
           name,
-          bar);
+          bar,
+          owner);
     }
     
     @Override
@@ -749,6 +791,12 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep owner(String owner) {
+        this.owner = owner;
         return this;
     }
     
@@ -775,10 +823,11 @@ public final class simpleOwnerAuth implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, String owner) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .owner(owner);
     }
     
     @Override
@@ -789,6 +838,11 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder owner(String owner) {
+      return (CopyOfBuilder) super.owner(owner);
     }
   }
   
@@ -826,9 +880,11 @@ public final class allowRead implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField BAR = field(\\"bar\\");
+  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -841,10 +897,15 @@ public final class allowRead implements Model {
       return bar;
   }
   
-  private allowRead(String id, String name, String bar) {
+  public String getOwner() {
+      return owner;
+  }
+  
+  private allowRead(String id, String name, String bar, String owner) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.owner = owner;
   }
   
   @Override
@@ -857,7 +918,8 @@ public final class allowRead implements Model {
       allowRead allowRead = (allowRead) obj;
       return ObjectsCompat.equals(getId(), allowRead.getId()) &&
               ObjectsCompat.equals(getName(), allowRead.getName()) &&
-              ObjectsCompat.equals(getBar(), allowRead.getBar());
+              ObjectsCompat.equals(getBar(), allowRead.getBar()) &&
+              ObjectsCompat.equals(getOwner(), allowRead.getOwner());
       }
   }
   
@@ -867,6 +929,7 @@ public final class allowRead implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -877,7 +940,8 @@ public final class allowRead implements Model {
       .append(\\"allowRead {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"owner=\\" + String.valueOf(getOwner()))
       .append(\\"}\\")
       .toString();
   }
@@ -908,6 +972,7 @@ public final class allowRead implements Model {
     return new allowRead(
       id,
       null,
+      null,
       null
     );
   }
@@ -915,13 +980,15 @@ public final class allowRead implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      owner);
   }
   public interface BuildStep {
     allowRead build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep owner(String owner);
   }
   
 
@@ -929,6 +996,7 @@ public final class allowRead implements Model {
     private String id;
     private String name;
     private String bar;
+    private String owner;
     @Override
      public allowRead build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -936,7 +1004,8 @@ public final class allowRead implements Model {
         return new allowRead(
           id,
           name,
-          bar);
+          bar,
+          owner);
     }
     
     @Override
@@ -948,6 +1017,12 @@ public final class allowRead implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep owner(String owner) {
+        this.owner = owner;
         return this;
     }
     
@@ -974,10 +1049,11 @@ public final class allowRead implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, String owner) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .owner(owner);
     }
     
     @Override
@@ -988,6 +1064,11 @@ public final class allowRead implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder owner(String owner) {
+      return (CopyOfBuilder) super.owner(owner);
     }
   }
   

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -214,7 +214,7 @@ export declare class SimpleModel {
   readonly id: string;
   readonly name?: string;
   readonly bar?: string;
-  readonly owner?: String;
+  readonly owner?: string;
   constructor(init: ModelInit<SimpleModel>);
   static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
 }"
@@ -285,7 +285,7 @@ export declare class SimpleModel {
   readonly id: string;
   readonly name?: string;
   readonly bar?: string;
-  readonly customOwnerField?: String;
+  readonly customOwnerField?: string;
   constructor(init: ModelInit<SimpleModel>);
   static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
 }"
@@ -356,8 +356,8 @@ export declare class SimpleModel {
   readonly id: string;
   readonly name?: string;
   readonly bar?: string;
-  readonly customOwnerField?: String;
-  readonly customOwnerField2?: String;
+  readonly customOwnerField?: string;
+  readonly customOwnerField2?: string;
   constructor(init: ModelInit<SimpleModel>);
   static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
 }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -200,6 +200,7 @@ describe('Metadata visitor', () => {
           name: 'associatedField',
           type: 'String',
         },
+        isConnectingFieldAutoCreated: false,
       };
       const getFieldNameSpy = jest.spyOn(visitor as any, 'getFieldName');
       const fieldWithHasManyConnection = { ...baseField, connectionInfo: hasManyAssociation };
@@ -228,6 +229,7 @@ describe('Metadata visitor', () => {
           type: 'model',
         },
         targetName: 'connectedId',
+        isConnectingFieldAutoCreated: false,
       };
       const getFieldNameSpy = jest.spyOn(visitor as any, 'getFieldName');
       const fieldWithBelongsToConnection = { ...baseField, connectionInfo: belongsToAssociation };
@@ -648,7 +650,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"5d997b204c79c66d009287de0054655e\\"
         };"
       `);
     });
@@ -769,7 +771,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"5d997b204c79c66d009287de0054655e\\"
         };"
       `);
     });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -1161,7 +1161,7 @@ describe('AppSyncSwiftVisitor', () => {
         `);
       });
 
-      it('should add the default owner field if it is not provided neither in schema nor in ownerField', () => {
+      it('should add the default owner field if it is not provided in schema and in ownerField', () => {
         const schema = /* GraphQL */ `
           type Post @model @auth(rules: [{ allow: owner }]) {
             id: ID!
@@ -1205,7 +1205,7 @@ describe('AppSyncSwiftVisitor', () => {
         `);
       });
 
-      it('should add the ownerField to model generation automatically if not provided in schema', () => {
+      it('should add the custom ownerField to model generation automatically if not provided in schema', () => {
         const schema = /* GraphQL */ `
           type Post @model @auth(rules: [{ allow: owner, ownerField: "customField" }]) {
             id: ID!

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
@@ -1,4 +1,4 @@
-import { CodeGenDirectives, CodeGenDirective, CodeGenModel, CodeGenField } from '../visitors/appsync-visitor';
+import { CodeGenDirectives, CodeGenDirective } from '../visitors/appsync-visitor';
 export enum AuthProvider {
   apiKey = 'apiKey',
   iam = 'iam',

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-auth.ts
@@ -67,7 +67,7 @@ export function processAuthDirective(directives: CodeGenDirectives): AuthDirecti
           return {
             // transformer looks for cognito:username when identityClaim is set to username
             provider: DEFAULT_AUTH_PROVIDER,
-            ownerField: DEFAULT_OWNER_FIELD,
+            ownerField: rule.ownerField ? rule.ownerField : DEFAULT_OWNER_FIELD,
             ...rule,
             identityClaim: identityClaim === 'username' ? 'cognito:username' : identityClaim,
             operations,
@@ -92,31 +92,4 @@ export function processAuthDirective(directives: CodeGenDirectives): AuthDirecti
       },
     };
   });
-}
-
-export function getOwnerAuthRules(modelObj: CodeGenModel): AuthRule[] {
-  let rules = Array<AuthRule>();
-  for (let directive of modelObj.directives) {
-    if ("auth" === directive.name) {
-      for (let rule of directive.arguments.rules) {
-        if (rule.allow === AuthStrategy.owner) {
-          rules.push(rule);
-        }
-      }
-    }
-  }
-  return rules;
-}
-
-export function getOwnerFieldName(rule: AuthRule): string | undefined {
-  if (rule.ownerField === undefined) {
-    return "owner";
-  } else {
-    return rule.ownerField
-  }
-}
-
-export function hasOwnerField(fields: CodeGenField[], ownerField: string): boolean {
-  let ownerFields = fields.filter(field => field.name === ownerField);
-  return ownerFields && ownerFields.length !== 0
 }

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -10,7 +10,6 @@ import {
   CodeGenEnum,
 } from './appsync-visitor';
 import { METADATA_SCALAR_MAP } from '../scalars';
-import { getOwnerAuthRules, getOwnerFieldName, hasOwnerField } from '../utils/process-auth';
 export type JSONSchema = {
   models: JSONSchemaModels;
   enums: JSONSchemaEnums;
@@ -194,20 +193,9 @@ export class AppSyncJSONVisitor<
   }
 
   private generateNonModelMetadata(nonModel: CodeGenModel): JSONSchemaNonModel {
-    let fields = nonModel.fields
-    let rules = getOwnerAuthRules(nonModel)
-    if (rules !== undefined) {
-      for (let rule of rules) {
-        let ownerFieldName = getOwnerFieldName(rule);
-        if (ownerFieldName !== undefined && !hasOwnerField(fields, ownerFieldName)) {
-        let ownerField = {"name":ownerFieldName, "type":"String", "isNullable":true, "isList":false} as CodeGenField
-        fields.push(ownerField);
-        }
-      }
-    }
     return {
       name: this.getModelName(nonModel),
-      fields: fields.reduce((acc: JSONModelFields, field: CodeGenField) => {
+      fields: nonModel.fields.reduce((acc: JSONModelFields, field: CodeGenField) => {
         const fieldMeta: JSONModelField = {
           name: this.getFieldName(field),
           isArray: field.isList,

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -1,7 +1,5 @@
 import { indentMultiline } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptDeclarationBlock } from '../languages/typescript-declaration-block';
-import { camelCase } from 'change-case';
-import { getOwnerAuthRules, getOwnerFieldName, hasOwnerField } from '../utils/process-auth';
 import {
   AppSyncModelVisitor,
   CodeGenEnum,
@@ -90,18 +88,6 @@ export class AppSyncModelTypeScriptVisitor<
         optional: field.isNullable,
       });
     });
-    let ownerAuthRules = getOwnerAuthRules(modelObj);
-    if (ownerAuthRules !== undefined) {
-      for (let rule of ownerAuthRules) {
-        let ownerFieldName = getOwnerFieldName(rule);
-        if (ownerFieldName !== undefined && !hasOwnerField(modelObj.fields, ownerFieldName)) {
-          modelDeclarations.addProperty(ownerFieldName, "String", undefined, 'DEFAULT', {
-            readonly: true,
-            optional: true,
-          });
-        }
-      }
-    }
 
     // Constructor
     modelDeclarations.addClassMethod(

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -26,7 +26,7 @@ import { getTypeInfo } from '../utils/get-type-info';
 import { CodeGenConnectionType, CodeGenFieldConnection, processConnections } from '../utils/process-connections';
 import { sortFields } from '../utils/sort';
 import { printWarning } from '../utils/warn';
-import { processAuthDirective } from '../utils/process-auth';
+import { processAuthDirective, AuthStrategy } from '../utils/process-auth';
 
 export enum CodeGenGenerateEnum {
   metadata = 'metadata',
@@ -479,6 +479,19 @@ export class AppSyncModelVisitor<
     Object.values(this.modelMap).forEach(model => {
       const filteredDirectives = model.directives.filter(d => d.name !== 'auth');
       const authDirectives = processAuthDirective(model.directives);
+      authDirectives.forEach(directive => {
+        directive.arguments.rules.forEach(rule => {
+          if (rule.allow === AuthStrategy.owner) {
+            addFieldToModel(model, {
+              type: 'String',
+              isList: false,
+              isNullable: true,
+              name: rule.ownerField ? rule.ownerField : 'owner',
+              directives: [],
+            });
+          }
+        });
+      });
       model.directives = [...filteredDirectives, ...authDirectives];
     });
   }


### PR DESCRIPTION
*Issue #, if available:*
aws-amplify/amplify-js#5687
*Description of changes:*
`amplify codegen models` will generate `ownerField` automatically as an optional string type `String` in implicit cases and will not override the field if it is defined explicitly for other type in the schema, which allows user to use custom type such as `[String!]` etc. The changes apply to all the SDKs(js, android and ios)
### Sample input and output for implicit cases
Schema:
```
 type Post @model @auth(rules: [
  { allow: owner , ownerField: "customOwnerField1"},
  { allow: owner , ownerField: "customOwnerField2"},
  ]) {
   id: ID!
   name: String!
 } 
```
Java output:
```
/** This is an auto generated class representing the Post type in your schema. */
@SuppressWarnings("all")
@ModelConfig(pluralName = "Posts", authRules = {
  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "customOwnerField1", identityClaim = "cognito:username", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "customOwnerField2", identityClaim = "cognito:username", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
})
public final class Post implements Model {
  public static final QueryField ID = field("id");
  public static final QueryField NAME = field("name");
  public static final QueryField CUSTOM_OWNER_FIELD1 = field("customOwnerField1");
  public static final QueryField CUSTOM_OWNER_FIELD2 = field("customOwnerField2");
  private final @ModelField(targetType="ID", isRequired = true) String id;
  private final @ModelField(targetType="String", isRequired = true) String name;
  private final @ModelField(targetType="String") String customOwnerField1;
  private final @ModelField(targetType="String") String customOwnerField2;
  public String getId() {
      return id;
  }
  
  public String getName() {
      return name;
  }
  
  public String getCustomOwnerField1() {
      return customOwnerField1;
  }
  
  public String getCustomOwnerField2() {
      return customOwnerField2;
  }
//...
//Constructors, getters and builders also get updated. See details in test snapshots.
```
Swift output:
```
// swiftlint:disable all
import Amplify
import Foundation

extension Post {
  // MARK: - CodingKeys 
   public enum CodingKeys: String, ModelKey {
    case id
    case name
    case customOwnerField1
    case customOwnerField2
  }
  
  public static let keys = CodingKeys.self
  //  MARK: - ModelSchema 
  
  public static let schema = defineSchema { model in
    let post = Post.keys
    
    model.authRules = [
      rule(allow: .owner, ownerField: "customOwnerField1", identityClaim: "cognito:username", operations: [.create, .update, .delete, .read]),
      rule(allow: .owner, ownerField: "customOwnerField2", identityClaim: "cognito:username", operations: [.create, .update, .delete, .read])
    ]
    
    model.pluralName = "Posts"
    
    model.fields(
      .id(),
      .field(post.name, is: .required, ofType: .string),
      .field(post.customOwnerField1, is: .optional, ofType: .string),
      .field(post.customOwnerField2, is: .optional, ofType: .string)
    )
    }
}
```
### Sample input and output(swift) for user-defined-type ownerField
Schema:
```
type Post
  @model
  @auth(rules: [
    { allow: owner, ownerField: "author" }, 
    { allow: owner, ownerField: "editors", operations: [update, read] }
  ]) {
  id: ID!
  title: String!
  author: String!
  editors: [String!]
}
```
Output:
```
"// swiftlint:disable all
import Amplify
import Foundation

extension Post {
  // MARK: - CodingKeys 
    public enum CodingKeys: String, ModelKey {
    case id
    case title
    case author
    case editors
  }
  
  public static let keys = CodingKeys.self
  //  MARK: - ModelSchema 
  
  public static let schema = defineSchema { model in
    let post = Post.keys
    
    model.authRules = [
      rule(allow: .owner, ownerField: \\"author\\", identityClaim: \\"cognito:username\\", operations: [.create, .update, .delete, .read]),
      rule(allow: .owner, ownerField: \\"editors\\", identityClaim: \\"cognito:username\\", operations: [.update, .read])
    ]
    
    model.pluralName = \\"Posts\\"
    
    model.fields(
      .id(),
      .field(post.title, is: .required, ofType: .string),
      .field(post.author, is: .required, ofType: .string),
      .field(post.editors, is: .required, ofType: .embeddedCollection(of: String.self))
    )
    }
}"
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.