### PR TITLE
fix: storage permission resource check - appsync

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -114,6 +114,8 @@ export const askExecRolePermissionsQuestions = async (
           context.print.warning(`Policies cannot be added for ${category}/${resourceName}`);
           continue;
         } else if (
+          // In case of AppSync storage resources they are not in the meta file so check for resource existence as well
+          amplifyMeta[category][resourceName] &&
           amplifyMeta[category][resourceName].service === 'S3AndCloudFront' &&
           !amplifyMeta[category][resourceName].providerPlugin
         ) {


### PR DESCRIPTION
*Description of changes:*

fix: storage permission resource check - appsync.

Additional Resource existence check is needed since an appsync storage resource does not exist in the meta file directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.