### PR TITLE
chore: fix e2e import auth tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,22 +937,6 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/function_3.test.ts
       CLI_REGION: ap-southeast-2
-  import_auth_1-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/import_auth_1.test.ts
-      CLI_REGION: us-east-2
-  import_auth_2-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_0
-    resource_class: large
-    steps: *ref_1
-    environment:
-      TEST_SUITE: src/__tests__/import_auth_2.test.ts
-      CLI_REGION: us-west-2
   schema-auth-3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -960,7 +944,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: us-east-2
   delete-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -968,7 +952,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/delete.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: us-west-2
   function_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -976,7 +960,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: eu-west-2
   auth_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -984,7 +968,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/auth_3.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-central-1
   layer-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -992,7 +976,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/layer.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: ap-northeast-1
   migration-api-key-migration1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1000,7 +984,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
   auth_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1008,7 +992,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/auth_4.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-southeast-2
   schema-auth-7-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1016,7 +1000,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: us-east-2
   schema-auth-8-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1024,7 +1008,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: us-west-2
   schema-searchable-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1032,7 +1016,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: eu-west-2
   schema-auth-4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1040,7 +1024,7 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-central-1
   api_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1048,6 +1032,22 @@ jobs:
     steps: *ref_1
     environment:
       TEST_SUITE: src/__tests__/api_3.test.ts
+      CLI_REGION: ap-northeast-1
+  import_auth_1-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/import_auth_1.test.ts
+      CLI_REGION: ap-southeast-1
+  import_auth_2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/import_auth_2.test.ts
       CLI_REGION: ap-southeast-2
   env-amplify_e2e_tests:
     working_directory: ~/repo
@@ -1291,32 +1291,32 @@ workflows:
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4
-            - migration-api-key-migration1-amplify_e2e_tests
+            - schema-auth-7-amplify_e2e_tests
             - env-amplify_e2e_tests
             - function_4-amplify_e2e_tests
             - api_1-amplify_e2e_tests
-            - auth_4-amplify_e2e_tests
+            - schema-auth-8-amplify_e2e_tests
             - auth_2-amplify_e2e_tests
             - schema-function-amplify_e2e_tests
             - schema-auth-5-amplify_e2e_tests
-            - schema-auth-7-amplify_e2e_tests
+            - schema-searchable-amplify_e2e_tests
             - schema-auth-9-amplify_e2e_tests
             - schema-model-amplify_e2e_tests
             - storage-amplify_e2e_tests
-            - schema-auth-8-amplify_e2e_tests
+            - schema-auth-4-amplify_e2e_tests
             - schema-auth-11-amplify_e2e_tests
             - migration-api-connection-migration-amplify_e2e_tests
             - api_2-amplify_e2e_tests
-            - function_2-amplify_e2e_tests
-            - schema-searchable-amplify_e2e_tests
-            - migration-api-key-migration2-amplify_e2e_tests
-            - schema-connection-amplify_e2e_tests
-            - auth_3-amplify_e2e_tests
-            - schema-auth-4-amplify_e2e_tests
-            - function_1-amplify_e2e_tests
-            - schema-auth-6-amplify_e2e_tests
             - layer-amplify_e2e_tests
             - api_3-amplify_e2e_tests
+            - migration-api-key-migration2-amplify_e2e_tests
+            - schema-connection-amplify_e2e_tests
+            - migration-api-key-migration1-amplify_e2e_tests
+            - import_auth_1-amplify_e2e_tests
+            - function_1-amplify_e2e_tests
+            - schema-auth-6-amplify_e2e_tests
+            - auth_4-amplify_e2e_tests
+            - import_auth_2-amplify_e2e_tests
             - schema-auth-1-amplify_e2e_tests
             - schema-auth-2-amplify_e2e_tests
           filters:
