### PR TITLE
fix(amplify-velocity-template): support 'get' and 'set' of array vars

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/query-and-mutation.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/query-and-mutation.test.ts
@@ -1,9 +1,8 @@
-import { makeExecutableSchema } from 'graphql-tools';
-import { GraphQLSchema, parse } from 'graphql';
+import { GraphQLError, GraphQLSchema, parse } from 'graphql';
 
-import { AppSyncGraphQLExecutionContext } from '../../../utils/graphql-runner';
 import { AmplifyAppSyncSimulatorAuthenticationType } from '../../../type-definition';
-
+import { AppSyncGraphQLExecutionContext } from '../../../utils/graphql-runner';
+import { makeExecutableSchema } from 'graphql-tools';
 import { runQueryOrMutation } from '../../../utils/graphql-runner/query-and-mutation';
 
 describe('runQueryAndMutation', () => {
@@ -145,18 +144,14 @@ describe('runQueryAndMutation', () => {
       }
     `);
 
-    executionContext.appsyncErrors = [
-      {
-        name: 'Template Error',
-        message: 'An error from template',
-      },
-    ];
+    const error = new GraphQLError('An error from template');
+    executionContext.appsyncErrors = [error];
     const variables = { var1: 'val1' };
     getNameResolver.mockReturnValue(name);
 
     await expect(runQueryOrMutation(schema, doc, variables, 'getName', executionContext)).resolves.toEqual({
       data: { getName: name },
-      errors: executionContext.appsyncErrors,
+      errors: [error],
     });
   });
 });

--- a/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
@@ -1,6 +1,6 @@
 import { AmplifyAppSyncSimulator } from '..';
-import { AppSyncSimulatorPipelineResolverConfig } from '../type-definition';
 import { AppSyncBaseResolver } from './base-resolver';
+import { AppSyncSimulatorPipelineResolverConfig } from '../type-definition';
 
 export class AppSyncPipelineResolver extends AppSyncBaseResolver {
   constructor(protected config: AppSyncSimulatorPipelineResolverConfig, simulatorContext: AmplifyAppSyncSimulator) {

--- a/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/unit-resolver.ts
@@ -1,6 +1,6 @@
 import { AmplifyAppSyncSimulator } from '..';
-import { AppSyncSimulatorUnitResolverConfig } from '../type-definition';
 import { AppSyncBaseResolver } from './base-resolver';
+import { AppSyncSimulatorUnitResolverConfig } from '../type-definition';
 
 export class AppSyncUnitResolver extends AppSyncBaseResolver {
   protected config: AppSyncSimulatorUnitResolverConfig;

--- a/packages/amplify-appsync-simulator/src/utils/expose-graphql-errors.ts
+++ b/packages/amplify-appsync-simulator/src/utils/expose-graphql-errors.ts
@@ -8,14 +8,18 @@
  * @param errors GraphQLError object
  *
  */
+
+import { GraphQLError } from 'graphql';
 export function exposeGraphQLErrors(errors = []) {
-  return errors.map(e => {
-    if (e.extensions) {
-      const additionalProps = Object.entries(e.extensions).reduce((sum, [k, v]) => {
-        return { ...sum, [k]: { value: v, enumerable: true } };
-      }, {});
-      return Object.defineProperties({}, additionalProps);
-    }
-    return e;
-  });
+  return errors
+    .filter(e => e.extensions || e instanceof GraphQLError)
+    .map(e => {
+      if (e.extensions) {
+        const additionalProps = Object.entries(e.extensions).reduce((sum, [k, v]) => {
+          return { ...sum, [k]: { value: v, enumerable: true } };
+        }, {});
+        return Object.defineProperties({}, additionalProps);
+      }
+      return e;
+    });
 }

--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -1,11 +1,12 @@
-import { Compile, parse } from 'amplify-velocity-template';
-import { AmplifyAppSyncSimulator } from '..';
 import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncVTLTemplate } from '../type-definition';
-import { create as createUtil, TemplateSentError } from './util';
+import { Compile, parse } from 'amplify-velocity-template';
+import { TemplateSentError, create as createUtil } from './util';
 import { map as convertToJavaTypes, map } from './value-mapper/mapper';
+
+import { AmplifyAppSyncSimulator } from '..';
+import { AppSyncGraphQLExecutionContext } from '../utils/graphql-runner';
 import { GraphQLResolveInfo } from 'graphql';
 import { createInfo } from './util/info';
-import { AppSyncGraphQLExecutionContext } from '../utils/graphql-runner';
 
 export type AppSyncSimulatorRequestContext = {
   jwt?: {
@@ -52,8 +53,12 @@ export class VelocityTemplate {
     info?: GraphQLResolveInfo,
   ): { result; stash; errors; isReturn: boolean } {
     const context = this.buildRenderContext(ctxValues, requestContext, info);
-
-    const templateResult = this.compiler.render(context);
+    let templateResult;
+    try {
+      templateResult = this.compiler.render(context);
+    } catch (e) {
+      return { result: null, errors: [...context.util.errors], isReturn: false, stash: context.ctx.stash.toJSON() };
+    }
     const isReturn = this.compiler._state.return; // If the template has #return, then set the value
     const stash = context.ctx.stash.toJSON();
     try {

--- a/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
@@ -1,8 +1,9 @@
-import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { KeyTransformer } from 'graphql-key-transformer';
-import { GraphQLTransform } from 'graphql-transformer-core';
-import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
+
+import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
+import { GraphQLClient } from './utils/graphql-client';
+import { GraphQLTransform } from 'graphql-transformer-core';
+import { KeyTransformer } from 'graphql-key-transformer';
 
 jest.setTimeout(2000000);
 

--- a/packages/amplify-velocity-template/src/compile/references.js
+++ b/packages/amplify-velocity-template/src/compile/references.js
@@ -1,4 +1,4 @@
-module.exports = function(Velocity, utils) {
+module.exports = function (Velocity, utils) {
   'use strict';
 
   function getSize(obj) {
@@ -75,12 +75,12 @@ module.exports = function(Velocity, utils) {
 
   utils.mixin(Velocity.prototype, {
     // 增加某些函数，不需要执行html转义
-    addIgnoreEscpape: function(key) {
+    addIgnoreEscpape: function (key) {
       if (!utils.isArray(key)) key = [key];
 
       utils.forEach(
         key,
-        function(key) {
+        function (key) {
           this.config.unescape[key] = true;
         },
         this,
@@ -93,7 +93,7 @@ module.exports = function(Velocity, utils) {
      * @param {bool} isVal 取值还是获取字符串，两者的区别在于，求值返回结果，求
      * 字符串，如果没有返回变量自身，比如$foo
      */
-    getReferences: function(ast, isVal) {
+    getReferences: function (ast, isVal) {
       if (ast.prue) {
         var define = this.defines[ast.id];
         if (utils.isArray(define)) {
@@ -124,7 +124,7 @@ module.exports = function(Velocity, utils) {
       if (ast.path) {
         utils.some(
           ast.path,
-          function(property, i, len) {
+          function (property, i, len) {
             if (ret === undefined) {
               this._throw(ast, property);
             }
@@ -148,14 +148,14 @@ module.exports = function(Velocity, utils) {
     /**
      * 获取局部变量，在macro和foreach循环中使用
      */
-    getLocal: function(ast) {
+    getLocal: function (ast) {
       var id = ast.id;
       var local = this.local;
       var ret = false;
 
       var isLocaled = utils.some(
         this.conditions,
-        function(contextId) {
+        function (contextId) {
           var _local = local[contextId];
           if (id in _local) {
             ret = _local[id];
@@ -179,7 +179,7 @@ module.exports = function(Velocity, utils) {
      * 第二次是$a.b返回值
      * @private
      */
-    getAttributes: function(property, baseRef, ast) {
+    getAttributes: function (property, baseRef, ast) {
       // fix #54
       if (baseRef === null || baseRef === undefined) {
         return undefined;
@@ -205,7 +205,7 @@ module.exports = function(Velocity, utils) {
      * $foo.bar[1] index求值
      * @private
      */
-    getPropIndex: function(property, baseRef) {
+    getPropIndex: function (property, baseRef) {
       var ast = property.id;
       var key;
       if (ast.type === 'references') {
@@ -222,7 +222,7 @@ module.exports = function(Velocity, utils) {
     /**
      * $foo.bar()求值
      */
-    getPropMethod: function(property, baseRef, ast) {
+    getPropMethod: function (property, baseRef, ast) {
       var id = property.id;
       var ret = '';
 
@@ -245,7 +245,7 @@ module.exports = function(Velocity, utils) {
       if (id.indexOf('set') === 0 && !baseRef[id]) {
         baseRef[id.slice(3)] = this.getLiteral(property.args[0]);
         // $page.setName(123)
-        baseRef.toString = function() {
+        baseRef.toString = function () {
           return '';
         };
         return baseRef;
@@ -255,7 +255,7 @@ module.exports = function(Velocity, utils) {
         return utils.keys(baseRef);
       } else if (id === 'entrySet' && !baseRef[id]) {
         ret = [];
-        utils.forEach(baseRef, function(value, key) {
+        utils.forEach(baseRef, function (value, key) {
           ret.push({ key: key, value: value });
         });
 
@@ -268,14 +268,16 @@ module.exports = function(Velocity, utils) {
         return baseRef.push(this.getLiteral(property.args[0]));
       } else if (id === 'remove') {
         if (utils.isArray(baseRef)) {
-          if (typeof index === 'number') {
-            var index = this.getLiteral(property.args[0]);
+          const itemToRemove = this.getLiteral(property.args[0]);
+          let indexToRemove;
+          if (typeof itemToRemove === 'number') {
+            indexToRemove = itemToRemove;
           } else {
-            var index = baseRef.indexOf(this.getLiteral(property.args[0]));
+            indexToRemove = baseRef.indexOf(itemToRemove);
           }
 
-          ret = baseRef[index];
-          baseRef.splice(index, 1);
+          ret = baseRef[indexToRemove];
+          baseRef.splice(indexToRemove, 1);
           return ret;
         } else if (utils.isObject(baseRef)) {
           ret = baseRef[this.getLiteral(property.args[0])];
@@ -292,7 +294,7 @@ module.exports = function(Velocity, utils) {
 
         utils.forEach(
           property.args,
-          function(exp) {
+          function (exp) {
             args.push(this.getLiteral(exp));
           },
           this,
@@ -302,7 +304,7 @@ module.exports = function(Velocity, utils) {
           var that = this;
 
           if (typeof baseRef === 'object' && baseRef) {
-            baseRef.eval = function() {
+            baseRef.eval = function () {
               return that.eval.apply(that, arguments);
             };
           }
@@ -326,7 +328,7 @@ module.exports = function(Velocity, utils) {
       return ret;
     },
 
-    _throw: function(ast, property, errorName) {
+    _throw: function (ast, property, errorName) {
       if (this.config.env !== 'development') {
         return;
       }

--- a/packages/amplify-velocity-template/tests/compile.js
+++ b/packages/amplify-velocity-template/tests/compile.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var parse = Velocity.parse;
 var Compile = Velocity.Compile;
 
-describe('Compile', function() {
+describe('Compile', function () {
   var render = Velocity.render;
 
   function getContext(str, context, macros) {
@@ -13,8 +13,8 @@ describe('Compile', function() {
     return compile.context;
   }
 
-  describe('References', function() {
-    it('get/is method', function() {
+  describe('References', function () {
+    it('get/is method', function () {
       var vm = '$customer.getAddress() $customer.getaddress()';
       var vm1 = '$customer.get("address") $customer.get("Address")';
       var vm3 = '$customer.isAddress() $customer.isaddress()';
@@ -44,12 +44,12 @@ describe('Compile', function() {
       );
     });
 
-    it('method with attribute', function() {
+    it('method with attribute', function () {
       var vm = '$foo().bar\n${foo().bar}';
       assert.equal(
         'hello\nhello',
         render(vm, {
-          foo: function() {
+          foo: function () {
             return { bar: 'hello' };
           },
         }),
@@ -58,29 +58,29 @@ describe('Compile', function() {
       assert.equal(
         'foo',
         render('${foo()}', {
-          foo: function() {
+          foo: function () {
             return 'foo';
           },
         }),
       );
     });
 
-    it('index notation', function() {
+    it('index notation', function () {
       var vm = '$foo[0] $foo[$i] $foo.get(1) $xx["oo"]';
       assert.equal('bar haha haha oo', render(vm, { foo: ['bar', 'haha'], i: 1, xx: { oo: 'oo' } }));
     });
 
-    it('set method', function() {
+    it('set method', function () {
       var vm = '$page.setTitle("My Home Page").setname("haha")' + '$page.Title $page.name';
       assert.equal('My Home Page haha', render(vm, { page: {} }));
     });
 
-    it('runt type support', function() {
+    it('runt type support', function () {
       var vm = '$page.header(page)';
       assert.equal('$page.header(page)', render(vm, { page: {} }));
     });
 
-    it('size method', function() {
+    it('size method', function () {
       var vm = '$foo.bar.size()';
       assert.equal('2', render(vm, { foo: { bar: [1, 2] } }));
       assert.equal('2', render(vm, { foo: { bar: { a: 1, b: 3 } } }));
@@ -96,27 +96,39 @@ describe('Compile', function() {
       assert.equal('3', render(vm3, { foo: { size: fooSize } }));
     });
 
-    it('quiet reference', function() {
+    it('remove method', function () {
+      const context = { foo: { bar: [12, 2] } };
+      var vm = '$foo.bar.remove(0)';
+      assert.equal('12', render(vm, context));
+      assert.deepEqual({ foo: { bar: [2] } }, context);
+
+      var vm2 = "$foo.bar.remove('something')";
+      const context2 = { foo: { bar: ['something', 2] } };
+      assert.equal('something', render(vm2, context2));
+      assert.deepEqual({ foo: { bar: [2] } }, context2);
+    });
+
+    it('quiet reference', function () {
       var vm = 'my email is $email';
       var vmquiet = 'my email is $!email.xxx';
       assert.equal(vm, render(vm));
       assert.equal('my email is ', render(vmquiet));
     });
 
-    it('silence all reference', function() {
+    it('silence all reference', function () {
       var vm = 'my email is $email';
 
       var compile = new Compile(parse(vm));
       assert.equal('my email is ', compile.render(null, null, true));
     });
 
-    it('this context keep correct, see #16', function() {
+    it('this context keep correct, see #16', function () {
       var data = 'a = $a.get()';
       function B(c) {
         this.c = c;
       }
 
-      B.prototype.get = function() {
+      B.prototype.get = function () {
         var t = this.eval(' hello $name', { name: 'hanwen' });
         return this.c + t;
       };
@@ -124,26 +136,26 @@ describe('Compile', function() {
       assert.equal('a = 1 hello hanwen', render(data, { a: new B(1) }));
     });
 
-    it('this context should keep corrent in macro', function() {
+    it('this context should keep corrent in macro', function () {
       var data = '#parse()';
-      var Macro = function(name) {
+      var Macro = function (name) {
         this.name = name;
       };
 
-      Macro.prototype.parse = function() {
+      Macro.prototype.parse = function () {
         return this.name;
       };
 
       assert.equal('hanwen', render(data, {}, new Macro('hanwen')));
     });
 
-    it('get variable form text', function() {
+    it('get variable form text', function () {
       var vm = 'hello $user.getName().getFullName("hanwen")';
       var data = { '$user.getName().getFullName("hanwen")': 'world' };
       assert.equal('hello world', render(vm, data));
     });
 
-    it('escape default', function() {
+    it('escape default', function () {
       var vm = '$name $name2 $cn $cn1';
       var data = {
         name: 'hello world',
@@ -156,7 +168,7 @@ describe('Compile', function() {
       assert.equal(ret, render(vm, data));
     });
 
-    it('add custom ignore escape function', function() {
+    it('add custom ignore escape function', function () {
       var vm = '$noIgnore($name), $ignore($name)';
       var expected = '&lt;i&gt;, <i>';
 
@@ -165,11 +177,11 @@ describe('Compile', function() {
 
       var context = {
         name: '<i>',
-        noIgnore: function(name) {
+        noIgnore: function (name) {
           return name;
         },
 
-        ignore: function(name) {
+        ignore: function (name) {
           return name;
         },
       };
@@ -178,14 +190,14 @@ describe('Compile', function() {
       assert.equal(expected, ret);
     });
 
-    it('config support', function() {
+    it('config support', function () {
       var vm = '$foo($name)';
       var expected = '<i>';
 
       var compile = new Compile(parse(vm), { escape: false });
       var context = {
         name: '<i>',
-        foo: function(name) {
+        foo: function (name) {
           return name;
         },
       };
@@ -220,8 +232,8 @@ describe('Compile', function() {
       assert.equal(ret.trim(), 'foo');
     });
 
-    describe('env', function() {
-      it('should throw on property when parent is null', function() {
+    describe('env', function () {
+      it('should throw on property when parent is null', function () {
         var vm = '$foo.bar';
         var compile = new Compile(parse(vm), { env: 'development' });
         function foo() {
@@ -230,7 +242,7 @@ describe('Compile', function() {
         foo.should.throw(/get property bar of undefined/);
       });
 
-      it('should throw on index when parent is null', function() {
+      it('should throw on index when parent is null', function () {
         var vm = '$foo[1]';
         var compile = new Compile(parse(vm), { env: 'development' });
         function foo() {
@@ -239,7 +251,7 @@ describe('Compile', function() {
         foo.should.throw(/get property 1 of undefined/);
       });
 
-      it('should throw on function when parent is null', function() {
+      it('should throw on function when parent is null', function () {
         var vm = '$foo.xx()';
         var compile = new Compile(parse(vm), { env: 'development' });
         function foo() {
@@ -248,7 +260,7 @@ describe('Compile', function() {
         foo.should.throw(/get property xx of undefined/);
       });
 
-      it('should throw when mult level', function() {
+      it('should throw when mult level', function () {
         var vm = '$foo.bar.xx.bar1';
         var compile = new Compile(parse(vm), { env: 'development' });
         function foo() {
@@ -257,7 +269,7 @@ describe('Compile', function() {
         foo.should.throw(/get property bar1 of undefined/);
       });
 
-      it('not function', function() {
+      it('not function', function () {
         var vm = '$foo.bar.xx()';
         var compile = new Compile(parse(vm), { env: 'development' });
         function foo() {
@@ -268,8 +280,8 @@ describe('Compile', function() {
     });
   });
 
-  describe('Literals', function() {
-    it('eval string value', function() {
+  describe('Literals', function () {
+    it('eval string value', function () {
       var vm =
         '#set( $directoryRoot = "www" )' +
         '#set( $templateName = "index.vm")' +
@@ -279,17 +291,17 @@ describe('Compile', function() {
       assert.equal('www/index.vm', render(vm));
     });
 
-    it('not eval string', function() {
+    it('not eval string', function () {
       var vm = "#set( $blargh = '$foo' )$blargh";
       assert.equal('$foo', render(vm));
     });
 
-    it('not parse #[[ ]]#', function() {
+    it('not parse #[[ ]]#', function () {
       var vm = '#foreach ($woogie in $boogie) nothing to $woogie #end';
       assert.equal(vm, render('#[[' + vm + ']]#'));
     });
 
-    it('Range Operator', function() {
+    it('Range Operator', function () {
       var vm1 = '#set($foo = [-1..2])';
       var vm2 = '#set($foo = [-1..$bar])';
       var vm3 = '#set($foo = [$bar..2])';
@@ -299,7 +311,7 @@ describe('Compile', function() {
       assert.deepEqual([], getContext('#set($foo = [$bar..1])').foo);
     });
 
-    it('map and array nest', function() {
+    it('map and array nest', function () {
       var vm1 = '' + '#set($a = [\n' + '  {"name": 1},\n' + '  {"name": 2}\n' + '])\n' + ' ';
 
       var vm2 =
@@ -323,28 +335,28 @@ describe('Compile', function() {
     });
   });
 
-  describe('Conditionals', function() {
-    it('#if', function() {
+  describe('Conditionals', function () {
+    it('#if', function () {
       var vm = '#if($foo)Velocity#end';
       assert.equal('Velocity', render(vm, { foo: 1 }));
     });
 
-    it('#if not work', function() {
+    it('#if not work', function () {
       var vm = '#if($!css_pureui)hello world#end';
       assert.equal('', render(vm));
     });
 
-    it('#elseif & #else', function() {
+    it('#elseif & #else', function () {
       var vm = '#if($foo < 5)Go North#elseif($foo == 8)' + 'Go East#{else}Go South#end';
       assert.equal('Go North', render(vm, { foo: 4 }));
       assert.equal('Go East', render(vm, { foo: 8 }));
       assert.equal('Go South', render(vm, { foo: 9 }));
     });
 
-    it('#if with arguments', function() {
+    it('#if with arguments', function () {
       var vm = '#if($foo.isTrue(true))true#{end}';
       var foo = {
-        isTrue: function(str) {
+        isTrue: function (str) {
           return !!str;
         },
       };
@@ -353,13 +365,13 @@ describe('Compile', function() {
     });
   });
 
-  describe('Velocimacros', function() {
-    it('simple #macro', function() {
+  describe('Velocimacros', function () {
+    it('simple #macro', function () {
       var vm = '#macro( d )<tr><td></td></tr>#end #d()';
       assert.equal(' <tr><td></td></tr>', render(vm));
     });
 
-    it('compex #macro', function() {
+    it('compex #macro', function () {
       var vm = '#macro( d $name)<tr><td>$!name</td></tr>#end #d($foo)';
       var vm1 = '#macro( d $a $b)#if($b)$a#end#end #d ( $foo $bar )';
 
@@ -370,57 +382,57 @@ describe('Compile', function() {
       assert.equal(' haha', render(vm1, { foo: 'haha', bar: true }));
     });
 
-    it('#macro call arguments', function() {
+    it('#macro call arguments', function () {
       var vm = '#macro( d $a $b $d)$a$b$!d#end #d ( $foo , $bar, $dd )';
       assert.equal(' ab', render(vm, { foo: 'a', bar: 'b' }));
       assert.equal(' abd', render(vm, { foo: 'a', bar: 'b', dd: 'd' }));
     });
 
-    it('#macro map argument', function() {
+    it('#macro map argument', function () {
       var vm = '#macro( d $a)#foreach($_item in $a.entrySet())' + '$_item.key = $_item.value #end#end #d ( {"foo": $foo,"bar":$bar} )';
       assert.equal(' foo = a bar = b ', render(vm, { foo: 'a', bar: 'b' }));
     });
 
-    it('#noescape', function() {
+    it('#noescape', function () {
       var vm = '#noescape()$hello#end';
       assert.equal('hello world', render(vm, { hello: 'hello world' }));
     });
   });
 
-  describe('Escaping', function() {
-    it('escape slash', function() {
+  describe('Escaping', function () {
+    it('escape slash', function () {
       var vm = '#set( $email = "foo" )$email \\$email';
       assert.equal('foo $email', render(vm));
     });
 
-    it('double slash', function() {
+    it('double slash', function () {
       var vm = '#set( $email = "foo" )\\\\$email \\\\\\$email';
       assert.equal('\\foo \\$email', render(vm));
     });
   });
 
-  describe('Error condiction', function() {
-    it('css color render', function() {
+  describe('Error condiction', function () {
+    it('css color render', function () {
       var vm = 'color: #666 height: 39px';
       assert.equal(vm, render(vm));
     });
 
-    it('jquery parse', function() {
+    it('jquery parse', function () {
       var vm = '$(function() { $("a").click() $.post() })';
       assert.equal(vm, render(vm));
     });
 
-    it('issue #7: $ meet with #', function() {
+    it('issue #7: $ meet with #', function () {
       var vm = '$bar.foo()#if(1>0)...#end';
       assert.equal('$bar.foo()...', render(vm));
     });
 
-    it('issue #15', function() {
+    it('issue #15', function () {
       var vm = '#macro(a $b $list)' + '#foreach($a in $list)${a}#end $b #end #a("hello", [1, 2])';
       assert.equal(' 12 hello ', render(vm));
     });
 
-    it('issue #18', function() {
+    it('issue #18', function () {
       var vm =
         '$!tradeDetailModel.goodsInfoModel.goodsTitle' +
         "[<a href=\"$!personalModule.setTarget('/p.htm')" +
@@ -431,60 +443,60 @@ describe('Compile', function() {
       assert.equal(ret, render(vm));
     });
 
-    it('issue #18, condiction 2', function() {
+    it('issue #18, condiction 2', function () {
       var vm = '$!a(**** **** **** $stringUtil.right($!b,4))';
       var ret = '(**** **** **** $stringUtil.right($!b,4))';
       assert.equal(ret, render(vm));
     });
 
-    it('# meet with css property', function() {
+    it('# meet with css property', function () {
       var vm = '#margin-top:2px';
       assert.equal(vm, render(vm));
     });
 
-    it('var end must in condiction var begin', function() {
+    it('var end must in condiction var begin', function () {
       var vm = 'stepFareNo:{$!result.getStepFareNo()}';
       assert.equal('stepFareNo:{}', render(vm));
     });
 
-    it('empty string condiction', function() {
+    it('empty string condiction', function () {
       assert.equal('', render(''));
       assert.equal('', render('##hello'));
       assert.equal('hello', render('hello'));
     });
   });
 
-  describe('throw friendly error message', function() {
-    it('print right posiont when error throw', function() {
+  describe('throw friendly error message', function () {
+    it('print right posiont when error throw', function () {
       var vm = '111\nsdfs\n$foo($name)';
 
       var compile = new Compile(parse(vm), { escape: false });
       var context = {
         name: '<i>',
-        foo: function() {
+        foo: function () {
           throw new Error('Run error');
         },
       };
-      assert.throws(function() {
+      assert.throws(function () {
         compile.render(context);
       }, /\$foo\(\$name\)/);
 
-      assert.throws(function() {
+      assert.throws(function () {
         compile.render(context);
       }, /L\/N 3:0/);
     });
 
-    it('print error stack of user-defined macro', function() {
+    it('print error stack of user-defined macro', function () {
       var vm = '111\n\n#foo($name)';
       var vm1 = '\nhello#parse("vm.vm")';
       var files = { 'vm.vm': vm, 'vm1.vm': vm1 };
 
       var compile = new Compile(parse('\n\n#parse("vm1.vm")'));
       var macros = {
-        foo: function() {
+        foo: function () {
           throw new Error('Run error');
         },
-        parse: function(name) {
+        parse: function (name) {
           return this.eval(files[name]);
         },
       };
@@ -499,23 +511,23 @@ describe('Compile', function() {
     });
   });
 
-  describe('self defined function', function() {
-    it('$control.setTemplate', function() {
-      var Control = function() {
+  describe('self defined function', function () {
+    it('$control.setTemplate', function () {
+      var Control = function () {
         this.__temp = {};
       };
 
       Control.prototype = {
         constructor: Control,
 
-        setTemplate: function(vm) {
+        setTemplate: function (vm) {
           this.vm = vm;
           return this;
         },
-        toString: function() {
+        toString: function () {
           return this.eval(this.vm, this.__temp);
         },
-        setParameter: function(key, value) {
+        setParameter: function (key, value) {
           this.__temp[key] = value;
           return this;
         },
@@ -529,16 +541,16 @@ describe('Compile', function() {
     });
   });
 
-  describe('issues', function() {
-    it('#29', function() {
+  describe('issues', function () {
+    it('#29', function () {
       var vm = '#set($total = 0) #foreach($i in [1,2,3])' + ' #set($total = $total + $i) #end $total';
       assert.equal(render(vm).trim(), '6');
     });
-    it('#30', function() {
+    it('#30', function () {
       var vm = '$foo.setName';
       assert.equal(render(vm, { foo: { setName: 'foo' } }).trim(), 'foo');
     });
-    it('#54', function() {
+    it('#54', function () {
       var vm = '$a.b.c';
       assert.equal(render(vm, { a: { b: null } }).trim(), '$a.b.c');
 
@@ -547,33 +559,33 @@ describe('Compile', function() {
     });
   });
 
-  describe('multiline', function() {
-    it('#set multiline', function() {
+  describe('multiline', function () {
+    it('#set multiline', function () {
       var vm = '$bar.foo()\n#set($foo=$bar)\n...';
       assert.equal('$bar.foo()\n...', render(vm));
     });
 
-    it('#if multiline', function() {
+    it('#if multiline', function () {
       var vm = '$bar.foo()\n#if(1>0)\n...#end';
       assert.equal('$bar.foo()\n...', render(vm));
     });
 
-    it('#set #set', function() {
+    it('#set #set', function () {
       var vm = '$bar.foo()\n...\n#set($foo=$bar)\n#set($foo=$bar)';
       assert.equal('$bar.foo()\n...\n', render(vm));
     });
 
-    it('#if multiline #set', function() {
+    it('#if multiline #set', function () {
       var vm = '$bar.foo()\n#if(1>0)\n#set($foo=$bar)\n...#end';
       assert.equal('$bar.foo()\n...', render(vm));
     });
 
-    it('#if multiline #set #end', function() {
+    it('#if multiline #set #end', function () {
       var vm = '$bar.foo()\n#if(1>0)...\n#set($foo=$bar)\n#end';
       assert.equal('$bar.foo()\n...\n', render(vm));
     });
 
-    it('with references', function() {
+    it('with references', function () {
       var vm = ['a', '#foreach($b in $nums)', '#if($b) ', 'b', 'e $b.alm', '#end', '#end', 'c'].join('\n');
       var expected = ['a', 'b', 'e 1', 'b', 'e 2', 'b', 'e 3', 'c'].join('\n');
 
@@ -581,21 +593,21 @@ describe('Compile', function() {
       assert.equal(expected, render(vm, data));
     });
 
-    it('multiple newlines after statement', function() {
+    it('multiple newlines after statement', function () {
       var vm = '#if(1>0)\n\nb#end';
       assert.equal('\nb', render(vm));
     });
   });
 
-  describe('define support', function() {
-    it('basic', function() {
+  describe('define support', function () {
+    it('basic', function () {
       var vm = '#define($block)\nHello $who#end\n#set($who = "World!")\n$block';
       assert.equal('Hello World!', render(vm));
     });
   });
 
-  describe('raw content render', function() {
-    it('simple', function() {
+  describe('raw content render', function () {
+    it('simple', function () {
       var vm = '#[[\nThis content is ignored. $val\n]]#';
       assert.equal(
         '\nThis content is ignored. $val\n',
@@ -605,7 +617,7 @@ describe('Compile', function() {
       );
     });
 
-    it('newline after', function() {
+    it('newline after', function () {
       var vm = '#[[This content is ignored. $val]]#\na';
       assert.equal(
         'This content is ignored. $val\na',
@@ -616,8 +628,8 @@ describe('Compile', function() {
     });
   });
 
-  describe('assignment via .put', function() {
-    it('should set a key to an object', function() {
+  describe('assignment via .put', function () {
+    it('should set a key to an object', function () {
       var vm = `
         #set($foo = {})
         #set($test = $foo.put('foo', 'bar'))
@@ -626,7 +638,7 @@ describe('Compile', function() {
       var expected = 'bar';
       assert.equal(render(vm).trim(), expected);
     });
-    it('should set a key to an object', function() {
+    it('should set a key to an object', function () {
       var vm = `
       $foo.put()
       `;
@@ -634,7 +646,7 @@ describe('Compile', function() {
       assert.equal(
         render(vm, {
           foo: {
-            put: function() {
+            put: function () {
               return 'bar';
             },
           },
@@ -644,8 +656,8 @@ describe('Compile', function() {
     });
   });
 
-  describe('Add into empty array', function() {
-    it('should add item to array', function() {
+  describe('Add into empty array', function () {
+    it('should add item to array', function () {
       var vm = `
         #set($foo = [])
         #set($ignore = $foo.add('foo'))
@@ -655,7 +667,7 @@ describe('Compile', function() {
       assert.equal(render(vm).trim(), expected);
     });
 
-    it('should add object to array', function() {
+    it('should add object to array', function () {
       var vm = `
         #set($foo = [])
         #set($ignore = $foo.add({'foo':'bar'}))
@@ -665,7 +677,7 @@ describe('Compile', function() {
       assert.equal(render(vm).trim(), expected);
     });
 
-    it('should not add when is object', function() {
+    it('should not add when is object', function () {
       var vm = `
         #set($foo = {})
         #set($ignore = $foo.add({'foo':'bar'}))
@@ -676,8 +688,8 @@ describe('Compile', function() {
     });
   });
 
-  describe('extracting items via .subList', function() {
-    it('should return empty array if original array is empty', function() {
+  describe('extracting items via .subList', function () {
+    it('should return empty array if original array is empty', function () {
       var vm = `
         #set($foo = [])
         #set($bar = $foo.subList(0, 1))
@@ -687,7 +699,7 @@ describe('Compile', function() {
       assert.equal(render(vm).trim(), expected);
     });
 
-    it('should return a single item', function() {
+    it('should return a single item', function () {
       var vm = `
         #set($foo = [1, 2, 3])
         #set($bar = $foo.subList(0, 1))
@@ -697,7 +709,7 @@ describe('Compile', function() {
       assert.equal(render(vm).trim(), expected);
     });
 
-    it('should return multiple items', function() {
+    it('should return multiple items', function () {
       var vm = `
         #set($foo = [1, 2, 3])
         #set($bar = $foo.subList(1, 3))
@@ -708,20 +720,20 @@ describe('Compile', function() {
     });
   });
 
-  describe('Object|Array#toString', function() {
-    it('simple object', function() {
+  describe('Object|Array#toString', function () {
+    it('simple object', function () {
       var vm = '$data';
       var expected = '{k=v, k2=v2}';
       assert.equal(render(vm, { data: { k: 'v', k2: 'v2' } }), expected);
     });
 
-    it('object.keySet()', function() {
+    it('object.keySet()', function () {
       var vm = '$data.keySet()';
       var expected = '[k, k2]';
       assert.equal(render(vm, { data: { k: 'v', k2: 'v2' } }), expected);
     });
 
-    it('object.keySet() with object that has keySet method', function() {
+    it('object.keySet() with object that has keySet method', function () {
       var vm = '$data.keySet()';
       var expected = '[k, k2]';
       function keySet() {
@@ -730,13 +742,13 @@ describe('Compile', function() {
       assert.equal(render(vm, { data: { keySet: keySet } }), expected);
     });
 
-    it('object.entrySet()', function() {
+    it('object.entrySet()', function () {
       var vm = '$data.entrySet()';
       var expected = '[{key=k, value=v}, {key=k2, value=v2}]';
       assert.equal(render(vm, { data: { k: 'v', k2: 'v2' } }), expected);
     });
 
-    it('object.entrySet() with object that has entrySet method', function() {
+    it('object.entrySet() with object that has entrySet method', function () {
       var vm = '$data.entrySet()';
       var expected = '{k=v, k2=v2}';
 
@@ -750,19 +762,19 @@ describe('Compile', function() {
       assert.equal(render(vm, { data: { entrySet: entrySet } }), expected);
     });
 
-    it('nested object', function() {
+    it('nested object', function () {
       var vm = '$data';
       var expected = '{k={k2=v2}, kk={k3=v3}}';
       assert.equal(render(vm, { data: { k: { k2: 'v2' }, kk: { k3: 'v3' } } }), expected);
     });
 
-    it('object that has toString as own property', function() {
+    it('object that has toString as own property', function () {
       var vm = '$data';
       var expected = 'custom';
       assert.equal(
         render(vm, {
           data: {
-            toString: function() {
+            toString: function () {
               return 'custom';
             },
             key: 'value',
@@ -774,25 +786,25 @@ describe('Compile', function() {
       );
     });
 
-    it('simple array', function() {
+    it('simple array', function () {
       var vm = '$data';
       var expected = '[a, b]';
       assert.equal(render(vm, { data: ['a', 'b'] }), expected);
     });
 
-    it('nested array', function() {
+    it('nested array', function () {
       var vm = '$data';
       var expected = '[a, [b]]';
       assert.equal(render(vm, { data: ['a', ['b']] }), expected);
     });
 
-    it('object in array', function() {
+    it('object in array', function () {
       var vm = '$data';
       var expected = '[a, {k=v}]';
       assert.equal(render(vm, { data: ['a', { k: 'v' }] }), expected);
     });
 
-    it('array in object', function() {
+    it('array in object', function () {
       var vm = '$data';
       var expected = '{k=[a, b]}';
       assert.equal(render(vm, { data: { k: ['a', 'b'] } }), expected);

--- a/packages/amplify-velocity-template/tests/compile.js
+++ b/packages/amplify-velocity-template/tests/compile.js
@@ -29,7 +29,7 @@ describe('Compile', function() {
             address: 'bar',
             Address: 'foo',
           },
-        })
+        }),
       );
 
       assert.equal('bar bar', render(vm1, { customer: { address: 'bar' } }));
@@ -40,7 +40,7 @@ describe('Compile', function() {
             Address: 'bar',
             address: 'foo',
           },
-        })
+        }),
       );
     });
 
@@ -52,7 +52,7 @@ describe('Compile', function() {
           foo: function() {
             return { bar: 'hello' };
           },
-        })
+        }),
       );
 
       assert.equal(
@@ -61,7 +61,7 @@ describe('Compile', function() {
           foo: function() {
             return 'foo';
           },
-        })
+        }),
       );
     });
 
@@ -214,7 +214,7 @@ describe('Compile', function() {
             values.push(value);
             return 'foo';
           },
-        }
+        },
       );
       assert.deepEqual(values, ['bar']);
       assert.equal(ret.trim(), 'foo');
@@ -471,7 +471,7 @@ describe('Compile', function() {
 
       assert.throws(function() {
         compile.render(context);
-      }, /Line number 3:0/);
+      }, /L\/N 3:0/);
     });
 
     it('print error stack of user-defined macro', function() {
@@ -601,7 +601,7 @@ describe('Compile', function() {
         '\nThis content is ignored. $val\n',
         render(vm, {
           val: 'foo',
-        })
+        }),
       );
     });
 
@@ -611,7 +611,7 @@ describe('Compile', function() {
         'This content is ignored. $val\na',
         render(vm, {
           val: 'foo',
-        })
+        }),
       );
     });
   });
@@ -639,7 +639,7 @@ describe('Compile', function() {
             },
           },
         }).trim(),
-        expected
+        expected,
       );
     });
   });
@@ -770,7 +770,7 @@ describe('Compile', function() {
             key3: { key4: 'value4' },
           },
         }),
-        expected
+        expected,
       );
     });
 


### PR DESCRIPTION
The implementation of set and get methods of an array in velocity is not working like in the real
environment.

fix is based on https://github.com/shepherdwind/velocity.js/pull/133

fix #5741

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.