### PR TITLE
fix: headless auth remove oauth when empty config specified

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-request-adaptor.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-request-adaptor.test.ts.snap
@@ -28,3 +28,27 @@ Object {
   "userpoolClientWriteAttributes": Array [],
 }
 `;
+
+exports[`get update auth request adaptor valid translations translates empty oAuth config into hostedUI: false 1`] = `
+Object {
+  "adminQueries": false,
+  "adminQueryGroup": undefined,
+  "authProviders": Array [],
+  "authSelections": "userPoolOnly",
+  "autoVerifiedAttributes": Array [],
+  "hostedUI": false,
+  "mfaConfiguration": "OFF",
+  "requiredAttributes": Array [
+    "required_attribute",
+  ],
+  "serviceName": "Cognito",
+  "thirdPartyAuth": false,
+  "updateFlow": "manual",
+  "useDefault": "manual",
+  "userPoolGroupList": Array [],
+  "userPoolGroups": false,
+  "userpoolClientReadAttributes": Array [],
+  "userpoolClientRefreshTokenValidity": undefined,
+  "userpoolClientWriteAttributes": Array [],
+}
+`;

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-request-adaptor.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-request-adaptor.test.ts
@@ -1,5 +1,8 @@
-import { AddAuthRequest, CognitoUserPoolSigninMethod, CognitoUserProperty } from 'amplify-headless-interface';
-import { getAddAuthRequestAdaptor } from '../../../../provider-utils/awscloudformation/utils/auth-request-adaptors';
+import { AddAuthRequest, CognitoUserPoolSigninMethod, CognitoUserProperty, UpdateAuthRequest } from 'amplify-headless-interface';
+import {
+  getAddAuthRequestAdaptor,
+  getUpdateAuthRequestAdaptor,
+} from '../../../../provider-utils/awscloudformation/utils/auth-request-adaptors';
 
 describe('get add auth request adaptor', () => {
   describe('valid translations', () => {
@@ -18,6 +21,25 @@ describe('get add auth request adaptor', () => {
       };
 
       expect(getAddAuthRequestAdaptor('javascript')(addAuthRequest)).toMatchSnapshot();
+    });
+  });
+});
+
+describe('get update auth request adaptor', () => {
+  describe('valid translations', () => {
+    it('translates empty oAuth config into hostedUI: false', () => {
+      const updateAuthRequest: UpdateAuthRequest = {
+        version: 1,
+        serviceModification: {
+          serviceName: 'Cognito',
+          userPoolModification: {
+            oAuth: {},
+          },
+          includeIdentityPool: false,
+        },
+      };
+
+      expect(getUpdateAuthRequestAdaptor('javascript', ['required_attribute'])(updateAuthRequest)).toMatchSnapshot();
     });
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -1,7 +1,7 @@
 const inquirer = require('inquirer');
 const chalk = require('chalk');
 const _ = require('lodash');
-const { uniq, pullAll } = require('lodash');
+const { uniq, pullAll, isEmpty } = require('lodash');
 const path = require('path');
 const { Sort } = require('enquirer');
 // const { parseTriggerSelections } = require('../utils/trigger-flow-auth-helper');
@@ -412,7 +412,7 @@ function userPoolProviders(oAuthProviders, coreAnswers, prevAnswers) {
     ? JSON.parse(JSON.stringify(answers.requiredAttributes)).concat('username')
     : ['email', 'username'];
   const res = {};
-  if (oAuthProviders) {
+  if (!isEmpty(oAuthProviders)) {
     res.hostedUIProviderMeta = JSON.stringify(
       oAuthProviders.map(el => {
         const delimmiter = el === 'Facebook' ? ',' : ' ';
@@ -458,8 +458,7 @@ function structureOAuthMetadata(coreAnswers, context, defaults, amplify) {
     delete context.updatingAuth.oAuthMetadata;
     return null;
   }
-  const prev = context.updatingAuth ? context.updatingAuth : {};
-  const answers = Object.assign(prev, coreAnswers);
+  const answers = Object.assign({}, context.updatingAuth, coreAnswers);
   let { AllowedOAuthFlows, AllowedOAuthScopes, CallbackURLs, LogoutURLs } = answers;
   if (CallbackURLs && coreAnswers.newCallbackURLs) {
     CallbackURLs = CallbackURLs.concat(coreAnswers.newCallbackURLs);

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
@@ -15,7 +15,7 @@ import {
   CognitoIdentityPoolModification,
 } from 'amplify-headless-interface';
 import { identityPoolProviders, userPoolProviders } from '../service-walkthroughs/auth-questions';
-import { merge } from 'lodash';
+import { isEmpty, merge } from 'lodash';
 import { authProviders as authProviderList } from '../assets/string-maps';
 import {
   ServiceQuestionsResult,
@@ -106,17 +106,22 @@ const mutableAttributeAdaptor = (
 
 // converts the oauth config to the existing format
 const oauthMap = (
-  oauthConfig?: CognitoOAuthConfiguration,
+  oauthConfig?: Partial<CognitoOAuthConfiguration>,
   requiredAttributes: string[] = [],
 ): (OAuthResult & SocialProviderResult) | {} => {
   if (!oauthConfig) return {};
+  if (isEmpty(oauthConfig)) {
+    return {
+      hostedUI: false,
+    };
+  }
   return {
     hostedUI: true,
     hostedUIDomainName: oauthConfig.domainPrefix,
     newCallbackURLs: oauthConfig.redirectSigninURIs,
     newLogoutURLs: oauthConfig.redirectSignoutURIs,
-    AllowedOAuthFlows: oauthConfig.oAuthGrantType.toLowerCase() as 'code' | 'implicit',
-    AllowedOAuthScopes: oauthConfig.oAuthScopes.map(scope => scope.toLowerCase()),
+    AllowedOAuthFlows: oauthConfig?.oAuthGrantType?.toLowerCase() as 'code' | 'implicit',
+    AllowedOAuthScopes: oauthConfig?.oAuthScopes?.map(scope => scope.toLowerCase()),
     ...socialProviderMap(oauthConfig.socialProviderConfigurations, requiredAttributes),
   };
 };

--- a/packages/amplify-headless-interface/schemas/auth/1/UpdateAuthRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/auth/1/UpdateAuthRequest.schema.json
@@ -47,7 +47,19 @@
                     ]
                 },
                 "userPoolModification": {
-                    "$ref": "#/definitions/Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\"|\"oAuth\"|\"addUserToGroup\"|\"emailBlacklist\"|\"emailWhitelist\"|\"customAuthScaffolding\">"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\"|\"addUserToGroup\"|\"emailBlacklist\"|\"emailWhitelist\"|\"customAuthScaffolding\">"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "oAuth": {
+                                    "$ref": "#/definitions/Partial<CognitoOAuthConfiguration>"
+                                }
+                            }
+                        }
+                    ]
                 }
             },
             "required": [
@@ -55,7 +67,7 @@
                 "userPoolModification"
             ]
         },
-        "Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\"|\"oAuth\"|\"addUserToGroup\"|\"emailBlacklist\"|\"emailWhitelist\"|\"customAuthScaffolding\">": {
+        "Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\"|\"addUserToGroup\"|\"emailBlacklist\"|\"emailWhitelist\"|\"customAuthScaffolding\">": {
             "type": "object",
             "properties": {
                 "userPoolGroups": {
@@ -144,9 +156,6 @@
                         ],
                         "type": "string"
                     }
-                },
-                "oAuth": {
-                    "$ref": "#/definitions/CognitoOAuthConfiguration"
                 },
                 "addUserToGroup": {
                     "type": "object",
@@ -335,7 +344,8 @@
                 "smsMessage"
             ]
         },
-        "CognitoOAuthConfiguration": {
+        "Partial<CognitoOAuthConfiguration>": {
+            "description": "Make all properties in T optional",
             "type": "object",
             "properties": {
                 "domainPrefix": {
@@ -379,13 +389,7 @@
                         "$ref": "#/definitions/CognitoSocialProviderConfiguration"
                     }
                 }
-            },
-            "required": [
-                "oAuthGrantType",
-                "oAuthScopes",
-                "redirectSigninURIs",
-                "redirectSignoutURIs"
-            ]
+            }
         },
         "CognitoSocialProviderConfiguration": {
             "type": "object",

--- a/packages/amplify-headless-interface/src/interface/auth/update.ts
+++ b/packages/amplify-headless-interface/src/interface/auth/update.ts
@@ -1,4 +1,4 @@
-import { CognitoUserPoolConfiguration, CognitoIdentityPoolConfiguration, NoCognitoIdentityPool } from './add';
+import { CognitoUserPoolConfiguration, CognitoIdentityPoolConfiguration, NoCognitoIdentityPool, CognitoOAuthConfiguration } from './add';
 
 export interface UpdateAuthRequest {
   version: 1;
@@ -27,10 +27,9 @@ export type CognitoUserPoolModification = Pick<
   | 'refreshTokenPeriod'
   | 'readAttributes'
   | 'writeAttributes'
-  | 'oAuth'
   | 'addUserToGroup'
   | 'emailBlacklist'
   | 'emailWhitelist'
   | 'customAuthScaffolding'
->;
+> & { oAuth?: Partial<CognitoOAuthConfiguration> };
 export type CognitoIdentityPoolModification = Pick<CognitoIdentityPoolConfiguration, 'unauthenticatedLogin' | 'identitySocialFederation'>;


### PR DESCRIPTION
Specifying an empty oAuth config in a headless auth update request (`"oAuth": {}`) now removes the oAuth configuration from the auth resource. Additionally, a partial oAuth config can be specified in a headless update and only the parameters specified will be updated; omitted parameters will retain their current value


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.