### PR TITLE
fix(amplify-codegen-appsync-model-plugin): add field level @auth process

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -425,6 +425,272 @@ public final class customClaim implements Model {
 "
 `;
 
+exports[`AppSyncModelVisitor Model with Auth should generate class with default field auth 1`] = `
+"package com.amplifyframework.datastore.generated.model;
+
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the Employee type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"Employees\\", authRules = {
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groups = { \\"Admins\\" }, operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+})
+public final class Employee implements Model {
+  public static final QueryField ID = field(\\"id\\");
+  public static final QueryField NAME = field(\\"name\\");
+  public static final QueryField ADDRESS = field(\\"address\\");
+  public static final QueryField SSN = field(\\"ssn\\");
+  public static final QueryField OWNER = field(\\"owner\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String address;
+  private final @ModelField(targetType=\\"String\\", authRules = {
+    @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  }) String ssn;
+  private final @ModelField(targetType=\\"String\\") String owner;
+  public String getId() {
+      return id;
+  }
+  
+  public String getName() {
+      return name;
+  }
+  
+  public String getAddress() {
+      return address;
+  }
+  
+  public String getSsn() {
+      return ssn;
+  }
+  
+  public String getOwner() {
+      return owner;
+  }
+  
+  private Employee(String id, String name, String address, String ssn, String owner) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+    this.ssn = ssn;
+    this.owner = owner;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Employee employee = (Employee) obj;
+      return ObjectsCompat.equals(getId(), employee.getId()) &&
+              ObjectsCompat.equals(getName(), employee.getName()) &&
+              ObjectsCompat.equals(getAddress(), employee.getAddress()) &&
+              ObjectsCompat.equals(getSsn(), employee.getSsn()) &&
+              ObjectsCompat.equals(getOwner(), employee.getOwner());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getName())
+      .append(getAddress())
+      .append(getSsn())
+      .append(getOwner())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"Employee {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
+      .append(\\"address=\\" + String.valueOf(getAddress()) + \\", \\")
+      .append(\\"ssn=\\" + String.valueOf(getSsn()) + \\", \\")
+      .append(\\"owner=\\" + String.valueOf(getOwner()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static NameStep builder() {
+      return new Builder();
+  }
+  
+  /** 
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   * @throws IllegalArgumentException Checks that ID is in the proper format
+   */
+  public static Employee justId(String id) {
+    try {
+      UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(
+              \\"Model IDs must be unique in the format of UUID. This method is for creating instances \\" +
+              \\"of an existing object with only its ID field for sending as a mutation parameter. When \\" +
+              \\"creating a new object, use the standard builder method and leave the ID field blank.\\"
+      );
+    }
+    return new Employee(
+      id,
+      null,
+      null,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      name,
+      address,
+      ssn,
+      owner);
+  }
+  public interface NameStep {
+    AddressStep name(String name);
+  }
+  
+
+  public interface AddressStep {
+    BuildStep address(String address);
+  }
+  
+
+  public interface BuildStep {
+    Employee build();
+    BuildStep id(String id) throws IllegalArgumentException;
+    BuildStep ssn(String ssn);
+    BuildStep owner(String owner);
+  }
+  
+
+  public static class Builder implements NameStep, AddressStep, BuildStep {
+    private String id;
+    private String name;
+    private String address;
+    private String ssn;
+    private String owner;
+    @Override
+     public Employee build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new Employee(
+          id,
+          name,
+          address,
+          ssn,
+          owner);
+    }
+    
+    @Override
+     public AddressStep name(String name) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        return this;
+    }
+    
+    @Override
+     public BuildStep address(String address) {
+        Objects.requireNonNull(address);
+        this.address = address;
+        return this;
+    }
+    
+    @Override
+     public BuildStep ssn(String ssn) {
+        this.ssn = ssn;
+        return this;
+    }
+    
+    @Override
+     public BuildStep owner(String owner) {
+        this.owner = owner;
+        return this;
+    }
+    
+    /** 
+     * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+     * This should only be set when referring to an already existing object.
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     * @throws IllegalArgumentException Checks that ID is in the proper format
+     */
+    public BuildStep id(String id) throws IllegalArgumentException {
+        this.id = id;
+        
+        try {
+            UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+        } catch (Exception exception) {
+          throw new IllegalArgumentException(\\"Model IDs must be unique in the format of UUID.\\",
+                    exception);
+        }
+        
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, String name, String address, String ssn, String owner) {
+      super.id(id);
+      super.name(name)
+        .address(address)
+        .ssn(ssn)
+        .owner(owner);
+    }
+    
+    @Override
+     public CopyOfBuilder name(String name) {
+      return (CopyOfBuilder) super.name(name);
+    }
+    
+    @Override
+     public CopyOfBuilder address(String address) {
+      return (CopyOfBuilder) super.address(address);
+    }
+    
+    @Override
+     public CopyOfBuilder ssn(String ssn) {
+      return (CopyOfBuilder) super.ssn(ssn);
+    }
+    
+    @Override
+     public CopyOfBuilder owner(String owner) {
+      return (CopyOfBuilder) super.owner(owner);
+    }
+  }
+  
+}
+"
+`;
+
 exports[`AppSyncModelVisitor Model with Auth should generate class with dynamic groups 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -249,6 +249,25 @@ describe('AppSyncModelVisitor', () => {
       expect(generatedCode).toMatchSnapshot();
     });
 
