### PR TITLE
fix(amplify-provider-awscloudformation): fix hosting output

### DIFF
--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -29,8 +29,7 @@ export function addDEVHosting(cwd: string) {
 
 export function addPRODHosting(cwd: string) {
   return new Promise((resolve, reject) => {
-    // Cloudfront distrubution takes a long time. Bumping up the timeout
-    spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true, noOutputTimeout: 30 * 60 * 1000 })
+    spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true })
       .wait('Select the plugin module to execute')
       .send(KEY_DOWN_ARROW)
       .sendCarriageReturn()
@@ -38,6 +37,32 @@ export function addPRODHosting(cwd: string) {
       .send(KEY_DOWN_ARROW)
       .sendCarriageReturn()
       .wait('hosting bucket name')
+      .sendCarriageReturn()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
+export function removePRODCloudFront(cwd: string) {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['update', 'hosting'], { cwd, stripColors: true })
+      .wait('Specify the section to configure')
+      .send(KEY_DOWN_ARROW)
+      .sendCarriageReturn()
+      .wait('Remove CloudFront from hosting')
+      .send('y')
+      .sendCarriageReturn()
+      .wait('index doc for the website')
+      .sendCarriageReturn()
+      .wait('error doc for the website')
+      .sendCarriageReturn()
+      .wait('Specify the section to configure')
+      .send(KEY_DOWN_ARROW)
       .sendCarriageReturn()
       .run((err: Error) => {
         if (!err) {

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -340,6 +340,10 @@ class CloudFormation {
                   }
                 }
 
+                if (resourceObject.service === 'S3AndCloudFront' && resourceObject.output) {
+                  updatedMeta[category][resource].output = formattedOutputs;
+                }
+
                 stateManager.setMeta(undefined, updatedMeta);
               }
             }


### PR DESCRIPTION
fix hosting category output after CloudFront is removed

fix #402

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.