### PR TITLE
fix: #5520 exclude pinpoint from provider check for false positives

### DIFF
--- a/packages/amplify-cli/src/utils/mobilehub-support.ts
+++ b/packages/amplify-cli/src/utils/mobilehub-support.ts
@@ -34,8 +34,8 @@ const checkIfMobileHubProject = (context: $TSContext): void => {
       Object.keys(meta[category]).forEach(resourceName => {
         const resource = meta[category][resourceName];
 
-        // Mobile hub migrated resources does not have an assigned provider
-        if (!resource.providerPlugin) {
+        // Mobile hub migrated resources and CLI created Pinoint ones does not have an assigned provider
+        if (!resource.providerPlugin && resource.service !== 'Pinpoint') {
           hasMigratedResources = true;
         }
       });


### PR DESCRIPTION
*Issue #, if available:*

fix: #5520 exclude pinpoint from provider check for false positives

*Description of changes:*

For pinpoint resources the CLI does not emit the `providerPlugin` field and projects using notifications and multi-env could get a false positive for any `env` command execution because of this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.