### PR TITLE
fix: use profile as key when asking for profile

### DIFF
--- a/packages/amplify-app/src/scripts/amplify-push.js
+++ b/packages/amplify-app/src/scripts/amplify-push.js
@@ -34,7 +34,7 @@ async function askForProfile(namedProfiles) {
     choices: Object.keys(namedProfiles),
   };
   const profileAnswer = await inquirer.prompt(profileQuestion);
-  return profileAnswer;
+  return profileAnswer.profile;
 }
 
 async function getValidProfile(profileToUse) {


### PR DESCRIPTION
fix #5394

*Issue #, if available:*

*Description of changes:*
Use string profile instead of object

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.