### PR TITLE
fix(amplify-appsync-simulator): utils.toJson false value

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -1,7 +1,8 @@
 import { create } from '../../../velocity/util/index';
 import { JavaMap } from '../../../velocity/value-mapper/map';
 import { GraphQLResolveInfo } from 'graphql';
-import { TemplateSentError } from '../../../velocity/util/errors';
+import { hasUncaughtExceptionCaptureCallback } from 'process';
+import { generalUtils } from '../../../velocity/util/general-utils';
 
 const stubInfo = {
   fieldName: 'testFieldName',
@@ -59,4 +60,30 @@ it('appendError_filterDataJavaMap', () => {
   util.appendError('test message', 'ERROR_TYPE', stubJavaMap);
   expect(util.errors.length).toBe(1);
   expect(util.errors[0].data).toStrictEqual({ field1: 'field1Value', field2: 'field2Value' });
+});
+
+describe('$utils.toJson', () => {
+  it('should stringify an object', () => {
+    const object = { foo: 'Bar' };
+    expect(generalUtils.toJson(object)).toBe('{"foo":"Bar"}');
+  });
+  it('should return "null" for null values', () => {
+    const object = null;
+    expect(generalUtils.toJson(object)).toBe('null');
+  });
+
+  it('should return "null" for undefined values', () => {
+    const object = undefined;
+    expect(generalUtils.toJson(object)).toBe('null');
+  });
+
+  it('should return "true" for true values', () => {
+    const object = true;
+    expect(generalUtils.toJson(object)).toBe('true');
+  });
+
+  it('should return "false" for false values', () => {
+    const object = false;
+    expect(generalUtils.toJson(object)).toBe('false');
+  });
 });

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -5,6 +5,7 @@ import { JavaArray } from '../value-mapper/array';
 import { JavaMap } from '../value-mapper/map';
 import jsStringEscape from 'js-string-escape';
 import { GraphQLResolveInfo, FieldNode } from 'graphql';
+
 export const generalUtils = {
   errors: [],
   quiet: () => '',
@@ -30,7 +31,7 @@ export const generalUtils = {
     return JSON.parse(value);
   },
   toJson(value) {
-    return value ? JSON.stringify(value) : JSON.stringify(null);
+    return value !== undefined ? JSON.stringify(value) : JSON.stringify(null);
   },
   autoId() {
     return autoId();


### PR DESCRIPTION
*Description of changes:*

`$utils.toJson(false)` should return `false` (as a json). Currently, it returns `null`.

I also added some tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.