@@ -1343,11 +1343,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - import_auth_1-amplify_e2e_tests:
+      - schema-auth-3-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - migration-api-key-migration1-amplify_e2e_tests:
+      - schema-auth-7-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1366,7 +1366,7 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - import_auth_1-amplify_e2e_tests
+            - schema-auth-3-amplify_e2e_tests
       - init-special-case-amplify_e2e_tests:
           filters: *ref_2
           requires:
@@ -1379,11 +1379,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - import_auth_2-amplify_e2e_tests:
+      - delete-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - auth_4-amplify_e2e_tests:
+      - schema-auth-8-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1402,7 +1402,7 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - import_auth_2-amplify_e2e_tests
+            - delete-amplify_e2e_tests
       - datastore-modelgen-amplify_e2e_tests:
           filters: *ref_2
           requires:
@@ -1415,11 +1415,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-3-amplify_e2e_tests:
+      - function_2-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-7-amplify_e2e_tests:
+      - schema-searchable-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1438,7 +1438,7 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - schema-auth-3-amplify_e2e_tests
+            - function_2-amplify_e2e_tests
       - amplify-configure-amplify_e2e_tests:
           filters: *ref_2
           requires:
@@ -1451,11 +1451,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - delete-amplify_e2e_tests:
+      - auth_3-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-8-amplify_e2e_tests:
+      - schema-auth-4-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1474,7 +1474,7 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-            - delete-amplify_e2e_tests
+            - auth_3-amplify_e2e_tests
       - init-amplify_e2e_tests:
           filters: *ref_2
           requires:
