### PR TITLE
fix(amplify-appsync-simulator): graphql info selectionset

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/graphql-info.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/graphql-info.test.ts
@@ -219,3 +219,88 @@ it('should generate a valid graphql info object', () => {
       '{\n  otherField\n  aliasedField: otherField\n  ...fragment\n  ... on FragmentType {\n    aliasedInlineFragmentField: inlineFragmentField\n    inlineFragmentField\n  }\n  someOtherField(varName: $foo) {\n    subField\n    aliasedSubField: subField\n    ...subfragment\n  }\n}',
   });
 });
+
+it('should generate a valid graphql info object with an object param value', () => {
+  // @ts-ignore
+  const info = createInfo({
+    fieldName: 'someField',
+    fieldNodes: [
+      {
+        kind: 'Field',
+        name: {
+          kind: 'Name',
+          value: 'someField',
+        },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: {
+              kind: 'Name',
+              value: 'param',
+            },
+            value: {
+              kind: 'ObjectValue',
+              fields: [
+                {
+                  kind: 'ObjectField',
+                  name: {
+                    kind: 'Name',
+                    value: 'bazz',
+                  },
+                  value: {
+                    kind: 'StringValue',
+                    value: 'buzz',
+                  },
+                },
+                {
+                  kind: 'ObjectField',
+                  name: {
+                    kind: 'Name',
+                    value: 'fizz',
+                  },
+                  value: {
+                    kind: 'ObjectValue',
+                    fields: [
+                      {
+                        kind: 'ObjectField',
+                        name: {
+                          kind: 'Name',
+                          value: 'fuzz',
+                        },
+                        value: {
+                          kind: 'StringValue',
+                          value: 'fazz',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: [
+            {
+              kind: 'Field',
+              name: {
+                kind: 'Name',
+                value: 'otherField',
+              },
+            },
+          ],
+        },
+      },
+    ],
+    // @ts-ignore
+    parentType: 'Query',
+  });
+  expect(info).toEqual({
+    fieldName: 'someField',
+    variables: undefined,
+    parentTypeName: 'Query',
+    selectionSetList: ['otherField'],
+    selectionSetGraphQL: '{\n  otherField\n}',
+  });
+});

--- a/packages/amplify-appsync-simulator/src/velocity/util/info.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/info.ts
@@ -26,8 +26,7 @@ export function createInfo(info: GraphQLResolveInfo) {
 
   const fieldNode = info.fieldNodes.find(f => f.name.value === info.fieldName);
   if (fieldNode && fieldNode.selectionSet) {
-    const query = print(fieldNode);
-    selectionSetGraphQL = query.substr(query.indexOf('{'));
+    selectionSetGraphQL = print(fieldNode.selectionSet);
     selectionSetList = getSelectionSet(fieldNode.selectionSet.selections);
   }
 


### PR DESCRIPTION
When the parameter values contains objects, the `selectionSetGraphQL` field from `context.info` is wrongly generated.

See:
https://github.com/bboure/serverless-appsync-simulator/issues/49

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.