### PR TITLE
ci: add docker hub auth to config

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -6,6 +6,9 @@ defaults: &defaults
   working_directory: ~/repo
   docker:
     - image: circleci/node:10.18
+      auth:
+        username: $DOCKERHUB_USERNAME
+        password: $DOCKERHUB_ACCESS_TOKEN
   resource_class: large
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ defaults:
   working_directory: ~/repo
   docker: &ref_0
     - image: 'circleci/node:10.18'
+      auth:
+        username: $DOCKERHUB_USERNAME
+        password: $DOCKERHUB_ACCESS_TOKEN
   resource_class: large
 jobs:
   build:


### PR DESCRIPTION
Adding Docker Hub authentication to the CircleCI pipeline to accommodate [this change](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress) in Docker's ToS.

Here's the same change in JS for reference: https://github.com/aws-amplify/amplify-js/pull/7007

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
