### PR TITLE
fix: eslintignore creation with uninitialized project

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@graphql-codegen/core": "1.8.3",
+    "amplify-cli-core": "1.6.1",
     "amplify-codegen-appsync-model-plugin": "1.20.10",
     "amplify-graphql-docs-generator": "2.1.16",
     "amplify-graphql-types-generator": "2.5.2",


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

`.eslintignore` file generation failed on uninitialized projects when project was created with `amplify-app`, this PR changes how the `projectPath` is read, to make it work in those situations as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.