### PR TITLE
fix(amplify-appsync-simulator): appsync scalars

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -76,7 +76,7 @@
       "!**/*.d.ts"
     ],
     "testURL": "http://localhost/",
-    "testRegex": "(src/__tests__/.*.test.*)$",
+    "testRegex": "(src/__tests__/.*.test.ts)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSJSON.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSJSON.test.ts
@@ -1,0 +1,62 @@
+import { scalars } from '../../schema/appsync-scalars';
+
+describe('AWSJSON parse', () => {
+  it('Should reject an invalid json encoded object', () => {
+    function parse() {
+      scalars.AWSJSON.parseValue('{Foo: "Not Valid"}');
+    }
+    expect(parse).toThrowErrorMatchingSnapshot();
+  });
+  it('Should reject a non json string', () => {
+    function parse() {
+      scalars.AWSJSON.parseValue('hello world');
+    }
+    expect(parse).toThrowErrorMatchingSnapshot();
+  });
+
+  it('Should reject a non json boolean', () => {
+    function parse() {
+      scalars.AWSJSON.parseValue(true);
+    }
+    expect(parse).toThrowErrorMatchingSnapshot();
+  });
+
+  it('Should reject a non json int', () => {
+    function parse() {
+      scalars.AWSJSON.parseValue(1);
+    }
+    expect(parse).toThrowErrorMatchingSnapshot();
+  });
+
+  it('Should accept a json encoded object', () => {
+    expect(scalars.AWSJSON.parseValue('{"Foo": "Bar"}')).toMatchObject({
+      Foo: 'Bar',
+    });
+  });
+
+  it('Should accept a json string', () => {
+    expect(scalars.AWSJSON.parseValue('"Hello world"')).toEqual('Hello world');
+  });
+
+  it('Should accept a json boolean', () => {
+    expect(scalars.AWSJSON.parseValue('true')).toEqual(true);
+  });
+
+  it('Should accept a json int', () => {
+    expect(scalars.AWSJSON.parseValue('1')).toEqual(1);
+  });
+});
+
+describe('AWSJSON serialize', () => {
+  it('Should serialize an obkect', () => {
+    expect(scalars.AWSJSON.serialize({ foo: 'Bar' })).toEqual('{"foo":"Bar"}');
+  });
+
+  it('Should serialize a boolean', () => {
+    expect(scalars.AWSJSON.serialize(true)).toEqual('true');
+  });
+
+  it('Should serialize an integer', () => {
+    expect(scalars.AWSJSON.serialize(1)).toEqual('1');
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSJSON.test.ts.snap
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSJSON.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AWSJSON parse Should reject a non json boolean 1`] = `"Unable to parse true as valid JSON."`;
+
+exports[`AWSJSON parse Should reject a non json int 1`] = `"Unable to parse 1 as valid JSON."`;
+
+exports[`AWSJSON parse Should reject a non json string 1`] = `"Unable to parse hello world as valid JSON."`;
+
+exports[`AWSJSON parse Should reject an invalid json encoded object 1`] = `"Unable to parse {Foo: \\"Not Valid\\"} as valid JSON."`;

--- a/packages/amplify-appsync-simulator/src/schema/index.ts
+++ b/packages/amplify-appsync-simulator/src/schema/index.ts
@@ -98,7 +98,10 @@ export function generateResolvers(
 
   return makeExecutableSchema({
     typeDefs: doc,
-    resolvers: resolverMapWithAuth,
+    resolvers: {
+      ...resolverMapWithAuth,
+      ...scalars,
+    },
     schemaDirectives,
   });
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #5207

*Description of changes:*

Several issues here.

1) AWS scalars were not used at all
AWS scalars were defined, but never injected in the schema. This is now fixed.
**Please let me know if this was intentional** (for some reason)

2) `AWSPhone` was needs to be instantiated in order to be injected into the schema.
Instead, the class itself was passed. 
`AWSPhone` also seems to accept [some options](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-appsync-simulator/src/schema/appsync-scalars/index.ts#L13) for the country. Since this was not used at all until now, I just left the defaults.

3) `AWSJSON`
Finally, this fixes #5207 
AWSJSON are stringified in AppSync but were returned as objects in the simulator. 


According to [the doc](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) and the reverse engineering I have been doing, it should act as follow:

**As an Input**
JSON strings are parsed as values before getting to mapping template. This means:
`"{\"Foo\":\"Bar\"}"` becomes `{Foo: "Bar"}` (object, or `Map`)
`"true"` (the string) becomes `true` (the boolean)
`"1"` (the string) becomes `1` (the integer)
`"\"Hello\""` (double quotes are important) becomes the `Hello` string
etc.

Any array of the above should also work. Example: `"[\"Hello\", \"World\"]"`

`"Hello"` is an invalid json representation and fails.
Any non-string value should fail.

**As an output**
Basically, any output will be encoded as a JSON
`{Foo: "Bar"}` becomes `{"Foo": "Bar"}`, and so on... (Basically, the reverse of the above)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.