### PR TITLE
test: run amplify post-install before migration tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -232,6 +232,7 @@ jobs:
           command: |
             source .circleci/local_publish_helpers.sh
             changeNpmGlobalPath
+            ./packages/amplify-cli/bin/amplify post-install
             cd packages/amplify-migration-tests
             yarn run migration_v4.0.0 --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
@@ -256,6 +257,7 @@ jobs:
           command: |
             source .circleci/local_publish_helpers.sh
             changeNpmGlobalPath
+            ./packages/amplify-cli/bin/amplify post-install
             cd packages/amplify-migration-tests
             yarn run migration --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,7 @@ jobs:
           command: |
             source .circleci/local_publish_helpers.sh
             changeNpmGlobalPath
+            ./packages/amplify-cli/bin/amplify post-install
             cd packages/amplify-migration-tests
             yarn run migration_v4.0.0 --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
@@ -314,6 +315,7 @@ jobs:
           command: |
             source .circleci/local_publish_helpers.sh
             changeNpmGlobalPath
+            ./packages/amplify-cli/bin/amplify post-install
             cd packages/amplify-migration-tests
             yarn run migration --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "rm-aa-dev-link": "rm -f $(yarn global bin)/amplify-app-dev",
     "link-dev": "cd packages/amplify-cli && ln -s $(pwd)/bin/amplify $(yarn global bin)/amplify-dev && cd -",
     "rm-dev-link": "rm -f $(yarn global bin)/amplify-dev",
-    "setup-dev": "yarn dev-build && yarn rm-dev-link && yarn link-dev && yarn rm-aa-dev-link && yarn link-aa-dev && yarn dev-postinstall",
+    "setup-dev": "yarn dev-build && yarn rm-dev-link && yarn link-dev && yarn rm-aa-dev-link && yarn link-aa-dev",
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify",
     "setup-dev-win": "yarn dev-build && yarn link-win && yarn link-caa",
     "split-e2e-tests":"yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -197,7 +197,7 @@ export async function loadPluginFromFactory(pluginPath, expectedFactoryFunction,
   try {
     plugin = await import(pluginPath);
   } catch (err) {
-    throw new Error('Could not load selected plugin');
+    throw new Error(`Could not load selected plugin. Error is [${err}]`);
   }
   if (!plugin) {
     throw new Error('Could not load selected plugin');


### PR DESCRIPTION
Because the migration tests do not install the CLI from verdaccio, the post-install script was never being run. Added a step to the job to explicitly run the post-install step

Tested by sshing to a circleci job
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.