### PR TITLE
Revert "enhance(amplify-provider-awscloudformation): multiple lambdas per resource"

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.js
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.js
@@ -353,19 +353,17 @@ function packageResources(context, resources) {
             };
           }
         } else {
-          Object.values(cfnMeta.Resources).forEach(value => {
-            if (value.Type === 'AWS::Serverless::Function' && typeof value.Properties.CodeUri === 'object') {
-              value.Properties.CodeUri = {
-                Bucket: s3Bucket,
-                Key: s3Key,
-              };
-            } else if (value.Type === 'AWS::Lambda::Function' && typeof value.Properties.Code === 'object') {
-              value.Properties.Code = {
-                S3Bucket: s3Bucket,
-                S3Key: s3Key,
-              };
-            }
-          });
+          if (cfnMeta.Resources.LambdaFunction.Type === 'AWS::Serverless::Function') {
+            cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
+              Bucket: s3Bucket,
+              Key: s3Key,
+            };
+          } else {
+            cfnMeta.Resources.LambdaFunction.Properties.Code = {
+              S3Bucket: s3Bucket,
+              S3Key: s3Key,
+            };
+          }
         }
         context.amplify.writeObjectAsJson(cfnFilePath, cfnMeta, true);
       });


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#5032

Caused several e2e test failures: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/2514/workflows/2982ec79-ca20-4cd4-ac3f-e154f3f8a5e4