### PR TITLE
feat(graphql-key-transformer): change default to add GSIs when using @key

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -533,6 +533,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: false,
       },
+      {
+        name: 'secondaryKeyAsGSI',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
     ]);
 
     this.registerFlag('frontend-ios', [
@@ -568,13 +574,7 @@ export class FeatureFlags {
         type: 'boolean',
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
-      },
-      {
-        name: 'defaultSecondaryIndex',
-        type: 'boolean',
-        defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: true,
-      },
+      }
     ]);
   };
 }

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -569,6 +569,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
       },
+      {
+        name: 'defaultSecondaryIndex',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
     ]);
   };
 }

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -138,9 +138,12 @@ export function addApiWithSchemaAndConflictDetection(cwd: string, schemaFile: st
   });
 }
 
-export function updateApiSchema(cwd: string, projectName: string, schemaName: string) {
+export function updateApiSchema(cwd: string, projectName: string, schemaName: string, forceUpdate: boolean = false) {
   const testSchemaPath = getSchemaPath(schemaName);
-  const schemaText = fs.readFileSync(testSchemaPath).toString();
+  let schemaText = fs.readFileSync(testSchemaPath).toString();
+  if (forceUpdate) {
+    schemaText += '  ';
+  }
   updateSchema(cwd, projectName, schemaText);
 }
 

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -4,6 +4,16 @@ import * as fs from 'fs-extra';
 import _ from 'lodash';
 import { JSONUtilities } from 'amplify-cli-core';
 
+function getFeatureFlagConfig(projRoot: string) {
+  const featureFlagPath = path.join(projRoot, 'amplify', 'cli.json');
+  return JSONUtilities.readJson(featureFlagPath);
+}
+
+function setFeatureFlagConfig(projRoot: string, config: any) {
+  const featureFlagPath = path.join(projRoot, 'amplify', 'cli.json');
+  JSONUtilities.writeJson(featureFlagPath, config);
+}
+
 function getAWSConfigAndroidPath(projRoot: string): string {
   return path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'awsconfiguration.json');
 }
@@ -114,6 +124,8 @@ function setParameters(projRoot: string, category: string, resourceName: string,
 }
 
 export {
+  getFeatureFlagConfig,
+  setFeatureFlagConfig,
   getProjectMeta,
   getProjectTags,
   getBackendAmplifyMeta,

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -4,16 +4,6 @@ import * as fs from 'fs-extra';
 import _ from 'lodash';
 import { JSONUtilities } from 'amplify-cli-core';
 
-function getFeatureFlagConfig(projRoot: string) {
-  const featureFlagPath = path.join(projRoot, 'amplify', 'cli.json');
-  return JSONUtilities.readJson(featureFlagPath);
-}
-
-function setFeatureFlagConfig(projRoot: string, config: any) {
-  const featureFlagPath = path.join(projRoot, 'amplify', 'cli.json');
-  JSONUtilities.writeJson(featureFlagPath, config);
-}
-
 function getAWSConfigAndroidPath(projRoot: string): string {
   return path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'awsconfiguration.json');
 }
