### PR TITLE
fix: use go lambda zip tool for packaging go lambda on win

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -183,7 +183,6 @@ const winZip = async (src: string, dest: string, print: any) => {
     `If the function ${resourceName} depends on assets outside of the go binary, you'll need to manually zip the binary along with the assets using WSL or another shell that generates a *nix-like zip file.`,
   );
   print.warning('See https://github.com/aws/aws-lambda-go/issues/13#issuecomment-358729411.');
-  print.wanring('Alternatively, you can put the assets in a Lambda Layer: https://docs.amplify.aws/cli/function/layers');
 };
 
 const nixZip = async (src: string, dest: string) => {

--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -1,6 +1,6 @@
 import { CheckDependenciesResult, PackageRequest, PackageResult, BuildRequest, BuildResult } from 'amplify-function-plugin-interface/src';
 import * as which from 'which';
-import * as execa from 'execa';
+import execa from 'execa';
 import archiver from 'archiver';
 import fs from 'fs-extra';
 import glob from 'glob';
@@ -160,41 +160,62 @@ export const buildResource = async (request: BuildRequest, context: any): Promis
   buildResourceInternal(request, context, false, false);
 
 export const packageResource = async (request: PackageRequest, context: any): Promise<PackageResult> => {
+  // check if repackaging is needed
   if (!request.lastPackageTimestamp || request.lastBuildTimestamp > request.lastPackageTimestamp) {
-    const outDir = path.join(request.srcRoot, BIN);
-    const mainFile = path.join(outDir, MAIN_BINARY);
-
-    // zip source and dependencies and write to specified file
-    const file = fs.createWriteStream(request.dstFilename);
     const packageHash = await context.amplify.hashDir(request.srcRoot, [DIST]);
-
-    return new Promise(async (resolve, reject) => {
-      file.on('close', () => {
-        resolve({ packageHash });
-      });
-
-      file.on('error', err => {
-        reject(new Error(`Failed to zip with error: [${err}]`));
-      });
-
-      const zip = archiver.create('zip', {});
-      zip.pipe(file);
-
-      // Add the main file and make sure to set 755 as mode so it will be runnable by Lambda
-      zip.file(mainFile, {
-        name: MAIN_BINARY,
-        mode: 755,
-      });
-
-      // Add every other files in the out directory
-      zip.glob('**/*', {
-        cwd: outDir,
-        ignore: [mainFile],
-      });
-
-      zip.finalize();
-    });
+    const zipFn = process.platform.startsWith('win') ? winZip : nixZip;
+    await zipFn(request.srcRoot, request.dstFilename, context.print);
+    return { packageHash };
   }
+  return {};
+};
 
-  return Promise.resolve({});
+const winZip = async (src: string, dest: string, print: any) => {
+  // get lambda zip tool
+  await execa(executableName, ['get', '-u', 'github.com/aws/aws-lambda-go/cmd/build-lambda-zip']);
+  const goPath = process.env.GOPATH;
+  if (!goPath) {
+    throw new Error('Could not determine GOPATH. Make sure it is set.');
+  }
+  await execa(path.join(goPath, 'bin', 'build-lambda-zip.exe'), ['-o', dest, path.join(src, BIN, MAIN_BINARY)]);
+  const resourceName = src.split(path.sep).pop();
+  print.warning(
+    `If the function ${resourceName} depends on assets outside of the go binary, you'll need to manually zip the binary along with the assets using WSL or another shell that generates a *nix-like zip file.`,
+  );
+  print.warning('See https://github.com/aws/aws-lambda-go/issues/13#issuecomment-358729411.');
+  print.wanring('Alternatively, you can put the assets in a Lambda Layer: https://docs.amplify.aws/cli/function/layers');
+};
+
+const nixZip = async (src: string, dest: string) => {
+  const outDir = path.join(src, BIN);
+  const mainFile = path.join(outDir, MAIN_BINARY);
+
+  // zip source and dependencies and write to specified file
+  const file = fs.createWriteStream(dest);
+  return new Promise(async (resolve, reject) => {
+    file.on('close', () => {
+      resolve();
+    });
+
+    file.on('error', err => {
+      reject(new Error(`Failed to zip with error: [${err}]`));
+    });
+
+    const zip = archiver.create('zip', {});
+    zip.pipe(file);
+
+    // Add the main file and make sure to set 755 as mode so it will be runnable by Lambda
+    zip.file(mainFile, {
+      name: MAIN_BINARY,
+      mode: 755,
+    });
+
+    // Add every other files in the out directory
+    zip.glob('**/*', {
+      cwd: outDir,
+      ignore: [mainFile],
+    });
+
+    zip.finalize();
+  });
 };


### PR DESCRIPTION
*Issue #, if available:*
#5209

*Description of changes:*
Use [build-lambda-zip](https://github.com/aws/aws-lambda-go#for-developers-on-windows) for zipping go lambdas on windows.
The tool does not support including other assets outside of the go binary in the zip file so I included a warning telling customers they will need to manually build the lambda or use a layer for their assets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.