### PR TITLE
fix(amplify-codegen-appsync-model-plugin): revert changes of adding ownerField for implicit cases for @auth

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -30,11 +30,9 @@ public final class customClaim implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField BAR = field(\\"bar\\");
-  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -47,15 +45,10 @@ public final class customClaim implements Model {
       return bar;
   }
   
-  public String getOwner() {
-      return owner;
-  }
-  
-  private customClaim(String id, String name, String bar, String owner) {
+  private customClaim(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.owner = owner;
   }
   
   @Override
@@ -68,8 +61,7 @@ public final class customClaim implements Model {
       customClaim customClaim = (customClaim) obj;
       return ObjectsCompat.equals(getId(), customClaim.getId()) &&
               ObjectsCompat.equals(getName(), customClaim.getName()) &&
-              ObjectsCompat.equals(getBar(), customClaim.getBar()) &&
-              ObjectsCompat.equals(getOwner(), customClaim.getOwner());
+              ObjectsCompat.equals(getBar(), customClaim.getBar());
       }
   }
   
@@ -79,7 +71,6 @@ public final class customClaim implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
-      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -90,8 +81,7 @@ public final class customClaim implements Model {
       .append(\\"customClaim {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
-      .append(\\"owner=\\" + String.valueOf(getOwner()))
+      .append(\\"bar=\\" + String.valueOf(getBar()))
       .append(\\"}\\")
       .toString();
   }
@@ -122,7 +112,6 @@ public final class customClaim implements Model {
     return new customClaim(
       id,
       null,
-      null,
       null
     );
   }
@@ -130,15 +119,13 @@ public final class customClaim implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      owner);
+      bar);
   }
   public interface BuildStep {
     customClaim build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep owner(String owner);
   }
   
 
@@ -146,7 +133,6 @@ public final class customClaim implements Model {
     private String id;
     private String name;
     private String bar;
-    private String owner;
     @Override
      public customClaim build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -154,8 +140,7 @@ public final class customClaim implements Model {
         return new customClaim(
           id,
           name,
-          bar,
-          owner);
+          bar);
     }
     
     @Override
@@ -167,12 +152,6 @@ public final class customClaim implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
         return this;
     }
     
@@ -199,11 +178,10 @@ public final class customClaim implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, String owner) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .owner(owner);
+        .bar(bar);
     }
     
     @Override
@@ -214,11 +192,6 @@ public final class customClaim implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
     }
   }
   
@@ -457,14 +430,12 @@ public final class Employee implements Model {
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField ADDRESS = field(\\"address\\");
   public static final QueryField SSN = field(\\"ssn\\");
-  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String address;
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
   }) String ssn;
-  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -481,16 +452,11 @@ public final class Employee implements Model {
       return ssn;
   }
   
-  public String getOwner() {
-      return owner;
-  }
-  
-  private Employee(String id, String name, String address, String ssn, String owner) {
+  private Employee(String id, String name, String address, String ssn) {
     this.id = id;
     this.name = name;
     this.address = address;
     this.ssn = ssn;
-    this.owner = owner;
   }
   
   @Override
@@ -504,8 +470,7 @@ public final class Employee implements Model {
       return ObjectsCompat.equals(getId(), employee.getId()) &&
               ObjectsCompat.equals(getName(), employee.getName()) &&
               ObjectsCompat.equals(getAddress(), employee.getAddress()) &&
-              ObjectsCompat.equals(getSsn(), employee.getSsn()) &&
-              ObjectsCompat.equals(getOwner(), employee.getOwner());
+              ObjectsCompat.equals(getSsn(), employee.getSsn());
       }
   }
   
