### PR TITLE
fix: do not attempt to modify a file when reading it

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.js
@@ -245,7 +245,6 @@ function getCacheFilePath(context) {
 function getProfileConfig(profileName) {
   let profileConfig;
   if (fs.existsSync(configFilePath)) {
-    makeFileOwnerReadWrite(configFilePath);
     const config = ini.parse(fs.readFileSync(configFilePath, 'utf-8'));
     Object.keys(config).forEach(key => {
       const keyName = key.replace('profile', '').trim();
@@ -260,7 +259,6 @@ function getProfileConfig(profileName) {
 function getProfileCredentials(profileName) {
   let profileCredentials;
   if (fs.existsSync(credentialsFilePath)) {
-    makeFileOwnerReadWrite(credentialsFilePath);
     const credentials = ini.parse(fs.readFileSync(credentialsFilePath, 'utf-8'));
 
     Object.keys(credentials).forEach(key => {
@@ -299,7 +297,6 @@ function getProfileRegion(profileName) {
 function getNamedProfiles() {
   let namedProfiles;
   if (fs.existsSync(configFilePath)) {
-    makeFileOwnerReadWrite(configFilePath);
     const config = ini.parse(fs.readFileSync(configFilePath, 'utf-8'));
     namedProfiles = {};
     Object.keys(config).forEach(key => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The configuration files can exist on a read-only mountpoint, and attempting to change the permissions
will fail then _even if the permissions are fine as they are_.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.