### PR TITLE
test: enable app creation for test that does pull

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/env.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env.test.ts
@@ -60,7 +60,7 @@ describe('environment commands', () => {
   });
 
   it('init a project, pull, add auth, pull to override auth change', async () => {
-    await initJSProjectWithProfile(projRoot, {});
+    await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false });
     await amplifyPull(projRoot, { override: false });
     await addAuthWithDefault(projRoot, {});
     await amplifyPull(projRoot, { override: true });


### PR DESCRIPTION
Fix e2e test failure

Test was failing because internal flag was being set to not create an Amplify App causing subsequent pull operations to fail.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.