### PR TITLE
feat: amplify uninstall command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,6 +853,14 @@ jobs:
           when: always
       - store_artifacts:
           path: ../uitest_android_results
+  uninstall-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_8
+    environment:
+      TEST_SUITE: src/__tests__/uninstall.test.ts
+      CLI_REGION: us-east-2
   plugin-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -860,7 +868,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   init-special-case-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -868,7 +876,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/init-special-case.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   datastore-modelgen-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -876,7 +884,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   amplify-configure-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -884,7 +892,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   init-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -892,7 +900,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/init.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   tags-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -900,7 +908,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/tags.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   schema-versioned-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -908,7 +916,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   schema-data-access-patterns-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -916,7 +924,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   interactions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -924,7 +932,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/interactions.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   schema-predictions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -932,7 +940,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   amplify-app-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -940,7 +948,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/amplify-app.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   hosting-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -948,7 +956,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/hosting.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   analytics-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -956,7 +964,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/analytics.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   feature-flags-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -964,7 +972,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/feature-flags.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   predictions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -972,7 +980,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/predictions.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   hostingPROD-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -980,7 +988,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   schema-auth-10-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -988,7 +996,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   schema-key-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -996,7 +1004,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-key.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   auth_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1004,7 +1012,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_1.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   auth_5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1012,7 +1020,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_5.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   function_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1020,7 +1028,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_3.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   schema-auth-3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1028,7 +1036,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   delete-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1036,7 +1044,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/delete.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   function_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1044,7 +1052,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   auth_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1052,7 +1060,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_3.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   layer-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1060,7 +1068,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/layer.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   migration-api-key-migration1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1068,7 +1076,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   auth_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1076,7 +1084,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_4.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   schema-auth-7-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1084,7 +1092,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   schema-auth-8-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1092,7 +1100,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   schema-searchable-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1100,7 +1108,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   schema-auth-4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1108,7 +1116,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   api_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1116,7 +1124,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/api_3.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   import_auth_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1124,7 +1132,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   import_auth_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1132,7 +1140,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   env-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1140,7 +1148,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/env.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   auth_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1148,7 +1156,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_2.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   schema-auth-9-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1156,7 +1164,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   schema-auth-11-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1164,7 +1172,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   migration-api-key-migration2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1172,7 +1180,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   function_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1180,7 +1188,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   schema-auth-1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1188,7 +1196,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   function_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1196,7 +1204,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_4.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   schema-function-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1204,7 +1212,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-function.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   schema-model-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1212,7 +1220,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-model.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   migration-api-connection-migration-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1220,7 +1228,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   schema-connection-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1228,7 +1236,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-connection.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   schema-auth-6-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1236,7 +1244,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   schema-auth-2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1244,7 +1252,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   api_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1252,7 +1260,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/api_1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   schema-auth-5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1260,7 +1268,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   storage-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1268,7 +1276,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/storage.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   api_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1276,7 +1284,17 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/api_2.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
+  uninstall-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/uninstall.test.ts
+      CLI_REGION: us-east-2
+    steps: *ref_9
   plugin-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_0
@@ -1285,7 +1303,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/plugin.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   init-special-case-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1295,7 +1313,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/init-special-case.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   datastore-modelgen-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1305,7 +1323,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   amplify-configure-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1315,7 +1333,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   init-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1325,7 +1343,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/init.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   tags-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1335,7 +1353,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/tags.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-versioned-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1345,7 +1363,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   schema-data-access-patterns-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1355,7 +1373,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   interactions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1365,7 +1383,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/interactions.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-predictions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1375,7 +1393,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   amplify-app-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1385,7 +1403,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/amplify-app.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   hosting-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1395,7 +1413,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/hosting.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   analytics-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1405,7 +1423,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/analytics.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   feature-flags-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1415,7 +1433,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/feature-flags.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   predictions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1425,7 +1443,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/predictions.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   hostingPROD-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1435,7 +1453,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-auth-10-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1445,7 +1463,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   schema-key-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1455,7 +1473,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-key.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   auth_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1465,7 +1483,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_1.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   auth_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1475,7 +1493,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_5.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   function_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1485,7 +1503,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_3.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   schema-auth-3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1495,7 +1513,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   delete-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1505,7 +1523,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/delete.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   function_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1515,7 +1533,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   auth_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1525,7 +1543,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_3.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   layer-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1535,7 +1553,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/layer.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1545,7 +1563,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   auth_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1555,7 +1573,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_4.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   schema-auth-7-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1565,7 +1583,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   schema-auth-8-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1575,7 +1593,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-searchable-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1585,7 +1603,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   schema-auth-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1595,7 +1613,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   api_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1605,7 +1623,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_3.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   import_auth_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1615,7 +1633,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   import_auth_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1625,7 +1643,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   env-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1635,7 +1653,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/env.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   auth_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1645,7 +1663,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_2.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-auth-9-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1655,7 +1673,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   schema-auth-11-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1665,7 +1683,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1675,7 +1693,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   function_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1685,7 +1703,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-auth-1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1695,7 +1713,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   function_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1705,7 +1723,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_4.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   schema-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1715,7 +1733,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-function.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-model-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1725,7 +1743,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-model.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1735,7 +1753,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   schema-connection-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1745,7 +1763,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-connection.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   schema-auth-6-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1755,7 +1773,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-auth-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1765,7 +1783,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   api_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1775,7 +1793,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   schema-auth-5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1785,7 +1803,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   storage-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1795,7 +1813,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/storage.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   api_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1805,7 +1823,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_2.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
 workflows:
   version: 2
