### PR TITLE
fix(graphql-transformer-core): "innerDiffs is not iterable" error on push

### DIFF
--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -139,7 +139,7 @@ export function cantEditGSIKeySchema(diff: Diff, currentBuild: DiffableProject, 
     const newIndexes = get(nextBuild, pathToGSIs);
     const oldIndexesDiffable = keyBy(oldIndexes, 'IndexName');
     const newIndexesDiffable = keyBy(newIndexes, 'IndexName');
-    const innerDiffs = getDiffs(oldIndexesDiffable, newIndexesDiffable);
+    const innerDiffs = getDiffs(oldIndexesDiffable, newIndexesDiffable) || [];
     // We must look at this inner diff or else we could confuse a situation
     // where the user adds a GSI to the beginning of the GlobalSecondaryIndexes list in CFN.
     // We re-key the indexes list so we can determine if a change occurred to an index that
@@ -192,7 +192,7 @@ export function cantAddAndRemoveGSIAtSameTime(diff: Diff, currentBuild: Diffable
     const newIndexes = get(nextBuild, pathToGSIs);
     const oldIndexesDiffable = keyBy(oldIndexes, 'IndexName');
     const newIndexesDiffable = keyBy(newIndexes, 'IndexName');
-    const innerDiffs = getDiffs(oldIndexesDiffable, newIndexesDiffable);
+    const innerDiffs = getDiffs(oldIndexesDiffable, newIndexesDiffable) || [];
     let sawDelete = false;
     let sawNew = false;
     for (const diff of innerDiffs) {
@@ -273,7 +273,7 @@ export function cantEditLSIKeySchema(diff: Diff, currentBuild: DiffableProject, 
     const newIndexes = get(nextBuild, pathToGSIs);
     const oldIndexesDiffable = keyBy(oldIndexes, 'IndexName');
     const newIndexesDiffable = keyBy(newIndexes, 'IndexName');
-    const innerDiffs = getDiffs(oldIndexesDiffable, newIndexesDiffable);
+    const innerDiffs = getDiffs(oldIndexesDiffable, newIndexesDiffable) || [];
     // We must look at this inner diff or else we could confuse a situation
     // where the user adds a LSI to the beginning of the LocalSecondaryIndex list in CFN.
     // We re-key the indexes list so we can determine if a change occurred to an index that


### PR DESCRIPTION
Issue: #5689

This change fixes a problem with "innerDiffs is not iterable" when there are changes to a schema but after diffing changed structures nothing is actually detected.
This can occur when for example when changing order of `@key` directives, all of the keys are the same and there is no change the only thing changing is their order in the schema.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.