### PR TITLE
fix: show app id when listing console apps

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/attach-backend.js
+++ b/packages/amplify-provider-awscloudformation/src/attach-backend.js
@@ -135,7 +135,7 @@ async function getAmplifyApp(context, amplifyClient) {
     const options = [];
     apps.forEach(app => {
       const option = {
-        name: `${app.name}`,
+        name: `${app.name} (${app.appId})`,
         value: app,
         short: app.appId,
       };


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Show Amplify Application ID when listing applications upon `pull` to help customers disambiguate if more applications are having the same name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.