@@ -516,7 +481,6 @@ public final class Employee implements Model {
       .append(getName())
       .append(getAddress())
       .append(getSsn())
-      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -528,8 +492,7 @@ public final class Employee implements Model {
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
       .append(\\"address=\\" + String.valueOf(getAddress()) + \\", \\")
-      .append(\\"ssn=\\" + String.valueOf(getSsn()) + \\", \\")
-      .append(\\"owner=\\" + String.valueOf(getOwner()))
+      .append(\\"ssn=\\" + String.valueOf(getSsn()))
       .append(\\"}\\")
       .toString();
   }
@@ -561,7 +524,6 @@ public final class Employee implements Model {
       id,
       null,
       null,
-      null,
       null
     );
   }
@@ -570,8 +532,7 @@ public final class Employee implements Model {
     return new CopyOfBuilder(id,
       name,
       address,
-      ssn,
-      owner);
+      ssn);
   }
   public interface NameStep {
     AddressStep name(String name);
@@ -587,7 +548,6 @@ public final class Employee implements Model {
     Employee build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep ssn(String ssn);
-    BuildStep owner(String owner);
   }
   
 
@@ -596,7 +556,6 @@ public final class Employee implements Model {
     private String name;
     private String address;
     private String ssn;
-    private String owner;
     @Override
      public Employee build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -605,8 +564,7 @@ public final class Employee implements Model {
           id,
           name,
           address,
-          ssn,
-          owner);
+          ssn);
     }
     
     @Override
@@ -626,12 +584,6 @@ public final class Employee implements Model {
     @Override
      public BuildStep ssn(String ssn) {
         this.ssn = ssn;
-        return this;
-    }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
         return this;
     }
     
@@ -658,12 +610,11 @@ public final class Employee implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String address, String ssn, String owner) {
+    private CopyOfBuilder(String id, String name, String address, String ssn) {
       super.id(id);
       super.name(name)
         .address(address)
-        .ssn(ssn)
-        .owner(owner);
+        .ssn(ssn);
     }
     
     @Override
@@ -679,11 +630,6 @@ public final class Employee implements Model {
     @Override
      public CopyOfBuilder ssn(String ssn) {
       return (CopyOfBuilder) super.ssn(ssn);
-    }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
     }
   }
   
@@ -920,11 +866,9 @@ public final class simpleOwnerAuth implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField BAR = field(\\"bar\\");
-  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -937,15 +881,10 @@ public final class simpleOwnerAuth implements Model {
       return bar;
   }
   
-  public String getOwner() {
-      return owner;
-  }
-  
-  private simpleOwnerAuth(String id, String name, String bar, String owner) {
+  private simpleOwnerAuth(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.owner = owner;
   }
   
   @Override
@@ -958,8 +897,7 @@ public final class simpleOwnerAuth implements Model {
       simpleOwnerAuth simpleOwnerAuth = (simpleOwnerAuth) obj;
       return ObjectsCompat.equals(getId(), simpleOwnerAuth.getId()) &&
               ObjectsCompat.equals(getName(), simpleOwnerAuth.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleOwnerAuth.getBar()) &&
-              ObjectsCompat.equals(getOwner(), simpleOwnerAuth.getOwner());
+              ObjectsCompat.equals(getBar(), simpleOwnerAuth.getBar());
       }
   }
   
@@ -969,7 +907,6 @@ public final class simpleOwnerAuth implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
-      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -980,8 +917,7 @@ public final class simpleOwnerAuth implements Model {
       .append(\\"simpleOwnerAuth {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
-      .append(\\"owner=\\" + String.valueOf(getOwner()))
+      .append(\\"bar=\\" + String.valueOf(getBar()))
       .append(\\"}\\")
       .toString();
   }
@@ -1012,7 +948,6 @@ public final class simpleOwnerAuth implements Model {
     return new simpleOwnerAuth(
       id,
       null,
-      null,
       null
     );
   }
@@ -1020,15 +955,13 @@ public final class simpleOwnerAuth implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      owner);
+      bar);
   }
   public interface BuildStep {
     simpleOwnerAuth build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep owner(String owner);
   }
   
 
