### PR TITLE
fix: use correct version of amplify-cli-core

### DIFF
--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "amplify-cli-core": "1.3.4",
+    "amplify-cli-core": "1.4.0",
     "aws-sdk": "^2.765.0",
     "detect-port": "^1.3.0",
     "event-to-promise": "^0.8.0",

--- a/packages/amplify-go-function-runtime-provider/package.json
+++ b/packages/amplify-go-function-runtime-provider/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib tsconfig.tsbuildinfo resources/localinvoke/go.sum resources/localinvoke/main resources/localinvoke/main.exe"
   },
   "dependencies": {
-    "amplify-cli-core": "1.3.4",
+    "amplify-cli-core": "1.4.0",
     "amplify-function-plugin-interface": "1.4.1",
     "archiver": "^3.1.1",
     "execa": "^4.0.0",

--- a/packages/amplify-java-function-runtime-provider/package.json
+++ b/packages/amplify-java-function-runtime-provider/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "amplify-cli-core": "1.3.4",
+    "amplify-cli-core": "1.4.0",
     "amplify-function-plugin-interface": "1.4.1",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-python-function-runtime-provider/package.json
+++ b/packages/amplify-python-function-runtime-provider/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "amplify-cli-core": "1.3.4",
+    "amplify-cli-core": "1.4.0",
     "amplify-function-plugin-interface": "1.4.1",
     "archiver": "^3.1.1",
     "execa": "^4.0.0",


### PR DESCRIPTION
Use latest version of amplify-cli-core in all packages

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.