### PR TITLE
chore: fix pub to verdaccio script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "publish:release": "lerna publish --conventional-commits --exact --yes --message 'chore(release): Publish [ci skip]'",
     "publish:backendManager": "lerna publish --preid=backend --dist-tag=backend --exact --include-merged-tags --conventional-prerelease --conventional-commits --yes --no-commit-hooks --no-git-tag-version",
     "postpublish:release": "git fetch . release:master && git push origin master",
-    "publish-to-verdaccio": "lerna publish --yes --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest --conventional-commits",
+    "publish-to-verdaccio": "lerna publish --yes --no-commit-hooks --no-push --exact --dist-tag=latest --conventional-commits",
     "commit": "git-cz",
     "coverage": "codecov || exit 0"
   },


### PR DESCRIPTION
Fixes the issue where the github release version is behind the CLI version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.