### PR TITLE
fix: use non-duplicate names for lambda execution role

### DIFF
--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -306,7 +306,7 @@
 			],
             "Type": "AWS::IAM::Policy",
             "Properties": {
-                "PolicyName": "amplify-lambda-execution-policy",
+                "PolicyName": "amplify-lambda-execution-policy-prediction",
                 "Roles": [
                     {
                         "Ref": "function<%= props.adminTriggerFunction %>LambdaExecutionRole"

--- a/packages/amplify-category-storage/resources/cloudformation-templates/s3-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/resources/cloudformation-templates/s3-cloudformation-template.json.ejs
@@ -369,7 +369,7 @@
             ],
             "Type": "AWS::IAM::Policy",
             "Properties": {
-                "PolicyName": "amplify-lambda-execution-policy",
+                "PolicyName": "amplify-lambda-execution-policy-storage",
                 "Roles": [
                     {
                         "Ref": "function<%= props.triggerFunction %>LambdaExecutionRole"


### PR DESCRIPTION
Hi all,

we have noticed that adding permissions to a lambda function that is triggered by another resource (e.g. an S3 bucket) will *remove* the permissions that lambda has on the triggering resource -- and you cannot re-add those permissions as that will introduce a cyclic dependency (the storage-stack depends on the function and the function-stack depends on the bucket). This is the behavior described in #1913 as well.

This behaviour is caused by using the same name `amplify-lambda-execution-policy` for both policies generated by the triggering resource and when adding permissions to the lambda.

I have solved that for now by changing the name of the policy generated by the triggering resource.

For now I have doubts about the following references to the name `amplify-lambda-execution-policy`:

* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/cloudformation-templates/CreateAuthChallenge.json.ejs:175`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/cloudformation-templates/CustomMessage.json.ejs:192`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/DefineAuthChallenge/cloudformation-templates/DefineAuthChallenge.json.ejs:168`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostAuthentication/cloudformation-templates/PostAuthentication.json.ejs:168`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/cloudformation-templates/PostConfirmation.json.ejs:175`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreAuthentication/cloudformation-templates/PreAuthentication.json.ejs:168`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreSignup/cloudformation-templates/PreSignup.json.ejs:182`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PreTokenGeneration/cloudformation-templates/PreTokenGeneration.json.ejs:168`
* `packages/amplify-category-auth/provider-utils/awscloudformation/triggers/VerifyAuthChallengeResponse/cloudformation-templates/VerifyAuthChallengeResponse.json.ejs:176`

Even stranger is the reference to `amplify-lambda-execution-policy-<%= props.triggerEventSourceMappings[i].modelName%>` to which I can find no resource actually creating it.

We think that this PR solves a *real* problem with amplify in an easy way:

![image](https://user-images.githubusercontent.com/183276/98530741-a0dd9800-227f-11eb-88b7-75a13902c2ea.png)

Cheers,
Philipp

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.