### PR TITLE
add DataStore prompt for amplify add api

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -284,7 +284,7 @@ async function askAdditionalQuestions(context, authConfig, defaultAuthType, mode
 async function askResolverConflictQuestion(context, modelTypes?) {
   let resolverConfig: any = {};
 
-  if (await context.prompt.confirm('Configure conflict detection ? (required for Amplify DataStore)')) {
+  if (await context.prompt.confirm('Configure conflict detection? (required for DataStore)')) {
     const askConflictResolutionStrategy = async msg => {
       let conflictResolutionStrategy;
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -258,7 +258,7 @@ async function askAdditionalQuestions(context, authConfig, defaultAuthType, mode
   const advancedSettingsQuestion = {
     type: 'list',
     name: 'advancedSettings',
-    message: 'Do you want to configure advanced settings for the GraphQL API',
+    message: 'Do you want to configure advanced settings for the GraphQL API? (including enabling Amplify DataStore)',
     choices: [
       {
         name: 'No, I am done.',
@@ -284,7 +284,7 @@ async function askAdditionalQuestions(context, authConfig, defaultAuthType, mode
 async function askResolverConflictQuestion(context, modelTypes?) {
   let resolverConfig: any = {};
 
-  if (await context.prompt.confirm('Configure conflict detection?')) {
+  if (await context.prompt.confirm('Configure conflict detection ? (required for Amplify DataStore)')) {
     const askConflictResolutionStrategy = async msg => {
       let conflictResolutionStrategy;
 


### PR DESCRIPTION
make it more obvious how to enable Amplify DataStore

current workflow is not obvious, for sucha. major feature:

```bash
? Please select from one of the below mentioned services: GraphQL
? Provide API name: trelloamplified
? Choose the default authorization type for the API Amazon Cognito User Pool
Use a Cognito user pool configured as a part of this project.
? Do you want to configure advanced settings for the GraphQL API Yes, I want to make some additional changes.
? Configure additional auth types? No
? Configure conflict detection? Yes
? Select the default resolution strategy (Use arrow keys)
❯ Auto Merge 
  Optimistic Concurrency 
  Custom Lambda 
  Learn More 
```

absolutely none of this says "DataStore". why do we make people read minds?

we specify this in the docs https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend/q/platform/js#create-new-appsync-graphql-api but why force people to read docs



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.