### PR TITLE
Removed extra blank space in error message in open-editor.ts

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/open-editor.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/open-editor.ts
@@ -43,7 +43,7 @@ export async function openEditor(context, filePath, waitToContinue = true) {
 
         subProcess.on('error', err => {
           context.print.error(
-            `Selected  editor ${editorSelected} was not found in your machine. Please manually edit the file created at ${filePath}`,
+            `Selected editor ${editorSelected} was not found in your machine. Please manually edit the file created at ${filePath}`,
           );
         });
 


### PR DESCRIPTION
Title says it all.
Got hit with this error message on my machine, and noticed the extra space.

------------
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.