### PR TITLE
fix(amplify-velocity-template): support 'get' and 'set' of array vars

### DIFF
--- a/packages/amplify-velocity-template/src/compile/references.js
+++ b/packages/amplify-velocity-template/src/compile/references.js
@@ -226,26 +226,10 @@ module.exports = function(Velocity, utils) {
       var id = property.id;
       var ret = '';
 
-      // getter 处理
-      if (id.indexOf('get') === 0 && !(id in baseRef)) {
-        if (id.length === 3) {
-          // get('address')
-          ret = getter(baseRef, this.getLiteral(property.args[0]));
-        } else {
-          // getAddress()
-          ret = getter(baseRef, id.slice(3));
-        }
-
-        return ret;
-
-        // setter 处理
-      } else if (id.indexOf('set') === 0 && !baseRef[id]) {
-        baseRef[id.slice(3)] = this.getLiteral(property.args[0]);
-        // $page.setName(123)
-        baseRef.toString = function() {
-          return '';
-        };
-        return baseRef;
+      if (id === 'get' && !baseRef[id]) {
+        return baseRef[this.getLiteral(property.args[0])];
+      } else if (id === 'set' && !baseRef[id] && typeof baseRef.splice === 'function') {
+        return baseRef[this.getLiteral(property.args[0])] = this.getLiteral(property.args[1]);
       } else if (id.indexOf('is') === 0 && !(id in baseRef)) {
         return getter(baseRef, id.slice(2));
       } else if (id === 'keySet' && !baseRef[id]) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-cli/issues/5593

*Description of changes:* Fixes velocity template to support `set` and `get` methods of array variables.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.