### PR TITLE
fix(graphql-elasticsearch-transformer): Fixed NoneType when attempting to retrieve error on streaming-lambda

### DIFF
--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -104,7 +104,7 @@ def post_to_es(payload):
                     'ES post unsuccessful, errors present, took=%sms', es_ret['took'])
                 # Filter errors
                 es_errors = [item for item in es_ret['items']
-                            if item.get('index').get('error')]
+                            if item.get('index', {}).get('error')]
                 logger.error('List of items with errors: %s',
                             json.dumps(es_errors))
             else:


### PR DESCRIPTION
*Issue #, if available:*
Sample JSON payload as `es_ret_str`:
```
{
        "took": 74,
        "errors": true,
        "items": [
            {
                "index": {
                    "_index": "table-v2",
                    "_type": "doc",
                    "_id": "c352f721-4bd0-4895-xxx",
                    "status": 409,
                    "error": {
                        "type": "version_conflict_engine_exception",
                        "reason": "[doc][xxx]: version conflict, current version [1] is higher or equal to the one provided [1]",
                        "index_uuid": "fVEyrXaZTXCTQxxx",
                        "shard": "1",
                        "index": "table-v2"
                    }
                }
            },
            {
                "delete": {
                    "_index": "table-v2",
                    "_type": "doc",
                    "_id": "id=c352f721-4bd0-4895-xxx",
                    "_version": 1,
                    "result": "not_found",
                    "_shards": {
                        "total": 2,
                        "successful": 1,
                        "failed": 0
                    },
                    "_seq_no": 2288,
                    "_primary_term": 3,
                    "status": 404
                }
            }
        ]
    }
```

You will hit the error below:
```
{
  "errorMessage": "'NoneType' object has no attribute 'get'",
  "errorType": "AttributeError",
  "stackTrace": [
    "  File \"/var/task/lambda_function.py\", line 197, in lambda_handler\n    es_errors = [item for item in es_ret['items']\n",
    "  File \"/var/task/lambda_function.py\", line 198, in <listcomp>\n    if item.get('index').get('error')]\n"
  ]
}
```

*Description of changes:*
Set a default value of`.get('index')` to `{}` if it's None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.