### PR TITLE
fix: backfill script - allow ak and sk arguments to be read when initiating lambda client

### DIFF
--- a/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
+++ b/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
@@ -28,7 +28,7 @@ def main():
     args.sk = args.sk or credentials.secret_key
     args.ak = args.ak or credentials.access_key
 
-  client = boto3.client('lambda', region_name=args.rn)
+  client = boto3.client('lambda', aws_access_key_id=args.ak, aws_secret_access_key=args.sk, region_name=args.rn)
   import_dynamodb_items_to_es(args.tn, args.sk, args.ak, args.rn, args.esarn, args.lf, scan_limit)
 
 def import_dynamodb_items_to_es(table_name, aws_secret, aws_access, aws_region, event_source_arn, lambda_f, scan_limit):


### PR DESCRIPTION
*Issue #, if available:*
No Issue.

*Description of changes:*
I use 2 different AWS Account IDs to manage by DEV / PROD environments.

Script would fail on the following conditions.
1. When I provide access key and secret key as an argument.
2. I am logged into my AWS CLI with DEV AWS Account.

On L31, when it initializes the client, it doesn't take my access key / secret key as arguments, so even if I am running the script on PROD, I would run to an error on L85 saying my DEV Lambda doesn't have to right to perform an action on a PROD thing.

```
lambda_response = client.invoke(
      FunctionName=lambda_f,
      Payload=records
  )
```

This fix will allow access key and secret key arguments to be read.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.