### PR TITLE
chore: pipeline updates

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -542,14 +542,13 @@ jobs:
           key: amplfiy-pkg-tag-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Install packaged Amplify CLI
-          # replace command with curl -sL https://aws-amplify.github.io/amplify-cli/install | version=v$version bash before pushing
           command: |
             version=$(cat .amplify-pkg-version)
-            curl -sL https://aws-amplify.github.io/amplify-cli/install | bash
-      # TODO enable this check once the packaged CLI is renamed to amplify from amp
-      # - run:
-      #     name: Sanity check install
-      #     command: amplify version
+            curl -sL https://aws-amplify.github.io/amplify-cli/install | version=v$version bash
+      - run:
+          name: Sanity check install
+          # TODO change to `amplify version` once the install script is modified to install to "amplify"
+          command: amp version
   github_release:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,9 +610,14 @@ jobs:
           key: 'amplfiy-pkg-tag-{{ .Branch }}-{{ .Revision }}'
       - run:
           name: Install packaged Amplify CLI
-          command: |
+          command: >
             version=$(cat .amplify-pkg-version)
-            curl -sL https://aws-amplify.github.io/amplify-cli/install | bash
+
+            curl -sL https://aws-amplify.github.io/amplify-cli/install |
+            version=v$version bash
+      - run:
+          name: Sanity check install
+          command: amp version
   github_release:
     working_directory: ~/repo
     docker: *ref_0

--- a/scripts/unified-changelog.ts
+++ b/scripts/unified-changelog.ts
@@ -3,22 +3,20 @@ import * as fs from 'fs-extra';
 import { join, parse, sep } from 'path';
 import { unifiedChangelogPath } from './constants';
 /**
- * This script is intended to be run after running `yarn publish-to-verdaccio` when all CHANGELOG file changes are staged but not committed
- * It will scan all staged CHANGELOG.md files and merge them into a single UNIFIED_CHANGELOG file
+ * This script is intended to be run after running `yarn publish-to-verdaccio` when all CHANGELOG file changes are in the latest commit added by lerna
+ * It will scan all CHANGELOG.md files in the latest commit and merge them into a single UNIFIED_CHANGELOG file
  */
 const packageRoot = join(__dirname, '..');
 // exported because this path is also referenced in github-prerelease.ts
 
 const getChangelogPaths = async (): Promise<string[]> => {
   console.log('Getting staged CHANGELOG files');
-  const { stdout: statusResult, stderr } = await execa.command('git status --porcelain', { cwd: packageRoot });
+  const { stdout: statusResult, stderr } = await execa.command('git diff --name-only HEAD HEAD~1', { cwd: packageRoot });
   if (stderr) {
     throw new Error(`git status failed with error [${stderr}]`);
   }
   const changelogPaths = statusResult
     .split('\n')
-    .filter(item => item.startsWith(' M '))
-    .map(item => item.slice(3)) // get rid of ' M ' prefix
     .filter(item => item.endsWith('CHANGELOG.md'))
     .map(item => join(packageRoot, item));
   return changelogPaths;


### PR DESCRIPTION
update the unified changelog script to work with recent changes to publish-to-verdaccio script.

Also update installation sanity check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.