### PR TITLE
fix(amplify-velocity-template): expression not equals works improperly

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
@@ -1,0 +1,51 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { AmplifyAppSyncSimulator } from '../..';
+import { AmplifyAppSyncSimulatorAuthenticationType } from '../../type-definition';
+import { VelocityTemplate } from '../../velocity';
+import { mockInfo } from './util/general-utils.test';
+
+describe('VelocityTemplate', () => {
+  let content;
+  let simulator;
+  beforeAll(() => {
+    content = `"$ctx.error.message, $ctx.error.type"`;
+    simulator = new AmplifyAppSyncSimulator();
+  });
+
+  describe('#render', () => {
+    it('should handle string comparison', () => {
+      const template = new VelocityTemplate(
+        {
+          path: 'INLINE_TEMPLATE',
+          content: `
+#if( $ctx.stash.get("current_user_id")!=$ctx.prev.result.current_user_id)
+"not the same value"
+#else
+"the same value"
+#end`,
+        },
+        simulator,
+      );
+      const info = mockInfo;
+      const result = template.render(
+        {
+          arguments: {},
+          source: {},
+          stash: {
+            current_user_id: 'someString',
+          },
+          prevResult: {
+            current_user_id: 'someString',
+          },
+        },
+        {
+          headers: { Key: 'value' },
+          requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.API_KEY,
+        },
+        info,
+      );
+      expect(result.errors).toEqual([]);
+      expect(result.result).toEqual('the same value');
+    });
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -41,7 +41,7 @@ const stubInfo = {
     },
   },
 } as unknown;
-const mockInfo = stubInfo as GraphQLResolveInfo;
+export const mockInfo = stubInfo as GraphQLResolveInfo;
 const stubJavaMap: JavaMap = new JavaMap({ field1: 'field1Value', field2: 'field2Value', field3: 'field3Value' }, x => x);
 var util;
 

--- a/packages/amplify-velocity-template/src/compile/expression.js
+++ b/packages/amplify-velocity-template/src/compile/expression.js
@@ -9,6 +9,14 @@ module.exports = function(Velocity, utils) {
      * 基本数据类型，使用 getLiteral求值，getLiteral遇到是引用的时候，使用
      * getReferences求值
      */
+    compareEqualExpressions: function(exp0, exp1) {
+      const val0 = this.getExpression(exp0);
+      const val1 = this.getExpression(exp1);
+      const val0Json = val0 && val0.toJSON ? val0.toJSON() : val0;
+      const val1Json = val1 && val1.toJSON ? val1.toJSON() : val1;
+      return _.isEqual(val0Json, val1Json);
+    },
+
     getExpression: function(ast) {
       var exp = ast.expression;
       var ret;
@@ -51,11 +59,7 @@ module.exports = function(Velocity, utils) {
             break;
 
           case '==':
-            const val0 = this.getExpression(exp[0]);
-            const val1 = this.getExpression(exp[1]);
-            const val0Json = val0 && val0.toJSON ? val0.toJSON() : val0;
-            const val1Json = val1 && val1.toJSON ? val1.toJSON() : val1;
-            ret = _.isEqual(val0Json, val1Json);
+            ret = this.compareEqualExpressions(exp[0], exp[1]);
             break;
 
           case '>=':
@@ -67,7 +71,7 @@ module.exports = function(Velocity, utils) {
             break;
 
           case '!=':
-            ret = this.getExpression(exp[0]) != this.getExpression(exp[1]);
+            ret = !this.compareEqualExpressions(exp[0], exp[1]);
             break;
 
           case 'minus':


### PR DESCRIPTION
When used with amplify-appsync-simulator the not equals (!=) expression doesn't work properly. Two
strings are considered inequal when should be considered equals.

fix #5570

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.