### PR TITLE
fix: store oauthMetadata properly on headless update

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-defaults-appliers.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-defaults-appliers.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`update auth defaults applier calls structureOAuthMetadata 1`] = `
+Object {
+  "authSelections": "userPoolOnly",
+  "include": "this value",
+  "some": "default value",
+  "useDefault": "manual",
+}
+`;

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
@@ -1,0 +1,29 @@
+import { ServiceQuestionsResult } from '../../../../provider-utils/awscloudformation/service-walkthrough-types';
+import { structureOAuthMetadata } from '../../../../provider-utils/awscloudformation/service-walkthroughs/auth-questions';
+import { getUpdateAuthDefaultsApplier } from '../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers';
+
+jest.mock(`../../../../provider-utils/awscloudformation/assets/cognito-defaults.js`, () => ({
+  functionMap: {
+    userPoolOnly: () => ({ some: 'default value' }),
+  },
+  getAllDefaults: jest.fn(),
+}));
+
+jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/auth-questions', () => ({
+  structureOAuthMetadata: jest.fn(result => (result.include = 'this value')),
+}));
+
+const structureOAuthMetadata_mock = structureOAuthMetadata as jest.MockedFunction<typeof structureOAuthMetadata>;
+
+describe('update auth defaults applier', () => {
+  it('calls structureOAuthMetadata', async () => {
+    const stubResult = {
+      useDefault: 'manual',
+      authSelections: 'userPoolOnly',
+    } as ServiceQuestionsResult;
+
+    const result = await getUpdateAuthDefaultsApplier({}, 'cognito-defaults.js', {} as ServiceQuestionsResult)(stubResult);
+    expect(result).toMatchSnapshot();
+    expect(structureOAuthMetadata_mock.mock.calls.length).toBe(1);
+  });
+});

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/resource-handlers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/resource-handlers.ts
@@ -36,7 +36,7 @@ export const getAddAuthHandler = (context: any) => async (request: ServiceQuesti
 
 export const getUpdateAuthHandler = (context: any) => async (request: ServiceQuestionsResult) => {
   const { cfnFilename, defaultValuesFilename, provider } = supportedServices[request.serviceName];
-  const requestWithDefaults = await getUpdateAuthDefaultsApplier(defaultValuesFilename, context.updatingAuth)(request);
+  const requestWithDefaults = await getUpdateAuthDefaultsApplier(context, defaultValuesFilename, context.updatingAuth)(request);
   await getResourceUpdater(
     context,
     cfnFilename,

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -28,10 +28,10 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
   return merge(functionMap[result.authSelections](result.resourceName), result, roles);
 };
 
-export const getUpdateAuthDefaultsApplier = (defaultValuesFilename: string, previousResult: ServiceQuestionsResult) => async (
+export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename: string, previousResult: ServiceQuestionsResult) => async (
   result: ServiceQuestionsResult,
 ): Promise<ServiceQuestionsResult> => {
-  const { functionMap } = await import(`../assets/${defaultValuesFilename}`);
+  const { functionMap, getAllDefaults } = await import(`../assets/${defaultValuesFilename}`);
   if (!result.authSelections) {
     result.authSelections = 'identityPoolAndUserPool';
   }
@@ -46,6 +46,8 @@ export const getUpdateAuthDefaultsApplier = (defaultValuesFilename: string, prev
   }
 
   await verificationBucketName(result, previousResult);
+
+  structureOAuthMetadata(result, context, getAllDefaults, context.amplify); // adds "oauthMetadata" to result
 
   return merge(defaults, removeDeprecatedProps(previousResult), result);
 };


### PR DESCRIPTION
Headless update auth was missing a call to format the oAuthMetadata field in parameters.json. Added that and a test to cover it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.