### PR TITLE
fix(amplify-codegen-appsync-model-plugin): pass targetName for hasOne relationships

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/utils/process-connections.test.ts
@@ -126,6 +126,7 @@ describe('process connection', () => {
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
         expect(connectionInfo.associatedWith).toEqual(modelMap.License.fields[0]);
         expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
+        expect(connectionInfo.targetName).toEqual("personLicenseId");
       });
 
       it('should return BELONGS_TO License.person field', () => {

--- a/packages/amplify-codegen-appsync-model-plugin/src/utils/process-connections.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/utils/process-connections.ts
@@ -20,6 +20,7 @@ export type CodeGenFieldConnectionBelongsTo = CodeGenConnectionTypeBase & {
 export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_ONE;
   associatedWith: CodeGenField;
+  targetName: string;
 };
 
 export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
@@ -186,6 +187,7 @@ export function processConnections(
             associatedWith: otherSideField,
             connectedModel: otherSide,
             isConnectingFieldAutoCreated,
+            targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
           };
         } else {
           /*

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-swift-visitor.ts
@@ -247,7 +247,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
         return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, targetName: "${connectionInfo.targetName}")`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
         return `.belongsTo(${name}, is: ${isRequired}, ofType: ${typeName}, targetName: "${connectionInfo.targetName}")`;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/920

*Description of changes:*
This adds the targetName for hasOne relationships, closely mirroring the same logic applied for belongsTo. 

*Testing done*
schema
```
type Project2 @model {
  id: ID!
  name: String
  teamID: ID! // Explicit field for Team association
  team: Team2 @connection(fields: ["teamID"])
}

type Team2 @model {
  id: ID!
  name: String!
}
```

Generated swift schema class without this change:
```swift
// swiftlint:disable all
import Amplify
import Foundation

extension Project2 {
  // MARK: - CodingKeys 
   public enum CodingKeys: String, ModelKey {
    case id
    case name
    case teamID
    case team
  }
  
  public static let keys = CodingKeys.self
  //  MARK: - ModelSchema 
  
  public static let schema = defineSchema { model in
    let project2 = Project2.keys
    
    model.pluralName = "Project2s"
    
    model.fields(
      .id(),
      .field(project2.name, is: .optional, ofType: .string),
      .field(project2.teamID, is: .required, ofType: .string),
      .hasOne(project2.team, is: .optional, ofType: Team2.self, associatedWith: Team2.keys.id)
    )
    }
}
```
Generated schema with this change:
```swift
.hasOne(project2.team, is: .optional, ofType: Team2.self, associatedWith: Team2.keys.id, targetName: "teamID")
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.