### PR TITLE
feat(cli): adds --env option to amplify init to override sampledev

### DIFF
--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -98,7 +98,8 @@ async function installPackage() {
 async function setLocalEnvDefaults(context: $TSContext) {
   const projectPath = process.cwd();
   const defaultEditor = 'vscode';
-  const envName = 'sampledev';
+
+  const envName = context.parameters.options.env || 'sampledev';
   context.print.warning(`Setting default editor to ${defaultEditor}`);
   context.print.warning(`Setting environment to ${envName}`);
   context.print.warning('Run amplify configure project to change the default configuration later');


### PR DESCRIPTION
*Issue*
https://github.com/aws-amplify/amplify-cli/issues/5946

*Description of changes:*
This PR adds the ability to define a custom env value to override the hard coded `sampledev` environment name. This allows multiple versions of an amplify project initialised from the same source app to be deployed into the same AWS account by running:

`amplify init --app {repo URL} --env {envName}`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.