### PR TITLE
feat: changes for native packaging

### DIFF
--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -8,6 +8,7 @@ export * from './state-manager';
 export * from './tags';
 export * from './errors';
 export * from './exitOnNextTick';
+export * from './isPackaged';
 
 // Temporary types until we can finish full type definition across the whole CLI
 

--- a/packages/amplify-cli-core/src/isPackaged.ts
+++ b/packages/amplify-cli-core/src/isPackaged.ts
@@ -1,0 +1,1 @@
+export const isPackaged = !!((process as unknown) as { pkg: any }).pkg;

--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
-require = require('esm')(module, { cache: false });
+if (process.pkg) {
+  require('../lib/utils/copy-override').copyOverride();
+} else {
+  // eslint-disable-next-line no-global-assign
+  require = require('esm')(module, { cache: false });
+}
 require('../lib/index').run();

--- a/packages/amplify-cli/src/domain/constants.ts
+++ b/packages/amplify-cli/src/domain/constants.ts
@@ -16,6 +16,7 @@ export const constants = {
   LocalNodeModules: 'cli-local-node-modules',
   ParentDirectory: 'cli-parent-directory',
   GlobalNodeModules: 'global-node-modules',
+  PackagedNodeModules: 'packaged-node-modules',
   ExecuteAmplifyCommand: 'executeAmplifyCommand',
   ExecuteAmplifyHeadlessCommand: 'executeAmplifyHeadlessCommand',
   HandleAmplifyEvent: 'handleAmplifyEvent',

--- a/packages/amplify-cli/src/utils/copy-override.ts
+++ b/packages/amplify-cli/src/utils/copy-override.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import { promisify } from 'util';
+// Workaround 'pkg' bug: https://github.com/zeit/pkg/issues/420
+// Copying files from snapshot via `fs.copyFileSync` crashes with ENOENT
+// Overriding copyFileSync with primitive alternative
+//
+// Copied from https://github.com/serverless/serverless/blob/94ff3b22ab13afc60fb4e672520b4db527ee0432/lib/utils/standalone-patch.js
+// with minimal modification to work in TS
+export const copyOverride = () => {
+  if (!fs.copyFile) return;
+
+  const path = require('path');
+
+  const originalCopyFile = fs.copyFile;
+  const originalCopyFileSync = fs.copyFileSync;
+
+  const isBundled = RegExp.prototype.test.bind(/^(?:\/snapshot\/|[A-Z]+:\\snapshot\\)/);
+
+  fs.copyFile = ((src, dest, flags, callback) => {
+    if (!isBundled(path.resolve(src))) {
+      return originalCopyFile(src, dest, flags, callback);
+    }
+    if (typeof flags === 'function') {
+      callback = flags;
+      flags = 0;
+    } else if (typeof callback !== 'function') {
+      throw new TypeError('Callback must be a function');
+    }
+
+    fs.readFile(src, (readError, content) => {
+      if (readError) {
+        callback(readError);
+        return;
+      }
+      // eslint-disable-next-line no-bitwise
+      if (flags & fs.constants.COPYFILE_EXCL) {
+        fs.stat(dest, statError => {
+          if (!statError) {
+            callback(Object.assign(new Error('File already exists'), { code: 'EEXIST' }));
+            return;
+          }
+          if (statError.code !== 'ENOENT') {
+            callback(statError);
+            return;
+          }
+          fs.writeFile(dest, content, callback);
+        });
+      } else {
+        fs.writeFile(dest, content, callback);
+      }
+    });
+  }) as any;
+
+  fs.copyFileSync = (src, dest, flags) => {
+    if (!isBundled(path.resolve(src))) {
+      originalCopyFileSync(src, dest, flags);
+      return;
+    }
+    const content = fs.readFileSync(src);
+    // eslint-disable-next-line no-bitwise
+    if (flags! & fs.constants.COPYFILE_EXCL) {
+      try {
+        fs.statSync(dest);
+      } catch (statError) {
+        if (statError.code !== 'ENOENT') throw statError;
+        fs.writeFileSync(dest, content);
+        return;
+      }
+      throw Object.assign(new Error('File already exists'), { code: 'EEXIST' });
+    }
+    fs.writeFileSync(dest, content);
+  };
+
+  if (!fs.promises) return;
+
+  fs.promises.copyFile = promisify(fs.copyFile);
+};

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -2,6 +2,7 @@ const constants = require('./constants');
 const path = require('path');
 const fs = require('fs-extra');
 const graphQLConfig = require('graphql-config');
+const { isPackaged } = require('amplify-cli-core');
 
 const CUSTOM_CONFIG_BLACK_LIST = [
   'aws_user_files_s3_dangerously_connect_to_http_endpoint_for_testing',
@@ -189,7 +190,17 @@ async function getCurrentAWSExports(context) {
   let awsExports = {};
 
   if (fs.existsSync(targetFilePath)) {
-    awsExports = require(targetFilePath).default;
+    if (isPackaged) {
+      // if packaged, we can't load an ES6 module because pkg doesn't support it yet
+      const es5export = 'module.exports = {default: awsmobile};\n';
+      const es6export = 'export default awsmobile;\n';
+      const fileContents = fs.readFileSync(targetFilePath, 'utf-8');
+      fs.writeFileSync(targetFilePath, fileContents.replace(es6export, es5export));
+      awsExports = require(targetFilePath).default;
+      fs.writeFileSync(targetFilePath, fileContents);
+    } else {
+      awsExports = require(targetFilePath).default;
+    }
   }
 
   return awsExports;

--- a/packages/amplify-frontend-javascript/package.json
+++ b/packages/amplify-frontend-javascript/package.json
@@ -16,6 +16,7 @@
     "aws"
   ],
   "dependencies": {
+    "amplify-cli-core": "1.3.4",
     "chalk": "^3.0.0",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
The following are some workarounds required to package the CLI using pkg
- esm is not supported
- fs.copyFile and fs.copyFileSync are not supported
- An additional directory in the snapshot filesystem needs to be scanned for plugins

There are a couple other changes needed to the CLI to support packaging, but in the spirit of keeping PRs small, I'm publishing this one.

Also note, all of the changes in functionality in this PR are behind and "isPackaged" check which is only true when the CLI is running as a packaged binary. There are no changes in functionality when the CLI is running in Node

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.