### PR TITLE
fix: headless auth username attributes must be an array

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/question-factories/core-questions.test.js
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/question-factories/core-questions.test.js
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
 
-const coreQuestions = require('../../provider-utils/awscloudformation/question-factories/core-questions');
-const defaults = require('../../provider-utils/awscloudformation/assets/cognito-defaults');
-const maps = require('../../provider-utils/awscloudformation/assets/string-maps');
+const coreQuestions = require('../../../../provider-utils/awscloudformation/question-factories/core-questions');
+const defaults = require('../../../../provider-utils/awscloudformation/assets/cognito-defaults');
+const maps = require('../../../../provider-utils/awscloudformation/assets/string-maps');
 
 const defaultFileName = 'cognito-defaults';
 const stringMapFileName = 'string-maps';

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-request-adaptor.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-request-adaptor.test.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get add auth request adaptor valid translations translates request with minimal user pool config only 1`] = `
+Object {
+  "adminQueries": false,
+  "adminQueryGroup": undefined,
+  "authProviders": Array [],
+  "authSelections": "userPoolOnly",
+  "autoVerifiedAttributes": Array [],
+  "identityPoolName": undefined,
+  "mfaConfiguration": "OFF",
+  "requiredAttributes": Array [
+    "email",
+  ],
+  "resourceName": "myTestAuth",
+  "serviceName": "Cognito",
+  "thirdPartyAuth": false,
+  "updateFlow": "manual",
+  "useDefault": "manual",
+  "userPoolGroupList": Array [],
+  "userPoolGroups": false,
+  "userPoolName": undefined,
+  "usernameAttributes": Array [
+    "email",
+  ],
+  "userpoolClientReadAttributes": Array [],
+  "userpoolClientRefreshTokenValidity": undefined,
+  "userpoolClientWriteAttributes": Array [],
+}
+`;

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-request-adaptor.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-request-adaptor.test.ts
@@ -1,0 +1,23 @@
+import { AddAuthRequest, CognitoUserPoolSigninMethod, CognitoUserProperty } from 'amplify-headless-interface';
+import { getAddAuthRequestAdaptor } from '../../../../provider-utils/awscloudformation/utils/auth-request-adaptors';
+
+describe('get add auth request adaptor', () => {
+  describe('valid translations', () => {
+    it('translates request with minimal user pool config only', () => {
+      const addAuthRequest: AddAuthRequest = {
+        version: 1,
+        resourceName: 'myTestAuth',
+        serviceConfiguration: {
+          serviceName: 'Cognito',
+          userPoolConfiguration: {
+            signinMethod: CognitoUserPoolSigninMethod.EMAIL,
+            requiredSignupAttributes: [CognitoUserProperty.EMAIL],
+          },
+          includeIdentityPool: false,
+        },
+      };
+
+      expect(getAddAuthRequestAdaptor('javascript')(addAuthRequest)).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/trigger-flow-auth-helper.test.js
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/trigger-flow-auth-helper.test.js
@@ -1,4 +1,4 @@
-const { handleTriggers } = require('../../provider-utils/awscloudformation/utils/trigger-flow-auth-helper');
+const { handleTriggers } = require('../../../../provider-utils/awscloudformation/utils/trigger-flow-auth-helper');
 
 const defaults = {
   envVars: {},

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
@@ -18,7 +18,7 @@ export interface ServiceQuestionsBaseResult {
   requiredAttributes: string[];
   authSelections: 'userPoolOnly' | 'identityPoolAndUserPool';
   userPoolName?: string;
-  usernameAttributes?: UsernameAttributes;
+  usernameAttributes?: UsernameAttributes[];
   userPoolGroups: boolean;
   userPoolGroupList?: string[];
   userpoolClientRefreshTokenValidity?: number;

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
@@ -74,7 +74,7 @@ export const getUpdateAuthRequestAdaptor = (projectType: string, requiredAttribu
 const immutableAttributeAdaptor = (userPoolConfig: CognitoUserPoolConfiguration, identityPoolConfig?: CognitoIdentityPoolConfiguration) => {
   return {
     userPoolName: userPoolConfig.userPoolName,
-    usernameAttributes: signinAttributeMap[userPoolConfig.signinMethod],
+    usernameAttributes: [signinAttributeMap[userPoolConfig.signinMethod]],
     ...immutableIdentityPoolMap(identityPoolConfig),
   };
 };


### PR DESCRIPTION
The headless add auth transformer set username attributes as a string instead of an array causing CFN failures.
Note this error is only encountered in headless mode, not when using the auth walkthrough

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.