### PR TITLE
fix(amplify-appsync-simulator): auth directive unauthorized message

### DIFF
--- a/packages/amplify-appsync-simulator/src/schema/directives/auth.ts
+++ b/packages/amplify-appsync-simulator/src/schema/directives/auth.ts
@@ -44,7 +44,7 @@ function getAuthDirectiveForField(
   schema: GraphQLSchema,
   field,
   typeName: string,
-  simulator: AmplifyAppSyncSimulator
+  simulator: AmplifyAppSyncSimulator,
 ): AmplifyAppSyncSimulatorAuthenticationType[] {
   const fieldDirectives = field.astNode.directives;
   const parentField = schema.getType(typeName);
@@ -109,7 +109,7 @@ export function protectResolversWithAuthRules(typeDef, existingResolvers, simula
         const groups = getCognitoGroups(ctx.jwt || {});
         const authorized = groups.some(group => allowedCognitoGroups.includes(group));
         if (!authorized) {
-          const err = new Unauthorized(`Not Authorized to access ${fieldName} on type ${typeName}`, info.operation.loc);
+          const err = new Unauthorized(`Not Authorized to access ${fieldName} on type ${typeName}`, info);
           throw err;
         }
       }

--- a/packages/amplify-appsync-simulator/src/velocity/util/errors.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/errors.ts
@@ -34,7 +34,7 @@ export class TemplateSentError extends Error {
 }
 
 export class Unauthorized extends TemplateSentError {
-  constructor(gqlMessage, info) {
+  constructor(gqlMessage, info: GraphQLResolveInfo) {
     super(gqlMessage, 'Unauthorized', {}, {}, info);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In current master the simulate server can respond with `"message": "Cannot read property 'key' of undefined",` when using the auth directive. Which I tracked down to this line:
https://github.com/aws-amplify/amplify-cli/blob/296ae55d1252168380dbac99d26e816221ddd470/packages/amplify-appsync-simulator/src/velocity/util/errors.ts#L11
 the auth directive handler seemingly passes down the wrong field from the Graphql info object. 

-------------------

Fixed by passing the correctly shaped info object and typing the constructor params. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.