### PR TITLE
chore: add circle ci tags to cf resources in e2e test projects

### DIFF
--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -78,16 +78,24 @@ export function generateLocalEnvInfoFile(context: $TSContext) {
 function generateLocalTagsFile(context: $TSContext) {
   if (context.exeInfo.isNewProject) {
     const { projectPath } = context.exeInfo.localEnvInfo;
-    const tags = [
-      {
+
+    // Preserve existing tags if present
+    const tags = stateManager.getProjectTags(projectPath);
+
+    if (!tags.find(t => t.Key === 'user:Stack')) {
+      tags.push({
         Key: 'user:Stack',
         Value: '{project-env}',
-      },
-      {
+      });
+    }
+
+    if (!tags.find(t => t.Key === 'user:Application')) {
+      tags.push({
         Key: 'user:Application',
         Value: '{project-name}',
-      },
-    ];
+      });
+    }
+
     stateManager.setProjectFileTags(projectPath, tags);
   }
 }

--- a/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn } from 'amplify-e2e-core';
+import { addCircleCITags, nspawn as spawn } from 'amplify-e2e-core';
 import { getCLIPath } from '../util';
 import { HOSTING_NOT_ENABLED, HOSTING_ENABLED_IN_CONSOLE, ORIGINAL_ENV } from './constants';
 
@@ -18,6 +18,9 @@ const defaultSettings = {
 
 export function initJSProjectWithProfile(cwd: string, providersParam: any) {
   const s = { ...defaultSettings };
+
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['init', '--providers', JSON.stringify(providersParam)], { cwd, stripColors: true })
       .wait('Enter a name for the project')

--- a/packages/amplify-e2e-core/src/init/index.ts
+++ b/packages/amplify-e2e-core/src/init/index.ts
@@ -3,4 +3,3 @@ export * from './amplifyPush';
 export * from './deleteProject';
 export * from './initProjectHelper';
 export * from './pull-headless';
-export { getProjectMeta } from '../utils';

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect } from '..';
+import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';
 
 const defaultSettings = {
   name: '\r',
@@ -42,6 +42,8 @@ export function initJSProjectWithProfile(cwd: string, settings: Object) {
     };
   }
 
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['init'], { cwd, stripColors: true, env })
       .wait('Enter a name for the project')
