### PR TITLE
fix: new auth triggers overwrite previous selections

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -1,6 +1,6 @@
 import { ServiceQuestionsResult } from '../service-walkthrough-types';
 import { verificationBucketName } from './verification-bucket-name';
-import { merge } from 'lodash';
+import { isEmpty, merge } from 'lodash';
 import { structureOAuthMetadata } from '../service-walkthroughs/auth-questions';
 import { removeDeprecatedProps } from './synthesize-resources';
 import { immutableAttributes, safeDefaults } from '../constants';
@@ -49,5 +49,9 @@ export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename
 
   structureOAuthMetadata(result, context, getAllDefaults, context.amplify); // adds "oauthMetadata" to result
 
+  // If there are new trigger selections, make sure they overwrite the previous selections
+  if (!isEmpty(result.triggers)) {
+    previousResult.triggers = Object.assign({}, result.triggers);
+  }
   return merge(defaults, removeDeprecatedProps(previousResult), result);
 };


### PR DESCRIPTION
previous commit caused a few e2e tests to fail because new auth trigger selections were not overwriting previous selections

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.