### PR TITLE
fix(graphql-predictions-transformer): fix json validation

### DIFF
--- a/packages/graphql-predictions-transformer/src/__tests__/__snapshots__/PredictionsTransformer.test.ts.snap
+++ b/packages/graphql-predictions-transformer/src/__tests__/__snapshots__/PredictionsTransformer.test.ts.snap
@@ -42,3 +42,167 @@ input TranslateLabelsInput {
 }
 "
 `;
+
+exports[`snapshot test to check generated function resolvers 1`] = `
+Object {
+  "DependsOn": Array [],
+  "Properties": Object {
+    "ApiId": Object {
+      "Ref": "AppSyncApiId",
+    },
+    "FieldName": "speakTranslatedImageText",
+    "Kind": "PIPELINE",
+    "PipelineConfig": Object {
+      "Functions": Array [
+        Object {
+          "Fn::GetAtt": Array [
+            "identifyTextFunction",
+            "FunctionId",
+          ],
+        },
+        Object {
+          "Fn::GetAtt": Array [
+            "translateTextFunction",
+            "FunctionId",
+          ],
+        },
+        Object {
+          "Fn::GetAtt": Array [
+            "convertTextToSpeechFunction",
+            "FunctionId",
+          ],
+        },
+      ],
+    },
+    "RequestMappingTemplate": Object {
+      "Fn::Join": Array [
+        "
+",
+        Array [
+          Object {
+            "Fn::If": Array [
+              "HasEnvironmentParameter",
+              Object {
+                "Fn::Sub": Array [
+                  "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                  Object {
+                    "env": Object {
+                      "Ref": "env",
+                    },
+                    "hash": Object {
+                      "Fn::Select": Array [
+                        3,
+                        Object {
+                          "Fn::Split": Array [
+                            "-",
+                            Object {
+                              "Ref": "AWS::StackName",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              Object {
+                "Fn::Sub": Array [
+                  "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                  Object {
+                    "hash": Object {
+                      "Fn::Select": Array [
+                        3,
+                        Object {
+                          "Fn::Split": Array [
+                            "-",
+                            Object {
+                              "Ref": "AWS::StackName",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+        ],
+      ],
+    },
+    "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+    "TypeName": "Query",
+  },
+  "Type": "AWS::AppSync::Resolver",
+}
+`;
+
+exports[`snapshot test to check generated function resolvers 2`] = `
+"#set( $bucketName = $ctx.stash.get(\\"s3Bucket\\") )
+$util.qr($ctx.stash.put(\\"isList\\", false))
+#set( $text = $util.defaultIfNull($ctx.args.input.convertTextToSpeech.text, $ctx.prev.result) )
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Invoke\\",
+  \\"payload\\":   $util.toJson({
+  \\"uuid\\": \\"$util.autoId()\\",
+  \\"action\\": \\"convertTextToSpeech\\",
+  \\"voiceID\\": $ctx.args.input.convertTextToSpeech.voiceID,
+  \\"text\\": $text
+})
+}"
+`;
+
+exports[`snapshot test to check generated function resolvers 3`] = `
+"#set( $bucketName = $ctx.stash.get(\\"s3Bucket\\") )
+#set( $identityTextKey = $ctx.args.input.identifyText.key )
+#set( $identifyTextPayload = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+      \\"body\\": {
+          \\"Image\\": {
+              \\"S3Object\\": {
+                  \\"Bucket\\": \\"$bucketName\\",
+                  \\"Name\\": \\"public/$identityTextKey\\"
+        }
+      }
+    },
+      \\"headers\\": {
+          \\"Content-Type\\": \\"application/x-amz-json-1.1\\",
+          \\"X-Amz-Target\\": \\"RekognitionService.DetectText\\"
+    }
+  }
+} )
+$util.toJson($identifyTextPayload)"
+`;
+
+exports[`snapshot test to check generated function resolvers 4`] = `
+"#set( $text = $util.defaultIfNull($ctx.args.input.translateText.text, $ctx.prev.result) )
+#set( $translateTextPayload = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+      \\"body\\": {
+          \\"SourceLanguageCode\\": $ctx.args.input.translateText.sourceLanguage,
+          \\"TargetLanguageCode\\": $ctx.args.input.translateText.targetLanguage,
+          \\"Text\\": $text
+    },
+      \\"headers\\": {
+          \\"Content-Type\\": \\"application/x-amz-json-1.1\\",
+          \\"X-Amz-Target\\": \\"AWSShineFrontendService_20170701.TranslateText\\"
+    }
+  }
+} )
+$util.toJson($translateTextPayload)"
+`;


### PR DESCRIPTION
fix json validation in predictions transformer so valid strings are allowed in the payload

re #4346

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.