### PR TITLE
test(graphql-transformers-e2e-tests): add regex for noun change

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
@@ -115,7 +115,7 @@ test('test translate and convert text to speech', async () => {
 });
 
 test('test translate text individually', async () => {
-  const germanTranslation = 'Dies ist ein Sprachtest';
+  const germanTranslation = /ist ein Sprachtest$/;
   const response = await GRAPHQL_CLIENT.query(
     `query TranslateThis($input: TranslateThisInput!) {
       translateThis(input: $input)

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
@@ -115,7 +115,7 @@ test('test translate and convert text to speech', async () => {
 });
 
 test('test translate text individually', async () => {
-  const germanTranslation = /ist ein Sprachtest$/;
+  const germanTranslation = /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein Sprachtest/i;
   const response = await GRAPHQL_CLIENT.query(
     `query TranslateThis($input: TranslateThisInput!) {
       translateThis(input: $input)


### PR DESCRIPTION
noun can potentially change adding regex to keep end phrase similar

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.