@@ -1487,11 +1487,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - function_2-amplify_e2e_tests:
+      - layer-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-searchable-amplify_e2e_tests:
+      - api_3-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1518,11 +1518,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - auth_3-amplify_e2e_tests:
+      - migration-api-key-migration1-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - schema-auth-4-amplify_e2e_tests:
+      - import_auth_1-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
@@ -1549,11 +1549,11 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - layer-amplify_e2e_tests:
+      - auth_4-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry
-      - api_3-amplify_e2e_tests:
+      - import_auth_2-amplify_e2e_tests:
           filters: *ref_2
           requires:
             - publish_to_local_registry

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
@@ -52,11 +52,20 @@ describe('auth import userpool only', () => {
     name: ogProjectPrefix,
   };
 
+  const dummyOGProjectSettings = {
+    name: 'dummyog1',
+  };
+
   // OG is the CLI project that creates the user pool to import by other test projects
   let ogProjectRoot: string;
   let ogShortId: string;
   let ogSettings: AddAuthUserPoolOnlyWithOAuthSettings;
   let ogProjectDetails: ProjectDetails;
+
+  // We need an extra OG project to make sure that autocomplete prompt hits in
+  let dummyOGProjectRoot: string;
+  let dummyOGShortId: string;
+  let dummyOGSettings: AddAuthUserPoolOnlyWithOAuthSettings;
 
   let projectRoot: string;
   let ignoreProjectDeleteErrors: boolean = false;
@@ -71,11 +80,22 @@ describe('auth import userpool only', () => {
     await amplifyPushAuth(ogProjectRoot);
 
     ogProjectDetails = getOGProjectDetails(ogProjectRoot);
+
+    dummyOGProjectRoot = await createNewProjectDir(dummyOGProjectSettings.name);
+    dummyOGShortId = getShortId();
+    dummyOGSettings = createUserPoolOnlyWithOAuthSettings(dummyOGProjectSettings.name, ogShortId);
+
+    await initJSProjectWithProfile(dummyOGProjectRoot, dummyOGProjectSettings);
+    await addAuthUserPoolOnlyWithOAuth(dummyOGProjectRoot, dummyOGSettings);
+    await amplifyPushAuth(dummyOGProjectRoot);
   });
 
   afterAll(async () => {
     await deleteProject(ogProjectRoot);
     deleteProjectDir(ogProjectRoot);
+
+    await deleteProject(dummyOGProjectRoot);
+    deleteProjectDir(dummyOGProjectRoot);
   });
 
   beforeEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_2.test.ts
@@ -26,7 +26,7 @@ import {
   ProjectDetails,
 } from '../import-helpers';
 
-const profileName = 'default';
+const profileName = 'amplify-integ-test-user';
 
 describe('auth import identity pool and userpool', () => {
   const projectPrefix = 'auimpidup';
@@ -40,11 +40,20 @@ describe('auth import identity pool and userpool', () => {
     name: ogProjectPrefix,
   };
 
+  const dummyOGProjectSettings = {
+    name: 'dummyog2',
+  };
+
   // OG is the CLI project that creates the user pool to import by other test projects
   let ogProjectRoot: string;
   let ogShortId: string;
   let ogSettings: AddAuthIdentityPoolAndUserPoolWithOAuthSettings;
   let ogProjectDetails: ProjectDetails;
+
+  // We need an extra OG project to make sure that autocomplete prompt hits in
+  let dummyOGProjectRoot: string;
+  let dummyOGShortId: string;
+  let dummyOGSettings: AddAuthIdentityPoolAndUserPoolWithOAuthSettings;
 
   let projectRoot: string;
   let ignoreProjectDeleteErrors: boolean = false;
@@ -59,11 +68,22 @@ describe('auth import identity pool and userpool', () => {
     await amplifyPushAuth(ogProjectRoot);
 
     ogProjectDetails = getOGProjectDetails(ogProjectRoot);
+
+    dummyOGProjectRoot = await createNewProjectDir(dummyOGProjectSettings.name);
+    dummyOGShortId = getShortId();
+    dummyOGSettings = createIDPAndUserPoolWithOAuthSettings(dummyOGProjectSettings.name, ogShortId);
+
+    await initJSProjectWithProfile(dummyOGProjectRoot, dummyOGProjectSettings);
+    await addAuthIdentityPoolAndUserPoolWithOAuth(dummyOGProjectRoot, dummyOGSettings);
+    await amplifyPushAuth(dummyOGProjectRoot);
   });
 
   afterAll(async () => {
     await deleteProject(ogProjectRoot);
     deleteProjectDir(ogProjectRoot);
+
+    await deleteProject(dummyOGProjectRoot);
+    deleteProjectDir(dummyOGProjectRoot);
   });
 
   beforeEach(async () => {

--- a/packages/amplify-provider-awscloudformation/src/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.js
@@ -111,14 +111,7 @@ async function run(context, resourceDefinition) {
       const importResources = resourcesToBeSynced.filter(r => r.sync === 'import');
 
       if (importResources.length > 0) {
-        const {
-          imported,
-          userPoolId,
-          authRoleArn,
-          authRoleName,
-          unauthRoleArn,
-          unauthRoleName,
-        } = context.amplify.getImportedAuthProperties(context);
+        const { imported, userPoolId } = context.amplify.getImportedAuthProperties(context);
 
         // Sanity check it will always be true in this case
         if (imported) {

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -43,8 +43,6 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/auth_1.test.ts',
   'src/__tests__/auth_5.test.ts',
   'src/__tests__/function_3.test.ts',
-  'src/__tests__/import_auth_1.test.ts',
-  'src/__tests__/import_auth_2.test.ts',
   //<30m
   'src/__tests__/schema-auth-3.test.ts',
   'src/__tests__/delete.test.ts',
@@ -59,6 +57,8 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/schema-searchable.test.ts',
   'src/__tests__/schema-auth-4.test.ts',
   'src/__tests__/api_3.test.ts',
+  'src/__tests__/import_auth_1.test.ts',
+  'src/__tests__/import_auth_2.test.ts',
   //<40m
   'src/__tests__/env.test.ts',
   'src/__tests__/auth_2.test.ts',


### PR DESCRIPTION
*Description of changes:*

Extend auth import tests with a dummy project to make sure test has at least 2 user pools and identity pools so can be more deterministic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.