### PR TITLE
fix: refactor mobile hub migration checks

### DIFF
--- a/packages/amplify-category-analytics/commands/analytics/add.js
+++ b/packages/amplify-category-analytics/commands/analytics/add.js
@@ -23,16 +23,18 @@ module.exports = {
         return providerController.addResource(context, category, result.service);
       })
       .then(resourceName => {
-        amplify.updateamplifyMetaAfterResourceAdd(category, resourceName, options);
-        const { print } = context;
-        print.success(`Successfully added resource ${resourceName} locally`);
-        print.info('');
-        print.success('Some next steps:');
-        print.info('"amplify push" builds all of your local backend resources and provisions them in the cloud');
-        print.info(
-          '"amplify publish" builds all your local backend and front-end resources (if you have hosting category added) and provisions them in the cloud',
-        );
-        print.info('');
+        if (resourceName) {
+          amplify.updateamplifyMetaAfterResourceAdd(category, resourceName, options);
+          const { print } = context;
+          print.success(`Successfully added resource ${resourceName} locally`);
+          print.info('');
+          print.success('Some next steps:');
+          print.info('"amplify push" builds all of your local backend resources and provisions them in the cloud');
+          print.info(
+            '"amplify publish" builds all your local backend and front-end resources (if you have hosting category added) and provisions them in the cloud',
+          );
+          print.info('');
+        }
       })
       .catch(err => {
         context.print.info(err.stack);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -36,7 +36,7 @@ export async function updateWalkthrough(context, defaultValuesFilename) {
   const { getAllDefaults } = await import(defaultValuesSrc);
   const allDefaultValues = getAllDefaults(amplify.getProjectDetails());
   const resources = allResources
-    .filter(resource => resource.service === serviceName && !!resource.providerPlugin)
+    .filter(resource => resource.service === serviceName && resource.mobileHubMigrated !== true)
     .map(resource => resource.resourceName);
 
   // There can only be one appsync resource

--- a/packages/amplify-category-auth/src/commands/auth/update.js
+++ b/packages/amplify-category-auth/src/commands/auth/update.js
@@ -24,7 +24,7 @@ module.exports = {
       for (let i = 0; i < services.length; i++) {
         const serviceMeta = existingAuth[services[i]];
 
-        if (serviceMeta.service === 'Cognito' && !serviceMeta.providerPlugin) {
+        if (serviceMeta.service === 'Cognito' && serviceMeta.mobileHubMigrated === true) {
           context.print.error('Auth is migrated from Mobile Hub and cannot be updated with Amplify CLI.');
           return context;
         } else if (serviceMeta.service === 'Cognito' && serviceMeta.serviceType === 'imported') {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -114,11 +114,10 @@ export const askExecRolePermissionsQuestions = async (
           context.print.warning(`Policies cannot be added for ${category}/${resourceName}`);
           continue;
         } else if (
-          // In case of AppSync storage resources they are not in the meta file so check for resource existence as well
+          // In case of some resources they are not in the meta file so check for resource existence as well
           amplifyMeta[category] &&
           amplifyMeta[category][resourceName] &&
-          amplifyMeta[category][resourceName].service === 'S3AndCloudFront' &&
-          !amplifyMeta[category][resourceName].providerPlugin
+          amplifyMeta[category][resourceName].mobileHubMigrated === true
         ) {
           context.print.warning(`Policies cannot be added for ${category}/${resourceName}, since it is a MobileHub imported resource.`);
           continue;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -59,7 +59,7 @@ export async function createWalkthrough(
  */
 export async function updateWalkthrough(context, lambdaToUpdate?: string) {
   const lambdaFuncResourceNames = ((await context.amplify.getResourceStatus()).allResources as any[])
-    .filter(resource => resource.service === ServiceName.LambdaFunction && !!resource.providerPlugin)
+    .filter(resource => resource.service === ServiceName.LambdaFunction && resource.mobileHubMigrated !== true)
     .map(resource => resource.resourceName);
 
   if (lambdaFuncResourceNames.length === 0) {

--- a/packages/amplify-category-hosting/commands/hosting/remove.js
+++ b/packages/amplify-category-hosting/commands/hosting/remove.js
@@ -39,8 +39,11 @@ async function chooseResource(context, inputResourceName) {
   const amplifyMetaFilePath = amplify.pathManager.getAmplifyMetaFilePath();
   if (fs.existsSync(amplifyMetaFilePath)) {
     const amplifyMeta = amplify.readJsonFile(amplifyMetaFilePath);
-    if (amplifyMeta[category] && Object.keys(amplifyMeta[category]).filter(r => !!amplifyMeta[category][r].providerPlugin).length > 0) {
-      let enabledResources = Object.keys(amplifyMeta[category]).filter(r => !!amplifyMeta[category][r].providerPlugin);
+    if (
+      amplifyMeta[category] &&
+      Object.keys(amplifyMeta[category]).filter(r => amplifyMeta[category][r].mobileHubMigrated !== true).length > 0
+    ) {
+      let enabledResources = Object.keys(amplifyMeta[category]).filter(r => amplifyMeta[category][r].mobileHubMigrated !== true);
 
       let inputIsValid = true;
       if (services && services.length > 0) {

--- a/packages/amplify-category-interactions/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
+++ b/packages/amplify-category-interactions/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
@@ -22,7 +22,7 @@ function updateWalkthrough(context, defaultValuesFilename, serviceMetadata) {
   const lexResources = {};
 
   Object.keys(amplifyMeta[category]).forEach(resourceName => {
-    if (amplifyMeta[category][resourceName].service === serviceName && !!amplifyMeta[category][resourceName].providerPlugin) {
+    if (amplifyMeta[category][resourceName].service === serviceName && amplifyMeta[category][resourceName].mobileHubMigrated !== true) {
       lexResources[resourceName] = amplifyMeta[category][resourceName];
     }
   });

--- a/packages/amplify-category-notifications/commands/notifications/add.js
+++ b/packages/amplify-category-notifications/commands/notifications/add.js
@@ -16,7 +16,7 @@ module.exports = {
       for (let i = 0; i < services.length; i++) {
         const serviceMeta = categoryMeta[services[i]];
 
-        if (!serviceMeta.providerPlugin) {
+        if (serviceMeta.mobileHubMigrated === true) {
           context.print.error('Notifications is migrated from Mobile Hub and channels cannot be added with Amplify CLI.');
           return context;
         }

--- a/packages/amplify-category-notifications/commands/notifications/remove.js
+++ b/packages/amplify-category-notifications/commands/notifications/remove.js
@@ -15,7 +15,7 @@ module.exports = {
     if (pinpointApp) {
       const pinpointResource = context.exeInfo.amplifyMeta.notifications[pinpointApp.Name];
 
-      if (pinpointResource && !pinpointResource.providerPlugin) {
+      if (pinpointResource && pinpointResource.mobileHubMigrated === true) {
         context.print.error('Notifications is migrated from Mobile Hub and cannot be removed with Amplify CLI.');
         return context;
       }

--- a/packages/amplify-category-notifications/lib/multi-env-manager.js
+++ b/packages/amplify-category-notifications/lib/multi-env-manager.js
@@ -44,7 +44,7 @@ async function constructPinpointNotificationsMeta(context) {
       for (const resourceName of Object.keys(analyticsMeta)) {
         const resource = analyticsMeta[resourceName];
 
-        if (resource.service === 'Pinpoint' && !resource.providerPlugin) {
+        if (resource.mobileHubMigrated === true) {
           isMobileHubMigrated = true;
           break;
         }

--- a/packages/amplify-category-notifications/lib/notifications-manager.js
+++ b/packages/amplify-category-notifications/lib/notifications-manager.js
@@ -69,7 +69,7 @@ async function configureChannel(context, channelName) {
   if (Object.keys(channelWorkers).indexOf(channelName) > -1) {
     context.exeInfo.pinpointClient = await pintpointHelper.getPinpointClient(context, 'update');
 
-    if (!context.exeInfo.serviceMeta.providerPlugin) {
+    if (context.exeInfo.serviceMeta.mobileHubMigrated === true) {
       context.print.error('No resources to update.');
       return false;
     }

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.js
@@ -24,7 +24,7 @@ function updateWalkthrough(context, defaultValuesFilename, serviceMetadata) {
   const dynamoDbResources = {};
 
   Object.keys(amplifyMeta[category]).forEach(resourceName => {
-    if (amplifyMeta[category][resourceName].service === serviceName && !!amplifyMeta[category][resourceName].providerPlugin) {
+    if (amplifyMeta[category][resourceName].service === serviceName && amplifyMeta[category][resourceName].mobileHubMigrated !== true) {
       dynamoDbResources[resourceName] = amplifyMeta[category][resourceName];
     }
   });

--- a/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
+++ b/packages/amplify-category-storage/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.js
@@ -61,7 +61,7 @@ function updateWalkthrough(context, defaultValuesFilename, serviceMetada) {
   const storageResources = {};
 
   Object.keys(amplifyMeta[category]).forEach(resourceName => {
-    if (amplifyMeta[category][resourceName].service === serviceName && !!amplifyMeta[category][resourceName].providerPlugin) {
+    if (amplifyMeta[category][resourceName].service === serviceName && amplifyMeta[category][resourceName].mobileHubMigrated !== true) {
       storageResources[resourceName] = amplifyMeta[category][resourceName];
     }
   });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.ts
@@ -40,14 +40,17 @@ export async function removeResource(
 ) {
   const amplifyMeta = stateManager.getMeta();
 
-  if (!amplifyMeta[category] || Object.keys(amplifyMeta[category]).filter(r => !!amplifyMeta[category][r].providerPlugin).length === 0) {
+  if (
+    !amplifyMeta[category] ||
+    Object.keys(amplifyMeta[category]).filter(r => amplifyMeta[category][r].mobileHubMigrated !== true).length === 0
+  ) {
     context.print.error('No resources added for this category');
     context.usageData.emitError(new ResourceDoesNotExistError());
     exitOnNextTick(1);
   }
 
   let enabledCategoryResources: { name; value } | { name; value }[] | string[] = Object.keys(amplifyMeta[category]).filter(
-    r => !!amplifyMeta[category][r].providerPlugin,
+    r => amplifyMeta[category][r].mobileHubMigrated !== true,
   );
 
   if (resourceName) {

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -78,10 +78,10 @@ export async function run() {
     context.usageData.emitInvoke();
 
     // For mobile hub migrated project validate project and command to be executed
-    // if (!ensureMobileHubCommandCompatibility((context as unknown) as $TSContext)) {
-    //   // Double casting until we have properly typed context
-    //   return 1;
-    // }
+    if (!ensureMobileHubCommandCompatibility((context as unknown) as $TSContext)) {
+      // Double casting until we have properly typed context
+      return 1;
+    }
 
     await executeCommand(context);
 

--- a/packages/amplify-cli/src/utils/mobilehub-support.ts
+++ b/packages/amplify-cli/src/utils/mobilehub-support.ts
@@ -34,8 +34,8 @@ const checkIfMobileHubProject = (context: $TSContext): void => {
       Object.keys(meta[category]).forEach(resourceName => {
         const resource = meta[category][resourceName];
 
-        // Mobile hub migrated resources and CLI created Pinoint ones does not have an assigned provider
-        if (!resource.providerPlugin && resource.service !== 'Pinpoint') {
+        // Mobile hub migrated resources has this property on the resource record set to true by migrator plugin.
+        if (resource.mobileHubMigrated === true) {
           hasMigratedResources = true;
         }
       });

--- a/packages/amplify-provider-awscloudformation/src/initialize-env.js
+++ b/packages/amplify-provider-awscloudformation/src/initialize-env.js
@@ -93,7 +93,7 @@ async function run(context, providerMetadata) {
         const resource = s3AmplifyMeta[category][resourceName];
 
         // Mobile hub migrated resources does not have an assigned provider
-        if (!resource.providerPlugin) {
+        if (resource.mobileHubMigrated === true) {
           _.set(amplifyMeta, [category, resourceName], resource);
           hasMigratedResources = true;
         }

--- a/packages/amplify-provider-awscloudformation/src/initialize-env.js
+++ b/packages/amplify-provider-awscloudformation/src/initialize-env.js
@@ -73,7 +73,7 @@ async function run(context, providerMetadata) {
   });
 
   //
-  // Download the meta file from the bucket and see if it has migrated resources (no provider field)
+  // Download the meta file from the bucket and see if it has migrated resources (mobileHubMigrated property === true)
   // copy those over to the reconstructed meta file.
   //
 


### PR DESCRIPTION
*Description of changes:*

The Mobile Hub migrator plugin has changed to include a `mobileHubMigrated` property on migrated resources. This PR updated the previous checks to be done against this property.

Also mobile hub checks for `env` commands are re-enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.