### PR TITLE
test: remove appClientSecret from e2es

### DIFF
--- a/packages/amplify-e2e-tests/src/import-helpers/expects.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/expects.ts
@@ -7,7 +7,6 @@ export const expectProjectDetailsMatch = (projectDetails: ProjectDetails, ogProj
 
   expect(projectDetails.meta.UserPoolId).toEqual(ogProjectDetails.meta.UserPoolId);
   expect(projectDetails.meta.AppClientID).toEqual(ogProjectDetails.meta.AppClientID);
-  expect(projectDetails.meta.AppClientSecret).toEqual(ogProjectDetails.meta.AppClientSecret);
   expect(projectDetails.meta.AppClientIDWeb).toEqual(ogProjectDetails.meta.AppClientIDWeb);
   expect(projectDetails.meta.HostedUIDomain).toEqual(ogProjectDetails.meta.HostedUIDomain);
 
@@ -49,7 +48,6 @@ export const expectLocalAndOGMetaFilesOutputMatching = (projectRoot: string, ogP
 
   expect(authMeta.output.AppClientID).toEqual(ogAuthMeta.output.AppClientID);
   expect(authMeta.output.AppClientIDWeb).toEqual(ogAuthMeta.output.AppClientIDWeb);
-  expect(authMeta.output.AppClientSecret).toEqual(ogAuthMeta.output.AppClientSecret);
   expect(authMeta.output.HostedUIDomain).toEqual(ogAuthMeta.output.HostedUIDomain);
   expect(authMeta.output.UserPoolId).toEqual(ogAuthMeta.output.UserPoolId);
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The optional appClientSecret is no longer generated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.