### PR TITLE
fix: #5662 - python fallback from python3

### DIFF
--- a/packages/amplify-python-function-runtime-provider/package.json
+++ b/packages/amplify-python-function-runtime-provider/package.json
@@ -26,7 +26,8 @@
     "archiver": "^3.1.1",
     "execa": "^4.0.0",
     "glob": "^7.1.6",
-    "semver": "^7.1.3"
+    "semver": "^7.1.3",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",

--- a/packages/amplify-python-function-runtime-provider/src/util/depUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/depUtils.ts
@@ -1,10 +1,10 @@
 import { CheckDependenciesResult } from 'amplify-function-plugin-interface/src';
-import { execAsStringPromise, majMinPyVersion } from './pyUtils';
+import { execAsStringPromise, getPythonBinaryName } from './pyUtils';
 import { coerce, lt } from 'semver';
 
 const minPyVersion = coerce('3.8')!;
 const pythonErrMsg =
-  'You must have python >= 3.8 installed and available on your PATH as "python3". It can be installed from https://www.python.org/downloads';
+  'You must have python >= 3.8 installed and available on your PATH as "python3" or "python". It can be installed from https://www.python.org/downloads';
 const pipenvErrMsg =
   'You must have pipenv installed and available on your PATH as "pipenv". It can be installed by running "pip3 install --user pipenv".';
 
@@ -12,17 +12,23 @@ export async function checkDeps(): Promise<CheckDependenciesResult> {
   let hasDeps = true;
   let errMsg = '';
 
-  let pyVersionStr;
-  try {
-    pyVersionStr = await execAsStringPromise('python3 --version');
-    const pyVersion = coerce(pyVersionStr);
-    if (!pyVersion || lt(pyVersion, minPyVersion)) {
-      hasDeps = false;
-      errMsg = `python3 found but version ${pyVersionStr} is less than the minimum required version.\n${pythonErrMsg}`;
-    }
-  } catch (err) {
+  const pyBinary = getPythonBinaryName();
+
+  if (!pyBinary) {
     hasDeps = false;
-    errMsg = `Error executing python3\n${pythonErrMsg}`;
+    errMsg = `Could not find "python3" or "python" executable in the PATH.`;
+  } else {
+    try {
+      const pyVersionStr = await execAsStringPromise(`${pyBinary} --version`);
+      const pyVersion = coerce(pyVersionStr);
+      if (!pyVersion || lt(pyVersion, minPyVersion)) {
+        hasDeps = false;
+        errMsg = `${pyBinary} found but version ${pyVersionStr} is less than the minimum required version.\n${pythonErrMsg}`;
+      }
+    } catch (err) {
+      hasDeps = false;
+      errMsg = `Error executing ${pyBinary}\n${pythonErrMsg}`;
+    }
   }
 
   // check pipenv
@@ -32,5 +38,6 @@ export async function checkDeps(): Promise<CheckDependenciesResult> {
     hasDeps = false;
     errMsg = errMsg.concat(errMsg ? '\n' : '', pipenvErrMsg);
   }
+
   return Promise.resolve({ hasRequiredDependencies: hasDeps, errorMessage: errMsg });
 }

--- a/packages/amplify-python-function-runtime-provider/src/util/invokeUtil.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/invokeUtil.ts
@@ -5,6 +5,7 @@ import execa from 'execa';
 import path from 'path';
 import { pathManager } from 'amplify-cli-core';
 import { packageName, relativeShimPath } from '../constants';
+import { getPythonBinaryName } from './pyUtils';
 
 const shimPath = path.join(pathManager.getAmplifyPackageLibDirPath(packageName), relativeShimPath);
 
@@ -12,17 +13,29 @@ export async function pythonInvoke(context: any, request: InvocationRequest): Pr
   const handlerParts = path.parse(request.handler);
   const handlerFile = path.join(request.srcRoot, 'src', handlerParts.dir, handlerParts.name);
   const handlerName = handlerParts.ext.replace('.', '');
-  const childProcess = execa('pipenv', ['run', 'python3', shimPath, handlerFile + '.py', handlerName]);
+
+  const pyBinary = getPythonBinaryName();
+
+  if (!pyBinary) {
+    throw new Error(`Could not find 'python3' or 'python' executable in the PATH.`);
+  }
+
+  const childProcess = execa('pipenv', ['run', pyBinary, shimPath, handlerFile + '.py', handlerName]);
+
   childProcess.stdout.pipe(process.stdout);
   childProcess.stdin.write(JSON.stringify({ event: request.event, context: {} }) + '\n');
+
   const { stdout } = await childProcess;
   const lines = stdout.split('\n');
   const lastLine = lines[lines.length - 1];
+
   let result = lastLine;
+
   try {
     result = JSON.parse(lastLine);
   } catch (err) {
     context.print.warning('Could not parse function output as JSON. Using raw output.');
   }
+
   return result;
 }

--- a/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
@@ -55,13 +55,13 @@ export const getPythonBinaryName = (): string | undefined => {
   const executables = ['python3', 'python'];
   let executablePath: string | null;
 
-  for (let i = 0; i < executables.length; i++) {
-    executablePath = which.sync(executables[i], {
+  for (const executable of executables) {
+    executablePath = which.sync(executable, {
       nothrow: true,
     });
 
     if (executablePath !== null) {
-      return executables[i];
+      return executable;
     }
   }
 };

--- a/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/pyUtils.ts
@@ -2,11 +2,18 @@ import path from 'path';
 import fs from 'fs-extra';
 import { ExecOptions } from 'child_process';
 import execa from 'execa';
+import * as which from 'which';
 
 // Gets the pipenv dir where this function's dependencies are located
 export async function getPipenvDir(srcRoot: string): Promise<string> {
   const pipEnvDir = await execAsStringPromise('pipenv --venv', { cwd: srcRoot });
-  const pyVersion = await execAsStringPromise('python3 --version');
+  const pyBinary = getPythonBinaryName();
+
+  if (!pyBinary) {
+    throw new Error(`Could not find 'python3' or 'python' executable in the PATH.`);
+  }
+
+  const pyVersion = await execAsStringPromise(`${pyBinary} --version`);
   let pipEnvPath = path.join(pipEnvDir, 'lib', 'python' + majMinPyVersion(pyVersion), 'site-packages');
   if (process.platform.startsWith('win')) {
     pipEnvPath = path.join(pipEnvDir, 'Lib', 'site-packages');
@@ -43,3 +50,18 @@ export async function execAsStringPromise(command: string, opts?: ExecOptions): 
     throw new Error(`Recieved error [${err}] running command [${command}]`);
   }
 }
+
+export const getPythonBinaryName = (): string | undefined => {
+  const executables = ['python3', 'python'];
+  let executablePath: string | null;
+
+  for (let i = 0; i < executables.length; i++) {
+    executablePath = which.sync(executables[i], {
+      nothrow: true,
+    });
+
+    if (executablePath !== null) {
+      return executables[i];
+    }
+  }
+};


### PR DESCRIPTION
*Issue #, if available:*

#5662 

*Description of changes:*

Fixes #5662 by adding a fallback support for 'python' as binary beside 'python3' which has a higher precedence. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.