### PR TITLE
feat: ff to turn off schema reserve word validation

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
@@ -10,7 +10,6 @@ import {
   CLIContextEnvironmentProvider,
   JSONUtilities,
   pathManager,
-  pathManager as realPathManager,
   FeatureFlagRegistration,
 } from '..';
 import { FeatureFlagEnvironmentProvider } from '../feature-flags/featureFlagEnvironmentProvider';
@@ -110,6 +109,31 @@ describe('feature flags', () => {
         const createdConfig = (await fs.readFile(projectConfigFileName)).toString();
 
         expect(createdConfig).not.toBe('');
+      } finally {
+        rimraf.sync(tempProjectDir);
+      }
+    });
+
+    test('initializes falsy feature flag with truthy default', async () => {
+      const templateConfigFileName = path.join(__dirname, 'testFiles', 'project-with-feature-off', amplifyConfigFileName);
+
+      const osTempDir = await fs.realpath(os.tmpdir());
+      const tempProjectDir = path.join(osTempDir, `amp-${uuid()}`);
+
+      try {
+        await fs.mkdirs(tempProjectDir);
+
+        process.chdir(tempProjectDir);
+
+        const projectConfigFileName = pathManager.getCLIJSONFilePath(tempProjectDir);
+
+        await fs.mkdirs(path.dirname(projectConfigFileName));
+
+        await fs.copyFile(templateConfigFileName, projectConfigFileName);
+
+        await FeatureFlags.initialize(({ getCurrentEnvName: () => 'dev' } as unknown) as CLIEnvironmentProvider);
+
+        expect(FeatureFlags.getBoolean('graphQLTransformer.validateTypeNameReservedWords')).toBe(false);
       } finally {
         rimraf.sync(tempProjectDir);
       }

--- a/packages/amplify-cli-core/src/__tests__/testFiles/project-with-feature-off/cli.json
+++ b/packages/amplify-cli-core/src/__tests__/testFiles/project-with-feature-off/cli.json
@@ -1,0 +1,7 @@
+{
+  "features": {
+    "graphqltransformer": {
+      "validateTypeNameReservedWords": false
+    }
+  }
+}

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -220,12 +220,10 @@ export class FeatureFlags {
     }
 
     // Check if effective values has a value for the requested flag
-    if (this.effectiveFlags[parts[0]] && this.effectiveFlags[parts[0]][parts[1]]) {
-      value = <T>this.effectiveFlags[parts[0]][parts[1]];
-    }
+    value = <T>this.effectiveFlags[parts[0]]?.[parts[1]];
 
     // If there is no value, return the registered defaults for existing projects
-    if (!value) {
+    if (value === undefined) {
       if (this.useNewDefaults) {
         value = <T>(flagRegistrationEntry.defaultValueForNewProjects as unknown);
       } else {
@@ -500,6 +498,12 @@ export class FeatureFlags {
         name: 'addMissingOwnerFields',
         type: 'boolean',
         defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
+      {
+        name: 'validateTypeNameReservedWords',
+        type: 'boolean',
+        defaultValueForExistingProjects: true,
         defaultValueForNewProjects: true,
       },
     ]);

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -140,7 +140,7 @@ export class DynamoDBModelTransformer extends Transformer {
       def.name.value === ctx.getMutationTypeName() ||
       def.name.value === ctx.getSubscriptionTypeName();
 
-    if (isTypeNameReserved) {
+    if (isTypeNameReserved && ctx.featureFlags.getBoolean('validateTypeNameReservedWords', true)) {
       throw new InvalidDirectiveError(
         `'${def.name.value}' is a reserved type name and currently in use within the default schema element.`,
       );


### PR DESCRIPTION
*Issue #, if available:*
#5554

*Description of changes:*
When we fixed the bug to validate and fail on using reserve words as type names in the gql schema, customers who were using those reserve words can no longer compile their schema. This change introduces a feature flag that will be on for existing and new project, but can manually be turned off for customers using reserve words in their schema.

This PR also includes a bug fix in the FF framework where false values were not correctly initialized

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.