### PR TITLE
fix(amplify-app): initialize feature flag 

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -106,8 +106,8 @@ async function createAmplifySkeletonProject() {
     console.log(`${emoji.get('guitar')} Creating base Amplify project`);
 
     return new Promise((resolve, reject) => {
-      const cmd = path.basename(process.argv[1]) === 'amplify-app-dev' ? amplifyDev : amplify;
-      const createSkeletonAmplifyProject = spawn(cmd, ['init', '--quickstart'], {
+      const amplifyCmd = path.basename(process.argv[1]) === 'amplify-app-dev' ? amplifyDev : amplify;
+      const createSkeletonAmplifyProject = spawn(amplifyCmd, ['init', '--quickstart'], {
         cwd: process.cwd(),
         env: process.env,
         stdio: 'inherit',

--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -14,6 +14,7 @@ const { engines } = require('../package.json');
 
 const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
 const amplify = /^win/.test(process.platform) ? 'amplify.cmd' : 'amplify';
+const amplifyDev = /^win/.test(process.platform) ? 'amplify-dev.cmd' : 'amplify-dev';
 const amplifyCliPackageName = '@aws-amplify/cli';
 
 function run() {
@@ -105,7 +106,8 @@ async function createAmplifySkeletonProject() {
     console.log(`${emoji.get('guitar')} Creating base Amplify project`);
 
     return new Promise((resolve, reject) => {
-      const createSkeletonAmplifyProject = spawn(amplify, ['init', '--quickstart'], {
+      const cmd = path.basename(process.argv[1]) === 'amplify-app-dev' ? amplifyDev : amplify;
+      const createSkeletonAmplifyProject = spawn(cmd, ['init', '--quickstart'], {
         cwd: process.cwd(),
         env: process.env,
         stdio: 'inherit',

--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -2,7 +2,14 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as url from 'url';
 import { execSync } from 'child_process';
-import { pathManager, $TSContext, NonEmptyDirectoryError, exitOnNextTick } from 'amplify-cli-core';
+import {
+  pathManager,
+  $TSContext,
+  NonEmptyDirectoryError,
+  exitOnNextTick,
+  CLIContextEnvironmentProvider,
+  FeatureFlags,
+} from 'amplify-cli-core';
 import { getPackageManager } from '../packageManagerHelpers';
 import { normalizePackageManagerForOS } from '../packageManagerHelpers';
 import { generateLocalEnvInfoFile } from './s9-onSuccess';
@@ -21,7 +28,7 @@ export async function preInitSetup(context: $TSContext) {
   }
 
   if (context.parameters.options.quickstart) {
-    await createAmplifySkeleton();
+    await createAmplifySkeleton(context);
     context.usageData.emitSuccess();
     exitOnNextTick(0);
   }
@@ -110,11 +117,24 @@ async function setLocalEnvDefaults(context: $TSContext) {
 /**
  * Extract amplify project structure with backend-config and project-config
  */
-async function createAmplifySkeleton() {
+async function createAmplifySkeleton(context: $TSContext) {
   insertAmplifyIgnore(pathManager.getGitIgnoreFilePath(process.cwd()));
 
   const skeletonLocalDir = path.join(__dirname, '..', '..', 'templates', 'amplify-skeleton');
   const skeletonProjectDir = path.join(pathManager.getAmplifyDirPath(process.cwd()));
 
   await fs.copy(skeletonLocalDir, skeletonProjectDir);
+
+  // Initialize feature flags
+  const contextEnvironmentProvider = new CLIContextEnvironmentProvider({
+    getEnvInfo: () => {
+      return context.exeInfo.localEnvInfo;
+    },
+  });
+
+  if (!FeatureFlags.isInitialized()) {
+    await FeatureFlags.initialize(contextEnvironmentProvider, true);
+  }
+
+  await FeatureFlags.ensureDefaultFeatureFlags(true);
 }

--- a/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
@@ -16,6 +16,7 @@ import {
   validateBackendConfig,
   validateModelgen,
   validateAmplifyPush,
+  validateFeatureFlags,
 } from '../amplify-app-helpers/amplify-app-validation';
 
 describe('amplify-app platform tests', () => {
@@ -37,6 +38,7 @@ describe('amplify-app platform tests', () => {
     validateProjectConfig(projRoot, 'android');
     validateApi(projRoot);
     validateBackendConfig(projRoot);
+    validateFeatureFlags(projRoot);
   });
 
   it('should setup an iOS project', async () => {
@@ -45,6 +47,7 @@ describe('amplify-app platform tests', () => {
     validateProjectConfig(projRoot, 'ios');
     validateApi(projRoot);
     validateBackendConfig(projRoot);
+    validateFeatureFlags(projRoot);
   });
 
   it('should set up a angular project', async () => {
@@ -53,6 +56,7 @@ describe('amplify-app platform tests', () => {
     validateProjectConfig(projRoot, 'javascript', 'angular');
     validateApi(projRoot);
     validateBackendConfig(projRoot);
+    validateFeatureFlags(projRoot);
   });
 
   it('should set up a react project and run scripts', async () => {
@@ -61,6 +65,7 @@ describe('amplify-app platform tests', () => {
     validateProjectConfig(projRoot, 'javascript', 'react');
     validateApi(projRoot);
     validateBackendConfig(projRoot);
+    validateFeatureFlags(projRoot);
     await addIntegAccountInConfig(projRoot);
     await amplifyModelgen(projRoot);
     validateModelgen(projRoot);

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { pathManager } from 'amplify-cli-core';
 
 function validateProject(projRoot: string, platform: string) {
   expect(fs.existsSync(path.join(projRoot, 'amplify'))).toBeTruthy();
@@ -83,4 +84,17 @@ function validateAmplifyPush(projRoot: string) {
   expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'amplify-meta.json'))).toBeTruthy();
 }
 
-export { validateProject, validateProjectConfig, validateApi, validateBackendConfig, validateModelgen, validateAmplifyPush };
+function validateFeatureFlags(projRoot: string) {
+  const testCLIJSONPath = pathManager.getCLIJSONFilePath(projRoot);
+  expect(fs.existsSync(testCLIJSONPath)).toBeTruthy();
+}
+
+export {
+  validateProject,
+  validateProjectConfig,
+  validateApi,
+  validateBackendConfig,
+  validateModelgen,
+  validateAmplifyPush,
+  validateFeatureFlags,
+};


### PR DESCRIPTION
Updated amplify-app to initialize feature flags and part of init process. Updated the Amplify App to load `amplify-dev` if the `amplify-app-dev` command is used