+    it('should generate class with default field auth', () => {
+      const schema = /* GraphQL */ `
+        type Employee @model
+        @auth(rules: [
+            { allow: owner },
+            { allow: groups, groups: ["Admins"] }
+        ]) {
+          id: ID!
+          name: String!
+          address: String!
+          ssn: String @auth(rules: [{allow: owner}])
+        }
+      `;
+      const visitor = getVisitor(schema, 'Employee');
+      const generatedCode = visitor.generate();
+      expect(() => validateJava(generatedCode)).not.toThrow();
+      expect(generatedCode).toMatchSnapshot();
+    });
+
     it('should generate class with private authorization and field auth', () => {
       const schema = /* GraphQL */ `
         type privateType @model @auth(rules: [{ allow: private }]) {

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -71,10 +71,10 @@ describe('Javascript visitor', () => {
       const imports = (visitor as any).generateImportsJavaScriptImplementation();
       validateTs(imports);
       expect(imports).toMatchInlineSnapshot(`
-        "// @ts-check
-        import { initSchema } from '@aws-amplify/datastore';
-        import { schema } from './schema';"
-      `);
+"// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';"
+`);
     });
   });
 
@@ -91,27 +91,27 @@ describe('Javascript visitor', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-        export enum SimpleEnum {
-          ENUM_VAL1 = \\"enumVal1\\",
-          ENUM_VAL2 = \\"enumVal2\\"
-        }
+export enum SimpleEnum {
+  ENUM_VAL1 = \\"enumVal1\\",
+  ENUM_VAL2 = \\"enumVal2\\"
+}
 
-        export declare class SimpleNonModelType {
-          readonly id: string;
-          readonly names?: string[];
-          constructor(init: ModelInit<SimpleNonModelType>);
-        }
+export declare class SimpleNonModelType {
+  readonly id: string;
+  readonly names?: string[];
+  constructor(init: ModelInit<SimpleNonModelType>);
+}
 
-        export declare class SimpleModel {
-          readonly id: string;
-          readonly name?: string;
-          readonly bar?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-        }"
-      `);
+export declare class SimpleModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly bar?: string;
+  constructor(init: ModelInit<SimpleModel>);
+  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+}"
+`);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -132,23 +132,23 @@ describe('Javascript visitor', () => {
     const codeBlock = jsVisitor.generate();
     validateTs(codeBlock);
     expect(codeBlock).toMatchInlineSnapshot(`
-      "// @ts-check
-      import { initSchema } from '@aws-amplify/datastore';
-      import { schema } from './schema';
+"// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
 
-      const SimpleEnum = {
-        \\"ENUM_VAL1\\": \\"enumVal1\\",
-        \\"ENUM_VAL2\\": \\"enumVal2\\"
-      };
+const SimpleEnum = {
+  \\"ENUM_VAL1\\": \\"enumVal1\\",
+  \\"ENUM_VAL2\\": \\"enumVal2\\"
+};
 
-      const { SimpleModel, SimpleNonModelType } = initSchema(schema);
+const { SimpleModel, SimpleNonModelType } = initSchema(schema);
 
-      export {
-        SimpleModel,
-        SimpleEnum,
-        SimpleNonModelType
-      };"
-    `);
+export {
+  SimpleModel,
+  SimpleEnum,
+  SimpleNonModelType
+};"
+`);
     expect(generateEnumObjectSpy).toHaveBeenCalledWith((jsVisitor as any).enumMap['SimpleEnum']);
 
     expect(generateImportsJavaScriptImplementationSpy).toHaveBeenCalledTimes(1);
@@ -197,28 +197,28 @@ describe('Javascript visitor with default owner auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-        export enum SimpleEnum {
-          ENUM_VAL1 = \\"enumVal1\\",
-          ENUM_VAL2 = \\"enumVal2\\"
-        }
+export enum SimpleEnum {
+  ENUM_VAL1 = \\"enumVal1\\",
+  ENUM_VAL2 = \\"enumVal2\\"
+}
 
-        export declare class SimpleNonModelType {
-          readonly id: string;
-          readonly names?: string[];
-          constructor(init: ModelInit<SimpleNonModelType>);
-        }
+export declare class SimpleNonModelType {
+  readonly id: string;
+  readonly names?: string[];
+  constructor(init: ModelInit<SimpleNonModelType>);
+}
 
-        export declare class SimpleModel {
-          readonly id: string;
-          readonly name?: string;
-          readonly bar?: string;
-          readonly owner?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-        }"
-      `);
+export declare class SimpleModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly bar?: string;
+  readonly owner?: string;
+  constructor(init: ModelInit<SimpleModel>);
+  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+}"
+`);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -267,28 +267,28 @@ describe('Javascript visitor with custom owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-        export enum SimpleEnum {
-          ENUM_VAL1 = \\"enumVal1\\",
-          ENUM_VAL2 = \\"enumVal2\\"
-        }
+export enum SimpleEnum {
+  ENUM_VAL1 = \\"enumVal1\\",
+  ENUM_VAL2 = \\"enumVal2\\"
+}
 
-        export declare class SimpleNonModelType {
-          readonly id: string;
-          readonly names?: string[];
-          constructor(init: ModelInit<SimpleNonModelType>);
-        }
+export declare class SimpleNonModelType {
+  readonly id: string;
+  readonly names?: string[];
+  constructor(init: ModelInit<SimpleNonModelType>);
+}
 
-        export declare class SimpleModel {
-          readonly id: string;
-          readonly name?: string;
-          readonly bar?: string;
-          readonly customOwnerField?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-        }"
-      `);
+export declare class SimpleModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly bar?: string;
+  readonly customOwnerField?: string;
+  constructor(init: ModelInit<SimpleModel>);
+  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+}"
+`);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -339,29 +339,29 @@ describe('Javascript visitor with multiple owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-        export enum SimpleEnum {
-          ENUM_VAL1 = \\"enumVal1\\",
-          ENUM_VAL2 = \\"enumVal2\\"
-        }
+export enum SimpleEnum {
+  ENUM_VAL1 = \\"enumVal1\\",
+  ENUM_VAL2 = \\"enumVal2\\"
+}
 
-        export declare class SimpleNonModelType {
-          readonly id: string;
-          readonly names?: string[];
-          constructor(init: ModelInit<SimpleNonModelType>);
-        }
+export declare class SimpleNonModelType {
+  readonly id: string;
+  readonly names?: string[];
+  constructor(init: ModelInit<SimpleNonModelType>);
+}
 
-        export declare class SimpleModel {
-          readonly id: string;
-          readonly name?: string;
-          readonly bar?: string;
-          readonly customOwnerField?: string;
-          readonly customOwnerField2?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-        }"
-      `);
+export declare class SimpleModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly bar?: string;
+  readonly customOwnerField?: string;
+  readonly customOwnerField2?: string;
+  constructor(init: ModelInit<SimpleModel>);
+  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+}"
+`);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -71,10 +71,10 @@ describe('Javascript visitor', () => {
       const imports = (visitor as any).generateImportsJavaScriptImplementation();
       validateTs(imports);
       expect(imports).toMatchInlineSnapshot(`