@@ -1036,7 +969,6 @@ public final class simpleOwnerAuth implements Model {
     private String id;
     private String name;
     private String bar;
-    private String owner;
     @Override
      public simpleOwnerAuth build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1044,8 +976,7 @@ public final class simpleOwnerAuth implements Model {
         return new simpleOwnerAuth(
           id,
           name,
-          bar,
-          owner);
+          bar);
     }
     
     @Override
@@ -1057,12 +988,6 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
         return this;
     }
     
@@ -1089,11 +1014,10 @@ public final class simpleOwnerAuth implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, String owner) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .owner(owner);
+        .bar(bar);
     }
     
     @Override
@@ -1104,11 +1028,6 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
     }
   }
   
@@ -1146,11 +1065,9 @@ public final class allowRead implements Model {
   public static final QueryField ID = field(\\"id\\");
   public static final QueryField NAME = field(\\"name\\");
   public static final QueryField BAR = field(\\"bar\\");
-  public static final QueryField OWNER = field(\\"owner\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"String\\") String owner;
   public String getId() {
       return id;
   }
@@ -1163,15 +1080,10 @@ public final class allowRead implements Model {
       return bar;
   }
   
-  public String getOwner() {
-      return owner;
-  }
-  
-  private allowRead(String id, String name, String bar, String owner) {
+  private allowRead(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.owner = owner;
   }
   
   @Override
@@ -1184,8 +1096,7 @@ public final class allowRead implements Model {
       allowRead allowRead = (allowRead) obj;
       return ObjectsCompat.equals(getId(), allowRead.getId()) &&
               ObjectsCompat.equals(getName(), allowRead.getName()) &&
-              ObjectsCompat.equals(getBar(), allowRead.getBar()) &&
-              ObjectsCompat.equals(getOwner(), allowRead.getOwner());
+              ObjectsCompat.equals(getBar(), allowRead.getBar());
       }
   }
   
@@ -1195,7 +1106,6 @@ public final class allowRead implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
-      .append(getOwner())
       .toString()
       .hashCode();
   }
@@ -1206,8 +1116,7 @@ public final class allowRead implements Model {
       .append(\\"allowRead {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
-      .append(\\"owner=\\" + String.valueOf(getOwner()))
+      .append(\\"bar=\\" + String.valueOf(getBar()))
       .append(\\"}\\")
       .toString();
   }
@@ -1238,7 +1147,6 @@ public final class allowRead implements Model {
     return new allowRead(
       id,
       null,
-      null,
       null
     );
   }
@@ -1246,15 +1154,13 @@ public final class allowRead implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      owner);
+      bar);
   }
   public interface BuildStep {
     allowRead build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep owner(String owner);
   }
   
 
@@ -1262,7 +1168,6 @@ public final class allowRead implements Model {
     private String id;
     private String name;
     private String bar;
-    private String owner;
     @Override
      public allowRead build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1270,8 +1175,7 @@ public final class allowRead implements Model {
         return new allowRead(
           id,
           name,
-          bar,
-          owner);
+          bar);
     }
     
     @Override
@@ -1283,12 +1187,6 @@ public final class allowRead implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
         return this;
     }
     
@@ -1315,11 +1213,10 @@ public final class allowRead implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, String owner) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .owner(owner);
+        .bar(bar);
     }
     
     @Override
