### PR TITLE
fix(amplify-appsync-simulator): handle Lexical error correctly

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
@@ -12,6 +12,31 @@ describe('VelocityTemplate', () => {
     simulator = new AmplifyAppSyncSimulator();
   });
 
+  describe('constructor', () => {
+    it('should handle bad template', () => {
+      expect(
+        () =>
+          new VelocityTemplate(
+            {
+              path: 'INLINE_TEMPLATE',
+              content: `{
+          "version": "2017-02-28",
+          "payload": {
+            "identity": $util.toJson($$context.identity)
+          }
+        }`,
+            },
+            simulator,
+          ),
+      ).toThrowError(
+        'Error:Parse error on INLINE_TEMPLATE:3: \n' +
+          'Lexical error on line 4. Unrecognized text.\n' +
+          '...tity": $util.toJson($$context.identity)\n' +
+          '-----------------------^',
+      );
+    });
+  });
+
   describe('#render', () => {
     it('should handle string comparison', () => {
       const template = new VelocityTemplate(

--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -39,7 +39,7 @@ export class VelocityTemplate {
       });
       this.template = template;
     } catch (e) {
-      const lineDetails = `${e.hash.line}:${e.hash.loc.first_column}`;
+      const lineDetails = `${e.hash.line}:${e.hash.loc?.first_column ? e.hash.loc.first_column : ''}`;
       const fileName = template.path ? `${template.path}:${lineDetails}` : lineDetails;
       const templateError = new VelocityTemplateParseError(`Error:Parse error on ${fileName} \n${e.message}`);
       templateError.stack = e.stack;


### PR DESCRIPTION
When theres has a Lexical error in the velocity template the VelocityTemplate constructor don't
handle it correctly

fix #5621

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.