### PR TITLE
feat: codegen on pull

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -82,6 +82,7 @@
     "folder-hash": "^3.3.0",
     "fs-extra": "^8.1.0",
     "global-prefix": "^3.0.0",
+    "graphql-transformer-core": "6.22.0",
     "ini": "^1.3.5",
     "inquirer": "^7.3.3",
     "lodash": "^4.17.19",

--- a/packages/amplify-cli/src/amplify-service-helper.ts
+++ b/packages/amplify-cli/src/amplify-service-helper.ts
@@ -1,5 +1,8 @@
-import { $TSObject, $TSContext } from 'amplify-cli-core';
+import { $TSObject, $TSContext, pathManager, stateManager } from 'amplify-cli-core';
+import { isDataStoreEnabled } from 'graphql-transformer-core';
 import { normalizeInputParams } from './input-params-manager';
+import * as path from 'path';
+import { entries } from 'lodash';
 
 export function constructInputParams(context: $TSContext) {
   const inputParams: $TSObject = normalizeInputParams(context);
@@ -22,6 +25,16 @@ export function constructInputParams(context: $TSContext) {
   return inputParams;
 }
 
-export async function postPullCodeGenCheck(context: $TSContext) {
-  context.print.info('');
-}
+export const postPullCodegen = async (context: $TSContext) => {
+  if (!!context?.exeInfo?.inputParams?.['no-codegen']) {
+    return;
+  }
+  const meta = stateManager.getCurrentMeta(undefined, { throwIfNotExist: false });
+  const gqlApiName = entries(meta?.api).find(([_, value]) => (value as any).service === 'AppSync')?.[0];
+  if (!gqlApiName) {
+    return;
+  }
+  if (await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', gqlApiName))) {
+    await context.amplify.invokePluginMethod(context, 'codegen', null, 'generateModels', [context]);
+  }
+};

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -5,7 +5,7 @@ import { queryProvider } from './attach-backend-steps/a10-queryProvider';
 import { analyzeProject } from './attach-backend-steps/a20-analyzeProject';
 import { initFrontend } from './attach-backend-steps/a30-initFrontend';
 import { generateFiles } from './attach-backend-steps/a40-generateFiles';
-import { postPullCodeGenCheck } from './amplify-service-helper';
+import { postPullCodegen } from './amplify-service-helper';
 import { initializeEnv } from './initialize-env';
 
 const backupAmplifyDirName = 'amplify-backup';
@@ -56,7 +56,7 @@ async function onSuccess(context: $TSContext) {
     }
   }
 