@@ -1330,11 +1227,6 @@ public final class allowRead implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
     }
   }
   

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -76,10 +76,10 @@ describe('Javascript visitor', () => {
       const imports = (visitor as any).generateImportsJavaScriptImplementation();
       validateTs(imports);
       expect(imports).toMatchInlineSnapshot(`
-"// @ts-check
-import { initSchema } from '@aws-amplify/datastore';
-import { schema } from './schema';"
-`);
+        "// @ts-check
+        import { initSchema } from '@aws-amplify/datastore';
+        import { schema } from './schema';"
+      `);
     });
   });
 
@@ -96,35 +96,35 @@ import { schema } from './schema';"
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: (string | null)[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: (string | null)[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly foo?: Bar[];
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          readonly foo?: Bar[];
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }
 
-export declare class Bar {
-  readonly id: string;
-  readonly simpleModelFooId?: string;
-  constructor(init: ModelInit<Bar>);
-  static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
-}"
-`);
+        export declare class Bar {
+          readonly id: string;
+          readonly simpleModelFooId?: string;
+          constructor(init: ModelInit<Bar>);
+          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -146,24 +146,24 @@ export declare class Bar {
     const codeBlock = jsVisitor.generate();
     validateTs(codeBlock);
     expect(codeBlock).toMatchInlineSnapshot(`
-"// @ts-check
-import { initSchema } from '@aws-amplify/datastore';
-import { schema } from './schema';
+      "// @ts-check
+      import { initSchema } from '@aws-amplify/datastore';
+      import { schema } from './schema';
 
-const SimpleEnum = {
-  \\"ENUM_VAL1\\": \\"enumVal1\\",
-  \\"ENUM_VAL2\\": \\"enumVal2\\"
-};
+      const SimpleEnum = {
+        \\"ENUM_VAL1\\": \\"enumVal1\\",
+        \\"ENUM_VAL2\\": \\"enumVal2\\"
+      };
 
-const { SimpleModel, Bar, SimpleNonModelType } = initSchema(schema);
+      const { SimpleModel, Bar, SimpleNonModelType } = initSchema(schema);
 
-export {
-  SimpleModel,
-  Bar,
-  SimpleEnum,
-  SimpleNonModelType
-};"
-`);
+      export {
+        SimpleModel,
+        Bar,
+        SimpleEnum,
+        SimpleNonModelType
+      };"
+    `);
     expect(generateEnumObjectSpy).toHaveBeenCalledWith((jsVisitor as any).enumMap['SimpleEnum']);
 
     expect(generateImportsJavaScriptImplementationSpy).toHaveBeenCalledTimes(1);
@@ -208,7 +208,7 @@ describe('Javascript visitor with default owner auth', () => {
       jest.resetAllMocks();
     });
 
-    it('should add owner field to Javascript declaration', () => {
+    it('should not add default owner field to Javascript declaration', () => {
       const declarationVisitor = getVisitor(schema, true);
       const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
       const generateEnumDeclarationsSpy = jest.spyOn(declarationVisitor as any, 'generateEnumDeclarations');
@@ -216,28 +216,27 @@ describe('Javascript visitor with default owner auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: (string | null)[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: (string | null)[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly owner?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -278,7 +277,7 @@ describe('Javascript visitor with custom owner field auth', () => {
       jest.resetAllMocks();
     });
 
-    it('should add custom owner field to Javascript declaration', () => {
+    it('should not add custom owner field to Javascript declaration', () => {
       const declarationVisitor = getVisitor(schema, true);
       const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
       const generateEnumDeclarationsSpy = jest.spyOn(declarationVisitor as any, 'generateEnumDeclarations');
@@ -286,28 +285,27 @@ describe('Javascript visitor with custom owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: (string | null)[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: (string | null)[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly customOwnerField?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -350,7 +348,7 @@ describe('Javascript visitor with multiple owner field auth', () => {
       jest.resetAllMocks();
     });
 
-    it('should add custom both owner fields to Javascript declaration', () => {
+    it('should not add custom both owner fields to Javascript declaration', () => {
       const declarationVisitor = getVisitor(schema, true);
       const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
       const generateEnumDeclarationsSpy = jest.spyOn(declarationVisitor as any, 'generateEnumDeclarations');
@@ -358,29 +356,27 @@ describe('Javascript visitor with multiple owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
 
-export enum SimpleEnum {
-  ENUM_VAL1 = \\"enumVal1\\",
-  ENUM_VAL2 = \\"enumVal2\\"
-}
+        export enum SimpleEnum {
+          ENUM_VAL1 = \\"enumVal1\\",
+          ENUM_VAL2 = \\"enumVal2\\"
+        }
 
-export declare class SimpleNonModelType {
-  readonly id: string;
-  readonly names?: (string | null)[];
-  constructor(init: ModelInit<SimpleNonModelType>);
-}
+        export declare class SimpleNonModelType {
+          readonly id: string;
+          readonly names?: (string | null)[];
+          constructor(init: ModelInit<SimpleNonModelType>);
+        }
 
-export declare class SimpleModel {
-  readonly id: string;
-  readonly name?: string;
-  readonly bar?: string;
-  readonly customOwnerField?: string;
-  readonly customOwnerField2?: string;
-  constructor(init: ModelInit<SimpleModel>);
-  static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
-}"
-`);
+        export declare class SimpleModel {
+          readonly id: string;
+          readonly name?: string;
+          readonly bar?: string;
+          constructor(init: ModelInit<SimpleModel>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+        }"
+      `);
       expect(generateImportSpy).toBeCalledTimes(1);
       expect(generateImportSpy).toBeCalledWith();
 
@@ -414,7 +410,7 @@ describe('Javascript visitor with auth directives in field level', () => {
       jest.resetAllMocks();
     });
 
-    it('should add custom both owner fields to Javascript declaration', () => {
+    it('should not add custom owner fields to Javascript declaration', () => {
       const declarationVisitor = getVisitor(schema, true);
       const generateImportSpy = jest.spyOn(declarationVisitor as any, 'generateImports');
       const generateModelDeclarationSpy = jest.spyOn(declarationVisitor as any, 'generateModelDeclaration');
@@ -432,7 +428,6 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly name: string;
           readonly address: string;
           readonly ssn?: string;
-          readonly owner?: string;
           constructor(init: ModelInit<Employee>);
           static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
         }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -507,10 +507,10 @@ describe('Metadata visitor', () => {
     it('should generate for typeDeclaration', () => {
       const typeDeclaration = getVisitor(schema, 'typeDeclaration');
       expect(typeDeclaration.generate()).toMatchInlineSnapshot(`
-"import { Schema } from '@aws-amplify/datastore';
+        "import { Schema } from '@aws-amplify/datastore';
 
-export declare const schema: Schema;"
-`);
+        export declare const schema: Schema;"
+      `);
     });
   });
 });