-"// @ts-check
-import { initSchema } from '@aws-amplify/datastore';
-import { schema } from './schema';"
-`);
+        "// @ts-check
+        import { initSchema } from '@aws-amplify/datastore';
+        import { schema } from './schema';"
+      `);
     });
   });
 
@@ -91,27 +91,27 @@ import { schema } from './schema';"
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: string[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: string[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -132,23 +132,23 @@ export declare class SimpleModel {
     const codeBlock = jsVisitor.generate();
     validateTs(codeBlock);
     expect(codeBlock).toMatchInlineSnapshot(`
-"// @ts-check
-import { initSchema } from '@aws-amplify/datastore';
-import { schema } from './schema';
+      "// @ts-check
+      import { initSchema } from '@aws-amplify/datastore';
+      import { schema } from './schema';
 
-const SimpleEnum = {
-  \\"ENUM_VAL1\\": \\"enumVal1\\",
-  \\"ENUM_VAL2\\": \\"enumVal2\\"
-};
+      const SimpleEnum = {
+        \\"ENUM_VAL1\\": \\"enumVal1\\",
+        \\"ENUM_VAL2\\": \\"enumVal2\\"
+      };
 
-const { SimpleModel, SimpleNonModelType } = initSchema(schema);
+      const { SimpleModel, SimpleNonModelType } = initSchema(schema);
 
-export {
-  SimpleModel,
-  SimpleEnum,
-  SimpleNonModelType
-};"
-`);
+      export {
+        SimpleModel,
+        SimpleEnum,
+        SimpleNonModelType
+      };"
+    `);
     expect(generateEnumObjectSpy).toHaveBeenCalledWith((jsVisitor as any).enumMap['SimpleEnum']);
 
     expect(generateImportsJavaScriptImplementationSpy).toHaveBeenCalledTimes(1);
@@ -197,28 +197,28 @@ describe('Javascript visitor with default owner auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: string[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: string[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly owner?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          readonly owner?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -267,28 +267,28 @@ describe('Javascript visitor with custom owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: string[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: string[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly customOwnerField?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          readonly customOwnerField?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -339,29 +339,29 @@ describe('Javascript visitor with multiple owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: string[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: string[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly customOwnerField?: string;
-  readonly customOwnerField2?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          readonly customOwnerField?: string;
+          readonly customOwnerField2?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -371,6 +371,59 @@ export declare class SimpleModel {
       expect(generateModelDeclarationSpy).toBeCalledTimes(2);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+    });
+  });
+});
+
+describe('Javascript visitor with auth directives in field level', () => {
+  const schema = /* GraphQL */ `
+    type Employee @model @auth(rules: [{ allow: owner }, { allow: groups, groups: ["Admins"] }]) {
+      id: ID!
+      name: String!
+      address: String!
+      ssn: String @auth(rules: [{ allow: owner }])
+    }
+  `;
+
+  let visitor: AppSyncModelJavascriptVisitor;
+  beforeEach(() => {
+    visitor = getVisitor(schema);
+  });
+
+  describe('generate', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should add custom both owner fields to Javascript declaration', () => {
+      const declarationVisitor = getVisitor(schema, true);
+      const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
+      const generateModelDeclarationSpy = jest.spyOn(declarationVisitor as any, 'generateModelDeclaration');
+      const declarations = declarationVisitor.generate();
+      validateTs(declarations);
+      expect(declarations).toMatchInlineSnapshot(`
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+
+
+
+
+
+        export declare class Employee {
+          readonly id: string;
+          readonly name: string;
+          readonly address: string;
+          readonly ssn?: string;
+          readonly owner?: string;
+          constructor(init: ModelInit<Employee>);
+          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
+        }"
+      `);
+
+      expect(generateImportSpy).toBeCalledTimes(1);
+      expect(generateImportSpy).toBeCalledWith();
+
+      expect(generateModelDeclarationSpy).toBeCalledTimes(1);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['Employee'], true);
     });
   });
 });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -507,10 +507,10 @@ describe('Metadata visitor', () => {
     it('should generate for typeDeclaration', () => {
       const typeDeclaration = getVisitor(schema, 'typeDeclaration');
       expect(typeDeclaration.generate()).toMatchInlineSnapshot(`
-"import { Schema } from '@aws-amplify/datastore';
+        "import { Schema } from '@aws-amplify/datastore';
 
-export declare const schema: Schema;"
-`);
+        export declare const schema: Schema;"
+      `);
     });
   });
 });