-  await postPullCodeGenCheck(context);
+  await postPullCodegen(context);
 
   if (!inputParams.yes) {
     const confirmKeepCodebase = await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-category-pluginInfo.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-category-pluginInfo.ts
@@ -1,9 +1,7 @@
 export function getCategoryPluginInfo(context, category, service?) {
   let categoryPluginInfo;
 
-  const pluginInfosForCategory = context.pluginPlatform.plugins[category].filter(pluginInfo => {
-    return pluginInfo.manifest.type === 'category';
-  });
+  const pluginInfosForCategory = context.pluginPlatform.plugins[category];
 
   if (pluginInfosForCategory.length > 0) {
     if (service) {

--- a/packages/amplify-cli/src/pull-backend.ts
+++ b/packages/amplify-cli/src/pull-backend.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import { initializeEnv } from './initialize-env';
-import { postPullCodeGenCheck } from './amplify-service-helper';
+import { postPullCodegen } from './amplify-service-helper';
 import { exitOnNextTick } from 'amplify-cli-core';
 
 export async function pullBackend(context, inputParams) {
@@ -33,7 +33,7 @@ export async function pullBackend(context, inputParams) {
 
   await initializeEnv(context);
   ensureBackendConfigFile(context);
-  await postPullCodeGenCheck(context);
+  await postPullCodegen(context);
   context.print.info('Post-pull status:');
   await context.amplify.showResourceTable();
   context.print.info('');

--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../amplify-category-function" },
     { "path": "../amplify-cli-core" },
     { "path": "../amplify-provider-awscloudformation" },
-    { "path": "../amplify-util-import" }
+    { "path": "../amplify-util-import" },
+    { "path": "../graphql-transformer-core"}
   ]
 }

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -70,7 +70,7 @@ async function generateModels(context) {
     ensureFileSync(outPutPath);
     writeFileSync(outPutPath, generatedCode[idx]);
   });
-  context.print.info(`Successfully generated models. Generated models can be found ${outputPath}`);
+  context.print.info(`Successfully generated models. Generated models can be found in ${outputPath}`);
 }
 
 async function validateSchema(context) {

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.js
@@ -25,7 +25,12 @@ async function init(context) {
   }
   normalizeInputParams(context);
 
-  const meta = stateManager.getMeta(undefined, { throwIfNotExist: false });
+  let meta = undefined;
+  try {
+    meta = stateManager.getMeta(undefined, { throwIfNotExist: false });
+  } catch {
+    // swallow the error. We handle undefined meta below
+  }
   if (meta?.providers?.awscloudformation && isAmplifyAdminApp(meta.providers.awscloudformation.AmplifyAppId)) {
     context.exeInfo.awsConfigInfo = {
       configLevel: 'amplifyAdmin',

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.js
@@ -31,7 +31,7 @@ async function init(context) {
   } catch {
     // swallow the error. We handle undefined meta below
   }
-  if (meta?.providers?.awscloudformation && isAmplifyAdminApp(meta.providers.awscloudformation.AmplifyAppId)) {
+  if (meta?.providers?.awscloudformation && (await isAmplifyAdminApp(meta.providers.awscloudformation.AmplifyAppId))) {
     context.exeInfo.awsConfigInfo = {
       configLevel: 'amplifyAdmin',
       config: {},

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -135,6 +135,11 @@ export async function writeConfig(projectDir: string, config: TransformConfig): 
   return config;
 }
 
+export const isDataStoreEnabled = async (projectDir: string): Promise<boolean> => {
+  const transformerConfig = await loadConfig(projectDir);
+  return transformerConfig?.ResolverConfig?.project !== undefined || transformerConfig?.ResolverConfig?.models !== undefined;
+};
+
 /**
  * Given an absolute path to an amplify project directory, load the
  * user defined configuration.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6024,51 +6024,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-app@2.17.17:
-  version "2.17.17"
-  resolved "https://registry.npmjs.org/amplify-app/-/amplify-app-2.17.17.tgz#4ca6339d36604c3a74f132e3be249afaedd15302"
-  integrity sha512-wSdlr8SyzMHupydbSsb8o0StXrBZD9uMmwBQuc4SQNM23JrRULzLqoHWqPu9fjxQ5wQo4lidgzIoneJQe9mI5w==
-  dependencies:
-    amplify-frontend-android "2.13.5"
-    amplify-frontend-ios "2.13.8"
-    amplify-frontend-javascript "2.17.2"
-    chalk "^3.0.0"
-    fs-extra "^8.1.0"
-    graphql "^14.5.8"
-    ini "^1.3.5"
-    inquirer "^7.3.3"
-    node-emoji "^1.10.0"
-    rimraf "^3.0.0"
-    semver "^7.1.1"
-    strip-ansi "^6.0.0"
-    xcode "^2.1.0"
-    yargs "^15.1.0"
-
-amplify-cli-core@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-1.5.1.tgz#7c5d2b460ef5cc6ec23292d864378098bed5503b"
-  integrity sha512-gzUNO/AiPGtowYgyVO20ofMZXukcbyK5908QlBYaStsUOqL71zzeK8H+S5n6nHAgiMAB/C+hr51mVlzCaoqp5Q==
-  dependencies:
-    ajv "^6.12.3"
-    dotenv "^8.2.0"
-    fs-extra "^8.1.0"
-    hjson "^3.2.1"
-    lodash "^4.17.19"
-
-amplify-frontend-javascript@2.17.2:
-  version "2.17.2"
-  resolved "https://registry.npmjs.org/amplify-frontend-javascript/-/amplify-frontend-javascript-2.17.2.tgz#275b0490b8c8596c32da7675af74985d480e32c5"
-  integrity sha512-mZDD9SYVjzGJiEhMXu8lv7M71U0D383PujODBGkc2QP5yc4BYMnAE74dp7MONEZQcgsJ3nMgsDjYsuhGJn8C1A==
-  dependencies:
-    amplify-cli-core "1.5.1"
-    chalk "^3.0.0"
-    execa "^4.0.0"
-    fs-extra "^8.1.0"
-    graphql-config "^2.2.1"
-    inquirer "^7.3.3"
-    lodash "^4.17.19"
-    promise-sequential "^1.1.1"
-
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"


### PR DESCRIPTION
On pull, if DataStore is enabled perform codegen models automatically. Adds a new --no-codegen flag to pull to skip this behavior if not desired

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.