@@ -80,6 +82,9 @@ export function initJSProjectWithProfile(cwd: string, settings: Object) {
 
 export function initAndroidProjectWithProfile(cwd: string, settings: Object) {
   const s = { ...defaultSettings, ...settings };
+
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['init'], {
       cwd,
@@ -106,6 +111,8 @@ export function initAndroidProjectWithProfile(cwd: string, settings: Object) {
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
+          addCircleCITags(cwd);
+
           resolve();
         } else {
           reject(err);
@@ -116,6 +123,9 @@ export function initAndroidProjectWithProfile(cwd: string, settings: Object) {
 
 export function initIosProjectWithProfile(cwd: string, settings: Object) {
   const s = { ...defaultSettings, ...settings };
+
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['init'], {
       cwd,
@@ -140,6 +150,8 @@ export function initIosProjectWithProfile(cwd: string, settings: Object) {
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
+          addCircleCITags(cwd);
+
           resolve();
         } else {
           reject(err);
@@ -150,6 +162,8 @@ export function initIosProjectWithProfile(cwd: string, settings: Object) {
 
 export function initFlutterProjectWithProfile(cwd: string, settings: Object) {
   const s = { ...defaultSettings, ...settings };
+
+  addCircleCITags(cwd);
 
   return new Promise((resolve, reject) => {
     let chain = spawn(getCLIPath(), ['init'], { cwd, stripColors: true })
@@ -184,6 +198,8 @@ export function initFlutterProjectWithProfile(cwd: string, settings: Object) {
 
 export function initProjectWithAccessKey(cwd: string, settings: { accessKeyId: string; secretAccessKey: string; region?: string }) {
   const s = { ...defaultSettings, ...settings };
+
+  addCircleCITags(cwd);
 
   return new Promise((resolve, reject) => {
     let chain = spawn(getCLIPath(), ['init'], {
@@ -235,6 +251,8 @@ export function initProjectWithAccessKey(cwd: string, settings: { accessKeyId: s
 }
 
 export function initNewEnvWithAccessKey(cwd: string, s: { envName: string; accessKeyId: string; secretAccessKey: string }) {
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     let chain = spawn(getCLIPath(), ['init'], {
       cwd,
@@ -271,6 +289,8 @@ export function initNewEnvWithAccessKey(cwd: string, s: { envName: string; acces
 }
 
 export function initNewEnvWithProfile(cwd: string, s: { envName: string }) {
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['init'], {
       cwd,

--- a/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
+++ b/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
@@ -1,0 +1,23 @@
+import { stateManager } from 'amplify-cli-core';
+
+export const addCircleCITags = (projectPath: string): void => {
+  if (process.env && process.env['CIRCLE_CI']) {
+    const tags = stateManager.getProjectTags(projectPath);
+
+    const addTagIfNotExist = (key: string, value: string): void => {
+      if (!tags.find(t => t.Key === key)) {
+        tags.push({
+          Key: key,
+          Value: value,
+        });
+      }
+    };
+
+    addTagIfNotExist('circleci', process.env['CIRCLE_CI'] || 'N/A');
+    addTagIfNotExist('circleci:branch', process.env['CIRCLE_BRANCH'] || 'N/A');
+    addTagIfNotExist('circleci:sha1', process.env['CIRCLE_SHA1'] || 'N/A');
+    addTagIfNotExist('circleci:workflow_id', process.env['CIRCLE_WORKFLOW_ID'] || 'N/A');
+
+    stateManager.setProjectFileTags(projectPath, tags);
+  }
+};

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -3,8 +3,10 @@ import * as fs from 'fs-extra';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
 
+export * from './add-circleci-tags';
 export * from './api';
 export * from './appsync';
+export * from './envVars';
 export * from './getAppId';
 export * from './headless';
 export * from './nexpect';
@@ -17,7 +19,6 @@ export * from './sdk-calls';
 export * from './selectors';
 export * from './sleep';
 export * from './transformConfig';
-export * from './envVars';
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -1,5 +1,5 @@
 import { Pinpoint } from 'aws-sdk';
-import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions } from '..';
+import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions, addCircleCITags } from '..';
 import _ from 'lodash';
 
 const settings = {
@@ -70,6 +70,8 @@ export async function pinpointAppExist(pinpointProjectId: string): Promise<boole
 }
 
 export function initProjectForPinpoint(cwd: string) {
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     let chain = spawn(getCLIPath(), ['init'], {
       cwd,

--- a/packages/amplify-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-e2e-tests/src/init-special-cases/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { nspawn as spawn, getCLIPath, singleSelect, amplifyRegions } from 'amplify-e2e-core';
+import { nspawn as spawn, getCLIPath, singleSelect, amplifyRegions, addCircleCITags } from 'amplify-e2e-core';
 import fs from 'fs-extra';
 import os from 'os';
 
@@ -42,6 +42,8 @@ export async function initWithoutCredentialFileAndNoNewUserSetup(projRoot) {
 }
 
 async function initWorkflow(cwd: string, settings: { accessKeyId: string; secretAccessKey: string; region: string }) {
+  addCircleCITags(cwd);
+
   return new Promise((resolve, reject) => {
     let chain = spawn(getCLIPath(), ['init'], {
       cwd,


### PR DESCRIPTION
*Description of changes:*

fix: preserve `tags.json` content if it exists during `amplify init`
chore: This PR adds Circle CI related tags that helps with the cleaning up of leftover resources after a cancelled or failed pipeline run.

Tags include:
- `circleci`: to enable filtering
- `circleci:branch`: GitHub branch
- `circleci:sha1`: Commit hash
- `circleci:workflow_id`: Id of the Circle CI workflow 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.