### PR TITLE
fix(graphql-relational-schema-transformer): escape SQL reserved keywords

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/AuroraDataAPIClient.ts
+++ b/packages/graphql-relational-schema-transformer/src/AuroraDataAPIClient.ts
@@ -50,7 +50,7 @@ export class AuroraDataAPIClient {
    * @return a list of column descriptions.
    */
   public describeTable = async (tableName: string) => {
-    this.Params.sql = `DESCRIBE ${tableName}`;
+    this.Params.sql = `DESCRIBE \`${tableName}\``;
     const response = await this.RDS.executeStatement(this.Params).promise();
     const listOfColumns = response['records'];
     let columnDescriptions = [];

--- a/packages/graphql-relational-schema-transformer/src/__tests__/AuroraDataAPIClient.test.ts
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/AuroraDataAPIClient.test.ts
@@ -440,7 +440,7 @@ test('Test describe table', async () => {
 
   const MockRDSClient = jest.fn<any>(() => ({
     executeStatement: jest.fn((params: DataApiParams) => {
-      if (params.sql == `DESCRIBE ${tableAName}`) {
+      if (params.sql == `DESCRIBE \`${tableAName}\``) {
         return rdsPromise;
       }
       throw new Error('Incorrect SQL given.');
@@ -457,7 +457,7 @@ test('Test describe table', async () => {
   Params.secretArn = secretStoreArn;
   Params.resourceArn = clusterArn;
   Params.database = databaseName;
-  Params.sql = `DESCRIBE ${tableAName}`;
+  Params.sql = `DESCRIBE \`${tableAName}\``;
   expect(mockRDS.executeStatement).toHaveBeenCalledWith(Params);
   expect(columnDescriptions.length).toEqual(3);
   // TODO: the rest of these tests


### PR DESCRIPTION
*Issues:*
#5525, #2293

*Description of changes:*
Escape reserved keywords used in table names when executing `DESCRIBE tableName`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.