### PR TITLE
fix(amplify-category-auth): external auth enabled bugfix

### DIFF
--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -159,7 +159,7 @@ async function externalAuthEnable(context, externalCategory, resourceName, requi
     const action = authExists ? 'updated' : 'added';
     context.print.success(`Successfully ${action} auth resource locally.`);
 
-    return requirements.resourceName;
+    return authProps.resourceName;
   } catch (e) {
     context.print.error('Error updating Cognito resource');
     throw e;


### PR DESCRIPTION
`externalAuthEnabled` was returning an incorrect value

*Issue #, if available:*
N/A
*Description of changes:*
Updating return value for `externalAuthEnabled` function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.