@@ -124,8 +114,6 @@ function setParameters(projRoot: string, category: string, resourceName: string,
 }
 
 export {
-  getFeatureFlagConfig,
-  setFeatureFlagConfig,
   getProjectMeta,
   getProjectTags,
   getBackendAmplifyMeta,

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts
@@ -1,6 +1,17 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushForce } from 'amplify-e2e-core';
-import { addApiWithSchema, apiGqlCompile } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  amplifyPushForce,
+  addApiWithSchema,
+  updateApiSchema,
+  apiGqlCompile,
+  createNewProjectDir,
+  deleteProjectDir,
+  getFeatureFlagConfig,
+  setFeatureFlagConfig,
+  amplifyPushUpdate,
+} from 'amplify-e2e-core';
 
 describe('amplify key force push', () => {
   let projRoot: string;
@@ -13,15 +24,39 @@ describe('amplify key force push', () => {
     deleteProjectDir(projRoot);
   });
 
-  it('init project, add key and migrate with force push', async () => {
+  // it('init project, add key and migrate with force push', async () => {
+  //   const projectName = 'keyforce';
+  //   const initialSchema = 'migrations_key/simple_key.graphql';
+  //   // init, add api and push with installed cli
+  //   await initJSProjectWithProfile(projRoot, { name: projectName });
+  //   await addApiWithSchema(projRoot, initialSchema);
+  //   await amplifyPush(projRoot);
+  //   // gql-compile and force push with codebase cli
+  //   await apiGqlCompile(projRoot, true);
+  //   await amplifyPushForce(projRoot, true);
+  // });
+
+  it('init project, add lsi key and force push expect error', async () => {
     const projectName = 'keyforce';
-    const initialSchema = 'migrations_key/simple_key.graphql';
+    const initialSchema = 'migrations_key/initial_schema.graphql';
     // init, add api and push with installed cli
     await initJSProjectWithProfile(projRoot, { name: projectName });
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+    // update feature flag
+    let featureFlagConfig = getFeatureFlagConfig(projRoot) as any;
+    featureFlagConfig.features.graphqltransformer['secondaryKeyAsGSI'] = true;
+    // write back to config
+    setFeatureFlagConfig(projRoot, featureFlagConfig);
+    // forceUpdateSchema
+    updateApiSchema(projRoot, projectName, initialSchema, true);
     // gql-compile and force push with codebase cli
-    await apiGqlCompile(projRoot, true);
-    await amplifyPushForce(projRoot, true);
+    await expect(
+      amplifyPushUpdate(
+        projRoot,
+        /Attempting to remove a local secondary index on the TodoTable table in the Todo stack.*/,
+        true,
+      ),
+    ).rejects.toThrowError(/Attempting to remove a local secondary index on the TodoTable table in the Todo stack.*/);
   });
 });

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts
@@ -8,9 +8,8 @@ import {
   apiGqlCompile,
   createNewProjectDir,
   deleteProjectDir,
-  getFeatureFlagConfig,
-  setFeatureFlagConfig,
   amplifyPushUpdate,
+  addFeatureFlag
 } from 'amplify-e2e-core';
 
 describe('amplify key force push', () => {
@@ -24,17 +23,17 @@ describe('amplify key force push', () => {
     deleteProjectDir(projRoot);
   });
 
-  // it('init project, add key and migrate with force push', async () => {
-  //   const projectName = 'keyforce';
-  //   const initialSchema = 'migrations_key/simple_key.graphql';
-  //   // init, add api and push with installed cli
-  //   await initJSProjectWithProfile(projRoot, { name: projectName });
-  //   await addApiWithSchema(projRoot, initialSchema);
-  //   await amplifyPush(projRoot);
-  //   // gql-compile and force push with codebase cli
-  //   await apiGqlCompile(projRoot, true);
-  //   await amplifyPushForce(projRoot, true);
-  // });
+  it('init project, add key and migrate with force push', async () => {
+    const projectName = 'keyforce';
+    const initialSchema = 'migrations_key/simple_key.graphql';
+    // init, add api and push with installed cli
+    await initJSProjectWithProfile(projRoot, { name: projectName });
+    await addApiWithSchema(projRoot, initialSchema);
+    await amplifyPush(projRoot);
+    // gql-compile and force push with codebase cli
+    await apiGqlCompile(projRoot, true);
+    await amplifyPushForce(projRoot, true);
+  });
 
   it('init project, add lsi key and force push expect error', async () => {
     const projectName = 'keyforce';
@@ -43,11 +42,8 @@ describe('amplify key force push', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
-    // update feature flag
-    let featureFlagConfig = getFeatureFlagConfig(projRoot) as any;
-    featureFlagConfig.features.graphqltransformer['secondaryKeyAsGSI'] = true;
-    // write back to config
-    setFeatureFlagConfig(projRoot, featureFlagConfig);
+    // add feature flag
+    addFeatureFlag(projRoot, 'graphqltransformer', 'secondaryKeyAsGSI', true);
     // forceUpdateSchema
     updateApiSchema(projRoot, projectName, initialSchema, true);
     // gql-compile and force push with codebase cli

--- a/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
@@ -31,6 +31,7 @@ import {
   migrateAPIProject,
   readProjectConfiguration,
   buildAPIProject,
+  TransformConfig,
 } from 'graphql-transformer-core';
 
 import { print } from 'graphql';
@@ -72,7 +73,7 @@ function getTransformerFactory(context, resourceDir, authConfig?) {
       transformerList.push(new SearchableModelTransformer());
     }
 
-    const customTransformersConfig = await readTransformerConfiguration(resourceDir);
+    const customTransformersConfig: TransformConfig = await readTransformerConfiguration(resourceDir);
     const customTransformers = (customTransformersConfig && customTransformersConfig.transformers
       ? customTransformersConfig.transformers
       : []

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -646,6 +646,7 @@ export class KeyTransformer extends Transformer {
     const tableResource = ctx.getResource(tableLogicalID);
     const primaryKeyDirective = getPrimaryKey(definition);
     const primaryPartitionKeyName = primaryKeyDirective ? getDirectiveArguments(primaryKeyDirective).fields[0] : 'id';
+    const defaultGSI = ctx.featureFlags.getBoolean('defaultSecondaryIndex', false);
     if (!tableResource) {
       throw new InvalidDirectiveError(`The @key directive may only be added to object definitions annotated with @model.`);
     } else {
@@ -656,7 +657,7 @@ export class KeyTransformer extends Transformer {
           ProjectionType: 'ALL',
         }),
       };
-      if (primaryPartitionKeyName === ks[0].AttributeName) {
+      if (primaryPartitionKeyName === ks[0].AttributeName && !defaultGSI) {
         // This is an LSI.
         // Add the new secondary index and update the table's attribute definitions.
         tableResource.Properties.LocalSecondaryIndexes = append(

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -646,7 +646,7 @@ export class KeyTransformer extends Transformer {
     const tableResource = ctx.getResource(tableLogicalID);
     const primaryKeyDirective = getPrimaryKey(definition);
     const primaryPartitionKeyName = primaryKeyDirective ? getDirectiveArguments(primaryKeyDirective).fields[0] : 'id';
-    const defaultGSI = ctx.featureFlags.getBoolean('defaultSecondaryIndex', false);
+    const defaultGSI = ctx.featureFlags.getBoolean('secondaryKeyAsGSI', false);
     if (!tableResource) {
       throw new InvalidDirectiveError(`The @key directive may only be added to object definitions annotated with @model.`);
     } else {

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -11,6 +11,7 @@ import { FeatureFlagProvider } from '../FeatureFlags';
 import {
   cantAddAndRemoveGSIAtSameTimeRule,
   cantAddLSILaterRule,
+  cantRemoveLSILater,
   cantEditGSIKeySchemaRule,
   cantEditKeySchemaRule,
   cantEditLSIKeySchemaRule,
@@ -64,6 +65,7 @@ export async function buildProject(opts: ProjectOptions) {
           // LSI
           cantEditKeySchemaRule,
           cantAddLSILaterRule,
+          cantRemoveLSILater,
           cantEditLSIKeySchemaRule,
         ];
 
@@ -74,6 +76,7 @@ export async function buildProject(opts: ProjectOptions) {
           // LSI
           cantEditKeySchemaRule,
           cantAddLSILaterRule,
+          cantRemoveLSILater,
           cantEditLSIKeySchemaRule,
           // GSI
           cantEditGSIKeySchemaRule,

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -333,6 +333,28 @@ export const cantEditLSIKeySchemaRule = (diff: Diff, currentBuild: DiffableProje
   }
 };
 
+export function cantRemoveLSILater(diff: Diff, currentBuild: DiffableProject, nextBuild: DiffableProject) {
+  const throwError = (stackName: string, tableName: string): void => {
+    throw new InvalidMigrationError(
+      `Attempting to remove a local secondary index on the ${tableName} table in the ${stackName} stack.`,
+      'A local secondary index cannot be removed after deployment.',
+      'In order to remove the local secondary index you need to delete or rename the table.',
+    );
+  };
+  // if removing more than one lsi
+  if (diff.kind === 'D' && diff.lhs && diff.path.length === 6 && diff.path[5] === 'LocalSecondaryIndexes') {
+    const tableName = diff.path[3];
+    const stackName = path.basename(diff.path[1], '.json');
+    throwError(stackName, tableName);
+  }
+ // if removing one lsi
+  if(diff.kind === 'A' && diff.item.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'LocalSecondaryIndexes') {
+    const tableName = diff.path[3];
+    const stackName = path.basename(diff.path[1], '.json');
+    throwError(stackName, tableName);
+  }
+}
+
 export const cantHaveMoreThan500ResourcesRule = (diffs: Diff[], currentBuild: DiffableProject, nextBuild: DiffableProject): void => {
   const stackKeys = Object.keys(nextBuild.stacks);
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -336,7 +336,7 @@ test('Test that a secondary @key with a multiple field adds an LSI.', () => {
         return defaultValue || '';
       },
       getBoolean: (featureName: string, defaultValue: boolean) => {
-        if (featureName === 'defaultSecondaryIndex') return true;
+        if (featureName === 'secondaryKeyAsGSI') return true;
         return defaultValue || false;
       },
       getObject: (featureName: string, defaultValue: Object) => {
@@ -388,7 +388,7 @@ test('Test that a secondary @key with a multiple field adds an GSI based on enab
         return defaultValue || '';
       },
       getBoolean: (featureName: string, defaultValue: boolean) => {
-        if (featureName === 'defaultSecondaryIndex') return true;
+        if (featureName === 'secondaryKeyAsGSI') return true;
         return defaultValue || false;
       },
       getObject: (featureName: string, defaultValue: Object) => {


### PR DESCRIPTION
*Description of changes:*
- changed the default to adding GSI when creating a secondary index
- Added sanity check when removing an LSI from an already existing table
- Will maintain previous behavior via a feature flag
```json
{
  "features":
  {
    "graphqltransformer":
    {
      "secondaryKeyAsGSI": true
    }
  }
}
```

*Issue #, if available:*
- re #2702 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.