### PR TITLE
fix: update current-cloud backend-config on resource removal

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
@@ -35,14 +35,7 @@ export const safeDefaults = [
 ];
 
 // These attributes cannot be modified once the auth resource is created
-export const immutableAttributes = [
-  'resourceName',
-  'userPoolName',
-  'identityPoolName',
-  'usernameAttributes',
-  'autoVerifiedAttributes',
-  'requiredAttributes',
-];
+export const immutableAttributes = ['resourceName', 'userPoolName', 'identityPoolName', 'usernameAttributes', 'requiredAttributes'];
 
 export const privateKeys = [
   'facebookAppIdUserPool',

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
@@ -53,7 +53,10 @@ function moveBackendResourcesToCurrentCloudBackend(resources) {
 
     fs.ensureDirSync(targetDir);
 
-    fs.copySync(sourceDir, targetDir);
+    // in the case that the resource is being deleted, the sourceDir won't exist
+    if (fs.pathExistsSync(sourceDir)) {
+      fs.copySync(sourceDir, targetDir);
+    }
   }
 
   fs.copySync(amplifyMetaFilePath, amplifyCloudMetaFilePath, { overwrite: true });
@@ -137,10 +140,12 @@ export async function updateamplifyMetaAfterPush(resources) {
     // Skip hash calculation for imported resources
     if (resources[i].serviceType !== 'imported') {
       const sourceDir = path.normalize(path.join(pathManager.getBackendDirPath(), resources[i].category, resources[i].resourceName));
-      const hashDir = await getHashForResourceDir(sourceDir);
-
-      amplifyMeta[resources[i].category][resources[i].resourceName].lastPushDirHash = hashDir;
-      amplifyMeta[resources[i].category][resources[i].resourceName].lastPushTimeStamp = currentTimestamp;
+      // skip hasing deleted resources
+      if (fs.pathExistsSync(sourceDir)) {
+        const hashDir = await getHashForResourceDir(sourceDir);
+        amplifyMeta[resources[i].category][resources[i].resourceName].lastPushDirHash = hashDir;
+        amplifyMeta[resources[i].category][resources[i].resourceName].lastPushTimeStamp = currentTimestamp;
+      }
     }
 
     // If the operation was a remove-sync then for imported resources we cannot set timestamp

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
@@ -140,7 +140,7 @@ export async function updateamplifyMetaAfterPush(resources) {
     // Skip hash calculation for imported resources
     if (resources[i].serviceType !== 'imported') {
       const sourceDir = path.normalize(path.join(pathManager.getBackendDirPath(), resources[i].category, resources[i].resourceName));
-      // skip hasing deleted resources
+      // skip hashing deleted resources
       if (fs.pathExistsSync(sourceDir)) {
         const hashDir = await getHashForResourceDir(sourceDir);
         amplifyMeta[resources[i].category][resources[i].resourceName].lastPushDirHash = hashDir;

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -41,6 +41,11 @@ function getBackendConfig(projectRoot: string) {
   return JSON.parse(fs.readFileSync(backendFConfigFilePath, 'utf8'));
 }
 
+function getCloudBackendConfig(projectRoot: string) {
+  const currentCloudPath = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'backend-config.json');
+  return JSON.parse(fs.readFileSync(currentCloudPath, 'utf8'));
+}
+
 function getTeamProviderInfo(projectRoot: string) {
   const teamProviderFilePath = path.join(projectRoot, 'amplify', 'team-provider-info.json');
   return JSON.parse(fs.readFileSync(teamProviderFilePath, 'utf8'));
@@ -78,4 +83,5 @@ export {
   getAmplifyDirPath,
   getBackendConfig,
   getTeamProviderInfo,
+  getCloudBackendConfig,
 };

--- a/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
@@ -6,6 +6,7 @@ import {
   addHeadlessAuth,
   updateHeadlessAuth,
   removeHeadlessAuth,
+  getCloudBackendConfig,
 } from 'amplify-e2e-core';
 import { addAuthWithDefault, getBackendAmplifyMeta } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool } from 'amplify-e2e-core';
@@ -85,10 +86,17 @@ describe('headless auth', () => {
   it('removes auth resource', async () => {
     await initJSProjectWithProfile(projRoot, defaultsSettings);
     await addAuthWithDefault(projRoot, {});
+    await amplifyPushAuth(projRoot);
     const { auth: authBefore } = getBackendAmplifyMeta(projRoot);
     const authResourceName = _.keys(authBefore).find(() => true); // first element or undefined
+    expect(authResourceName).toBeDefined();
+    const { auth: authBackendConfigBefore } = getCloudBackendConfig(projRoot);
+    expect(_.isEmpty(authBackendConfigBefore)).toBe(false);
     await removeHeadlessAuth(projRoot, authResourceName);
+    await amplifyPushAuth(projRoot);
     const { auth: authAfter } = getBackendAmplifyMeta(projRoot);
     expect(_.isEmpty(authAfter)).toBe(true);
+    const { auth: authBackendConfigAfter } = getCloudBackendConfig(projRoot);
+    expect(_.isEmpty(authBackendConfigAfter)).toBe(true);
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.js
@@ -68,7 +68,7 @@ async function run(context, resourceDefinition) {
     await postPushGraphQLCodegen(context);
     await amplifyServiceManager.postPushCheck(context);
 
-    if (resources.length > 0) {
+    if (resources.concat(resourcesToBeDeleted).length > 0) {
       await context.amplify.updateamplifyMetaAfterPush(resources);
     }
 


### PR DESCRIPTION
Update #current-cloud-backend/backend-config.json on resource removal
Also remove autoVerifiedAttributes from auth immutable attribute list as it is mutable: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-autoverifiedattributes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.