### PR TITLE
feat: add BatchGetItem to appsync-simulator(#5963)

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/data-loader/dynamo-db/utils/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/data-loader/dynamo-db/utils/index.test.ts
@@ -1,0 +1,10 @@
+import { mapTableObject, unmarshall } from '../../../../data-loader/dynamo-db/utils';
+
+describe('mapTableObject', () => {
+  it(`will returns mapped TableName key object`, () => {
+    expect(mapTableObject({ TestTable: { id: { S: '1' } }, OtherTable: { id: { S: '2' } } }, item => unmarshall(item))).toEqual({
+      TestTable: { id: '1' },
+      OtherTable: { id: '2' },
+    });
+  });
+});

--- a/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/utils/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/utils/index.ts
@@ -26,9 +26,14 @@ export function unmarshall(raw, isRaw: boolean = true) {
         ...sum,
         [key]: unmarshall(value, false),
       }),
-      {}
+      {},
     );
   }
 
   return content;
+}
+
+type TableObject<T> = { [tableName: string]: T };
+export function mapTableObject<T, R>(tableObject: TableObject<T>, mapper: (inp: T) => R): TableObject<R> {
+  return Object.fromEntries(Object.entries(tableObject).map(([tableName, value]) => [tableName, mapper(value)]));
 }


### PR DESCRIPTION
*Issue #, if available:*
#5963 

*Description of changes:*
- add BatchGetItem to amplify-appsync-simulator

- tests done
  - ran existing unit tests
  - ran unit test for added utility function
  - done E2E manual tests and checked that the BatchGetItem operation will returns response like [documented](https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-dynamodb-batch.html#error-handling) 

I'm not sure how to test it completely.  
if any idea / conventions, please let me know!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.