@@ -1872,6 +1890,10 @@ workflows:
                 - master
       - done_with_node_e2e_tests:
           requires:
+            - auth_4-amplify_e2e_tests
+            - import_auth_2-amplify_e2e_tests
+            - schema-auth-1-amplify_e2e_tests
+            - schema-auth-2-amplify_e2e_tests
             - schema-auth-7-amplify_e2e_tests
             - env-amplify_e2e_tests
             - function_4-amplify_e2e_tests
@@ -1896,12 +1918,12 @@ workflows:
             - import_auth_1-amplify_e2e_tests
             - function_1-amplify_e2e_tests
             - schema-auth-6-amplify_e2e_tests
-            - auth_4-amplify_e2e_tests
-            - import_auth_2-amplify_e2e_tests
-            - schema-auth-1-amplify_e2e_tests
-            - schema-auth-2-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           requires:
+            - auth_4-amplify_e2e_tests_pkg_linux
+            - import_auth_2-amplify_e2e_tests_pkg_linux
+            - schema-auth-1-amplify_e2e_tests_pkg_linux
+            - schema-auth-2-amplify_e2e_tests_pkg_linux
             - schema-auth-7-amplify_e2e_tests_pkg_linux
             - env-amplify_e2e_tests_pkg_linux
             - function_4-amplify_e2e_tests_pkg_linux
@@ -1926,10 +1948,6 @@ workflows:
             - import_auth_1-amplify_e2e_tests_pkg_linux
             - function_1-amplify_e2e_tests_pkg_linux
             - schema-auth-6-amplify_e2e_tests_pkg_linux
-            - auth_4-amplify_e2e_tests_pkg_linux
-            - import_auth_2-amplify_e2e_tests_pkg_linux
-            - schema-auth-1-amplify_e2e_tests_pkg_linux
-            - schema-auth-2-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           filters:
             branches:
@@ -1969,11 +1987,47 @@ workflows:
                 - release
                 - master
                 - beta
-      - plugin-amplify_e2e_tests:
+      - uninstall-amplify_e2e_tests:
           filters: &ref_10
             branches:
               only:
                 - master
+          requires:
+            - publish_to_local_registry
+      - schema-versioned-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - feature-flags-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - function_3-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - auth_4-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - uninstall-amplify_e2e_tests
+      - import_auth_2-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - schema-versioned-amplify_e2e_tests
+      - schema-auth-1-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - feature-flags-amplify_e2e_tests
+      - schema-auth-2-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - function_3-amplify_e2e_tests
+      - plugin-amplify_e2e_tests:
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-data-access-patterns-amplify_e2e_tests:
@@ -2178,37 +2232,42 @@ workflows:
           requires:
             - publish_to_local_registry
             - auth_5-amplify_e2e_tests
-      - schema-versioned-amplify_e2e_tests:
-          filters: *ref_10
+      - uninstall-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-      - feature-flags-amplify_e2e_tests:
-          filters: *ref_10
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - schema-versioned-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-      - function_3-amplify_e2e_tests:
-          filters: *ref_10
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - feature-flags-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-      - auth_4-amplify_e2e_tests:
-          filters: *ref_10
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - function_3-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-      - import_auth_2-amplify_e2e_tests:
-          filters: *ref_10
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - auth_4-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-            - schema-versioned-amplify_e2e_tests
-      - schema-auth-1-amplify_e2e_tests:
-          filters: *ref_10
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - uninstall-amplify_e2e_tests_pkg_linux
+      - import_auth_2-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-            - feature-flags-amplify_e2e_tests
-      - schema-auth-2-amplify_e2e_tests:
-          filters: *ref_10
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - schema-versioned-amplify_e2e_tests_pkg_linux
+      - schema-auth-1-amplify_e2e_tests_pkg_linux:
           requires:
