### PR TITLE
fix: imported s3 bucket us-east-1 not getting region assigned

### DIFF
--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/import/import-s3.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/import/import-s3.ts
@@ -95,7 +95,6 @@ const importServiceWalkthrough = async (
   }
 
   const s3 = await providerUtils.createS3Service(context);
-  const amplifyMeta = stateManager.getMeta();
 
   // Get list of user pools to see if there is anything to import
   const bucketList = await s3.listBuckets();

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -52,6 +52,13 @@ export class S3Service implements IS3Service {
       })
       .promise();
 
-    return response.LocationConstraint!;
+    // For us-east-1 buckets the LocationConstraint is always emtpy, we have to return a
+    // region in every case.
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
+    if (response.LocationConstraint === '' || response.LocationConstraint === null) {
+      return 'us-east-1';
+    }
+
+    return response.LocationConstraint;
   }
 }


### PR DESCRIPTION
*Description of changes:*

For import S3 buckets when they reside in `us-east-1`, `getBucketLocation` returns empty, so meta file ends up with no region. This PR fixes that edge case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.