### PR TITLE
feat(amplify-appsync-simulator): add TransactWriteItems support 

### DIFF
--- a/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/AppSyncTransactionWriteItems.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/AppSyncTransactionWriteItems.ts
@@ -1,0 +1,86 @@
+import {
+  ConditionExpression,
+  ExpressionAttributeNameMap,
+  ExpressionAttributeValueMap,
+  Key,
+  PutItemInputAttributeMap,
+  UpdateExpression,
+} from 'aws-sdk/clients/dynamodb';
+
+export interface AppSyncPutItemTransactionWriteItems {
+  table: string;
+  operation: 'PutItem';
+  key: Key;
+  attributeValues: PutItemInputAttributeMap;
+  condition?: {
+    expression: ConditionExpression;
+    expressionNames?: ExpressionAttributeNameMap;
+    expressionValues?: ExpressionAttributeValueMap;
+    returnValuesOnConditionCheckFailure?: true | false;
+  };
+}
+
+export interface AppSyncUpdateItemTransactionWriteItems {
+  table: string;
+  operation: 'UpdateItem';
+  key: Key;
+  update: {
+    expression: string;
+    expressionNames?: ExpressionAttributeNameMap;
+    expressionValues?: ExpressionAttributeValueMap;
+  };
+  condition?: {
+    expression: ConditionExpression;
+    expressionNames?: ExpressionAttributeNameMap;
+    expressionValues?: ExpressionAttributeValueMap;
+    returnValuesOnConditionCheckFailure?: true | false;
+  };
+}
+
+export interface AppSyncDeleteItemTransactionWriteItems {
+  table: 'table3';
+  operation: 'DeleteItem';
+  key: Key;
+  condition?: {
+    expression: ConditionExpression;
+    expressionNames?: ExpressionAttributeNameMap;
+    expressionValues?: ExpressionAttributeValueMap;
+    returnValuesOnConditionCheckFailure?: true | false;
+  };
+}
+
+export interface AppSyncConditionCheckTransactionWriteItems {
+  table: 'table4';
+  operation: 'ConditionCheck';
+  key: Key;
+  condition: {
+    expression: ConditionExpression;
+    expressionNames?: ExpressionAttributeNameMap;
+    expressionValues?: ExpressionAttributeValueMap;
+    returnValuesOnConditionCheckFailure?: true | false;
+  };
+}
+
+export type AppSyncTransactionWriteItem =
+  | AppSyncPutItemTransactionWriteItems
+  | AppSyncUpdateItemTransactionWriteItems
+  | AppSyncDeleteItemTransactionWriteItems
+  | AppSyncConditionCheckTransactionWriteItems;
+export type AppSyncTransactionWriteItems = AppSyncTransactionWriteItem[];
+
+export interface AppSyncTransactionWriteItemsOperation {
+  version: '2018-05-29';
+  operation: 'TransactWriteItems';
+  transactItems: AppSyncTransactionWriteItems;
+}
+
+export interface AppSyncTransactionWriteItemsCancellationReasons {
+  item?: PutItemInputAttributeMap;
+  type: string;
+  message: string;
+}
+
+export interface AppSyncTransactionWriteItemsOperationResponse {
+  keys: Key[] | null;
+  cancellationReasons: AppSyncTransactionWriteItemsCancellationReasons[] | null;
+}


### PR DESCRIPTION
add TransactWriteItems support to DynamoDB operations

Add TransactWriteItems support to `amplify-appsync-simulator`

*Issue #, if available:*
implement aws-amplify/amplify-category-api#259

*Description of changes:*
Implement the missing TransactWriteItems operator to DynamoDB data loader 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.