### PR TITLE
fix add-to-group.js template from using mixed async/sync AWS Lambda code style

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
@@ -21,7 +21,10 @@ exports.handler = async (event, context) => {
 
   try {
     await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
-    return event
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ event })
+    }
   } catch (error) {
     return {
       statusCode: 500,

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
@@ -23,12 +23,12 @@ exports.handler = async (event, context) => {
     await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
     return {
       statusCode: 500,
-      body: JSON.stringify({ event })
+      body: JSON.stringify(event)
     }
   } catch (error) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error })
+      body: JSON.stringify(error)
     }
   }
 };

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
@@ -1,6 +1,6 @@
 /* eslint-disable-line */ const aws = require('aws-sdk');
 
-exports.handler = async (event, context, callback) => {
+exports.handler = async (event, context) => {
   const cognitoidentityserviceprovider = new aws.CognitoIdentityServiceProvider({ apiVersion: '2016-04-18' });
   const groupParams = {
     GroupName: process.env.GROUP,
@@ -21,8 +21,11 @@ exports.handler = async (event, context, callback) => {
 
   try {
     await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
-    callback(null, event);
-  } catch (e) {
-    callback(e);
+    return event
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error })
+    }
   }
 };

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
@@ -22,7 +22,7 @@ exports.handler = async (event, context) => {
   try {
     await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
     return {
-      statusCode: 500,
+      statusCode: 200,
       body: JSON.stringify(event)
     }
   } catch (error) {


### PR DESCRIPTION
*Description of changes:* we use both `async` and `callback` style lambda functions in the functions we generate for people. [this is an antipattern](https://dev.to/theburningmonk/common-node-js-mistakes-in-lambda-4a4j)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.