### PR TITLE
[fix] Helpful "Learn More" answer for "Do you want to add an admin queries API?" 

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -308,7 +308,7 @@ export const supportedServices = {
       {
         key: 'adminQueries',
         question: 'Do you want to add an admin queries API?',
-        learnMore: 'TODO: Find out what admin queries APIs are',
+        learnMore: 'Admin Queries API let you perform user admin functions from your frontend. See https://docs.amplify.aws/cli/auth/admin#admin-queries-api for more.',
         required: true,
         type: 'list',
         map: 'booleanOptions',

--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -308,7 +308,7 @@ export const supportedServices = {
       {
         key: 'adminQueries',
         question: 'Do you want to add an admin queries API?',
-        learnMore: 'This flow will help you add multiple user pool groups to your user-pool',
+        learnMore: 'TODO: Find out what admin queries APIs are',
         required: true,
         type: 'list',
         map: 'booleanOptions',


### PR DESCRIPTION
*Description of changes:*

This prompt is duplicated from the prompt above it. It is very frustrating to hit "Learn More" and get an unhelpful answer, it is beyond frustrating to get a duplicate answer.