-            - publish_to_local_registry
-            - function_3-amplify_e2e_tests
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - feature-flags-amplify_e2e_tests_pkg_linux
+      - schema-auth-2-amplify_e2e_tests_pkg_linux:
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - function_3-amplify_e2e_tests_pkg_linux
       - plugin-amplify_e2e_tests_pkg_linux:
           requires:
             - done_with_node_e2e_tests
@@ -2415,34 +2474,3 @@ workflows:
             - done_with_node_e2e_tests
             - build_pkg_binaries
             - auth_5-amplify_e2e_tests_pkg_linux
-      - schema-versioned-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - feature-flags-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - function_3-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - auth_4-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - import_auth_2-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - schema-versioned-amplify_e2e_tests_pkg_linux
-      - schema-auth-1-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - feature-flags-amplify_e2e_tests_pkg_linux
-      - schema-auth-2-amplify_e2e_tests_pkg_linux:
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - function_3-amplify_e2e_tests_pkg_linux

--- a/packages/amplify-cli/amplify-plugin.json
+++ b/packages/amplify-cli/amplify-plugin.json
@@ -16,6 +16,7 @@
     "pull",
     "run",
     "status",
+    "uninstall",
     "version"
   ],
   "commandAliases": {

--- a/packages/amplify-cli/src/commands/uninstall.ts
+++ b/packages/amplify-cli/src/commands/uninstall.ts
@@ -1,0 +1,34 @@
+import { isPackaged, pathManager } from 'amplify-cli-core';
+import execa from 'execa';
+import * as fs from 'fs-extra';
+
+export const run = async context => {
+  if (
+    !context?.input?.options?.yes &&
+    !(await context.amplify.confirmPrompt('Are you sure you want to uninstall the Amplify CLI?', false))
+  ) {
+    context.print.warning('Not removing the Amplify CLI.');
+    return;
+  }
+  if (!isPackaged) {
+    await uninstallNodeCli();
+  }
+  await removeHomeDotAmplifyDir();
+  context.print.success('Uninstalled the Amplify CLI');
+};
+
+const uninstallNodeCli = async () => {
+  const command = 'npm uninstall -g @aws-amplify/cli';
+  const { stderr } = await execa.command(command, { stdio: 'inherit' });
+  if (stderr) {
+    throw new Error(`[${command}] failed with [${stderr}]\nYou'll need to manually uninstall the CLI using npm.`);
+  }
+};
+
+const removeHomeDotAmplifyDir = async () => {
+  try {
+    await fs.remove(pathManager.getHomeDotAmplifyDirPath());
+  } catch (ex) {
+    throw new Error(`Failed to remove [${pathManager.getHomeDotAmplifyDirPath()}]\nYou'll need to manually remove this directory.`);
+  }
+};

--- a/packages/amplify-e2e-tests/src/__tests__/uninstall.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/uninstall.test.ts
@@ -1,0 +1,32 @@
+import { pathManager } from 'amplify-cli-core';
+import { createLinkWithCache } from 'aws-appsync';
+import execa from 'execa';
+import * as fs from 'fs-extra';
+import which from 'which';
+
+describe('amplify uninstall', () => {
+  /**
+   * NOTE: This test has side effetcs! It will remove the global amplify installation and wipe out the ~/.amplify directory
+   * This is okay on CircleCI because each test suite runs in a separate box, but if you are running this test locally,
+   * you will need to reinstall your global CLI instance.
+   */
+  it('amplify is unavailable after uninstall', async () => {
+    // check amplify is available initially
+    try {
+      const { stderr: beforeError } = await execa.command('amplify version');
+      if (beforeError) {
+        throw new Error(`There's an issue with the amplify installation. [${beforeError}]`);
+      }
+    } catch (err) {
+      throw new Error(`Initial amplify installation check failed with [${err}]`);
+    }
+    const { stderr: uninstallError, stdout: uninstallStdout } = await execa.command('amplify uninstall --yes');
+    if (uninstallError) {
+      throw new Error(`amplify uninstall command failed with [${uninstallError}]`);
+    }
+    expect(uninstallStdout.includes('Uninstalled the Amplify CLI')).toBe(true);
+    await expect(which('amplify')).rejects.toMatchInlineSnapshot(`[Error: not found: amplify]`);
+    // expect ~/.amplify to be deleted
+    expect(fs.pathExistsSync(pathManager.getHomeDotAmplifyDirPath())).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds an `amplify uninstall` command to the CLI. This command can be used by both packaged and non-packaged versions of the CLI to uninstall. On Node, the command is basically an alias for `npm uninstall -g @aws-amplify/cli`. The `~/.amplify` folder is removed regardless of the CLI installation type (for the packaged CLI this also removes the installation which is at `~/.amplify/bin/amplify`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.