### PR TITLE
More descriptive error on env cmd

### DIFF
--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -3,6 +3,7 @@ import { attachBackend } from '../attach-backend';
 import { constructInputParams } from '../amplify-service-helper';
 import { run as envCheckout } from './env/checkout';
 import { stateManager } from 'amplify-cli-core';
+import { get } from 'lodash';
 
 export const run = async context => {
   const inputParams = constructInputParams(context);

--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -13,13 +13,19 @@ export const run = async context => {
     const teamProviderInfo = stateManager.getTeamProviderInfo(projectPath);
     const { envName } = stateManager.getLocalEnvInfo(projectPath);
 
-    const { AmplifyAppId } = teamProviderInfo[envName].awscloudformation;
+    const appId = get(teamProviderInfo, [envName, 'awscloudformation', 'AmplifyAppId'], false);
+
     const localEnvNames = Object.keys(teamProviderInfo);
 
-    if (inputAppId && AmplifyAppId && inputAppId !== AmplifyAppId) {
+    if (inputAppId && appId && inputAppId !== appId) {
       context.print.error('Amplify appId mismatch.');
-      context.print.info(`You are currently working in the amplify project with Id ${AmplifyAppId}`);
-      throw new Error('Amplify appId');
+      context.print.info(`You are currently working in the amplify project with Id ${appId}`);
+      process.exit(1);
+    } else if (!appId) {
+      context.print.error(`Environment '${envName}' not found.`);
+      context.print.info(`Try running "amplify env add" to add a new environment.`);
+      context.print.info(`If this backend already exists, try restoring it's definition in your team-provider-info.json file.`);
+      process.exit(1);
     }
 
     if (inputEnvName) {

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -62,7 +62,11 @@ export async function initializeEnv(context: $TSContext, currentAmplifyMeta?: $T
       isPulling ? `Fetching updates to backend environment: ${currentEnv} from the cloud.` : `Initializing your environment: ${currentEnv}`,
     );
 
-    await sequential(initializationTasks);
+    try {
+      await sequential(initializationTasks);
+    } catch (e) {
+      throw Error(`Environment '${currentEnv}' not found in team-provider-info.json.`);
+    }
 
     spinner.succeed(
       isPulling ? `Successfully pulled backend environment ${currentEnv} from the cloud.` : 'Initialized provider successfully.',

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -65,7 +65,10 @@ export async function initializeEnv(context: $TSContext, currentAmplifyMeta?: $T
     try {
       await sequential(initializationTasks);
     } catch (e) {
-      throw Error(`${currentEnv} environment not found. Try running "amplify env add" to add a new environment.`);
+      context.print.error(`Environment '${currentEnv}' not found.`);
+      context.print.info(`Try running "amplify env add" to add a new environment.`);
+      context.print.info(`If this backend already exists, try restoring it's definition in your team-provider-info.json file.`);
+      process.exit(1);
     }
 
     spinner.succeed(

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -65,7 +65,7 @@ export async function initializeEnv(context: $TSContext, currentAmplifyMeta?: $T
     try {
       await sequential(initializationTasks);
     } catch (e) {
-      throw Error(`Environment '${currentEnv}' not found in team-provider-info.json.`);
+      throw Error(`${currentEnv} environment not found. Try running "amplify env add" to add a new environment.`);
     }
 
     spinner.succeed(


### PR DESCRIPTION
In a multi-backend workflow, if a teammate removes your backend/env from team-provider-info, amplify will fail on most env commands with a non-helpful error. This fixes that.

New CLI response:
![image](https://user-images.githubusercontent.com/4655474/96540466-76418600-1263-11eb-912f-e21482785410.png)


*Issue #, if available:*

*Description of changes:*
On the failing code, this applies a more descriptive error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.