### PR TITLE
chore: remove console.logs from e2e tests

### DIFF
--- a/packages/amplify-e2e-tests/src/plugin/verifyPluginStructure.ts
+++ b/packages/amplify-e2e-tests/src/plugin/verifyPluginStructure.ts
@@ -3,8 +3,6 @@ import * as fs from 'fs-extra';
 import { readJsonFile } from 'amplify-e2e-core';
 
 export function verifyPlugin(pluginDirPath: string): boolean {
-  console.log('pluginDirPath', pluginDirPath);
-
   if (fs.existsSync(pluginDirPath) && fs.statSync(pluginDirPath).isDirectory()) {
     return verifyNodePackage(pluginDirPath);
   }

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -178,7 +178,6 @@ export async function signInUser2(username: string, realPw: string) {
   });
   const user = Amplify.Auth.createCognitoUser(username);
   const authRes: any = await authenticateUser(user, authDetails, realPw);
-  console.log(`Logged in ${username} \n${authRes.getIdToken().getJwtToken()}`);
   return user;
 }
 

--- a/packages/graphql-transformers-e2e-tests/src/CloudFormationClient.ts
+++ b/packages/graphql-transformers-e2e-tests/src/CloudFormationClient.ts
@@ -55,7 +55,7 @@ export class CloudFormationClient {
         Parameters: params,
         TemplateBody: JSON.stringify(template),
       },
-      this.client
+      this.client,
     );
   }
 
@@ -77,7 +77,7 @@ export class CloudFormationClient {
             return reject(`No stack named: ${name}`);
           }
           resolve(data.Stacks[0]);
-        }
+        },
       );
     });
   }
@@ -107,18 +107,14 @@ export class CloudFormationClient {
       'UPDATE_ROLLBACK_IN_PROGRESS',
     ],
     maxPolls: number = 1000,