@@ -779,6 +779,213 @@ describe('Metadata visitor', () => {
                 }
             },
             \\"version\\": \\"5d997b204c79c66d009287de0054655e\\"
+        };"
+      `);
+    });
+  });
+});
+
+describe('Metadata visitor for auth process in field level', () => {
+  const schema = /* GraphQL */ `
+    type Employee @model @auth(rules: [{ allow: owner }, { allow: groups, groups: ["Admins"] }]) {
+      id: ID!
+      name: String!
+      address: String!
+      ssn: String @auth(rules: [{ allow: owner }])
+    }
+  `;
+  let visitor: AppSyncJSONVisitor;
+  beforeEach(() => {
+    visitor = getVisitor(schema);
+  });
+
+  describe('metadata snapshots', () => {
+    it('should generate for Javascript', () => {
+      const jsVisitor = getVisitor(schema, 'javascript');
+      expect(jsVisitor.generate()).toMatchInlineSnapshot(`
+        "export const schema = {
+            \\"models\\": {
+                \\"Employee\\": {
+                    \\"name\\": \\"Employee\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"name\\": {
+                            \\"name\\": \\"name\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"address\\": {
+                            \\"name\\": \\"address\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"ssn\\": {
+                            \\"name\\": \\"ssn\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"owner\\": {
+                            \\"name\\": \\"owner\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    },
+                    \\"syncable\\": true,
+                    \\"pluralName\\": \\"Employees\\",
+                    \\"attributes\\": [
+                        {
+                            \\"type\\": \\"model\\",
+                            \\"properties\\": {}
+                        },
+                        {
+                            \\"type\\": \\"auth\\",
+                            \\"properties\\": {
+                                \\"rules\\": [
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"owner\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    },
+                                    {
+                                        \\"groupClaim\\": \\"cognito:groups\\",
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"allow\\": \\"groups\\",
+                                        \\"groups\\": [
+                                            \\"Admins\\"
+                                        ],
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            \\"enums\\": {},
+            \\"nonModels\\": {},
+            \\"version\\": \\"38f7db9c1e8eab155fd9ce672a92f248\\"
+        };"
+      `);
+    });
+
+    it('should generate for typescript', () => {
+      const tsVisitor = getVisitor(schema, 'typescript');
+      expect(tsVisitor.generate()).toMatchInlineSnapshot(`
+        "import { Schema } from \\"@aws-amplify/datastore\\";
+
+        export const schema: Schema = {
+            \\"models\\": {
+                \\"Employee\\": {
+                    \\"name\\": \\"Employee\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"name\\": {
+                            \\"name\\": \\"name\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"address\\": {
+                            \\"name\\": \\"address\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"ssn\\": {
+                            \\"name\\": \\"ssn\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"owner\\": {
+                            \\"name\\": \\"owner\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    },
+                    \\"syncable\\": true,
+                    \\"pluralName\\": \\"Employees\\",
+                    \\"attributes\\": [
+                        {
+                            \\"type\\": \\"model\\",
+                            \\"properties\\": {}
+                        },
+                        {
+                            \\"type\\": \\"auth\\",
+                            \\"properties\\": {
+                                \\"rules\\": [
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"owner\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    },
+                                    {
+                                        \\"groupClaim\\": \\"cognito:groups\\",
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"allow\\": \\"groups\\",
+                                        \\"groups\\": [
+                                            \\"Admins\\"
+                                        ],
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            \\"enums\\": {},
+            \\"nonModels\\": {},
+            \\"version\\": \\"38f7db9c1e8eab155fd9ce672a92f248\\"
         };"
       `);
     });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -507,10 +507,10 @@ describe('Metadata visitor', () => {
     it('should generate for typeDeclaration', () => {
       const typeDeclaration = getVisitor(schema, 'typeDeclaration');
       expect(typeDeclaration.generate()).toMatchInlineSnapshot(`
-        "import { Schema } from '@aws-amplify/datastore';
+"import { Schema } from '@aws-amplify/datastore';
 
-        export declare const schema: Schema;"
-      `);
+export declare const schema: Schema;"
+`);
     });
   });
 });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -311,6 +311,40 @@ describe('AppSyncModelVisitor', () => {
       expect(groupRule.groupClaim).toEqual('cognito:groups');
       expect(groupRule.operations).toEqual(['create', 'update', 'delete', 'read']);
     });
+
+    it('should field level process with owner authorization', () => {
+      const schema = /* GraphQL*/ `
+        type Employee @model
+          @auth(rules: [
+              { allow: owner },
+              { allow: groups, groups: ["Admins"] }
+          ]) {
+            id: ID!
+            name: String!
+            address: String!
+            ssn: String @auth(rules: [{allow: owner}])
+        }
+      `;
+      const ast = parse(schema);
+      const builtSchema = buildSchemaWithDirectives(schema);
+      const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
+      visit(ast, { leave: visitor });
+      visitor.generate();
+
+      const ssnField = visitor.models.Employee.fields.find(f => f.name === 'ssn');
+      const authDirective = ssnField.directives.find(d => d.name === 'auth');
+      expect(authDirective).toBeDefined();
+      const authRules = authDirective!.arguments.rules;
+      expect(authRules).toBeDefined();
+      expect(authRules).toHaveLength(1);
+      const ownerRule = authRules[0];
+      expect(ownerRule).toBeDefined();
+
+      expect(ownerRule.provider).toEqual('userPools');
+      expect(ownerRule.identityClaim).toEqual('cognito:username');
+      expect(ownerRule.ownerField).toEqual('owner');
+      expect(ownerRule.operations).toEqual(['create', 'update', 'delete', 'read']);
+    });
   });
   describe('model less type', () => {
     let visitor;

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -312,7 +312,7 @@ describe('AppSyncModelVisitor', () => {
       expect(groupRule.operations).toEqual(['create', 'update', 'delete', 'read']);
     });
 
-    it('should field level process with owner authorization', () => {
+    it('should process field level auth with default owner authorization', () => {
       const schema = /* GraphQL*/ `
         type Employee @model
           @auth(rules: [


### PR DESCRIPTION
*Issue #, if available:*
fix #5499
*Description of changes:*
Added field level process for `@auth`
### Sample Schema
```GraphQL
type Employee @model
  @auth(rules: [
      { allow: owner },
      { allow: groups, groups: ["Admins"] }
  ]) {
    id: ID!
    name: String!
    address: String!
    ssn: String @auth(rules: [{allow: owner}])
}
```
### Sample Output
```Java
@ModelConfig(pluralName = "Employees", authRules = {
  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Admins" }, operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
})
public final class Employee implements Model {
  public static final QueryField ID = field("id");
  public static final QueryField NAME = field("name");
  public static final QueryField ADDRESS = field("address");
  public static final QueryField SSN = field("ssn");
  public static final QueryField OWNER = field("owner");
  private final @ModelField(targetType="ID", isRequired = true) String id;
  private final @ModelField(targetType="String", isRequired = true) String name;
  private final @ModelField(targetType="String", isRequired = true) String address;
  private final @ModelField(targetType="String", authRules = {
    @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
  }) String ssn;
  private final @ModelField(targetType="String") String owner;

  //...methods
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.