### PR TITLE
fix(amplify-appsync-simulator): make ExpressionAttributeNames optional

### DIFF
--- a/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/index.ts
@@ -143,16 +143,15 @@ export class DynamoDBDataLoader implements AmplifyAppSyncSimulatorDataLoader {
       UpdateExpression: update.expression,
       ConditionExpression: condition.expression,
       ReturnValues: 'ALL_NEW',
-      ExpressionAttributeNames: {
+      ExpressionAttributeNames: nullIfEmpty({
         ...(condition.expressionNames || {}),
-        ...update.expressionNames,
-      },
-      ExpressionAttributeValues: {
+        ...(update.expressionNames || {}),
+      }),
+      ExpressionAttributeValues: nullIfEmpty({
         ...(condition.expressionValues || {}),
-        ...update.expressionValues,
-      },
+        ...(update.expressionValues || {}),
+      }),
     };
-
     const { Attributes: updated } = await this.client.updateItem(params).promise();
     return unmarshall(updated);
   }


### PR DESCRIPTION
When you map a unit or a function to use a DynamoDB data source and use the operation UpdateItem and
do not set condition.expressionNames or update.expressionNames in the payload the
amplify-appsync-simulator stops execution. The AppSync DynamoDB template reference says that those
attributes are optional.

*Issue #, if available:*
fix #5573

*Description of changes:*
Replace to null if the object is empty, the same approach used in the `Query` operator. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.