-    pollInterval: number = 20
+    pollInterval: number = 20,
   ): Promise<CloudFormation.Stack> {
     const stack = await this.describeStack(name);
     if (success.includes(stack.StackStatus)) {
-      console.log(`Cloudformation successfully deployed...`);
       return Promise.resolve(stack);
     } else if (failure.includes(stack.StackStatus)) {
-      console.log(`Cloudformation failed...`);
-      console.log(JSON.stringify(stack, null, 4));
       return Promise.reject(new Error(`Stack ${stack.StackName} failed with status "${stack.StackStatus}"`));
     } else if (poll.includes(stack.StackStatus)) {
-      console.log(`Polling cloudformation...`);
       if (maxPolls === 0) {
         return Promise.reject(new Error(`Stack did not finish before hitting the max poll count.`));
       } else {
@@ -130,7 +126,7 @@ export class CloudFormationClient {
           failure,
           poll,
           maxPolls - 1,
-          pollInterval
+          pollInterval,
         );
       }
     }

--- a/packages/graphql-transformers-e2e-tests/src/LambdaHelper.ts
+++ b/packages/graphql-transformers-e2e-tests/src/LambdaHelper.ts
@@ -12,7 +12,6 @@ export class LambdaHelper {
 
   async createFunction(name: string, roleArn: string, filePrefix: string) {
     const filePath = path.join(__dirname, 'testfunctions', `${filePrefix}.zip`);
-    console.log(`Uploading lambda from path: ${filePath}`);
     const zipContents = fs.readFileSync(filePath);
     return await this.client
       .createFunction({

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -5,11 +5,10 @@ import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { CloudFormationClient } from '../CloudFormationClient';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { GraphQLClient } from '../GraphQLClient';
-import { deploy } from '../deployNestedStacks';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { default as moment } from 'moment';
-import emptyBucket from '../emptyBucket';
 
 jest.setTimeout(2000000);
 
@@ -100,578 +99,481 @@ beforeAll(async () => {
   } catch (e) {
     console.error(`Failed to create S3 bucket: ${e}`);
   }
-  try {
-    console.log('Creating Stack ' + STACK_NAME);
-    const finishedStack = await deploy(
-      customS3Client,
-      cf,
-      STACK_NAME,
-      out,
-      { CreateAPIKey: '1', DynamoDBEnablePointInTimeRecovery: 'true' },
-      TMP_ROOT,
-      BUCKET_NAME,
-      ROOT_KEY,
-      BUILD_TIMESTAMP,
-    );
-    expect(finishedStack).toBeDefined();
-    console.log(JSON.stringify(finishedStack, null, 4));
-    const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
-    const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
-    GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
-    console.log(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
+  const finishedStack = await deploy(
+    customS3Client,
+    cf,
+    STACK_NAME,
+    out,
+    { CreateAPIKey: '1', DynamoDBEnablePointInTimeRecovery: 'true' },
+    TMP_ROOT,
+    BUCKET_NAME,
+    ROOT_KEY,
+    BUILD_TIMESTAMP,
+  );
+  expect(finishedStack).toBeDefined();
+  const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+  const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+  GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
 
-    const apiKey = getApiKey(finishedStack.Outputs);
-    console.log(`API KEY: ${apiKey}`);
-    expect(apiKey).toBeTruthy();
-    expect(GRAPHQL_ENDPOINT).toBeTruthy();
-    GRAPHQL_CLIENT = new GraphQLClient(GRAPHQL_ENDPOINT, { 'x-api-key': apiKey });
-  } catch (e) {
-    console.log(e);
-    expect(true).toEqual(false);
-  }
+  const apiKey = getApiKey(finishedStack.Outputs);
+  expect(apiKey).toBeTruthy();
+  expect(GRAPHQL_ENDPOINT).toBeTruthy();
+  GRAPHQL_CLIENT = new GraphQLClient(GRAPHQL_ENDPOINT, { 'x-api-key': apiKey });
 });
 
 afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.log(e);
-    }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.error(`Failed to empty S3 bucket: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf);
 });
 
 afterEach(async () => {
-  try {
-    // delete all the records
-    console.log('deleting posts');
-    const response = await GRAPHQL_CLIENT.query(
-      `
-    query {
-      listPosts {
-        items {
-          id
-        }
+  // delete all the records
+  const response = await GRAPHQL_CLIENT.query(
+    `
+  query {
+    listPosts {
+      items {
+        id
       }
-    }`,
-      {},
+    }
+  }`,
+    {},
+  );
+  const rows = response.data.listPosts.items || [];
+  const deletePromises = [];
+  rows.forEach(row => {
+    deletePromises.push(
+      GRAPHQL_CLIENT.query(`mutation delete{
+      deletePost(input: {id: "${row.id}"}) { id }
+    }`),
     );
-    const rows = response.data.listPosts.items || [];
-    const deletePromises = [];
-    rows.forEach(row => {
-      deletePromises.push(
-        GRAPHQL_CLIENT.query(`mutation delete{
-        deletePost(input: {id: "${row.id}"}) { id }
-      }`),
-      );
-    });
-    await Promise.all(deletePromises);
-  } catch (e) {
-    console.log(e);
-  }
+  });
+  await Promise.all(deletePromises);
 });
 
 /**
  * Test queries below
  */
 test('Test createAuthor mutation', async () => {
-  try {
-    const response = await GRAPHQL_CLIENT.query(
-      `mutation($input: CreateAuthorInput!) {
-            createAuthor(input: $input) {
-                id
-                name
-                entityMetadata {
-                    isActive
-                }
-                createdAt
-                updatedAt
-            }
-        }`,
-      {
-        input: {
-          name: 'Jeff B',
-          entityMetadata: {
-            isActive: true,
-          },
+  const response = await GRAPHQL_CLIENT.query(
+    `mutation($input: CreateAuthorInput!) {
+          createAuthor(input: $input) {
+              id
+              name
+              entityMetadata {
+                  isActive
+              }
+              createdAt
+              updatedAt
+          }
+      }`,
+    {
+      input: {
+        name: 'Jeff B',
+        entityMetadata: {
+          isActive: true,
         },
       },
-    );
-    expect(response.data.createAuthor.id).toBeDefined();
-    expect(response.data.createAuthor.name).toEqual('Jeff B');
-    expect(response.data.createAuthor.createdAt).toBeDefined();
-    expect(response.data.createAuthor.updatedAt).toBeDefined();
-    expect(response.data.createAuthor.entityMetadata).toBeDefined();
-    expect(response.data.createAuthor.entityMetadata.isActive).toEqual(true);
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+    },
+  );
+  expect(response.data.createAuthor.id).toBeDefined();
+  expect(response.data.createAuthor.name).toEqual('Jeff B');
+  expect(response.data.createAuthor.createdAt).toBeDefined();
+  expect(response.data.createAuthor.updatedAt).toBeDefined();
+  expect(response.data.createAuthor.entityMetadata).toBeDefined();
+  expect(response.data.createAuthor.entityMetadata.isActive).toEqual(true);
 });
 
 test('Test createPost mutation', async () => {
-  try {
-    const response = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Hello, World!" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    expect(response.data.createPost.id).toBeDefined();
-    expect(response.data.createPost.title).toEqual('Hello, World!');
-    expect(response.data.createPost.createdAt).toBeDefined();
-    expect(response.data.createPost.updatedAt).toBeDefined();
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const response = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Hello, World!" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(response.data.createPost.id).toBeDefined();
+  expect(response.data.createPost.title).toEqual('Hello, World!');
+  expect(response.data.createPost.createdAt).toBeDefined();
+  expect(response.data.createPost.updatedAt).toBeDefined();
 });
 
 test('Test updatePost mutation', async () => {
-  try {
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Test Update" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(createResponse, null, 4));
-    expect(createResponse.data.createPost.id).toBeDefined();
-    expect(createResponse.data.createPost.title).toEqual('Test Update');
-    const updateResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            updatePost(input: { id: "${createResponse.data.createPost.id}", title: "Bye, World!" }) {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(updateResponse, null, 4));
-    expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Test Update" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toBeDefined();
+  expect(createResponse.data.createPost.title).toEqual('Test Update');
+  const updateResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          updatePost(input: { id: "${createResponse.data.createPost.id}", title: "Bye, World!" }) {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
 });
 
 test('Test createPost and updatePost mutation with a client generated id.', async () => {
-  try {
-    const clientId = 'a-client-side-generated-id';
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { id: "${clientId}" title: "Test Update" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(createResponse, null, 4));
-    expect(createResponse.data.createPost.id).toEqual(clientId);
-    expect(createResponse.data.createPost.title).toEqual('Test Update');
-    const updateResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            updatePost(input: { id: "${clientId}", title: "Bye, World!" }) {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(updateResponse, null, 4));
-    expect(updateResponse.data.updatePost.id).toEqual(clientId);
-    expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
-    const getResponse = await GRAPHQL_CLIENT.query(
-      `query {
-            getPost(id: "${clientId}") {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(getResponse, null, 4));
-    expect(getResponse.data.getPost.id).toEqual(clientId);
-    expect(getResponse.data.getPost.title).toEqual('Bye, World!');
+  const clientId = 'a-client-side-generated-id';
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { id: "${clientId}" title: "Test Update" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toEqual(clientId);
+  expect(createResponse.data.createPost.title).toEqual('Test Update');
+  const updateResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          updatePost(input: { id: "${clientId}", title: "Bye, World!" }) {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(updateResponse.data.updatePost.id).toEqual(clientId);
+  expect(updateResponse.data.updatePost.title).toEqual('Bye, World!');
+  const getResponse = await GRAPHQL_CLIENT.query(
+    `query {
+          getPost(id: "${clientId}") {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(getResponse.data.getPost.id).toEqual(clientId);
+  expect(getResponse.data.getPost.title).toEqual('Bye, World!');
 
-    const deleteResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            deletePost(input: { id: "${clientId}" }) {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(deleteResponse, null, 4));
-    expect(deleteResponse.data.deletePost.id).toEqual(clientId);
-    expect(deleteResponse.data.deletePost.title).toEqual('Bye, World!');
+  const deleteResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          deletePost(input: { id: "${clientId}" }) {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(deleteResponse.data.deletePost.id).toEqual(clientId);
+  expect(deleteResponse.data.deletePost.title).toEqual('Bye, World!');
 
-    const getResponse2 = await GRAPHQL_CLIENT.query(
-      `query {
-            getPost(id: "${clientId}") {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(getResponse2, null, 4));
-    expect(getResponse2.data.getPost).toBeNull();
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const getResponse2 = await GRAPHQL_CLIENT.query(
+    `query {
+          getPost(id: "${clientId}") {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(getResponse2.data.getPost).toBeNull();
 });
 
 test('Test deletePost mutation', async () => {
-  try {
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Test Delete" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(createResponse, null, 4));
-    expect(createResponse.data.createPost.id).toBeDefined();
-    expect(createResponse.data.createPost.title).toEqual('Test Delete');
-    const deleteResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            deletePost(input: { id: "${createResponse.data.createPost.id}" }) {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(deleteResponse, null, 4));
-    expect(deleteResponse.data.deletePost.title).toEqual('Test Delete');
-    const getResponse = await GRAPHQL_CLIENT.query(
-      `query {
-            getPost(id: "${createResponse.data.createPost.id}") {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(getResponse, null, 4));
-    expect(getResponse.data.getPost).toBeNull();
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Test Delete" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toBeDefined();
+  expect(createResponse.data.createPost.title).toEqual('Test Delete');
+  const deleteResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          deletePost(input: { id: "${createResponse.data.createPost.id}" }) {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(deleteResponse.data.deletePost.title).toEqual('Test Delete');
+  const getResponse = await GRAPHQL_CLIENT.query(
+    `query {
+          getPost(id: "${createResponse.data.createPost.id}") {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(getResponse.data.getPost).toBeNull();
 });
 
 test('Test getPost query', async () => {
-  try {
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Test Get" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    expect(createResponse.data.createPost.id).toBeTruthy();
-    expect(createResponse.data.createPost.title).toEqual('Test Get');
-    const getResponse = await GRAPHQL_CLIENT.query(
-      `query {
-            getPost(id: "${createResponse.data.createPost.id}") {
-                id
-                title
-            }
-        }`,
-      {},
-    );
-    expect(getResponse.data.getPost.title).toEqual('Test Get');
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Test Get" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toBeTruthy();
+  expect(createResponse.data.createPost.title).toEqual('Test Get');
+  const getResponse = await GRAPHQL_CLIENT.query(
+    `query {
+          getPost(id: "${createResponse.data.createPost.id}") {
+              id
+              title
+          }
+      }`,
+    {},
+  );
+  expect(getResponse.data.getPost.title).toEqual('Test Get');
 });
 
 test('Test listPosts query', async () => {
-  try {
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Test List" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    expect(createResponse.data.createPost.id).toBeDefined();
-    expect(createResponse.data.createPost.title).toEqual('Test List');
-    const listResponse = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts {
-                items {
-                    id
-                    title
-                }
-            }
-        }`,
-      {},
-    );
-    expect(listResponse.data.listPosts.items).toBeDefined();
-    const items = listResponse.data.listPosts.items;
-    expect(items.length).toBeGreaterThan(0);
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Test List" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toBeDefined();
+  expect(createResponse.data.createPost.title).toEqual('Test List');
+  const listResponse = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts {
+              items {
+                  id
+                  title
+              }
+          }
+      }`,
+    {},
+  );
+  expect(listResponse.data.listPosts.items).toBeDefined();
+  const items = listResponse.data.listPosts.items;
+  expect(items.length).toBeGreaterThan(0);
 });
 
 test('Test listPosts query with filter', async () => {
-  try {
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Test List with filter" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    expect(createResponse.data.createPost.id).toBeDefined();
-    expect(createResponse.data.createPost.title).toEqual('Test List with filter');
-    const listWithFilterResponse = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: {
-                title: {
-                    contains: "List with filter"
-                }
-            }) {
-                items {
-                    id
-                    title
-                }
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(listWithFilterResponse, null, 4));
-    expect(listWithFilterResponse.data.listPosts.items).toBeDefined();
-    const items = listWithFilterResponse.data.listPosts.items;
-    expect(items.length).toEqual(1);
-    expect(items[0].title).toEqual('Test List with filter');
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Test List with filter" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toBeDefined();
+  expect(createResponse.data.createPost.title).toEqual('Test List with filter');
+  const listWithFilterResponse = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: {
+              title: {
+                  contains: "List with filter"
+              }
+          }) {
+              items {
+                  id
+                  title
+              }
+          }
+      }`,
+    {},
+  );
+  expect(listWithFilterResponse.data.listPosts.items).toBeDefined();
+  const items = listWithFilterResponse.data.listPosts.items;
+  expect(items.length).toEqual(1);
+  expect(items[0].title).toEqual('Test List with filter');
 });
 
 test('Test enum filters List', async () => {
-  try {
-    await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Appears in New Hope", appearsIn: [NEWHOPE], episode: NEWHOPE }) {
+  await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Appears in New Hope", appearsIn: [NEWHOPE], episode: NEWHOPE }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Appears in Jedi", appearsIn: [JEDI], episode: JEDI }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  await GRAPHQL_CLIENT.query(
+    `mutation {
+            createPost(input: { title: "Appears in Empire", appearsIn: [EMPIRE], episode: EMPIRE }) {
                 id
                 title
                 createdAt
                 updatedAt
             }
         }`,
-      {},
-    );
-    await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Appears in Jedi", appearsIn: [JEDI], episode: JEDI }) {
+    {},
+  );
+
+  await GRAPHQL_CLIENT.query(
+    `mutation {
+            createPost(input: { title: "Appears in Empire & JEDI", appearsIn: [EMPIRE, JEDI] }) {
                 id
                 title
                 createdAt
                 updatedAt
             }
         }`,
-      {},
-    );
-    await GRAPHQL_CLIENT.query(
-      `mutation {
-              createPost(input: { title: "Appears in Empire", appearsIn: [EMPIRE], episode: EMPIRE }) {
-                  id
+    {},
+  );
+
+  // filter list of enums
+  const appearsInWithFilterResponseJedi = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: { appearsIn: {eq: [JEDI]}}) {
+              items {
                   title
-                  createdAt
-                  updatedAt
-              }
-          }`,
-      {},
-    );
-
-    await GRAPHQL_CLIENT.query(
-      `mutation {
-              createPost(input: { title: "Appears in Empire & JEDI", appearsIn: [EMPIRE, JEDI] }) {
                   id
-                  title
-                  createdAt
-                  updatedAt
               }
-          }`,
-      {},
-    );
+          }
+      }
+      `,
+    {},
+  );
+  expect(appearsInWithFilterResponseJedi.data.listPosts.items).toBeDefined();
+  const items = appearsInWithFilterResponseJedi.data.listPosts.items;
+  expect(items.length).toEqual(1);
+  expect(items[0].title).toEqual('Appears in Jedi');
 
-    // filter list of enums
-    const appearsInWithFilterResponseJedi = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: { appearsIn: {eq: [JEDI]}}) {
-                items {
-                    title
-                    id
-                }
-            }
-        }
-        `,
-      {},
-    );
-    expect(appearsInWithFilterResponseJedi.data.listPosts.items).toBeDefined();
-    const items = appearsInWithFilterResponseJedi.data.listPosts.items;
-    expect(items.length).toEqual(1);
-    expect(items[0].title).toEqual('Appears in Jedi');
+  const appearsInWithFilterResponseNonJedi = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: { appearsIn: {ne: [JEDI]}}) {
+              items {
+                  title
+                  id
+              }
+          }
+      }
+      `,
+    {},
+  );
+  expect(appearsInWithFilterResponseNonJedi.data.listPosts.items).toBeDefined();
+  const appearsInNonJediItems = appearsInWithFilterResponseNonJedi.data.listPosts.items;
+  expect(appearsInNonJediItems.length).toEqual(3);
+  appearsInNonJediItems.forEach(item => {
+    expect(['Appears in Empire & JEDI', 'Appears in New Hope', 'Appears in Empire'].includes(item.title)).toBeTruthy();
+  });
 
-    const appearsInWithFilterResponseNonJedi = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: { appearsIn: {ne: [JEDI]}}) {
-                items {
-                    title
-                    id
-                }
-            }
-        }
-        `,
-      {},
-    );
-    expect(appearsInWithFilterResponseNonJedi.data.listPosts.items).toBeDefined();
-    const appearsInNonJediItems = appearsInWithFilterResponseNonJedi.data.listPosts.items;
-    expect(appearsInNonJediItems.length).toEqual(3);
-    appearsInNonJediItems.forEach(item => {
-      expect(['Appears in Empire & JEDI', 'Appears in New Hope', 'Appears in Empire'].includes(item.title)).toBeTruthy();
-    });
+  const appearsInContainingJedi = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: { appearsIn: {contains: JEDI }}) {
+              items {
+                  title
+                  id
+              }
+          }
+      }
+      `,
+    {},
+  );
+  expect(appearsInContainingJedi.data.listPosts.items).toBeDefined();
+  const appearsInWithJediItems = appearsInContainingJedi.data.listPosts.items;
+  expect(appearsInWithJediItems.length).toEqual(2);
+  appearsInWithJediItems.forEach(item => {
+    expect(['Appears in Empire & JEDI', 'Appears in Jedi'].includes(item.title)).toBeTruthy();
+  });
 
-    const appearsInContainingJedi = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: { appearsIn: {contains: JEDI }}) {
-                items {
-                    title
-                    id
-                }
-            }
-        }
-        `,
-      {},
-    );
-    expect(appearsInContainingJedi.data.listPosts.items).toBeDefined();
-    const appearsInWithJediItems = appearsInContainingJedi.data.listPosts.items;
-    expect(appearsInWithJediItems.length).toEqual(2);
-    appearsInWithJediItems.forEach(item => {
-      expect(['Appears in Empire & JEDI', 'Appears in Jedi'].includes(item.title)).toBeTruthy();
-    });
+  const appearsInNotContainingJedi = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: { appearsIn: {notContains: JEDI }}) {
+              items {
+                  title
+                  id
+              }
+          }
+      }
+      `,
+    {},
+  );
+  expect(appearsInNotContainingJedi.data.listPosts.items).toBeDefined();
+  const appearsInWithNonJediItems = appearsInNotContainingJedi.data.listPosts.items;
+  expect(appearsInWithNonJediItems.length).toEqual(2);
+  appearsInWithNonJediItems.forEach(item => {
+    expect(['Appears in New Hope', 'Appears in Empire'].includes(item.title)).toBeTruthy();
+  });
 
-    const appearsInNotContainingJedi = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: { appearsIn: {notContains: JEDI }}) {
-                items {
-                    title
-                    id
-                }
-            }
-        }
-        `,
-      {},
-    );
-    expect(appearsInNotContainingJedi.data.listPosts.items).toBeDefined();
-    const appearsInWithNonJediItems = appearsInNotContainingJedi.data.listPosts.items;
-    expect(appearsInWithNonJediItems.length).toEqual(2);
-    appearsInWithNonJediItems.forEach(item => {
-      expect(['Appears in New Hope', 'Appears in Empire'].includes(item.title)).toBeTruthy();
-    });
+  // enum filter
+  const jediEpisode = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: { episode: {eq: JEDI }}) {
+              items {
+                  title
+                  id
+              }
+          }
+      }
+      `,
+    {},
+  );
+  expect(jediEpisode.data.listPosts.items).toBeDefined();
+  const jediEpisodeItems = jediEpisode.data.listPosts.items;
+  expect(jediEpisodeItems.length).toEqual(1);
+  expect(jediEpisodeItems[0].title).toEqual('Appears in Jedi');
 
-    // enum filter
-    const jediEpisode = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: { episode: {eq: JEDI }}) {
-                items {
-                    title
-                    id
-                }
-            }
-        }
-        `,
-      {},
-    );
-    expect(jediEpisode.data.listPosts.items).toBeDefined();
-    const jediEpisodeItems = jediEpisode.data.listPosts.items;
-    expect(jediEpisodeItems.length).toEqual(1);
-    expect(jediEpisodeItems[0].title).toEqual('Appears in Jedi');
-
-    const nonJediEpisode = await GRAPHQL_CLIENT.query(
-      `query {
-            listPosts(filter: { episode: {ne: JEDI }}) {
-                items {
-                    title
-                    id
-                }
-            }
-        }
-        `,
-      {},
-    );
-    expect(nonJediEpisode.data.listPosts.items).toBeDefined();
-    const nonJediEpisodeItems = nonJediEpisode.data.listPosts.items;
-    expect(nonJediEpisodeItems.length).toEqual(3);
-    nonJediEpisodeItems.forEach(item => {
-      expect(['Appears in New Hope', 'Appears in Empire', 'Appears in Empire & JEDI'].includes(item.title)).toBeTruthy();
-    });
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+  const nonJediEpisode = await GRAPHQL_CLIENT.query(
+    `query {
+          listPosts(filter: { episode: {ne: JEDI }}) {
+              items {
+                  title
+                  id
+              }
+          }
+      }
+      `,
+    {},
+  );
+  expect(nonJediEpisode.data.listPosts.items).toBeDefined();
+  const nonJediEpisodeItems = nonJediEpisode.data.listPosts.items;
+  expect(nonJediEpisodeItems.length).toEqual(3);
+  nonJediEpisodeItems.forEach(item => {
+    expect(['Appears in New Hope', 'Appears in Empire', 'Appears in Empire & JEDI'].includes(item.title)).toBeTruthy();
+  });
 });
 
 test('Test next token', async () => {
@@ -736,124 +638,110 @@ test('Test next token', async () => {
 });
 
 test('Test createPost mutation with non-model types', async () => {
-  try {
-    const response = await GRAPHQL_CLIENT.query(
-      `mutation CreatePost($input: CreatePostInput!) {
-            createPost(input: $input) {
-                id
-                title
-                createdAt
-                updatedAt
-                metadata {
-                    tags {
-                        published
-                        metadata {
-                            tags {
-                                published
-                            }
-                        }
-                    }
-                }
-                appearsIn
-            }
-        }`,
-      {
-        input: {
-          title: 'Check that metadata exists',
-          metadata: {
-            tags: {
-              published: true,
-              metadata: {
-                tags: {
-                  published: false,
-                },
+  const response = await GRAPHQL_CLIENT.query(
+    `mutation CreatePost($input: CreatePostInput!) {
+          createPost(input: $input) {
+              id
+              title
+              createdAt
+              updatedAt
+              metadata {
+                  tags {
+                      published
+                      metadata {
+                          tags {
+                              published
+                          }
+                      }
+                  }
+              }
+              appearsIn
+          }
+      }`,
+    {
+      input: {
+        title: 'Check that metadata exists',
+        metadata: {
+          tags: {
+            published: true,
+            metadata: {
+              tags: {
+                published: false,
               },
             },
           },
-          appearsIn: ['NEWHOPE'],
         },
+        appearsIn: ['NEWHOPE'],
       },
-    );
-    expect(response.data.createPost.id).toBeDefined();
-    expect(response.data.createPost.title).toEqual('Check that metadata exists');
-    expect(response.data.createPost.createdAt).toBeDefined();
-    expect(response.data.createPost.updatedAt).toBeDefined();
-    expect(response.data.createPost.metadata).toBeDefined();
-    expect(response.data.createPost.metadata.tags.published).toEqual(true);
-    expect(response.data.createPost.metadata.tags.metadata.tags.published).toEqual(false);
-    expect(response.data.createPost.appearsIn).toEqual(['NEWHOPE']);
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+    },
+  );
+  expect(response.data.createPost.id).toBeDefined();
+  expect(response.data.createPost.title).toEqual('Check that metadata exists');
+  expect(response.data.createPost.createdAt).toBeDefined();
+  expect(response.data.createPost.updatedAt).toBeDefined();
+  expect(response.data.createPost.metadata).toBeDefined();
+  expect(response.data.createPost.metadata.tags.published).toEqual(true);
+  expect(response.data.createPost.metadata.tags.metadata.tags.published).toEqual(false);
+  expect(response.data.createPost.appearsIn).toEqual(['NEWHOPE']);
 });
 
 test('Test updatePost mutation with non-model types', async () => {
-  try {
-    const createResponse = await GRAPHQL_CLIENT.query(
-      `mutation {
-            createPost(input: { title: "Test Update" }) {
-                id
-                title
-                createdAt
-                updatedAt
-            }
-        }`,
-      {},
-    );
-    console.log(JSON.stringify(createResponse, null, 4));
-    expect(createResponse.data.createPost.id).toBeDefined();
-    expect(createResponse.data.createPost.title).toEqual('Test Update');
-    const updateResponse = await GRAPHQL_CLIENT.query(
-      `mutation UpdatePost($input: UpdatePostInput!) {
-            updatePost(input: $input) {
-                id
-                title
-                createdAt
-                updatedAt
-                metadata {
-                    tags {
-                        published
-                        metadata {
-                            tags {
-                                published
-                            }
-                        }
-                    }
-                }
-                appearsIn
-            }
-        }`,
-      {
-        input: {
-          id: createResponse.data.createPost.id,
-          title: 'Add some metadata',
-          metadata: {
-            tags: {
-              published: true,
-              metadata: {
-                tags: {
-                  published: false,
-                },
+  const createResponse = await GRAPHQL_CLIENT.query(
+    `mutation {
+          createPost(input: { title: "Test Update" }) {
+              id
+              title
+              createdAt
+              updatedAt
+          }
+      }`,
+    {},
+  );
+  expect(createResponse.data.createPost.id).toBeDefined();
+  expect(createResponse.data.createPost.title).toEqual('Test Update');
+  const updateResponse = await GRAPHQL_CLIENT.query(
+    `mutation UpdatePost($input: UpdatePostInput!) {
+          updatePost(input: $input) {
+              id
+              title
+              createdAt
+              updatedAt
+              metadata {
+                  tags {
+                      published
+                      metadata {
+                          tags {
+                              published
+                          }
+                      }
+                  }
+              }
+              appearsIn
+          }
+      }`,
+    {
+      input: {
+        id: createResponse.data.createPost.id,
+        title: 'Add some metadata',
+        metadata: {
+          tags: {
+            published: true,
+            metadata: {
+              tags: {
+                published: false,
               },
             },
           },
-          appearsIn: ['NEWHOPE', 'EMPIRE'],
         },
+        appearsIn: ['NEWHOPE', 'EMPIRE'],
       },
-    );
-    console.log(JSON.stringify(updateResponse, null, 4));
-    expect(updateResponse.data.updatePost.title).toEqual('Add some metadata');
-    expect(updateResponse.data.updatePost.metadata).toBeDefined();
-    expect(updateResponse.data.updatePost.metadata.tags.published).toEqual(true);
-    expect(updateResponse.data.updatePost.metadata.tags.metadata.tags.published).toEqual(false);
-    expect(updateResponse.data.updatePost.appearsIn).toEqual(['NEWHOPE', 'EMPIRE']);
-  } catch (e) {
-    console.log(e);
-    // fail
-    expect(e).toBeUndefined();
-  }
+    },
+  );
+  expect(updateResponse.data.updatePost.title).toEqual('Add some metadata');
+  expect(updateResponse.data.updatePost.metadata).toBeDefined();
+  expect(updateResponse.data.updatePost.metadata.tags.published).toEqual(true);
+  expect(updateResponse.data.updatePost.metadata.tags.metadata.tags.published).toEqual(false);
+  expect(updateResponse.data.updatePost.appearsIn).toEqual(['NEWHOPE', 'EMPIRE']);
 });
 
 describe('Timestamp configuration', () => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/FunctionTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/FunctionTransformerTests.e2e.test.ts
@@ -7,8 +7,7 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { GraphQLClient } from '../GraphQLClient';
 import { default as moment } from 'moment';
-import emptyBucket from '../emptyBucket';
-import { deploy } from '../deployNestedStacks';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { LambdaHelper } from '../LambdaHelper';
@@ -114,8 +113,6 @@ beforeAll(async () => {
   );
   // Arbitrary wait to make sure everything is ready.
   await cf.wait(5, () => Promise.resolve());
-  console.log('Successfully created stack ' + STACK_NAME);
-  console.log(finishedStack);
   expect(finishedStack).toBeDefined();
   const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
   const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
@@ -127,26 +124,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.error(e);
-      expect(true).toEqual(false);
-    }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.warn(`Error during bucket cleanup: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf);
+
   try {
     await LAMBDA_HELPER.deleteFunction(ECHO_FUNCTION_NAME);
   } catch (e) {
@@ -190,7 +169,6 @@ test('Test simple echo function', async () => {
     }`,
     {},
   );
-  console.log(JSON.stringify(response, null, 4));
   expect(response.data.echo.arguments.msg).toEqual('Hello');
   expect(response.data.echo.typeName).toEqual('Query');
   expect(response.data.echo.fieldName).toEqual('echo');
@@ -209,7 +187,6 @@ test('Test simple echoEnv function', async () => {
     }`,
     {},
   );
-  console.log(JSON.stringify(response, null, 4));
   expect(response.data.echoEnv.arguments.msg).toEqual('Hello');
   expect(response.data.echoEnv.typeName).toEqual('Query');
   expect(response.data.echoEnv.fieldName).toEqual('echoEnv');
@@ -228,7 +205,6 @@ test('Test simple duplicate function', async () => {
     }`,
     {},
   );
-  console.log(JSON.stringify(response, null, 4));
   expect(response.data.duplicate.arguments.msg).toEqual('Hello');
   expect(response.data.duplicate.typeName).toEqual('Query');
   expect(response.data.duplicate.fieldName).toEqual('duplicate');
@@ -241,7 +217,6 @@ test('Test pipeline of @function(s)', async () => {
     }`,
     {},
   );
-  console.log(JSON.stringify(response, null, 4));
   expect(response.data.pipeline).toEqual('Hello, world!');
 });
 
@@ -258,7 +233,6 @@ test('Test pipelineReverse of @function(s)', async () => {
     }`,
     {},
   );
-  console.log(JSON.stringify(response, null, 4));
   expect(response.data.pipelineReverse.arguments.msg).toEqual('Hello');
   expect(response.data.pipelineReverse.typeName).toEqual('Query');
   expect(response.data.pipelineReverse.fieldName).toEqual('pipelineReverse');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -7,8 +7,7 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { GraphQLClient } from '../GraphQLClient';
 import { default as moment } from 'moment';
-import emptyBucket from '../emptyBucket';
-import { deploy } from '../deployNestedStacks';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 
@@ -123,7 +122,6 @@ beforeAll(async () => {
   );
   // Arbitrary wait to make sure everything is ready.
   await cf.wait(5, () => Promise.resolve());
-  console.log('Successfully created stack ' + STACK_NAME);
   expect(finishedStack).toBeDefined();
   const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
   const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
@@ -135,26 +133,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    // await cf.waitForStack(STACK_NAME)
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.error(e);
-      expect(true).toEqual(false);
-    }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.warn(`Error during bucket cleanup: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf);
 });
 
 /**

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -200,7 +200,6 @@ test('Test that a secondary @key with 3 fields changes the hash and sort keys an
   });
 
   const out = transformer.transform(validSchema);
-  console.log(out.schema);
   let tableResource = out.stacks.Test.Resources.TestTable;
   expect(tableResource).toBeDefined();
   const hashKey = tableResource.Properties.KeySchema.find(o => o.KeyType === 'HASH');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -6,8 +6,7 @@ import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { CloudFormationClient } from '../CloudFormationClient';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { GraphQLClient } from '../GraphQLClient';
-import { deploy } from '../deployNestedStacks';
-import emptyBucket from '../emptyBucket';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { default as moment } from 'moment';
@@ -92,7 +91,6 @@ beforeAll(async () => {
     console.error(`Failed to create S3 bucket: ${e}`);
   }
   try {
-    console.log('Creating Stack ' + STACK_NAME);
     const finishedStack = await deploy(
       customS3Client,
       cf,
@@ -107,9 +105,7 @@ beforeAll(async () => {
 
     // Arbitrary wait to make sure everything is ready.
     await cf.wait(5, () => Promise.resolve());
-    console.log('Successfully created stack ' + STACK_NAME);
     expect(finishedStack).toBeDefined();
-    console.log(JSON.stringify(finishedStack, null, 4));
     const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
     const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
     const endpoint = getApiEndpoint(finishedStack.Outputs);
@@ -124,26 +120,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.error(e);
-      expect(true).toEqual(false);
-    }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.error(`Failed to empty S3 bucket: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf);
 });
 
 /**

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -14,10 +14,9 @@ import { default as CognitoClient } from 'aws-sdk/clients/cognitoidentityservice
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { S3Client } from '../S3Client';
 import * as path from 'path';
-import { deploy } from '../deployNestedStacks';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { default as moment } from 'moment';
-import emptyBucket from '../emptyBucket';
-import { createUserPool, createUserPoolClient, deleteUserPool, signupAndAuthenticateUser, configureAmplify } from '../cognitoUtils';
+import { createUserPool, createUserPoolClient, signupAndAuthenticateUser, configureAmplify } from '../cognitoUtils';
 import Role from 'cloudform-types/types/iam/role';
 import UserPoolClient from 'cloudform-types/types/cognito/userPoolClient';
 import IdentityPool from 'cloudform-types/types/cognito/identityPool';
@@ -512,19 +511,13 @@ beforeAll(async () => {
     const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
     const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
     GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
-    console.log(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
 
     const apiKey = getApiKey(finishedStack.Outputs);
-    console.log(`API KEY: ${apiKey}`);
     expect(apiKey).toBeTruthy();
 
     const getIdentityPoolId = outputValueSelector('IdentityPoolId');
     const identityPoolId = getIdentityPoolId(finishedStack.Outputs);
     expect(identityPoolId).toBeTruthy();
-    console.log(`Identity Pool Id: ${identityPoolId}`);
-
-    console.log(`User pool Id: ${USER_POOL_ID}`);
-    console.log(`User pool ClientId: ${userPoolClientId}`);
 
     // Verify we have all the details
     expect(GRAPHQL_ENDPOINT).toBeTruthy();
@@ -591,27 +584,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await deleteUserPool(cognitoClient, USER_POOL_ID);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.error(e);
-      expect(true).toEqual(false);
-    }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.error(`Failed to empty S3 bucket: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf, { cognitoClient, userPoolId: USER_POOL_ID });
 });
 
 /**

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
@@ -7,8 +7,7 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { GraphQLClient } from '../GraphQLClient';
 import { default as moment } from 'moment';
-import emptyBucket from '../emptyBucket';
-import { deploy } from '../deployNestedStacks';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 
@@ -76,7 +75,6 @@ beforeAll(async () => {
   );
   // Arbitrary wait to make sure everything is ready.
   await cf.wait(5, () => Promise.resolve());
-  console.log('Successfully created stack ' + STACK_NAME);
   expect(finishedStack).toBeDefined();
   const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
   const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
@@ -88,28 +86,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // delete stack
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.error(e);
-      expect(true).toEqual(false);
-    }
-  }
-  // empty bucket
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.warn(`Error during bucket cleanup: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf);
 });
 
 test('test translate and convert text to speech', async () => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
@@ -8,10 +8,9 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { S3Client } from '../S3Client';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { GraphQLClient } from '../GraphQLClient';
-import { deploy } from '../deployNestedStacks';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { default as moment } from 'moment';
 import { default as S3 } from 'aws-sdk/clients/s3';
-import emptyBucket from '../emptyBucket';
 import addStringSets from '../stringSetMutations';
 
 // tslint:disable: no-magic-numbers
@@ -30,11 +29,10 @@ const S3_ROOT_DIR_KEY = 'deployments';
 
 const fragments = [`fragment FullPost on Post { id author title ups downs percentageUp isPublished createdAt }`];
 
-const runQuery = async (query: string, logContent: string) => {
+const runQuery = async (query: string) => {
   try {
     const q = [query, ...fragments].join('\n');
     const response = await GRAPHQL_CLIENT.query(q, {});
-    console.log(logContent + JSON.stringify(response, null, 4));
     return response;
   } catch (e) {
     console.error(e);
@@ -44,15 +42,14 @@ const runQuery = async (query: string, logContent: string) => {
 
 const createEntries = async () => {
   // create posts
-  const logContent = 'createPost response: ';
-  await runQuery(getCreatePostsMutation('snvishna', 'test', 157, 10, 97.4, true), logContent);
-  await runQuery(getCreatePostsMutation('snvishna', 'test title', 60, 30, 21.0, false), logContent);
-  await runQuery(getCreatePostsMutation('shankar', 'test title', 160, 30, 97.6, false), logContent);
-  await runQuery(getCreatePostsMutation('snvishna', 'test TITLE', 170, 30, 88.8, true), logContent);
-  await runQuery(getCreatePostsMutation('snvishna', 'test title', 200, 50, 11.9, false), logContent);
-  await runQuery(getCreatePostsMutation('snvishna', 'test title', 170, 30, 88.8, true), logContent);
-  await runQuery(getCreatePostsMutation('snvishna', 'test title', 160, 30, 97.6, false), logContent);
-  await runQuery(getCreatePostsMutation('snvishna', 'test title', 170, 30, 77.7, true), logContent);
+  await runQuery(getCreatePostsMutation('snvishna', 'test', 157, 10, 97.4, true));
+  await runQuery(getCreatePostsMutation('snvishna', 'test title', 60, 30, 21.0, false));
+  await runQuery(getCreatePostsMutation('shankar', 'test title', 160, 30, 97.6, false));
+  await runQuery(getCreatePostsMutation('snvishna', 'test TITLE', 170, 30, 88.8, true));
+  await runQuery(getCreatePostsMutation('snvishna', 'test title', 200, 50, 11.9, false));
+  await runQuery(getCreatePostsMutation('snvishna', 'test title', 170, 30, 88.8, true));
+  await runQuery(getCreatePostsMutation('snvishna', 'test title', 160, 30, 97.6, false));
+  await runQuery(getCreatePostsMutation('snvishna', 'test title', 170, 30, 77.7, true));
   // create users
   await GRAPHQL_CLIENT.query(getCreateUsersMutation(), {
     input: { name: 'user1', userItems: ['thing1', 'thing2'], createdAt: '2016-07-20' },
@@ -73,7 +70,6 @@ const createEntries = async () => {
   await GRAPHQL_CLIENT.query(createBookMutation(), { input: { author: 'Agatha Christie', name: 'Death on the Nile', genre: 'Mystery' } });
   await GRAPHQL_CLIENT.query(createBookMutation(), { input: { author: 'Ayn Rand', name: 'Anthem', genre: 'Science Fiction' } });
   // Waiting for the ES Cluster + Streaming Lambda infra to be setup
-  console.log('Waiting for the ES Cluster + Streaming Lambda infra to be setup');
   await cf.wait(120, () => Promise.resolve());
 };
 
@@ -165,7 +161,6 @@ beforeAll(async () => {
     // change create/update to create string sets
     const out = addStringSets(transformer.transform(validSchema));
     // fs.writeFileSync('./out.json', JSON.stringify(out, null, 4))
-    console.log('Creating Stack ' + STACK_NAME);
     const finishedStack = await deploy(
       customS3Client,
       cf,
@@ -179,7 +174,6 @@ beforeAll(async () => {
     );
     // Arbitrary wait to make sure everything is ready.
     await cf.wait(120, () => Promise.resolve());
-    console.log('Successfully created stack ' + STACK_NAME);
     expect(finishedStack).toBeDefined();
     const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
     const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
@@ -198,26 +192,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  try {
-    console.log('Deleting stack ' + STACK_NAME);
-    await cf.deleteStack(STACK_NAME);
-    await cf.waitForStack(STACK_NAME);
-    console.log('Successfully deleted stack ' + STACK_NAME);
-  } catch (e) {
-    if (e.code === 'ValidationError' && e.message === `Stack with id ${STACK_NAME} does not exist`) {
-      // The stack was deleted. This is good.
-      expect(true).toEqual(true);
-      console.log('Successfully deleted stack ' + STACK_NAME);
-    } else {
-      console.error(e);
-      expect(true).toEqual(false);
-    }
-  }
-  try {
-    await emptyBucket(BUCKET_NAME);
-  } catch (e) {
-    console.error(`Failed to empty S3 bucket: ${e}`);
-  }
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf);
 });
 
 test('Test searchPosts with sort field on a string field', async () => {
@@ -233,7 +208,6 @@ test('Test searchPosts with sort field on a string field', async () => {
             nextToken
           }
     }`,
-    'Test searchPosts with filter ',
   );
   expect(firstQuery).toBeDefined();
   expect(firstQuery.data.searchPosts).toBeDefined();
@@ -250,7 +224,6 @@ test('Test searchPosts with sort field on a string field', async () => {
             nextToken
           }
     }`,
-    'Test searchPosts with limit ',
   );
   expect(secondQuery).toBeDefined();
   expect(secondQuery.data.searchPosts).toBeDefined();
@@ -268,7 +241,6 @@ test('Test searchPosts with sort field on a string field', async () => {
             nextToken
           }
     }`,
-    'Test searchPosts with sort limit and nextToken  ',
   );
   expect(thirdQuery).toBeDefined();
   expect(thirdQuery.data.searchPosts).toBeDefined();
@@ -290,7 +262,6 @@ test('Test searchPosts with offset pagination', async () => {
             total
           }
     }`,
-    'Test searchPosts with offset pagination ',
   );
   expect(firstQuery).toBeDefined();
   expect(firstQuery.data.searchPosts).toBeDefined();
@@ -308,7 +279,6 @@ test('Test searchPosts with offset pagination', async () => {
             total
           }
     }`,
-    'Test searchPosts with offset pagination 2 ',
   );
   expect(secondQuery).toBeDefined();
   expect(secondQuery.data.searchPosts).toBeDefined();
@@ -332,7 +302,6 @@ test('Test searchPosts with sort on date type', async () => {
             }
         }
     }`,
-    'Test search posts with date type response: ',
   );
   expect(query).toBeDefined();
   expect(query.data.searchPosts).toBeDefined();
@@ -348,7 +317,6 @@ test('Test searchPosts query without filter', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts response without filter response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -365,7 +333,6 @@ test('Test searchPosts query with basic filter', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts response with basic filter response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -387,7 +354,6 @@ test('Test searchPosts query with non-recursive filter', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts response with non-recursive filter response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -420,7 +386,6 @@ test('Test searchPosts query with recursive filter 1', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts response with recursive filter 1 response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -453,7 +418,6 @@ test('Test searchPosts query with recursive filter 2', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts response with recursive filter 2 response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -485,7 +449,6 @@ test('Test searchPosts query with recursive filter 3', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts query with recursive filter 3 response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -527,7 +490,6 @@ test('Test searchPosts query with recursive filter 4', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts query with recursive filter 4 response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -569,7 +531,6 @@ test('Test searchPosts query with recursive filter 5', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts query with recursive filter 5 response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -610,7 +571,6 @@ test('Test searchPosts query with recursive filter 6', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test searchPosts query with recursive filter 6 response: ',
   );
   expect(response).toBeDefined();
   expect(response.data.searchPosts.items).toBeDefined();
@@ -621,10 +581,7 @@ test('Test searchPosts query with recursive filter 6', async () => {
 test('Test deletePosts syncing with Elasticsearch', async () => {
   // Create Post
   const title = 'to be deleted';
-  const postToBeDeletedResponse = await runQuery(
-    getCreatePostsMutation('test author new', title, 1157, 1000, 22.2, true),
-    'createPost (to be deleted) response: ',
-  );
+  const postToBeDeletedResponse = await runQuery(getCreatePostsMutation('test author new', title, 1157, 1000, 22.2, true));
   expect(postToBeDeletedResponse).toBeDefined();
   expect(postToBeDeletedResponse.data.createPost).toBeDefined();
   expect(postToBeDeletedResponse.data.createPost.id).toBeDefined();
@@ -640,7 +597,6 @@ test('Test deletePosts syncing with Elasticsearch', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test deletePosts syncing with Elasticsearch Search_Before response: ',
   );
   expect(searchResponse1).toBeDefined();
   expect(searchResponse1.data.searchPosts.items).toBeDefined();
@@ -662,7 +618,6 @@ test('Test deletePosts syncing with Elasticsearch', async () => {
             ...FullPost
         }
     }`,
-    'Test deletePosts syncing with Elasticsearch Perform_Delete response: ',
   );
   expect(deleteResponse).toBeDefined();
   expect(deleteResponse.data.deletePost).toBeDefined();
@@ -679,7 +634,6 @@ test('Test deletePosts syncing with Elasticsearch', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test deletePosts syncing with Elasticsearch Search_After response: ',
   );
   expect(searchResponse2).toBeDefined();
   expect(searchResponse2.data.searchPosts.items).toBeDefined();
@@ -696,10 +650,7 @@ test('Test updatePost syncing with Elasticsearch', async () => {
   const percentageUp = 22.2;
   const isPublished = true;
 
-  const postToBeUpdatedResponse = await runQuery(
-    getCreatePostsMutation(author, title, ups, downs, percentageUp, isPublished),
-    'createPost (to be updated) response: ',
-  );
+  const postToBeUpdatedResponse = await runQuery(getCreatePostsMutation(author, title, ups, downs, percentageUp, isPublished));
   expect(postToBeUpdatedResponse).toBeDefined();
   expect(postToBeUpdatedResponse.data.createPost).toBeDefined();
 
@@ -717,7 +668,6 @@ test('Test updatePost syncing with Elasticsearch', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test updatePost syncing with Elasticsearch Search_Before response: ',
   );
   expect(searchResponse1).toBeDefined();
   expect(searchResponse1.data.searchPosts.items).toBeDefined();
@@ -746,7 +696,6 @@ test('Test updatePost syncing with Elasticsearch', async () => {
             ...FullPost
         }
     }`,
-    'Test updatePost syncing with Elasticsearch Perform_Update response: ',
   );
   expect(updateResponse).toBeDefined();
   expect(updateResponse.data.updatePost).toBeDefined();
@@ -764,7 +713,6 @@ test('Test updatePost syncing with Elasticsearch', async () => {
             items { ...FullPost }
         }
     }`,
-    'Test updatePost syncing with Elasticsearch Search_After response: ',
   );
   expect(searchResponse2).toBeDefined();
   expect(searchResponse2.data.searchPosts.items).toBeDefined();
@@ -821,7 +769,6 @@ test('query using string range between names', async () => {
   );
   expect(searchResponse).toBeDefined();
   const items = searchResponse.data.searchUsers.items;
-  console.log(items);
   expect(items.length).toEqual(expectedLength);
   items.forEach((item: any) => {
     expect(expectedUsers).toContain(item.name);
@@ -851,7 +798,6 @@ test('query using date range using lte and gte for createdAt', async () => {
   );
   expect(searchResponse).toBeDefined();
   const items = searchResponse.data.searchUsers.items;
-  console.log(items);
   expect(items.length).toEqual(expectedLength);
   items.forEach((item: any) => {
     expect(expectedDates).toContain(item.createdAt);

--- a/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
@@ -78,7 +78,7 @@ export async function signupAndAuthenticateUser(userPoolId: string, username: st
     // Sign up then login user 1.ß
     await signupUser(userPoolId, username, tmpPw);
   } catch (e) {
-    console.log(`Trying to login with temp password`);
+    console.error(`Trying to login with temp password`, e);
   }
 
   try {
@@ -90,7 +90,7 @@ export async function signupAndAuthenticateUser(userPoolId: string, username: st
     const authRes = await authenticateUser(user, authDetails, realPw);
     return authRes;
   } catch (e) {
-    console.log(`Trying to login with real password`);
+    console.error(`Trying to login with real password`, e);
   }
 
   try {
@@ -100,11 +100,9 @@ export async function signupAndAuthenticateUser(userPoolId: string, username: st
     });
     const user = Amplify.Auth.createCognitoUser(username);
     const authRes: any = await authenticateUser(user, authDetails, realPw);
-    console.log(`Logged in ${username} \n${authRes.getIdToken().getJwtToken()}`);
     return authRes;
   } catch (e) {
-    console.error(`Failed to login.\n`);
-    console.error(e);
+    console.error(`Failed to login`, e);
   }
 }
 

--- a/packages/graphql-transformers-e2e-tests/src/emptyBucket.ts
+++ b/packages/graphql-transformers-e2e-tests/src/emptyBucket.ts
@@ -12,7 +12,6 @@ const emptyBucket = async (bucket: string) => {
       const objectIds = listObjects.Contents.map(content => ({
         Key: content.Key,
       }));
-      console.log(`Deleting keys: \n${JSON.stringify(objectIds, null, 4)}`);
       const response = await awsS3Client
         .deleteObjects({
           Bucket: bucket,
@@ -21,12 +20,10 @@ const emptyBucket = async (bucket: string) => {
           },
         })
         .promise();
-      console.error(JSON.stringify(response.Errors, null, 4));
     } catch (e) {
       console.error(`Error deleting objects: ${e}`);
     }
     if (listObjects.NextContinuationToken) {
-      console.log(`Listing next page of objects after token: ${listObjects.NextContinuationToken}`);
       listObjects = await awsS3Client
         .listObjectsV2({
           Bucket: bucket,
@@ -34,7 +31,6 @@ const emptyBucket = async (bucket: string) => {
         })
         .promise();
     } else {
-      console.log(`Finished deleting keys`);
       break;
     }
   }

--- a/packages/graphql-transformers-e2e-tests/tsconfig.tests.json
+++ b/packages/graphql-transformers-e2e-tests/tsconfig.tests.json
@@ -20,5 +20,5 @@
     { "path": "../graphql-transformer-core" },
     { "path": "../graphql-versioned-transformer" }
   ],
-  "exclude": ["**/lib/**/*"]
+  "exclude": ["**/lib/**/*", "resources/**/*"]
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

- This PR removes the excessive `console.log` statements from the GraphQL E2E tests.
- Consolidate test cleanup code into 1 method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.