### PR TITLE
(fix) suggest fix for zipping failure message

### DIFF
--- a/packages/amplify-console-hosting/hosting/manual/publish.js
+++ b/packages/amplify-console-hosting/hosting/manual/publish.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 const ZIPPING_MESSAGE = 'Zipping artifacts.. ';
 const ZIPPING_SUCCESS_MESSAGE = 'Zipping artifacts completed.';
-const ZIPPING_FAILURE_MESSAGE = 'Zipping artifacts failed. This is often because your DistributionDir is configured to a nonexistent folder, e.g. "build" instead of "dist". Check /amplify/.config/project-config.json and fix accordingly.';
+const ZIPPING_FAILURE_MESSAGE = 'Zipping artifacts failed. This is often due to an invalid distribution directory path. Run "amplify configure project" to check if your Distribution Directory is pointing to a valid path.';
 
 
 async function publish(context, doSkipBuild, doSkipPush) {

--- a/packages/amplify-console-hosting/hosting/manual/publish.js
+++ b/packages/amplify-console-hosting/hosting/manual/publish.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 const ZIPPING_MESSAGE = 'Zipping artifacts.. ';
 const ZIPPING_SUCCESS_MESSAGE = 'Zipping artifacts completed.';
-const ZIPPING_FAILURE_MESSAGE = 'Zipping artifacts failed.';
+const ZIPPING_FAILURE_MESSAGE = 'Zipping artifacts failed. This is often because your DistributionDir is configured to a nonexistent folder. Check /amplify/.config/project-config.json and fix accordingly.';
 
 
 async function publish(context, doSkipBuild, doSkipPush) {

--- a/packages/amplify-console-hosting/hosting/manual/publish.js
+++ b/packages/amplify-console-hosting/hosting/manual/publish.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 const ZIPPING_MESSAGE = 'Zipping artifacts.. ';
 const ZIPPING_SUCCESS_MESSAGE = 'Zipping artifacts completed.';
-const ZIPPING_FAILURE_MESSAGE = 'Zipping artifacts failed. This is often because your DistributionDir is configured to a nonexistent folder. Check /amplify/.config/project-config.json and fix accordingly.';
+const ZIPPING_FAILURE_MESSAGE = 'Zipping artifacts failed. This is often because your DistributionDir is configured to a nonexistent folder, e.g. "build" instead of "dist". Check /amplify/.config/project-config.json and fix accordingly.';
 
 
 async function publish(context, doSkipBuild, doSkipPush) {


### PR DESCRIPTION
closes https://github.com/aws-amplify/amplify-cli/issues/4532


*Description of changes:* this builds in a fix to the failure message so that users know how to resolve their own issues.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.