### PR TITLE
fix: move mobile hub flag to context directly

### DIFF
--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -19,6 +19,7 @@ export type $TSContext = {
   amplify: AmplifyToolkit;
   print: $TSAny;
   migrationInfo: $TSAny;
+  projectHasMobileHubResources: boolean;
   prompt: $TSAny;
   exeInfo: $TSAny;
   input: $TSAny;

--- a/packages/amplify-cli/src/__tests__/test-aborting.test.ts
+++ b/packages/amplify-cli/src/__tests__/test-aborting.test.ts
@@ -52,9 +52,7 @@ describe('test SIGINT with execute', () => {
       emitSuccess: jest.fn(),
       init: jest.fn(),
     };
-    mockContext.migrationInfo = {
-      projectHasMobileHubResources: false,
-    };
+    mockContext.projectHasMobileHubResources = false;
     mockContext.amplify = jest.genMockFromModule('../domain/amplify-toolkit');
     jest.setMock('../context-manager', {
       constructContext: jest.fn().mockReturnValue(mockContext),

--- a/packages/amplify-cli/src/migrate-project.ts
+++ b/packages/amplify-cli/src/migrate-project.ts
@@ -66,7 +66,7 @@ async function migrateFrom0To1(context: $TSContext, projectPath, projectConfig) 
   try {
     amplifyDirPath = pathManager.getAmplifyDirPath(projectPath);
     backupAmplifyDirPath = backup(amplifyDirPath, projectPath);
-    context.migrationInfo = { ...context.migrationInfo, ...generateMigrationInfo(projectConfig, projectPath) };
+    context.migrationInfo = generateMigrationInfo(projectConfig, projectPath);
 
     // Give each category a chance to migrate their respective files
     const categoryMigrationTasks: Function[] = [];

--- a/packages/amplify-cli/src/utils/mobilehub-support.ts
+++ b/packages/amplify-cli/src/utils/mobilehub-support.ts
@@ -1,12 +1,12 @@
 import { $TSContext, pathManager, stateManager } from 'amplify-cli-core';
 
 export const ensureMobileHubCommandCompatibility = (context: $TSContext): boolean => {
-  context.migrationInfo = { ...context.migrationInfo, projectHasMobileHubResources: false };
+  context.projectHasMobileHubResources = false;
 
   checkIfMobileHubProject(context);
 
   // Only do further checks if it is mobile hub migrated project
-  if (context.migrationInfo.projectHasMobileHubResources !== true) {
+  if (!context.projectHasMobileHubResources) {
     return true;
   }
 
@@ -41,7 +41,7 @@ const checkIfMobileHubProject = (context: $TSContext): void => {
       });
     });
 
-  context.migrationInfo = { ...context.migrationInfo, projectHasMobileHubResources: hasMigratedResources };
+  context.projectHasMobileHubResources = hasMigratedResources;
 };
 
 const isCommandSupported = (context: $TSContext): boolean => {


### PR DESCRIPTION
*Description of changes:*

Having mobile hub flag in `context.migrationInfo` interfered with other parts of the CLI so it is moved out to context directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.