### PR TITLE
fix(amplify-codegen): sourceDir path issues in graphql schema location

### DIFF
--- a/packages/amplify-app/src/framework-config-mapping.js
+++ b/packages/amplify-app/src/framework-config-mapping.js
@@ -8,8 +8,8 @@ const reactConfig = {
 };
 
 const reactNativeConfig = {
-  SourceDir: '/',
-  DistributionDir: '/',
+  SourceDir: './',
+  DistributionDir: './',
   BuildCommand: `${npm} run-script build`,
   StartCommand: `${npm} run-script start`,
 };
@@ -36,7 +36,7 @@ const vueConfig = {
 };
 
 const emberConfig = {
-  SourceDir: '/',
+  SourceDir: './',
   DistributionDir: 'dist',
   BuildCommand: `${npm} run-script build -- -e production`,
   StartCommand: `${npm} run-script start`,

--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const { pathManager } = require('amplify-cli-core');
+
 const loadConfig = require('../codegen-config');
 const generateStatements = require('../commands/statements');
 const generateTypes = require('../commands/types');
@@ -10,12 +13,17 @@ async function postPushCallback(context, graphQLConfig) {
     return;
   }
 
+  const projectPath = pathManager.findProjectRoot();
+  if (!projectPath) {
+    return;
+  }
+
   if (!graphQLConfig.gqlConfig.schema) {
     const config = loadConfig(context);
     const schemaLocation = getSchemaDownloadLocation(context);
 
     const newProject = graphQLConfig.gqlConfig;
-    newProject.schema = schemaLocation;
+    newProject.schema = path.join(projectPath, schemaLocation);
     config.addProject(newProject);
     config.save();
   }

--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -13,17 +13,14 @@ async function postPushCallback(context, graphQLConfig) {
     return;
   }
 
-  const projectPath = pathManager.findProjectRoot();
-  if (!projectPath) {
-    return;
-  }
-
   if (!graphQLConfig.gqlConfig.schema) {
     const config = loadConfig(context);
-    const schemaLocation = getSchemaDownloadLocation(context);
+
+    const projectPath = pathManager.findProjectRoot() || process.cwd();
+    const schemaLocation = path.join(projectPath, getSchemaDownloadLocation(context));
 
     const newProject = graphQLConfig.gqlConfig;
-    newProject.schema = path.join(projectPath, schemaLocation);
+    newProject.schema = schemaLocation;
     config.addProject(newProject);
     config.save();
   }

--- a/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
+++ b/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
@@ -12,8 +12,8 @@ const reactConfig = {
 };
 
 const reactNativeConfig = {
-  SourceDir: '/',
-  DistributionDir: '/',
+  SourceDir: './',
+  DistributionDir: './',
   BuildCommand: `${npm} run-script build`,
   StartCommand: `${npm} run-script start`,
 };
@@ -40,7 +40,7 @@ const vueConfig = {
 };
 
 const emberConfig = {
-  SourceDir: '/',
+  SourceDir: './',
   DistributionDir: 'dist',
   BuildCommand: `${npm} run-script build -- -e production`,
   StartCommand: `${npm} run-script start`,


### PR DESCRIPTION
*Issue #, if available:*
Resolves #5483

*Description of changes:*
#5334 c63014558547f75a0afa7e506116d8bb124c44d2 changed `amplify-codegen` from hard coding `src` to using `SourceDir` in the config file. 
This resulted in the default sourceDir value `/` (system root) for reactnative being used. This PR corrects the default dir values to `./`.

The commit/bug in question affects releases starting from CLI version `4.29.4`.

**UPDATE:** the root cause has been identified to be in `doPushCallback.js` where the GraphQL schema location did not use `path.join` with project root. The PR has been updated to make the correction.

*Other:*
Docs PR: aws-amplify/docs#2581

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.