### PR TITLE
fix: remove appClientSecret as best practice

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -1146,8 +1146,6 @@ Outputs :
   AppClientID:
     Value: !Ref 'UserPoolClient'
     Description: The user pool app client id
-  AppClientSecret:
-    Value: !GetAtt UserPoolClientInputs.appSecret
   <%if (props.mfaConfiguration != 'OFF') { %>
   CreatedSNSRole: 
     Value: !GetAtt SNSRole.Arn

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -202,7 +202,6 @@ function getCognitoConfig(cognitoResources, projectRegion) {
         Default: {
           PoolId: cognitoResource.output.UserPoolId,
           AppClientId: cognitoResource.output.AppClientID,
-          AppClientSecret: cognitoResource.output.AppClientSecret,
           Region: projectRegion,
         },
       },
@@ -239,7 +238,6 @@ function getCognitoConfig(cognitoResources, projectRegion) {
     const oauth = {
       WebDomain: domain,
       AppClientId: cognitoResource.output.AppClientID,
-      AppClientSecret: cognitoResource.output.AppClientSecret,
       SignInRedirectURI: redirectSignIn,
       SignOutRedirectURI: redirectSignOut,
       Scopes: scope,

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -179,7 +179,6 @@ function getCognitoConfig(cognitoResources, projectRegion) {
         Default: {
           PoolId: cognitoResource.output.UserPoolId,
           AppClientId: cognitoResource.output.AppClientID,
-          AppClientSecret: cognitoResource.output.AppClientSecret,
           Region: projectRegion,
         },
       },
@@ -221,7 +220,6 @@ function getCognitoConfig(cognitoResources, projectRegion) {
     const oauth = {
       WebDomain: domain,
       AppClientId: cognitoResource.output.AppClientID,
-      AppClientSecret: cognitoResource.output.AppClientSecret,
       SignInRedirectURI: redirectSignIn,
       SignOutRedirectURI: redirectSignOut,
       Scopes: scope,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the optional appClientSecret for future Android and iOS apps created with the CLI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.