@@ -568,20 +568,6 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"customOwnerField\\": {
-                            \\"name\\": \\"customOwnerField\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"customOwnerField2\\": {
-                            \\"name\\": \\"customOwnerField2\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -656,7 +642,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"5d997b204c79c66d009287de0054655e\\"
+            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
         };"
       `);
     });
@@ -690,20 +676,6 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"customOwnerField\\": {
-                            \\"name\\": \\"customOwnerField\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"customOwnerField2\\": {
-                            \\"name\\": \\"customOwnerField2\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -778,7 +750,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"5d997b204c79c66d009287de0054655e\\"
+            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
         };"
       `);
     });
@@ -835,13 +807,6 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"owner\\": {
-                            \\"name\\": \\"owner\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -889,7 +854,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"38f7db9c1e8eab155fd9ce672a92f248\\"
+            \\"version\\": \\"bff2efaf6e138056991c723932df2763\\"
         };"
       `);
     });
@@ -931,13 +896,6 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"owner\\": {
-                            \\"name\\": \\"owner\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -985,7 +943,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"38f7db9c1e8eab155fd9ce672a92f248\\"
+            \\"version\\": \\"bff2efaf6e138056991c723932df2763\\"
         };"
       `);
     });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -1161,7 +1161,7 @@ describe('AppSyncSwiftVisitor', () => {
         `);
       });
 
-      it('should add the default owner field if it is not provided in schema and in ownerField', () => {
+      it('should not add the default owner field if it is not provided in schema and in ownerField', () => {
         const schema = /* GraphQL */ `
           type Post @model @auth(rules: [{ allow: owner }]) {
             id: ID!
@@ -1180,7 +1180,6 @@ describe('AppSyncSwiftVisitor', () => {
              public enum CodingKeys: String, ModelKey {
               case id
               case title
-              case owner
             }
             
             public static let keys = CodingKeys.self
@@ -1197,15 +1196,14 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.fields(
                 .id(),
-                .field(post.title, is: .required, ofType: .string),
-                .field(post.owner, is: .optional, ofType: .string)
+                .field(post.title, is: .required, ofType: .string)
               )
               }
           }"
         `);
       });
 
-      it('should add the custom ownerField to model generation automatically if not provided in schema', () => {
+      it('should not add the custom ownerField to model generation automatically if not provided in schema', () => {
         const schema = /* GraphQL */ `
           type Post @model @auth(rules: [{ allow: owner, ownerField: "customField" }]) {
             id: ID!
@@ -1224,7 +1222,6 @@ describe('AppSyncSwiftVisitor', () => {
              public enum CodingKeys: String, ModelKey {
               case id
               case title
-              case customField
             }
             
             public static let keys = CodingKeys.self
@@ -1241,8 +1238,7 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.fields(
                 .id(),
-                .field(post.title, is: .required, ofType: .string),
-                .field(post.customField, is: .optional, ofType: .string)
+                .field(post.title, is: .required, ofType: .string)
               )
               }
           }"
@@ -1323,7 +1319,6 @@ describe('AppSyncSwiftVisitor', () => {
               case name
               case address
               case ssn
-              case owner
             }
             
             public static let keys = CodingKeys.self
@@ -1343,8 +1338,7 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(employee.name, is: .required, ofType: .string),
                 .field(employee.address, is: .required, ofType: .string),
-                .field(employee.ssn, is: .optional, ofType: .string),
-                .field(employee.owner, is: .optional, ofType: .string)
+                .field(employee.ssn, is: .optional, ofType: .string)
               )
               }
           }"

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -480,38 +480,12 @@ export class AppSyncModelVisitor<
     Object.values(this.modelMap).forEach(model => {
       const filteredDirectives = model.directives.filter(d => d.name !== 'auth');
       const authDirectives = processAuthDirective(model.directives);
-      authDirectives.forEach(directive => {
-        directive.arguments.rules.forEach(rule => {
-          if (rule.allow === AuthStrategy.owner) {
-            addFieldToModel(model, {
-              type: 'String',
-              isList: false,
-              isNullable: true,
-              name: rule.ownerField ? rule.ownerField : 'owner',
-              directives: [],
-            });
-          }
-        });
-      });
       model.directives = [...filteredDirectives, ...authDirectives];
 
       //field @auth process
       model.fields.forEach(field => {
         const nonAuthDirectives = field.directives.filter(d => d.name != 'auth');
         const authDirectives = processAuthDirective(field.directives);
-        authDirectives.forEach(directive => {
-          directive.arguments.rules.forEach(rule => {
-            if (rule.allow === AuthStrategy.owner) {
-              addFieldToModel(model, {
-                type: 'String',
-                isList: false,
-                isNullable: true,
-                name: rule.ownerField ? rule.ownerField : 'owner',
-                directives: [],
-              });
-            }
-          });
-        });
         field.directives = [...nonAuthDirectives, ...authDirectives];
       });
     });

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -26,7 +26,7 @@ import { getTypeInfo } from '../utils/get-type-info';
 import { CodeGenConnectionType, CodeGenFieldConnection, processConnections } from '../utils/process-connections';
 import { sortFields } from '../utils/sort';
 import { printWarning } from '../utils/warn';
-import { processAuthDirective, AuthStrategy } from '../utils/process-auth';
+import { processAuthDirective } from '../utils/process-auth';
 
 export enum CodeGenGenerateEnum {
   metadata = 'metadata',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert the changes of PR #5335 #5455 . `ownerField` will not be added to modelgen output automatically in implicit cases for @auth. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.