### PR TITLE
fix: cli.json update on pull, E2E enhancements

### DIFF
--- a/packages/amplify-e2e-core/src/categories/analytics.ts
+++ b/packages/amplify-e2e-core/src/categories/analytics.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath } from '../../src';
+import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath } from '..';
 
 export function addPinpoint(cwd: string, settings: any) {
   return new Promise((resolve, reject) => {
@@ -9,8 +9,8 @@ export function addPinpoint(cwd: string, settings: any) {
       .sendLine(settings.wrongName)
       .wait('Resource name should be alphanumeric')
       .send('\b')
+      .delay(500) // Some delay required for autocomplete and terminal to catch up
       .sendLine(settings.rightName)
-      .wait('Apps need authorization to send analytics events. Do you want to allow guests')
       .sendLine('n')
       .wait(`Successfully added resource ${settings.rightName} locally`)
       .sendEof()

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -1,6 +1,5 @@
-import { nspawn as spawn, KEY_DOWN_ARROW } from '../../src';
+import { getCLIPath, updateSchema, nspawn as spawn, KEY_DOWN_ARROW } from '..';
 import * as fs from 'fs-extra';
-import { getCLIPath, updateSchema } from '../../src';
 import { selectRuntime, selectTemplate } from './lambda-function';
 import { singleSelect, multiSelect } from '../utils/selectors';
 import _ from 'lodash';

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1,5 +1,4 @@
-import { KEY_UP_ARROW } from '../utils';
-import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath, getSocialProviders } from '../../src';
+import { nspawn as spawn, KEY_UP_ARROW, KEY_DOWN_ARROW, getCLIPath, getSocialProviders } from '..';
 
 export function addAuthWithDefault(cwd: string, settings: any = {}) {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-e2e-core/src/categories/codegen.ts
@@ -1,4 +1,4 @@
-import { getCLIPath, nspawn as spawn } from '../../src';
+import { getCLIPath, nspawn as spawn } from '..';
 
 export function generateModels(cwd: string) {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -1,6 +1,6 @@
-import fs from 'fs-extra';
-import path from 'path';
-import { nspawn as spawn, getCLIPath, createNewProjectDir, KEY_DOWN_ARROW, readJsonFile } from '../../src';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { nspawn as spawn, getCLIPath, createNewProjectDir, KEY_DOWN_ARROW, readJsonFile } from '..';
 import { spawnSync } from 'child_process';
 
 export function addDEVHosting(cwd: string) {

--- a/packages/amplify-e2e-core/src/categories/interactions.ts
+++ b/packages/amplify-e2e-core/src/categories/interactions.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath } from '../../src';
+import { nspawn as spawn, getCLIPath } from '..';
 
 export function addSampleInteraction(cwd: string, settings: any) {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, ExecutionContext, KEY_DOWN_ARROW, getCLIPath, getProjectMeta, invokeFunction } from '../../src';
+import { nspawn as spawn, ExecutionContext, KEY_DOWN_ARROW, getCLIPath, getProjectMeta, invokeFunction } from '..';
 import { Lambda } from 'aws-sdk';
 import { singleSelect, multiSelect, moveUp, moveDown } from '../utils/selectors';
 

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -1,8 +1,8 @@
-import { JSONUtilities } from 'amplify-cli-core';
-import fs from 'fs-extra';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import _ from 'lodash';
-import path from 'path';
-import { nspawn as spawn, ExecutionContext, getCLIPath, KEY_DOWN_ARROW } from '../../src';
+import { JSONUtilities } from 'amplify-cli-core';
+import { nspawn as spawn, ExecutionContext, getCLIPath, KEY_DOWN_ARROW } from '..';
 import { getLayerVersion, listVersions } from '../utils/sdk-calls';
 import { multiSelect } from '../utils/selectors';
 

--- a/packages/amplify-e2e-core/src/categories/predictions.ts
+++ b/packages/amplify-e2e-core/src/categories/predictions.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath } from '../../src';
+import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath } from '..';
 
 // add convert resource
 export function addConvert(cwd: string, settings: any) {

--- a/packages/amplify-e2e-core/src/categories/storage.ts
+++ b/packages/amplify-e2e-core/src/categories/storage.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath } from '../../src';
+import { nspawn as spawn, KEY_DOWN_ARROW, getCLIPath } from '..';
 import { singleSelect, multiSelect } from '../utils/selectors';
 
 export function addSimpleDDB(cwd: string, settings: any) {

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect } from '../../src';
+import { nspawn as spawn, getCLIPath, singleSelect } from '..';
 
 type AmplifyConfiguration = {
   accessKeyId: string;

--- a/packages/amplify-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPull.ts
@@ -1,4 +1,4 @@
-import { getCLIPath, nspawn as spawn } from '../../src';
+import { getCLIPath, nspawn as spawn } from '..';
 
 export function amplifyPull(cwd: string, settings: { override?: boolean; emptyDir?: boolean; appId?: string; withRestore?: boolean }) {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-e2e-core/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-core/src/init/deleteProject.ts
@@ -1,5 +1,4 @@
-import { nspawn as spawn, retry } from '../../src';
-import { getCLIPath, describeCloudFormationStack, getProjectMeta } from '../../src';
+import { nspawn as spawn, retry, getCLIPath, describeCloudFormationStack, getProjectMeta } from '..';
 
 export const deleteProject = async (cwd: string, profileConfig?: any) => {
   const { StackName: stackName, Region: region } = getProjectMeta(cwd).providers.awscloudformation;

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect } from '../../src';
+import { nspawn as spawn, getCLIPath, singleSelect } from '..';
 
 const defaultSettings = {
   name: '\r',

--- a/packages/amplify-e2e-core/src/init/pull-headless.ts
+++ b/packages/amplify-e2e-core/src/init/pull-headless.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath } from '../../src';
+import { nspawn as spawn, getCLIPath } from '..';
 
 const defaultSettings = {
   name: '\r',

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -584,7 +584,7 @@ export function nspawn(command: string | string[], params: string[] = [], option
   // For push operations in E2E we have to explicitly disable the Amplify Console App creation
   // as for the tests that need it, it is already enabled for init, setting the env var here
   // disables the post push check we have in the CLI.
-  if (command && ((!command.length && command.toLowerCase() === 'push') || (command.length && command[0].toLowerCase() === 'push'))) {
+  if (params.length > 0 && params[0].toLowerCase() === 'push') {
     pushEnv = {
       CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
     };

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -19,7 +19,6 @@ import { AssertionError } from 'assert';
 import strip = require('strip-ansi');
 import { EOL } from 'os';
 import retimer = require('retimer');
-import { max } from 'lodash';
 
 const DEFAULT_NO_OUTPUT_TIMEOUT = 5 * 60 * 1000; // 5 Minutes
 const EXIT_CODE_TIMEOUT = 2;

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -19,6 +19,7 @@ import { AssertionError } from 'assert';
 import strip = require('strip-ansi');
 import { EOL } from 'os';
 import retimer = require('retimer');
+import { max } from 'lodash';
 
 const DEFAULT_NO_OUTPUT_TIMEOUT = 5 * 60 * 1000; // 5 Minutes
 const EXIT_CODE_TIMEOUT = 2;
@@ -58,7 +59,12 @@ export type ExecutionContext = {
   sendLine: (line: string) => ExecutionContext;
   sendCarriageReturn: () => ExecutionContext;
   send: (line: string) => ExecutionContext;
+  sendKeyDown: (repeat?: number) => ExecutionContext;
+  sendKeyUp: (repeat?: number) => ExecutionContext;
+  sendConfirmYes: () => ExecutionContext;
+  sendConfirmNo: () => ExecutionContext;
   sendEof: () => ExecutionContext;
+  delay: (milliseconds: number) => ExecutionContext;
   run: (cb: (err: any, signal?: any) => void) => ExecutionContext;
 };
 
@@ -109,7 +115,7 @@ function chain(context: Context): ExecutionContext {
         },
         name: '_expect',
         shift: true,
-        description: '[expect] ' + expectation,
+        description: `[expect] ${expectation}`,
         requiresInput: true,
         expectation: expectation,
       };
@@ -129,7 +135,7 @@ function chain(context: Context): ExecutionContext {
         },
         name: '_wait',
         shift: false,
-        description: '[wait] ' + expectation,
+        description: `[wait] ${expectation}`,
         requiresInput: true,
         expectation: expectation,
       };
@@ -139,12 +145,12 @@ function chain(context: Context): ExecutionContext {
     sendLine: function(line: string): ExecutionContext {
       let _sendline: ExecutionStep = {
         fn: () => {
-          context.process.write(line + EOL);
+          context.process.write(`${line}${EOL}`);
           return true;
         },
         name: '_sendline',
         shift: true,
-        description: '[sendline] ' + line,
+        description: `[sendline] ${line}`,
         requiresInput: false,
       };
       context.queue.push(_sendline);
@@ -158,7 +164,7 @@ function chain(context: Context): ExecutionContext {
         },
         name: '_sendline',
         shift: true,
-        description: '[sendline] ',
+        description: '[sendline] <CR>',
         requiresInput: false,
       };
       context.queue.push(_sendline);
@@ -172,7 +178,69 @@ function chain(context: Context): ExecutionContext {
         },
         name: '_send',
         shift: true,
-        description: '[send] ' + line,
+        description: `[send] ${line}`,
+        requiresInput: false,
+      };
+      context.queue.push(_send);
+      return chain(context);
+    },
+    sendKeyDown: function(repeat?: number): ExecutionContext {
+      const repeatitions = repeat ? Math.max(1, repeat) : 1;
+      var _send: ExecutionStep = {
+        fn: () => {
+          for (let i = 0; i < repeatitions; i++) {
+            context.process.write(KEY_DOWN_ARROW);
+          }
+          return true;
+        },
+        name: '_send',
+        shift: true,
+        description: `'[send] <Down> (${repeatitions})`,
+        requiresInput: false,
+      };
+      context.queue.push(_send);
+      return chain(context);
+    },
+    sendKeyUp: function(repeat?: number): ExecutionContext {
+      const repeatitions = repeat ? Math.max(1, repeat) : 1;
+      var _send: ExecutionStep = {
+        fn: () => {
+          for (let i = 0; i < repeatitions; i++) {
+            context.process.write(KEY_UP_ARROW);
+          }
+          return true;
+        },
+        name: '_send',
+        shift: true,
+        description: `'[send] <Up> (${repeatitions})`,
+        requiresInput: false,
+      };
+      context.queue.push(_send);
+      return chain(context);
+    },
+    sendConfirmYes: function(): ExecutionContext {
+      var _send: ExecutionStep = {
+        fn: () => {
+          context.process.write(`Y${EOL}`);
+          return true;
+        },
+        name: '_send',
+        shift: true,
+        description: `'[send] Y <CR>`,
+        requiresInput: false,
+      };
+      context.queue.push(_send);
+      return chain(context);
+    },
+    sendConfirmNo: function(): ExecutionContext {
+      var _send: ExecutionStep = {
+        fn: () => {
+          context.process.write(`N${EOL}`);
+          return true;
+        },
+        name: '_send',
+        shift: true,
+        description: `'[send] N <CR>`,
         requiresInput: false,
       };
       context.queue.push(_send);
@@ -190,6 +258,23 @@ function chain(context: Context): ExecutionContext {
         requiresInput: false,
       };
       context.queue.push(_sendEof);
+      return chain(context);
+    },
+    delay: function(milliseconds: number): ExecutionContext {
+      var _delay: ExecutionStep = {
+        fn: () => {
+          const startCallback = Date.now();
+
+          while (Date.now() - startCallback < milliseconds) {}
+
+          return true;
+        },
+        shift: true,
+        name: '_delay',
+        description: `'[delay] (${milliseconds})`,
+        requiresInput: false,
+      };
+      context.queue.push(_delay);
       return chain(context);
     },
     run: function(callback: (err: any, code?: number, signal?: string | number) => void): ExecutionContext {
@@ -269,7 +354,8 @@ function chain(context: Context): ExecutionContext {
           onError(new Error('Cannot process non-function on nexpect stack.'), true);
           return false;
         } else if (
-          ['_expect', '_sendline', '_send', '_wait', '_sendEof', '_pauseRecording', '_resumeRecording'].indexOf(currentFnName) === -1
+          ['_expect', '_sendline', '_send', '_wait', '_sendEof', '_delay', '_pauseRecording', '_resumeRecording'].indexOf(currentFnName) ===
+          -1
         ) {
           //
           // If the `currentFn` is a function, but not those set by `.sendline()` or
@@ -494,12 +580,23 @@ export function nspawn(command: string | string[], params: string[] = [], option
   }
 
   let childEnv = undefined;
+  let pushEnv = undefined;
+
+  // For push operations in E2E we have to explicitly disable the Amplify Console App creation
+  // as for the tests that need it, it is already enabled for init, setting the env var here
+  // disables the post push check we have in the CLI.
+  if (command && ((!command.length && command.toLowerCase() === 'push') || (command.length && command[0].toLowerCase() === 'push'))) {
+    pushEnv = {
+      CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
+    };
+  }
 
   // If we have an environment passed in we've to add the current process' environment, otherwised the forked
   // process would not have $PATH and others that is required to run amplify-cli successfully.
-  if (options.env) {
+  if (options.env || pushEnv) {
     childEnv = {
       ...process.env,
+      ...pushEnv,
       ...options.env,
     };
   }

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -1,5 +1,5 @@
 import { Pinpoint } from 'aws-sdk';
-import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions } from '../../src';
+import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions } from '..';
 import _ from 'lodash';
 
 const settings = {

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -27,13 +27,23 @@ function getProjectMeta(projectRoot: string) {
 }
 
 function getProjectTags(projectRoot: string) {
-  const metaFilePath = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'tags.json');
-  return JSON.parse(fs.readFileSync(metaFilePath, 'utf8'));
+  const projectTagsFilePath = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'tags.json');
+  return JSON.parse(fs.readFileSync(projectTagsFilePath, 'utf8'));
 }
 
 function getBackendAmplifyMeta(projectRoot: string) {
   const metaFilePath = path.join(projectRoot, 'amplify', 'backend', 'amplify-meta.json');
   return JSON.parse(fs.readFileSync(metaFilePath, 'utf8'));
+}
+
+function getBackendConfig(projectRoot: string) {
+  const backendFConfigFilePath = path.join(projectRoot, 'amplify', 'backend', 'backend-config.json');
+  return JSON.parse(fs.readFileSync(backendFConfigFilePath, 'utf8'));
+}
+
+function getTeamProviderInfo(projectRoot: string) {
+  const teamProviderFilePath = path.join(projectRoot, 'amplify', 'team-provider-info.json');
+  return JSON.parse(fs.readFileSync(teamProviderFilePath, 'utf8'));
 }
 
 function getS3StorageBucketName(projectRoot: string) {
@@ -66,4 +76,6 @@ export {
   getAWSConfigIOSPath,
   getS3StorageBucketName,
   getAmplifyDirPath,
+  getBackendConfig,
+  getTeamProviderInfo,
 };

--- a/packages/amplify-e2e-core/src/utils/selectors.ts
+++ b/packages/amplify-e2e-core/src/utils/selectors.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '../../src';
+import { ExecutionContext } from '..';
 
 export const moveDown = (chain: ExecutionContext, nMoves: number) =>
   Array.from(Array(nMoves).keys()).reduce((chain, _idx) => chain.send('j'), chain);

--- a/packages/amplify-provider-awscloudformation/src/attach-backend.js
+++ b/packages/amplify-provider-awscloudformation/src/attach-backend.js
@@ -258,8 +258,9 @@ async function downloadBackend(context, backendEnv, awsConfig) {
       absolute: true,
     });
     const amplifyDir = pathManager.getAmplifyDirPath();
+    const isPulling = context.input.command === 'pull' || (context.input.command === 'env' && context.input.subCommands[0] === 'pull');
 
-    if (context.exeInfo && context.exeInfo.restoreBackend) {
+    if ((context.exeInfo && context.exeInfo.restoreBackend) || isPulling) {
       // If backend must be restored then copy out the config files and overwrite existing ones.
       for (const cliJSONFilePath of cliJSONFiles) {
         const targetPath = path.join(amplifyDir, path.basename(cliJSONFilePath));


### PR DESCRIPTION
*Description of changes:*

fix: handle cli.json copy upon pull to empty dir

chore(amplify-e2e-core): cleanup, new nexpect methods
- disable amplify app creation upon push command
- remove extra 'src' from imports
- add new methods to nexpect
- add delay to flaky test for kinesis

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.