### PR TITLE
feat: add support for multiple @key changes in same @model

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -851,6 +851,7 @@ workflows:
             branches:
               only:
                 - master
+                - iterative-update
           requires:
             - build
             - mock_e2e_tests
@@ -869,6 +870,8 @@ workflows:
               only:
                 - master
                 - beta
+                - backendManager
+                - iterative-update
                 - release
           requires:
             - build
@@ -887,6 +890,7 @@ workflows:
             branches:
               only:
                 - master
+                - iterative-update
           requires:
             - publish_to_local_registry
       - done_with_node_e2e_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -958,6 +958,14 @@ jobs:
           when: always
       - store_artifacts:
           path: ../uitest_android_results
+  schema-iterative-update-locking-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_8
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
+      CLI_REGION: us-east-2
   plugin-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -965,7 +973,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   init-special-case-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -973,7 +981,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/init-special-case.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   datastore-modelgen-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -981,7 +989,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   amplify-configure-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -989,7 +997,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   init-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -997,7 +1005,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/init.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   tags-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1005,7 +1013,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/tags.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   schema-versioned-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1013,7 +1021,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   schema-data-access-patterns-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1021,7 +1029,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   interactions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1029,7 +1037,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/interactions.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   schema-predictions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1037,7 +1045,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   amplify-app-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1045,7 +1053,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/amplify-app.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   hosting-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1053,7 +1061,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/hosting.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   analytics-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1061,7 +1069,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/analytics.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   feature-flags-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1069,7 +1077,15 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/feature-flags.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
+  schema-iterative-update-2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_8
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts
+      CLI_REGION: us-west-2
   predictions-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1077,7 +1093,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/predictions.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-west-2
   hostingPROD-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1085,7 +1101,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-central-1
   schema-auth-10-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1093,7 +1109,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-northeast-1
   schema-key-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1101,7 +1117,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-key.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-1
   auth_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1109,7 +1125,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_1.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-2
   auth_5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1117,7 +1133,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_5.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-east-2
   function_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1125,7 +1141,15 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_3.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-west-2
+  schema-iterative-update-1-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_8
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts
+      CLI_REGION: eu-west-2
   schema-auth-3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1133,7 +1157,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
   delete-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1141,7 +1165,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/delete.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
   function_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1149,7 +1173,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
   auth_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1157,7 +1181,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_3.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
   layer-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1165,7 +1189,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/layer.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
   migration-api-key-migration1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1173,7 +1197,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
   auth_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1181,7 +1205,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_4.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
   schema-auth-7-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1189,7 +1213,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
   schema-auth-8-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1197,7 +1221,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
   schema-searchable-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1205,7 +1229,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
   schema-auth-4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1213,7 +1237,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
   api_3-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1221,7 +1245,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/api_3.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
   import_auth_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1229,7 +1253,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
   import_auth_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1237,7 +1261,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
   import_s3_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1245,7 +1269,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/import_s3_1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
   import_dynamodb_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1253,7 +1277,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
   env-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1261,7 +1285,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/env.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
   auth_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1269,7 +1293,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/auth_2.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
   schema-auth-9-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1277,7 +1301,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
   schema-auth-11-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1285,7 +1309,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
   migration-api-key-migration2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1293,7 +1317,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
   function_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1301,7 +1325,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
   schema-auth-1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1309,7 +1333,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
   function_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1317,7 +1341,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/function_4.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
   schema-function-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1325,7 +1349,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-function.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
   schema-model-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1333,7 +1357,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-model.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
   migration-api-connection-migration-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1341,7 +1365,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
   schema-connection-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1349,7 +1373,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-connection.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
   schema-auth-6-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1357,7 +1381,15 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
+  schema-iterative-update-3-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_8
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts
+      CLI_REGION: ap-northeast-1
   schema-auth-2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1365,7 +1397,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-southeast-1
   api_1-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1373,7 +1405,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/api_1.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-2
   schema-auth-5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1381,7 +1413,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: us-east-2
   storage-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1389,7 +1421,7 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/storage.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-west-2
   api_2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -1397,7 +1429,25 @@ jobs:
     steps: *ref_8
     environment:
       TEST_SUITE: src/__tests__/api_2.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-west-2
+  schema-iterative-update-4-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_8
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
+      CLI_REGION: eu-central-1
+  schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
+      CLI_REGION: us-east-2
+    steps: *ref_9
   plugin-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_0
@@ -1406,7 +1456,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/plugin.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   init-special-case-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1416,7 +1466,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/init-special-case.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   datastore-modelgen-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1426,7 +1476,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   amplify-configure-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1436,7 +1486,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   init-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1446,7 +1496,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/init.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   tags-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1456,7 +1506,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/tags.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-versioned-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1466,7 +1516,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_9
   schema-data-access-patterns-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1476,7 +1526,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_9
   interactions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1486,7 +1536,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/interactions.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-predictions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1496,7 +1546,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   amplify-app-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1506,7 +1556,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/amplify-app.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   hosting-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1516,7 +1566,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/hosting.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   analytics-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1526,7 +1576,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/analytics.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   feature-flags-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1536,7 +1586,17 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/feature-flags.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
+    steps: *ref_9
+  schema-iterative-update-2-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts
+      CLI_REGION: us-west-2
     steps: *ref_9
   predictions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1546,7 +1606,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/predictions.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   hostingPROD-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1556,7 +1616,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   schema-auth-10-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1566,7 +1626,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   schema-key-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1576,7 +1636,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-key.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   auth_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1586,7 +1646,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_1.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   auth_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1596,7 +1656,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_5.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-east-2
     steps: *ref_9
   function_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1606,7 +1666,17 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_3.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-west-2
+    steps: *ref_9
+  schema-iterative-update-1-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-auth-3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1616,7 +1686,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   delete-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1626,7 +1696,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/delete.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   function_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1636,7 +1706,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_2.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   auth_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1646,7 +1716,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_3.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   layer-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1656,7 +1726,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/layer.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
     steps: *ref_9
   migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1666,7 +1736,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
     steps: *ref_9
   auth_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1676,7 +1746,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_4.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-auth-7-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1686,7 +1756,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   schema-auth-8-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1696,7 +1766,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   schema-searchable-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1706,7 +1776,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   schema-auth-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1716,7 +1786,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   api_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1726,7 +1796,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_3.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
     steps: *ref_9
   import_auth_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1736,7 +1806,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
     steps: *ref_9
   import_auth_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1746,7 +1816,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   import_s3_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1756,7 +1826,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_s3_1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   import_dynamodb_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1766,7 +1836,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   env-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1776,7 +1846,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/env.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   auth_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1786,7 +1856,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_2.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-auth-9-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1796,7 +1866,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
     steps: *ref_9
   schema-auth-11-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1806,7 +1876,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
     steps: *ref_9
   migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1816,7 +1886,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   function_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1826,7 +1896,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_1.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
     steps: *ref_9
   schema-auth-1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1836,7 +1906,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   function_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1846,7 +1916,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_4.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   schema-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1856,7 +1926,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-function.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-model-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1866,7 +1936,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-model.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
     steps: *ref_9
   migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1876,7 +1946,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
     steps: *ref_9
   schema-connection-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1886,7 +1956,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-connection.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
     steps: *ref_9
   schema-auth-6-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1896,7 +1966,17 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
+    steps: *ref_9
+  schema-iterative-update-3-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts
+      CLI_REGION: ap-northeast-1
     steps: *ref_9
   schema-auth-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1906,7 +1986,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_9
   api_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1916,7 +1996,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_1.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-2
     steps: *ref_9
   schema-auth-5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1926,7 +2006,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: us-east-2
     steps: *ref_9
   storage-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1936,7 +2016,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/storage.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-west-2
     steps: *ref_9
   api_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1946,7 +2026,17 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_2.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-west-2
+    steps: *ref_9
+  schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
+      CLI_REGION: eu-central-1
     steps: *ref_9
 workflows:
   version: 2
@@ -1981,6 +2071,7 @@ workflows:
             branches:
               only:
                 - master
+                - iterative-update
           requires:
             - build
             - mock_e2e_tests
@@ -1999,6 +2090,8 @@ workflows:
               only:
                 - master
                 - beta
+                - backendManager
+                - iterative-update
                 - release
           requires:
             - build
@@ -2014,64 +2107,64 @@ workflows:
                 - master
       - done_with_node_e2e_tests:
           requires:
-            - schema-auth-7-amplify_e2e_tests
-            - import_s3_1-amplify_e2e_tests
-            - function_1-amplify_e2e_tests
-            - schema-auth-6-amplify_e2e_tests
-            - schema-auth-8-amplify_e2e_tests
-            - import_dynamodb_1-amplify_e2e_tests
-            - schema-auth-1-amplify_e2e_tests
-            - schema-auth-2-amplify_e2e_tests
-            - schema-searchable-amplify_e2e_tests
-            - env-amplify_e2e_tests
-            - function_4-amplify_e2e_tests
-            - api_1-amplify_e2e_tests
-            - schema-auth-4-amplify_e2e_tests
-            - auth_2-amplify_e2e_tests
-            - schema-function-amplify_e2e_tests
-            - schema-auth-5-amplify_e2e_tests
             - api_3-amplify_e2e_tests
             - schema-auth-9-amplify_e2e_tests
             - schema-model-amplify_e2e_tests
-            - storage-amplify_e2e_tests
+            - schema-auth-5-amplify_e2e_tests
             - import_auth_1-amplify_e2e_tests
             - schema-auth-11-amplify_e2e_tests
             - migration-api-connection-migration-amplify_e2e_tests
-            - api_2-amplify_e2e_tests
-            - auth_4-amplify_e2e_tests
+            - storage-amplify_e2e_tests
             - import_auth_2-amplify_e2e_tests
             - migration-api-key-migration2-amplify_e2e_tests
             - schema-connection-amplify_e2e_tests
+            - api_2-amplify_e2e_tests
+            - import_s3_1-amplify_e2e_tests
+            - function_1-amplify_e2e_tests
+            - schema-auth-6-amplify_e2e_tests
+            - schema-iterative-update-4-amplify_e2e_tests
+            - schema-auth-8-amplify_e2e_tests
+            - import_dynamodb_1-amplify_e2e_tests
+            - schema-auth-1-amplify_e2e_tests
+            - schema-iterative-update-3-amplify_e2e_tests
+            - schema-searchable-amplify_e2e_tests
+            - env-amplify_e2e_tests
+            - function_4-amplify_e2e_tests
+            - schema-auth-2-amplify_e2e_tests
+            - schema-auth-4-amplify_e2e_tests
+            - auth_2-amplify_e2e_tests
+            - schema-function-amplify_e2e_tests
+            - api_1-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           requires:
-            - schema-auth-7-amplify_e2e_tests_pkg_linux
-            - import_s3_1-amplify_e2e_tests_pkg_linux
-            - function_1-amplify_e2e_tests_pkg_linux
-            - schema-auth-6-amplify_e2e_tests_pkg_linux
-            - schema-auth-8-amplify_e2e_tests_pkg_linux
-            - import_dynamodb_1-amplify_e2e_tests_pkg_linux
-            - schema-auth-1-amplify_e2e_tests_pkg_linux
-            - schema-auth-2-amplify_e2e_tests_pkg_linux
-            - schema-searchable-amplify_e2e_tests_pkg_linux
-            - env-amplify_e2e_tests_pkg_linux
-            - function_4-amplify_e2e_tests_pkg_linux
-            - api_1-amplify_e2e_tests_pkg_linux
-            - schema-auth-4-amplify_e2e_tests_pkg_linux
-            - auth_2-amplify_e2e_tests_pkg_linux
-            - schema-function-amplify_e2e_tests_pkg_linux
-            - schema-auth-5-amplify_e2e_tests_pkg_linux
             - api_3-amplify_e2e_tests_pkg_linux
             - schema-auth-9-amplify_e2e_tests_pkg_linux
             - schema-model-amplify_e2e_tests_pkg_linux
-            - storage-amplify_e2e_tests_pkg_linux
+            - schema-auth-5-amplify_e2e_tests_pkg_linux
             - import_auth_1-amplify_e2e_tests_pkg_linux
             - schema-auth-11-amplify_e2e_tests_pkg_linux
             - migration-api-connection-migration-amplify_e2e_tests_pkg_linux
-            - api_2-amplify_e2e_tests_pkg_linux
-            - auth_4-amplify_e2e_tests_pkg_linux
+            - storage-amplify_e2e_tests_pkg_linux
             - import_auth_2-amplify_e2e_tests_pkg_linux
             - migration-api-key-migration2-amplify_e2e_tests_pkg_linux
             - schema-connection-amplify_e2e_tests_pkg_linux
+            - api_2-amplify_e2e_tests_pkg_linux
+            - import_s3_1-amplify_e2e_tests_pkg_linux
+            - function_1-amplify_e2e_tests_pkg_linux
+            - schema-auth-6-amplify_e2e_tests_pkg_linux
+            - schema-iterative-update-4-amplify_e2e_tests_pkg_linux
+            - schema-auth-8-amplify_e2e_tests_pkg_linux
+            - import_dynamodb_1-amplify_e2e_tests_pkg_linux
+            - schema-auth-1-amplify_e2e_tests_pkg_linux
+            - schema-iterative-update-3-amplify_e2e_tests_pkg_linux
+            - schema-searchable-amplify_e2e_tests_pkg_linux
+            - env-amplify_e2e_tests_pkg_linux
+            - function_4-amplify_e2e_tests_pkg_linux
+            - schema-auth-2-amplify_e2e_tests_pkg_linux
+            - schema-auth-4-amplify_e2e_tests_pkg_linux
+            - auth_2-amplify_e2e_tests_pkg_linux
+            - schema-function-amplify_e2e_tests_pkg_linux
+            - api_1-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           filters:
             branches:
@@ -2144,18 +2237,142 @@ workflows:
             branches:
               only:
                 - release
-      - plugin-amplify_e2e_tests:
+      - schema-iterative-update-locking-amplify_e2e_tests:
           filters: &ref_10
             branches:
               only:
                 - master
+                - iterative-update
+          requires:
+            - publish_to_local_registry
+      - schema-versioned-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - feature-flags-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - auth_5-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - layer-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - schema-iterative-update-locking-amplify_e2e_tests
+      - api_3-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - schema-versioned-amplify_e2e_tests
+      - schema-auth-9-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - feature-flags-amplify_e2e_tests
+      - schema-model-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - auth_5-amplify_e2e_tests
+      - schema-auth-5-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - layer-amplify_e2e_tests
+      - plugin-amplify_e2e_tests:
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-data-access-patterns-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
+      - schema-iterative-update-2-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - function_3-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - migration-api-key-migration1-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - plugin-amplify_e2e_tests
+      - import_auth_1-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - schema-data-access-patterns-amplify_e2e_tests
+      - schema-auth-11-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - schema-iterative-update-2-amplify_e2e_tests
+      - migration-api-connection-migration-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - function_3-amplify_e2e_tests
+      - storage-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - migration-api-key-migration1-amplify_e2e_tests
+      - init-special-case-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - interactions-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
       - predictions-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - schema-iterative-update-1-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - auth_4-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - init-special-case-amplify_e2e_tests
+      - import_auth_2-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - interactions-amplify_e2e_tests
+      - migration-api-key-migration2-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - predictions-amplify_e2e_tests
+      - schema-connection-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - schema-iterative-update-1-amplify_e2e_tests
+      - api_2-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+            - auth_4-amplify_e2e_tests
+      - datastore-modelgen-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - schema-predictions-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - hostingPROD-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
@@ -2167,31 +2384,36 @@ workflows:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - plugin-amplify_e2e_tests
+            - datastore-modelgen-amplify_e2e_tests
       - import_s3_1-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - schema-data-access-patterns-amplify_e2e_tests
+            - schema-predictions-amplify_e2e_tests
       - function_1-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - predictions-amplify_e2e_tests
+            - hostingPROD-amplify_e2e_tests
       - schema-auth-6-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
             - schema-auth-3-amplify_e2e_tests
-      - init-special-case-amplify_e2e_tests:
+      - schema-iterative-update-4-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-      - interactions-amplify_e2e_tests:
+            - schema-auth-7-amplify_e2e_tests
+      - amplify-configure-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-      - hostingPROD-amplify_e2e_tests:
+      - amplify-app-amplify_e2e_tests:
+          filters: *ref_10
+          requires:
+            - publish_to_local_registry
+      - schema-auth-10-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
@@ -2203,31 +2425,31 @@ workflows:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - init-special-case-amplify_e2e_tests
+            - amplify-configure-amplify_e2e_tests
       - import_dynamodb_1-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - interactions-amplify_e2e_tests
+            - amplify-app-amplify_e2e_tests
       - schema-auth-1-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - hostingPROD-amplify_e2e_tests
-      - schema-auth-2-amplify_e2e_tests:
+            - schema-auth-10-amplify_e2e_tests
+      - schema-iterative-update-3-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
             - delete-amplify_e2e_tests
-      - datastore-modelgen-amplify_e2e_tests:
+      - init-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-      - schema-predictions-amplify_e2e_tests:
+      - hosting-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-      - schema-auth-10-amplify_e2e_tests:
+      - schema-key-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
@@ -2239,31 +2461,31 @@ workflows:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - datastore-modelgen-amplify_e2e_tests
+            - init-amplify_e2e_tests
       - env-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - schema-predictions-amplify_e2e_tests
+            - hosting-amplify_e2e_tests
       - function_4-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - schema-auth-10-amplify_e2e_tests
-      - api_1-amplify_e2e_tests:
+            - schema-key-amplify_e2e_tests
+      - schema-auth-2-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
             - function_2-amplify_e2e_tests
-      - amplify-configure-amplify_e2e_tests:
+      - tags-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-      - amplify-app-amplify_e2e_tests:
+      - analytics-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-      - schema-key-amplify_e2e_tests:
+      - auth_1-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
@@ -2275,130 +2497,77 @@ workflows:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - amplify-configure-amplify_e2e_tests
+            - tags-amplify_e2e_tests
       - auth_2-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - amplify-app-amplify_e2e_tests
+            - analytics-amplify_e2e_tests
       - schema-function-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
-            - schema-key-amplify_e2e_tests
-      - schema-auth-5-amplify_e2e_tests:
+            - auth_1-amplify_e2e_tests
+      - api_1-amplify_e2e_tests:
           filters: *ref_10
           requires:
             - publish_to_local_registry
             - auth_3-amplify_e2e_tests
-      - init-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - hosting-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - auth_1-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - layer-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - api_3-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - init-amplify_e2e_tests
-      - schema-auth-9-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - hosting-amplify_e2e_tests
-      - schema-model-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - auth_1-amplify_e2e_tests
-      - storage-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - layer-amplify_e2e_tests
-      - tags-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - analytics-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - auth_5-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - migration-api-key-migration1-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - import_auth_1-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - tags-amplify_e2e_tests
-      - schema-auth-11-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - analytics-amplify_e2e_tests
-      - migration-api-connection-migration-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - auth_5-amplify_e2e_tests
-      - api_2-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - migration-api-key-migration1-amplify_e2e_tests
-      - schema-versioned-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - feature-flags-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - function_3-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - auth_4-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-      - import_auth_2-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - schema-versioned-amplify_e2e_tests
-      - migration-api-key-migration2-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - feature-flags-amplify_e2e_tests
-      - schema-connection-amplify_e2e_tests:
-          filters: *ref_10
-          requires:
-            - publish_to_local_registry
-            - function_3-amplify_e2e_tests
-      - plugin-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           filters: &ref_11
             branches:
               only:
                 - master
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - schema-versioned-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - feature-flags-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - auth_5-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - layer-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
+      - api_3-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - schema-versioned-amplify_e2e_tests_pkg_linux
+      - schema-auth-9-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - feature-flags-amplify_e2e_tests_pkg_linux
+      - schema-model-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - auth_5-amplify_e2e_tests_pkg_linux
+      - schema-auth-5-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - layer-amplify_e2e_tests_pkg_linux
+      - plugin-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
@@ -2407,7 +2576,107 @@ workflows:
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
+      - schema-iterative-update-2-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - function_3-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - plugin-amplify_e2e_tests_pkg_linux
+      - import_auth_1-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
+      - schema-auth-11-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
+      - migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - function_3-amplify_e2e_tests_pkg_linux
+      - storage-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
+      - init-special-case-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - interactions-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
       - predictions-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - schema-iterative-update-1-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - auth_4-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - init-special-case-amplify_e2e_tests_pkg_linux
+      - import_auth_2-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - interactions-amplify_e2e_tests_pkg_linux
+      - migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - predictions-amplify_e2e_tests_pkg_linux
+      - schema-connection-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - schema-iterative-update-1-amplify_e2e_tests_pkg_linux
+      - api_2-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+            - auth_4-amplify_e2e_tests_pkg_linux
+      - datastore-modelgen-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - schema-predictions-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - hostingPROD-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
@@ -2422,36 +2691,42 @@ workflows:
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - plugin-amplify_e2e_tests_pkg_linux
+            - datastore-modelgen-amplify_e2e_tests_pkg_linux
       - import_s3_1-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
+            - schema-predictions-amplify_e2e_tests_pkg_linux
       - function_1-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - predictions-amplify_e2e_tests_pkg_linux
+            - hostingPROD-amplify_e2e_tests_pkg_linux
       - schema-auth-6-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
             - schema-auth-3-amplify_e2e_tests_pkg_linux
-      - init-special-case-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-      - interactions-amplify_e2e_tests_pkg_linux:
+            - schema-auth-7-amplify_e2e_tests_pkg_linux
+      - amplify-configure-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-      - hostingPROD-amplify_e2e_tests_pkg_linux:
+      - amplify-app-amplify_e2e_tests_pkg_linux:
+          filters: *ref_11
+          requires:
+            - done_with_node_e2e_tests
+            - build_pkg_binaries
+      - schema-auth-10-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
@@ -2466,36 +2741,36 @@ workflows:
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - init-special-case-amplify_e2e_tests_pkg_linux
+            - amplify-configure-amplify_e2e_tests_pkg_linux
       - import_dynamodb_1-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - interactions-amplify_e2e_tests_pkg_linux
+            - amplify-app-amplify_e2e_tests_pkg_linux
       - schema-auth-1-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - hostingPROD-amplify_e2e_tests_pkg_linux
-      - schema-auth-2-amplify_e2e_tests_pkg_linux:
+            - schema-auth-10-amplify_e2e_tests_pkg_linux
+      - schema-iterative-update-3-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
             - delete-amplify_e2e_tests_pkg_linux
-      - datastore-modelgen-amplify_e2e_tests_pkg_linux:
+      - init-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-      - schema-predictions-amplify_e2e_tests_pkg_linux:
+      - hosting-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-      - schema-auth-10-amplify_e2e_tests_pkg_linux:
+      - schema-key-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
@@ -2510,36 +2785,36 @@ workflows:
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - datastore-modelgen-amplify_e2e_tests_pkg_linux
+            - init-amplify_e2e_tests_pkg_linux
       - env-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - schema-predictions-amplify_e2e_tests_pkg_linux
+            - hosting-amplify_e2e_tests_pkg_linux
       - function_4-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - schema-auth-10-amplify_e2e_tests_pkg_linux
-      - api_1-amplify_e2e_tests_pkg_linux:
+            - schema-key-amplify_e2e_tests_pkg_linux
+      - schema-auth-2-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
             - function_2-amplify_e2e_tests_pkg_linux
-      - amplify-configure-amplify_e2e_tests_pkg_linux:
+      - tags-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-      - amplify-app-amplify_e2e_tests_pkg_linux:
+      - analytics-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-      - schema-key-amplify_e2e_tests_pkg_linux:
+      - auth_1-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
@@ -2554,148 +2829,22 @@ workflows:
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - amplify-configure-amplify_e2e_tests_pkg_linux
+            - tags-amplify_e2e_tests_pkg_linux
       - auth_2-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - amplify-app-amplify_e2e_tests_pkg_linux
+            - analytics-amplify_e2e_tests_pkg_linux
       - schema-function-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
-            - schema-key-amplify_e2e_tests_pkg_linux
-      - schema-auth-5-amplify_e2e_tests_pkg_linux:
+            - auth_1-amplify_e2e_tests_pkg_linux
+      - api_1-amplify_e2e_tests_pkg_linux:
           filters: *ref_11
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
             - auth_3-amplify_e2e_tests_pkg_linux
-      - init-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - hosting-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - auth_1-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - layer-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - api_3-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - init-amplify_e2e_tests_pkg_linux
-      - schema-auth-9-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - hosting-amplify_e2e_tests_pkg_linux
-      - schema-model-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - auth_1-amplify_e2e_tests_pkg_linux
-      - storage-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - layer-amplify_e2e_tests_pkg_linux
-      - tags-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - analytics-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - auth_5-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - import_auth_1-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - tags-amplify_e2e_tests_pkg_linux
-      - schema-auth-11-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - analytics-amplify_e2e_tests_pkg_linux
-      - migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - auth_5-amplify_e2e_tests_pkg_linux
-      - api_2-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
-      - schema-versioned-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - feature-flags-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - function_3-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - auth_4-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-      - import_auth_2-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - schema-versioned-amplify_e2e_tests_pkg_linux
-      - migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - feature-flags-amplify_e2e_tests_pkg_linux
-      - schema-connection-amplify_e2e_tests_pkg_linux:
-          filters: *ref_11
-          requires:
-            - done_with_node_e2e_tests
-            - build_pkg_binaries
-            - function_3-amplify_e2e_tests_pkg_linux

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "amplify-cli-core": "1.10.0",
     "amplify-function-plugin-interface": "1.5.1",
-    "cloudform-types": "4.2.0",
+    "cloudform-types": "^4.2.0",
     "enquirer": "^2.3.6",
     "folder-hash": "^3.3.2",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-cli-core/src/deploymentState.ts
+++ b/packages/amplify-cli-core/src/deploymentState.ts
@@ -1,0 +1,43 @@
+export type DeploymentState = {
+  version: '1';
+  startedAt?: string;
+  finishedAt?: string;
+  status: DeploymentStatus;
+  currentStepIndex: number;
+  steps: DeploymentStepState[];
+};
+
+export type DeploymentStepState = {
+  status: DeploymentStepStatus;
+};
+
+export enum DeploymentStatus {
+  'IDLE' = 'IDLE',
+  'DEPLOYING' = 'DEPLOYING',
+  'DEPLOYED' = 'DEPLOYED',
+  'ROLLING_BACK' = 'ROLLING_BACK',
+  'ROLLED_BACK' = 'ROLLED_BACK',
+  'FAILED' = 'FAILED',
+}
+
+export enum DeploymentStepStatus {
+  'WAITING_FOR_DEPLOYMENT' = 'WAITING_FOR_DEPLOYMENT',
+  'DEPLOYING' = 'DEPLOYING',
+  'DEPLOYED' = 'DEPLOYED',
+  'WAITING_FOR_TABLE_TO_BE_READY' = 'WAITING_FOR_TABLE_TO_BE_READY',
+  'WAITING_FOR_ROLLBACK' = 'WAITING_FOR_ROLLBACK',
+  'ROLLING_BACK' = 'ROLLING_BACK',
+  'ROLLED_BACK' = 'ROLLED_BACK',
+}
+
+export interface IDeploymentStateManager {
+  startDeployment(steps: DeploymentStepState[]): Promise<boolean>;
+  failDeployment(): Promise<void>;
+  updateCurrentStepStatus(status: DeploymentStepStatus): Promise<void>;
+  startCurrentStep(): Promise<void>;
+  advanceStep(): Promise<void>;
+  startRollback(): Promise<void>;
+
+  isDeploymentInProgress(): Promise<boolean>;
+  getStatus(): DeploymentState | undefined;
+}

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -504,6 +504,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: false,
       },
+      {
+        name: 'enableIterativeGSIUpdates',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: false,
+      },
     ]);
   };
 }

--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -14,6 +14,7 @@ export * from './exitOnNextTick';
 export * from './isPackaged';
 export * from './cliConstants';
 export * from './deploymentSecretsHelper';
+export * from './deploymentState';
 
 // Temporary types until we can finish full type definition across the whole CLI
 
@@ -104,15 +105,15 @@ export type $TSTeamProviderInfo = any;
 export type $TSObject = Record<string, $TSAny>;
 
 export enum AmplifyFrontend {
-  android = "android",
-  ios = "ios",
-  javascript = "javascript"
+  android = 'android',
+  ios = 'ios',
+  javascript = 'javascript',
 }
 export interface AmplifyProjectConfig {
-  projectName: string,
-  version: string,
-  frontend: AmplifyFrontend,
-  providers: string[],
+  projectName: string;
+  version: string;
+  frontend: AmplifyFrontend;
+  providers: string[];
 }
 
 // Temporary interface until Context refactor
@@ -165,7 +166,12 @@ interface AmplifyToolkit {
     optionNameOverrides?: Record<string, string>,
   ) => Promise<ServiceSelection>;
   updateProjectConfig: () => $TSAny;
-  updateamplifyMetaAfterResourceUpdate: () => $TSAny;
+  updateamplifyMetaAfterResourceUpdate: (
+    category: string,
+    resourceName: string,
+    metaResourceKey?: $TSAny,
+    metaResourceData?: $TSAny,
+  ) => $TSAny;
   updateamplifyMetaAfterResourceAdd: (
     category: string,
     resourceName: string,

--- a/packages/amplify-cli/src/__tests__/commands/init.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/init.test.ts
@@ -1,11 +1,11 @@
 import { execSync } from 'child_process';
-import { ensureDir, existsSync, readFileSync, readJSON, readdirSync, } from 'fs-extra';
+import { ensureDir, existsSync, readFileSync, readJSON, readdirSync } from 'fs-extra';
 
 import { $TSContext, pathManager } from 'amplify-cli-core';
 
-import { preInitSetup } from '../../init-steps/preInitSetup'
-import { analyzeProject } from '../../init-steps/s0-analyzeProject'
-import { initFrontend } from '../../init-steps/s1-initFrontend'
+import { preInitSetup } from '../../init-steps/preInitSetup';
+import { analyzeProject } from '../../init-steps/s0-analyzeProject';
+import { initFrontend } from '../../init-steps/s1-initFrontend';
 import { scaffoldProjectHeadless } from '../../init-steps/s8-scaffoldHeadless';
 
 jest.mock('child_process', () => ({ execSync: jest.fn() }));
@@ -16,8 +16,6 @@ jest.mock('fs-extra');
 (readFileSync as jest.Mock).mockReturnValue('{}');
 (existsSync as jest.Mock).mockReturnValue(true);
 (readdirSync as jest.Mock).mockReturnValue([]);
-
-
 
 jest.mock('../../packageManagerHelpers', () => ({
   getPackageManager: () => 'yarn',
@@ -40,8 +38,8 @@ describe('amplify init: ', () => {
     getBackendDirPath: mockGetBackendDirPath,
     getGitIgnoreFilePath: mockGetGitIgnoreFilePath,
   };
-  
-  const mockContext = {
+
+  const mockContext = ({
     amplify: {
       AmplifyToolkit: jest.fn(),
       pathManager: mockPathManager,
@@ -63,14 +61,13 @@ describe('amplify init: ', () => {
     prompt: jest.fn(),
     exeInfo: {
       inputParams: {
-        amplify: {
-        }
-      }
+        amplify: {},
+      },
     },
     input: {},
     runtime: {},
     pluginPlatform: {},
-  } as unknown as $TSContext;
+  } as unknown) as $TSContext;
   jest.mock('amplify-cli-core', () => ({
     exitOnNextTick: jest.fn(),
   }));
@@ -82,26 +79,25 @@ describe('amplify init: ', () => {
     jest.clearAllMocks();
   });
 
-
   it('init run method should exist', () => {
     expect(initCommand).toBeDefined();
   });
 
   describe('init:preInit', () => {
-    it('should set up a sample app in an empty directory', async() => {
+    it('should set up a sample app in an empty directory', async () => {
       const appUrl = 'https://github.com/aws-samples/aws-amplify-graphql';
       const context = {
         ...mockContext,
         parameters: {
           options: {
             app: appUrl,
-          }
+          },
         },
       };
       await preInitSetup(context);
-      expect(execSync).toBeCalledWith(`git ls-remote ${appUrl}`, {'stdio': 'ignore'});
-      expect(execSync).toBeCalledWith(`git clone ${appUrl} .`, {'stdio': 'inherit'});
-      expect(execSync).toBeCalledWith('yarn install', {'stdio': 'inherit'});
+      expect(execSync).toBeCalledWith(`git ls-remote ${appUrl}`, { stdio: 'ignore' });
+      expect(execSync).toBeCalledWith(`git clone ${appUrl} .`, { stdio: 'inherit' });
+      expect(execSync).toBeCalledWith('yarn install', { stdio: 'inherit' });
     });
   });
 
@@ -117,7 +113,7 @@ describe('amplify init: ', () => {
 
   describe('init:initFrontend', () => {
     it('should use current project config if it is not a new project', async () => {
-      await initFrontend({ ...mockContext, exeInfo: { isNewProject: false }});
+      await initFrontend({ ...mockContext, exeInfo: { isNewProject: false } });
       expect(mockGetProjectConfig).toBeCalled();
     });
   });
@@ -132,13 +128,13 @@ describe('amplify init: ', () => {
           projectConfig: {
             projectName,
             frontend,
-          }
+          },
         },
       };
       const cwd = 'currentdir';
       const spy = jest.spyOn(process, 'cwd');
       spy.mockReturnValue(cwd);
-      
+
       await scaffoldProjectHeadless(context);
       expect(mockGetAmplifyDirPath).toBeCalledWith(cwd);
       expect(mockGetDotConfigDirPath).toBeCalledWith(cwd);

--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -1,11 +1,7 @@
 import * as fs from 'fs-extra';
 import * as url from 'url';
 import { execSync } from 'child_process';
-import {
-  $TSContext,
-  NonEmptyDirectoryError,
-  exitOnNextTick,
-} from 'amplify-cli-core';
+import { $TSContext, NonEmptyDirectoryError, exitOnNextTick } from 'amplify-cli-core';
 import { getPackageManager } from '../packageManagerHelpers';
 import { normalizePackageManagerForOS } from '../packageManagerHelpers';
 import { generateLocalEnvInfoFile } from './s9-onSuccess';

--- a/packages/amplify-cli/src/init-steps/s8-scaffoldHeadless.ts
+++ b/packages/amplify-cli/src/init-steps/s8-scaffoldHeadless.ts
@@ -29,7 +29,7 @@ export async function scaffoldProjectHeadless(context: $TSContext) {
 
   // copy project-config.json file
   const projectConfigFile = JSONUtilities.readJson<AmplifyProjectConfig>(
-    path.join(skeletonLocalDir, PathConstants.DotConfigDirName, `project-config__${frontend}.json`)
+    path.join(skeletonLocalDir, PathConstants.DotConfigDirName, `project-config__${frontend}.json`),
   );
 
   if (!projectConfigFile) {
@@ -40,7 +40,7 @@ export async function scaffoldProjectHeadless(context: $TSContext) {
   JSONUtilities.writeJson(pathManager.getProjectConfigFilePath(projectPath), projectConfigFile);
 
   // copy backend folder
-  await fs.copy(path.join(skeletonLocalDir, PathConstants.BackendDirName), pathManager.getBackendDirPath(projectPath))
+  await fs.copy(path.join(skeletonLocalDir, PathConstants.BackendDirName), pathManager.getBackendDirPath(projectPath));
 
   insertAmplifyIgnore(pathManager.getGitIgnoreFilePath(projectPath));
 

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -9,8 +9,8 @@ const platformToLanguageMap = {
   android: 'java',
   ios: 'swift',
   flutter: 'dart',
-  javascript: 'javascript'
-}
+  javascript: 'javascript',
+};
 
 async function generateModels(context) {
   // steps:

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -65,7 +65,7 @@ export function addApiWithoutSchema(cwd: string, opts: Partial<AddApiOptions> = 
   });
 }
 
-export function addApiWithSchema(cwd: string, schemaFile: string, opts: Partial<AddApiOptions> = {}) {
+export function addApiWithSchema(cwd: string, schemaFile: string, opts: Partial<AddApiOptions & { apiKeyExpirationDays: number }> = {}) {
   const options = _.assign(defaultOptions, opts);
   const schemaPath = getSchemaPath(schemaFile);
   return new Promise((resolve, reject) => {
@@ -79,7 +79,7 @@ export function addApiWithSchema(cwd: string, schemaFile: string, opts: Partial<
       .wait(/.*Enter a description for the API key.*/)
       .sendCarriageReturn()
       .wait(/.*After how many days from now the API key should expire.*/)
-      .sendLine('1')
+      .sendLine(opts.apiKeyExpirationDays ? opts.apiKeyExpirationDays.toString() : '1')
       .wait(/.*Do you want to configure advanced settings for the GraphQL API.*/)
       .sendCarriageReturn()
       .wait('Do you have an annotated GraphQL schema?')

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -9,6 +9,7 @@ export * from './init/';
 export * from './utils/';
 export * from './categories';
 export * from './utils/sdk-calls';
+export { addFeatureFlag } from './utils/feature-flags';
 
 declare global {
   namespace NodeJS {

--- a/packages/amplify-e2e-core/src/utils/feature-flags.ts
+++ b/packages/amplify-e2e-core/src/utils/feature-flags.ts
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import { pathManager, stateManager, FeatureFlagsEntry, JSONUtilities } from 'amplify-cli-core';
+
+type FeatureFlagData = { features: FeatureFlagsEntry };
+const getFeatureFlagFilePath = (projectRoot: string) => {
+  return pathManager.getCLIJSONFilePath(projectRoot);
+};
+export const loadFeatureFlags = (projectRoot: string): FeatureFlagData => {
+  const ffPath = getFeatureFlagFilePath(projectRoot);
+  return (
+    JSONUtilities.readJson<FeatureFlagData>(ffPath, { throwIfNotExist: false, preserveComments: true }) ?? {
+      features: {},
+    }
+  );
+};
+
+export const saveFeatureFlagFile = (projectRoot: string, data: FeatureFlagData) => {
+  const ffPath = getFeatureFlagFilePath(projectRoot);
+  JSONUtilities.writeJson(ffPath, data);
+};
+
+/**
+ * Set an feature flag
+ * @param section Feature flag section
+ * @param name feature flag name
+ * @param value value for the feature flag
+ */
+export const addFeatureFlag = (projectRoot: string, section: string, name: string, value: boolean): void => {
+  const ff = loadFeatureFlags(projectRoot);
+  _.set(ff, ['features', section, name], value);
+  saveFeatureFlagFile(projectRoot, ff);
+};

--- a/packages/amplify-e2e-core/src/utils/feature-flags.ts
+++ b/packages/amplify-e2e-core/src/utils/feature-flags.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { pathManager, stateManager, FeatureFlagsEntry, JSONUtilities } from 'amplify-cli-core';
+import { pathManager, FeatureFlagsEntry, JSONUtilities } from 'amplify-cli-core';
 
 type FeatureFlagData = { features: FeatureFlagsEntry };
 const getFeatureFlagFilePath = (projectRoot: string) => {

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-one-key-multiple-models/final-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-one-key-multiple-models/final-schema.graphql
@@ -1,0 +1,34 @@
+type Something
+  @model
+  @key(name: "byTodo", fields: ["todoID"])
+  @key(name: "byTodo2", fields: ["todo2ID"])
+  @key(name: "byTodo3", fields: ["todo3ID"]) {
+  id: ID!
+  todoID: ID!
+  todo2ID: ID!
+  todo3ID: ID!
+}
+
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  reltn: [Something] @connection(keyName: "byTodo", fields: ["id"])
+}
+
+type Todo2 @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  reltn: [Something] @connection(keyName: "byTodo2", fields: ["id"])
+}
+
+type Todo3 @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  reltn: [Something] @connection(keyName: "byTodo3", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-one-key-multiple-models/initial-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-one-key-multiple-models/initial-schema.graphql
@@ -1,0 +1,13 @@
+type Something @model @key(name: "byTodo", fields: ["todoID"]) @key(name: "byTodo2", fields: ["todo2ID"]) {
+  id: ID!
+  todoID: ID!
+  todo2ID: ID!
+}
+
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  reltn: [Something] @connection(keyName: "byTodo", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-remove-and-update-key/final-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-remove-and-update-key/final-schema.graphql
@@ -1,0 +1,27 @@
+type Blog @model {
+  id: ID!
+  name: String!
+  posts: [Post] @connection(keyName: "byBlog4", fields: ["id"])
+}
+
+type Post
+  @model
+  @key(name: "byBlog1", fields: ["blogID", "createdAt"]) # edit
+  # New keys
+  @key(name: "byBlog4", fields: ["blogID"])
+  @key(name: "byBlog5", fields: ["blogID"])
+  @key(name: "byBlog6", fields: ["blogID"]) {
+  id: ID!
+  title: String!
+  blogID: ID!
+  blog: Blog @connection(fields: ["blogID"])
+  comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
+  createdAt: AWSTimestamp
+}
+
+type Comment @model @key(name: "byPost", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  post: Post @connection(fields: ["postID"])
+  content: String!
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-remove-and-update-key/initial-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-remove-and-update-key/initial-schema.graphql
@@ -1,0 +1,24 @@
+type Blog @model {
+  id: ID!
+  name: String!
+  posts: [Post] @connection(keyName: "byBlog1", fields: ["id"])
+}
+
+type Post
+  @model
+  @key(name: "byBlog1", fields: ["blogID"])
+  @key(name: "byBlog2", fields: ["blogID"])
+  @key(name: "byBlog3", fields: ["blogID"]) {
+  id: ID!
+  title: String!
+  blogID: ID!
+  blog: Blog @connection(fields: ["blogID"])
+  comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
+}
+
+type Comment @model @key(name: "byPost", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  post: Post @connection(fields: ["postID"])
+  content: String!
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/change-model-name/final-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/change-model-name/final-schema.graphql
@@ -1,0 +1,12 @@
+type Comment @model @key(name: "byTodos", fields: ["todoID"]) {
+  id: ID!
+  todoID: ID!
+}
+
+type Todos @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  Comments: [Comment] @connection(keyName: "byTodos", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/change-model-name/initial-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/change-model-name/initial-schema.graphql
@@ -1,0 +1,12 @@
+type Comment @model @key(name: "byTodo", fields: ["todoID"]) {
+  id: ID!
+  todoID: ID!
+}
+
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  Comments: [Comment] @connection(keyName: "byTodo", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/multiple-key-delete/final-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/multiple-key-delete/final-schema.graphql
@@ -1,0 +1,14 @@
+type Todo3 @model {
+  id: ID!
+}
+
+type Something @model {
+  id: ID!
+}
+
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/multiple-key-delete/initial-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/multiple-key-delete/initial-schema.graphql
@@ -1,0 +1,18 @@
+type Todo3 @model {
+  id: ID!
+  Something: [Something] @connection(keyName: "byTodo3", fields: ["id"])
+}
+
+type Something @model @key(name: "byTodo3", fields: ["todo3ID"]) @key(name: "byTodo", fields: ["todoID"]) {
+  id: ID!
+  todo3ID: ID!
+  todoID: ID!
+}
+
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+  addfield2: String
+  Something: [Something] @connection(keyName: "byTodo", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
@@ -1,4 +1,4 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from 'amplify-e2e-core';
+import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate, addFeatureFlag } from 'amplify-e2e-core';
 import { addApiWithSchema, updateApiSchema } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
 
@@ -17,7 +17,10 @@ describe('amplify add api', () => {
     const projectName = 'addconnection';
     const initialSchema = 'migrations_connection/initial_schema.graphql';
     const nextSchema1 = 'migrations_connection/cant_add_a_sort_key.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
@@ -33,7 +36,10 @@ describe('amplify add api', () => {
     const projectName = 'iremoveaddconnection';
     const initialSchema = 'migrations_connection/initial_schema.graphql';
     const nextSchema1 = 'migrations_connection/cant_add_and_remove_at_same_time.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
@@ -49,7 +55,10 @@ describe('amplify add api', () => {
     const projectName = 'changeconnection';
     const initialSchema = 'migrations_connection/initial_schema.graphql';
     const nextSchema1 = 'migrations_connection/cant_change_connection_field_name.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
@@ -66,7 +75,10 @@ describe('amplify add api', () => {
     const initialSchema = 'migrations_connection/initial_schema.graphql';
     const nextSchema1 = 'migrations_connection/remove_connection.graphql';
     const nextSchema2 = 'migrations_connection/add_a_sort_key.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration1.test.ts
@@ -1,4 +1,4 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from 'amplify-e2e-core';
+import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate, addFeatureFlag } from 'amplify-e2e-core';
 import { addApiWithSchema, updateApiSchema } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
 
@@ -17,9 +17,13 @@ describe('amplify add api', () => {
     const projectName = 'migratingkey';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/cant_add_lsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await expect(
       amplifyPushUpdate(
@@ -33,9 +37,13 @@ describe('amplify add api', () => {
     const projectName = 'migratingkey';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/cant_change_gsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await expect(
       amplifyPushUpdate(projRoot, /Attempting to edit the global secondary index SomeGSI on the TodoTable table in the Todo stack.*/),
@@ -46,9 +54,13 @@ describe('amplify add api', () => {
     const projectName = 'migratingkey';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/cant_change_key_schema.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await expect(
       amplifyPushUpdate(projRoot, /Attempting to edit the key schema of the TodoTable table in the Todo stack.*/),
@@ -59,9 +71,13 @@ describe('amplify add api', () => {
     const projectName = 'migrationchangelsi';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/cant_change_lsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await expect(
       amplifyPushUpdate(projRoot, /Attempting to edit the local secondary index SomeLSI on the TodoTable table in the Todo stack.*/),

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration2.test.ts
@@ -1,4 +1,4 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate } from 'amplify-e2e-core';
+import { initJSProjectWithProfile, deleteProject, amplifyPush, amplifyPushUpdate, addFeatureFlag } from 'amplify-e2e-core';
 import { addApiWithSchema, updateApiSchema } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
 
@@ -17,9 +17,13 @@ describe('amplify add api', () => {
     const projectName = 'migratingkey';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/cant_add_more_gsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await expect(
       amplifyPushUpdate(
@@ -33,9 +37,13 @@ describe('amplify add api', () => {
     const projectName = 'migratingkey1';
     const initialSchema = 'migrations_key/initial_schema1.graphql';
     const nextSchema1 = 'migrations_key/cant_remove_more_gsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await expect(
       amplifyPushUpdate(
@@ -49,7 +57,10 @@ describe('amplify add api', () => {
     const projectName = 'migratingkey2';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/cant_update_delete_gsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
@@ -63,11 +74,16 @@ describe('amplify add api', () => {
 
   it('init project, run invalid migration when adding more than one gsi on the same table', async () => {
     const projectName = 'invalidgsiupdate';
+
     const initialSchema = 'migrations_key/simple_key.graphql';
     const nextSchema = 'migrations_key/cant_add_multiple_gsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema);
     await expect(
       amplifyPushUpdate(
@@ -81,9 +97,13 @@ describe('amplify add api', () => {
     const projectName = 'twotableupdategsi';
     const initialSchema = 'migrations_key/two_key_model_schema.graphql';
     const nextSchema = 'migrations_key/four_key_model_schema.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema);
     await amplifyPushUpdate(projRoot, /GraphQL endpoint:.*/);
   });
@@ -92,9 +112,13 @@ describe('amplify add api', () => {
     const projectName = 'validaddinggsi';
     const initialSchema = 'migrations_key/initial_schema.graphql';
     const nextSchema1 = 'migrations_key/add_gsi.graphql';
+
     await initJSProjectWithProfile(projRoot, { name: projectName });
+    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+
     await addApiWithSchema(projRoot, initialSchema);
     await amplifyPush(projRoot);
+
     updateApiSchema(projRoot, projectName, nextSchema1);
     await amplifyPushUpdate(projRoot, /GraphQL endpoint:.*/);
   });

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-1.test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  deleteProject,
+  deleteProjectDir,
+  addApiWithSchema,
+  addFeatureFlag,
+  amplifyPush,
+  updateApiSchema,
+  amplifyPushUpdate,
+} from 'amplify-e2e-core';
+
+describe('Schema iterative update - rename @key', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createNewProjectDir('schemaIterative');
+    await initJSProjectWithProfile(projectDir, {});
+
+    addFeatureFlag(projectDir, 'graphqltransformer', 'enableiterativegsiupdates', true);
+  });
+  afterAll(async () => {
+    await deleteProject(projectDir);
+    deleteProjectDir(projectDir);
+  });
+  it('should support changing gsi name', async () => {
+    const apiName = 'renamekey';
+
+    const initialSchema = path.join('iterative-push', 'change-model-name', 'initial-schema.graphql');
+    await addApiWithSchema(projectDir, initialSchema, { apiName, apiKeyExpirationDays: 7 });
+    await amplifyPush(projectDir);
+
+    const finalSchema = path.join('iterative-push', 'change-model-name', 'final-schema.graphql');
+    await updateApiSchema(projectDir, apiName, finalSchema);
+    await amplifyPushUpdate(projectDir);
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-2.test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  deleteProject,
+  deleteProjectDir,
+  addApiWithSchema,
+  addFeatureFlag,
+  amplifyPush,
+  updateApiSchema,
+  amplifyPushUpdate,
+} from 'amplify-e2e-core';
+
+describe('Schema iterative update - add new @models and @key', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createNewProjectDir('schemaIterative');
+    await initJSProjectWithProfile(projectDir, {});
+
+    addFeatureFlag(projectDir, 'graphqltransformer', 'enableiterativegsiupdates', true);
+  });
+  afterAll(async () => {
+    await deleteProject(projectDir);
+    deleteProjectDir(projectDir);
+  });
+  it('should support adding a new @key to existing @model and adding multiple @modles ', async () => {
+    const apiName = 'addkeyandmodel';
+
+    const initialSchema = path.join('iterative-push', 'add-one-key-multiple-models', 'initial-schema.graphql');
+    await addApiWithSchema(projectDir, initialSchema, { apiName, apiKeyExpirationDays: 7 });
+    await amplifyPush(projectDir);
+
+    const finalSchema = path.join('iterative-push', 'add-one-key-multiple-models', 'final-schema.graphql');
+    await updateApiSchema(projectDir, apiName, finalSchema);
+    await amplifyPushUpdate(projectDir);
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-3.test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  deleteProject,
+  deleteProjectDir,
+  addApiWithSchema,
+  addFeatureFlag,
+  amplifyPush,
+  updateApiSchema,
+  amplifyPushUpdate,
+} from 'amplify-e2e-core';
+
+describe('Schema iterative update - delete', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createNewProjectDir('schemaIterative');
+    await initJSProjectWithProfile(projectDir, {});
+
+    addFeatureFlag(projectDir, 'graphqltransformer', 'enableiterativegsiupdates', true);
+  });
+  afterAll(async () => {
+    await deleteProject(projectDir);
+    deleteProjectDir(projectDir);
+  });
+  it('should support removal of multiple @key directive from a single @model ', async () => {
+    const apiName = 'deletekeys';
+
+    const initialSchema = path.join('iterative-push', 'multiple-key-delete', 'initial-schema.graphql');
+    await addApiWithSchema(projectDir, initialSchema, { apiName, apiKeyExpirationDays: 7 });
+    await amplifyPush(projectDir);
+
+    const finalSchema = path.join('iterative-push', 'multiple-key-delete', 'final-schema.graphql');
+    await updateApiSchema(projectDir, apiName, finalSchema);
+    await amplifyPushUpdate(projectDir);
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  deleteProject,
+  deleteProjectDir,
+  addApiWithSchema,
+  addFeatureFlag,
+  amplifyPush,
+  updateApiSchema,
+  amplifyPushUpdate,
+} from 'amplify-e2e-core';
+
+describe('Schema iterative update - create update and delete', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createNewProjectDir('schemaIterative');
+    await initJSProjectWithProfile(projectDir, {});
+
+    addFeatureFlag(projectDir, 'graphqltransformer', 'enableiterativegsiupdates', true);
+  });
+  afterAll(async () => {
+    await deleteProject(projectDir);
+    deleteProjectDir(projectDir);
+  });
+  it('should support updating, adding and removing of @keys from same model', async () => {
+    const apiName = 'iterativetest1';
+
+    const initialSchema = path.join('iterative-push', 'add-remove-and-update-key', 'initial-schema.graphql');
+    await addApiWithSchema(projectDir, initialSchema, { apiName, apiKeyExpirationDays: 7 });
+    await amplifyPush(projectDir);
+
+    const finalSchema = path.join('iterative-push', 'add-remove-and-update-key', 'final-schema.graphql');
+    await updateApiSchema(projectDir, apiName, finalSchema);
+    await amplifyPushUpdate(projectDir);
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
@@ -75,7 +75,7 @@ describe('Schema iterative update - locking', () => {
     let retry = 0;
     const maxRetries = 3;
     const retryDelay = 3000;
-    const stateFileName: string = 'deploymentState.json';
+    const stateFileName: string = 'deployment-state.json';
 
     while (retry < maxRetries || !lockFileExists) {
       try {

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
@@ -1,0 +1,116 @@
+import * as path from 'path';
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  deleteProject,
+  deleteProjectDir,
+  addApiWithSchema,
+  addFeatureFlag,
+  amplifyPush,
+  updateApiSchema,
+  amplifyPushUpdate,
+  getAppId,
+  amplifyPull,
+  getProjectMeta,
+  sleep,
+} from 'amplify-e2e-core';
+import S3 from 'aws-sdk/clients/s3';
+import { DeploymentState, DeploymentStatus, JSONUtilities } from 'amplify-cli-core';
+
+describe('Schema iterative update - locking', () => {
+  let projectRoot: string;
+
+  beforeAll(async () => {
+    projectRoot = await createNewProjectDir('schemaIterativeLock');
+
+    await initJSProjectWithProfile(projectRoot, {
+      disableAmplifyAppCreation: false,
+    });
+
+    addFeatureFlag(projectRoot, 'graphqltransformer', 'enableiterativegsiupdates', true);
+  });
+
+  afterAll(async () => {
+    await deleteProject(projectRoot);
+    deleteProjectDir(projectRoot);
+  });
+
+  it('other push should fail due to locking', async () => {
+    const apiName = 'iterlock';
+
+    // Create and push project with API
+    const initialSchema = path.join('iterative-push', 'change-model-name', 'initial-schema.graphql');
+    await addApiWithSchema(projectRoot, initialSchema, { apiName, apiKeyExpirationDays: 7 });
+    await amplifyPush(projectRoot);
+
+    // Apply updates to first project
+    const finalSchema = path.join('iterative-push', 'change-model-name', 'final-schema.graphql');
+    await updateApiSchema(projectRoot, apiName, finalSchema);
+
+    const appId = getAppId(projectRoot);
+    expect(appId).toBeDefined();
+
+    let projectRootPull;
+
+    projectRootPull = await createNewProjectDir('iterlock-pull');
+
+    await amplifyPull(projectRootPull, { override: false, emptyDir: true, appId });
+
+    // Apply modifications to second projects
+    await updateApiSchema(projectRootPull, apiName, finalSchema);
+
+    // Start push to have iterative updates
+    const firstPush = amplifyPushUpdate(projectRoot);
+
+    // Poll for the lock file in S3 to make sure test execution will be predictable
+    const meta = getProjectMeta(projectRoot);
+    const projectRegion = meta.providers.awscloudformation.Region;
+    const deploymentBucketName = meta.providers.awscloudformation.DeploymentBucketName;
+
+    const s3 = new S3({
+      region: projectRegion,
+    });
+
+    let lockFileExists = false;
+    let retry = 0;
+    const maxRetries = 3;
+    const retryDelay = 3000;
+    const stateFileName: string = 'deploymentState.json';
+
+    while (retry < maxRetries || !lockFileExists) {
+      try {
+        const deploymentStateObject = await s3
+          .getObject({
+            Bucket: deploymentBucketName,
+            Key: stateFileName,
+          })
+          .promise();
+
+        const deploymentState = JSONUtilities.parse<DeploymentState>(deploymentStateObject.Body.toString());
+
+        if (deploymentState.status === DeploymentStatus.DEPLOYING) {
+          lockFileExists = true;
+          break;
+        } else {
+          retry++;
+
+          await sleep(retryDelay);
+        }
+      } catch {
+        // Intentionally left blank
+      }
+    }
+
+    expect(lockFileExists).toBe(true);
+
+    // Start second push and expect failure
+    const secondPush = amplifyPushUpdate(
+      projectRootPull,
+      /A deployment is already in progress for the project, cannot push resources until it finishes.*/,
+    );
+
+    await Promise.all([firstPush, secondPush]);
+
+    deleteProjectDir(projectRootPull);
+  });
+});

--- a/packages/amplify-e2e-tests/src/schema-api-directives/index.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/index.ts
@@ -55,3 +55,4 @@ export async function testSchema(projectDir: string, directive: string, section:
     return false;
   }
 }
+export * from './authHelper';

--- a/packages/amplify-frontend-ios/amplify-plugin.json
+++ b/packages/amplify-frontend-ios/amplify-plugin.json
@@ -1,8 +1,6 @@
 {
-    "name": "ios",
-    "type": "frontend",
-    "commands": [
-        "help"
-    ],
-    "eventHandlers": ["PostInit", "PostCodegenModels"]
+  "name": "ios",
+  "type": "frontend",
+  "commands": ["help"],
+  "eventHandlers": ["PostInit", "PostCodegenModels"]
 }

--- a/packages/amplify-frontend-ios/index.js
+++ b/packages/amplify-frontend-ios/index.js
@@ -52,7 +52,7 @@ async function executeAmplifyCommand(context) {
 }
 
 async function handleAmplifyEvent(context, args) {
-  switch(args.event) {
+  switch (args.event) {
     case 'PostInit':
       await onPostInit.run(context, args);
       break;

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -18,6 +18,8 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "yarn jest",
+    "test-ci": "yarn jest --ci",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "watch": "tsc --watch"
   },
@@ -35,8 +37,9 @@
     "cfn-lint": "^1.9.7",
     "chalk": "^3.0.0",
     "cloudform": "^4.2.0",
+    "cloudform-types": "^4.2.0",
     "columnify": "^1.5.4",
-    "cors": "^2.8.5",
+    "deep-diff": "^1.0.2",
     "extract-zip": "^2.0.1",
     "folder-hash": "^3.3.0",
     "fs-extra": "^8.1.0",
@@ -59,17 +62,23 @@
     "inquirer": "^7.3.3",
     "jose": "^2.0.2",
     "lodash": "^4.17.19",
+    "lodash.throttle": "^4.1.1",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.1",
     "open": "^7.0.0",
     "ora": "^4.0.3",
     "promise-sequential": "^1.1.1",
     "proxy-agent": "^3.1.1",
-    "rimraf": "^3.0.0"
+    "rimraf": "^3.0.0",
+    "xstate": "^4.14.0"
   },
   "devDependencies": {
+    "@types/columnify": "^1.5.0",
+    "@types/deep-diff": "^1.0.0",
+    "@types/lodash.throttle": "^4.1.6",
     "@types/node": "^12.12.6"
   },
+
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -39,6 +39,7 @@
     "cloudform": "^4.2.0",
     "cloudform-types": "^4.2.0",
     "columnify": "^1.5.4",
+    "cors": "^2.8.5",
     "deep-diff": "^1.0.2",
     "extract-zip": "^2.0.1",
     "folder-hash": "^3.3.0",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/diff-test-helper.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/diff-test-helper.ts
@@ -1,0 +1,35 @@
+import * as gsiTestHelper from './gsi-test-helpers';
+import { Diff, diff as getDiffs } from 'deep-diff';
+import { DynamoDB } from 'cloudform';
+import { DiffableProject } from '../../graphql-transformer/utils';
+
+export const getDiffedProject = (
+  currentGSI: gsiTestHelper.GSIDefinition[] | undefined,
+  nextGSI: gsiTestHelper.GSIDefinition[] | undefined,
+) => {
+  const table1 = gsiTestHelper.makeTableWithGSI({
+    gsis: currentGSI,
+  });
+  const table2 = gsiTestHelper.makeTableWithGSI({
+    gsis: nextGSI,
+  });
+
+  const currentProj = makeProj('Post', table1);
+  const nextProj = makeProj('Post', table2);
+
+  const diffedValue = getDiffs(currentProj, nextProj);
+  return { current: currentProj, next: nextProj, diff: diffedValue };
+};
+
+export const makeProj = (stackName: string, table: DynamoDB.Table): DiffableProject => {
+  return {
+    root: {},
+    stacks: {
+      [stackName]: {
+        Resources: {
+          [`${table.Properties.TableName || 'MyTable'}Table`]: table,
+        },
+      },
+    },
+  };
+};

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/dynamodb-gsi-utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/dynamodb-gsi-utils.test.ts
@@ -1,0 +1,331 @@
+import * as gsiUtils from '../../graphql-transformer/dynamodb-gsi-helpers';
+import { makeTableWithGSI } from './gsi-test-helpers';
+
+describe('DynamoDB GSI Utils', () => {
+  describe('getGSIDetails', () => {
+    describe('With hash key', () => {
+      const table1 = makeTableWithGSI({
+        gsis: [
+          {
+            indexName: 'index1',
+            attributes: {
+              hash: {
+                name: 'title',
+                type: 'N',
+              },
+            },
+          },
+        ],
+      });
+
+      it('should get the index', () => {
+        const gsiDetils = gsiUtils.getGSIDetails('index1', table1);
+        expect(gsiDetils).toBeDefined();
+        expect(gsiDetils?.gsi).toEqual(table1.Properties.GlobalSecondaryIndexes?.[0]);
+      });
+
+      it('should get the attributes used in index', () => {
+        const gsiDetils = gsiUtils.getGSIDetails('index1', table1);
+        expect(gsiDetils).toBeDefined();
+        expect(gsiDetils?.attributeDefinition).toEqual([
+          {
+            AttributeName: 'title',
+            AttributeType: 'N',
+          },
+        ]);
+      });
+    });
+
+    describe('with hash and sort key', () => {
+      const table1 = makeTableWithGSI({
+        gsis: [
+          {
+            indexName: 'index1',
+            attributes: {
+              hash: {
+                name: 'title',
+                type: 'S',
+              },
+              sort: {
+                name: 'createdAt',
+                type: 'S',
+              },
+            },
+          },
+        ],
+      });
+      it('should get the index', () => {
+        const gsiDetils = gsiUtils.getGSIDetails('index1', table1);
+        expect(gsiDetils).toBeDefined();
+        expect(gsiDetils?.gsi).toEqual(table1.Properties.GlobalSecondaryIndexes?.[0]);
+      });
+
+      it('should get the attributes used in index', () => {
+        const gsiDetils = gsiUtils.getGSIDetails('index1', table1);
+        expect(gsiDetils).toBeDefined();
+        expect(gsiDetils?.attributeDefinition).toEqual([
+          {
+            AttributeName: 'title',
+            AttributeType: 'S',
+          },
+          {
+            AttributeName: 'createdAt',
+            AttributeType: 'S',
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('addGsi', () => {
+    const gsiItem = {
+      attributeDefinition: [
+        {
+          AttributeName: 'id',
+          AttributeType: 'N',
+        },
+        {
+          AttributeName: 'title',
+          AttributeType: 'N',
+        },
+      ],
+      gsi: {
+        IndexName: 'byTitileAndId',
+        KeySchema: [
+          {
+            AttributeName: 'title',
+            KeyType: 'HASH',
+          },
+          {
+            AttributeName: 'id',
+            KeyType: 'SORT',
+          },
+        ],
+        Projection: {},
+      },
+    };
+    it('should add GSI to a table with no GSI', () => {
+      const tableWithNoGSI = makeTableWithGSI({
+        gsis: [],
+      });
+      const updatedTable = gsiUtils.addGsi(gsiItem, tableWithNoGSI);
+      expect(updatedTable).toBeDefined();
+      expect(updatedTable).not.toEqual(tableWithNoGSI);
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual([
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'title',
+          AttributeType: 'N',
+        },
+      ]);
+      expect(updatedTable.Properties.GlobalSecondaryIndexes).toEqual([gsiItem.gsi]);
+    });
+
+    it('should add GSI to a table with existing GSI', () => {
+      const tableWithGSI = makeTableWithGSI({
+        gsis: [
+          {
+            indexName: 'byDescription',
+            attributes: {
+              hash: { name: 'description' },
+            },
+          },
+        ],
+      });
+      const updatedTable = gsiUtils.addGsi(gsiItem, tableWithGSI);
+      expect(updatedTable).toBeDefined();
+      expect(updatedTable).not.toEqual(tableWithGSI);
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual([
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'description',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'title',
+          AttributeType: 'N',
+        },
+      ]);
+      expect(updatedTable.Properties.GlobalSecondaryIndexes).toEqual([
+        ...(tableWithGSI.Properties.GlobalSecondaryIndexes as []),
+        gsiItem.gsi,
+      ]);
+    });
+
+    it('should throw error when an index with the same name exists', () => {
+      const tableWithGSI = makeTableWithGSI({
+        gsis: [
+          {
+            indexName: 'byTitileAndId',
+            attributes: {
+              hash: { name: 'title' },
+            },
+          },
+        ],
+      });
+      expect(() => gsiUtils.addGsi(gsiItem, tableWithGSI)).toThrowError(`An index with name ${gsiItem.gsi.IndexName} already exists`);
+    });
+
+    it(`should throw error when adding new index to a table with ${gsiUtils.MAX_GSI_PER_TABLE} GSIs`, () => {
+      const tableWithMaxGSI = makeTableWithGSI({
+        gsis: new Array(gsiUtils.MAX_GSI_PER_TABLE).fill(0).reduce((acc, i, idx) => {
+          return [
+            ...acc,
+            {
+              indexName: `byTitile${idx}AndId`,
+              attributes: {
+                hash: { name: `title${idx}` },
+              },
+            },
+          ];
+        }, []),
+      });
+      expect(() => gsiUtils.addGsi(gsiItem, tableWithMaxGSI)).toThrowError(
+        `DynamoDB ${tableWithMaxGSI.Properties.TableName} can have max of ${gsiUtils.MAX_GSI_PER_TABLE} GSIs`,
+      );
+    });
+
+    it('should not have duplicate AttributeDefinitions', () => {
+      const tableWithGSI = makeTableWithGSI({
+        gsis: [
+          {
+            indexName: 'originalTitleAndId',
+            attributes: {
+              hash: {
+                name: 'title',
+                type: 'S',
+              },
+              sort: {
+                name: 'id',
+                type: 'S',
+              },
+            },
+          },
+        ],
+      });
+      const updatedTable = gsiUtils.addGsi(gsiItem, tableWithGSI);
+      expect(updatedTable).toBeDefined();
+      expect(updatedTable).not.toEqual(tableWithGSI);
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual([
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'title',
+          AttributeType: 'S',
+        },
+      ]);
+      expect(updatedTable.Properties.GlobalSecondaryIndexes).toEqual([
+        ...(tableWithGSI.Properties.GlobalSecondaryIndexes as []),
+        gsiItem.gsi,
+      ]);
+    });
+  });
+  describe('removeGsi', () => {
+    const tableDefinition = {
+      gsis: [
+        {
+          indexName: 'byTitle',
+          attributes: {
+            hash: {
+              name: 'title',
+              type: 'S',
+            },
+          },
+        },
+      ],
+    };
+    it('should throw error if there are no GSIs in the table', () => {
+      const tableWithNoGSI = makeTableWithGSI({ gsis: [] });
+      expect(() => gsiUtils.removeGsi('missingGsi', tableWithNoGSI)).toThrowError('No GSIs are present in the table');
+    });
+
+    it('should throw error when trying to remove index which does not exist', () => {
+      const tableWitGSI = makeTableWithGSI(tableDefinition);
+      expect(() => gsiUtils.removeGsi('missingGsi', tableWitGSI)).toThrowError(`Table MyTable does not contain GSI missingGsi`);
+    });
+    it('should remove index when the GSI is present', () => {
+      const tableWitGSI = makeTableWithGSI(tableDefinition);
+
+      const updatedTable = gsiUtils.removeGsi('byTitle', tableWitGSI);
+
+      expect(updatedTable).not.toEqual(tableWitGSI);
+      expect(updatedTable.Properties.GlobalSecondaryIndexes).toBeUndefined();
+
+      expect(updatedTable.Properties.AttributeDefinitions).not.toEqual(tableWitGSI.Properties.AttributeDefinitions);
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual([
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        },
+      ]);
+    });
+
+    it('should keep the attributes that are in other indices even if the same is used in removed index', () => {
+      const tableWitGSI = makeTableWithGSI({
+        ...tableDefinition,
+        gsis: [
+          ...tableDefinition.gsis,
+          {
+            indexName: 'byTitleAndId',
+            attributes: {
+              hash: {
+                name: 'title',
+                type: 'S',
+              },
+              sort: {
+                name: 'updatedAt',
+                type: 'N',
+              },
+            },
+          },
+        ],
+      });
+      const updatedTable = gsiUtils.removeGsi('byTitle', tableWitGSI);
+
+      expect(updatedTable).not.toEqual(tableWitGSI);
+      expect(updatedTable.Properties.GlobalSecondaryIndexes).toHaveLength(1);
+      expect(updatedTable.Properties.GlobalSecondaryIndexes).toEqual([
+        {
+          IndexName: 'byTitleAndId',
+          KeySchema: [
+            {
+              AttributeName: 'title',
+              KeyType: 'HASH',
+            },
+            {
+              AttributeName: 'updatedAt',
+              KeyType: 'SORT',
+            },
+          ],
+          Projection: {
+            ProjectionType: 'ALL',
+          },
+        },
+      ]);
+
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual(tableWitGSI.Properties.AttributeDefinitions);
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual([
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'title',
+          AttributeType: 'S',
+        },
+        {
+          AttributeName: 'updatedAt',
+          AttributeType: 'N',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/dynamodb-gsi-utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/dynamodb-gsi-utils.test.ts
@@ -1,4 +1,5 @@
 import * as gsiUtils from '../../graphql-transformer/dynamodb-gsi-helpers';
+
 import { makeTableWithGSI } from './gsi-test-helpers';
 
 describe('DynamoDB GSI Utils', () => {
@@ -77,7 +78,7 @@ describe('DynamoDB GSI Utils', () => {
     });
   });
 
-  describe('addGsi', () => {
+  describe('addGSI', () => {
     const gsiItem = {
       attributeDefinition: [
         {
@@ -108,7 +109,7 @@ describe('DynamoDB GSI Utils', () => {
       const tableWithNoGSI = makeTableWithGSI({
         gsis: [],
       });
-      const updatedTable = gsiUtils.addGsi(gsiItem, tableWithNoGSI);
+      const updatedTable = gsiUtils.addGSI(gsiItem, tableWithNoGSI);
       expect(updatedTable).toBeDefined();
       expect(updatedTable).not.toEqual(tableWithNoGSI);
       expect(updatedTable.Properties.AttributeDefinitions).toEqual([
@@ -135,7 +136,7 @@ describe('DynamoDB GSI Utils', () => {
           },
         ],
       });
-      const updatedTable = gsiUtils.addGsi(gsiItem, tableWithGSI);
+      const updatedTable = gsiUtils.addGSI(gsiItem, tableWithGSI);
       expect(updatedTable).toBeDefined();
       expect(updatedTable).not.toEqual(tableWithGSI);
       expect(updatedTable.Properties.AttributeDefinitions).toEqual([
@@ -169,7 +170,7 @@ describe('DynamoDB GSI Utils', () => {
           },
         ],
       });
-      expect(() => gsiUtils.addGsi(gsiItem, tableWithGSI)).toThrowError(`An index with name ${gsiItem.gsi.IndexName} already exists`);
+      expect(() => gsiUtils.addGSI(gsiItem, tableWithGSI)).toThrowError(`An index with name ${gsiItem.gsi.IndexName} already exists`);
     });
 
     it(`should throw error when adding new index to a table with ${gsiUtils.MAX_GSI_PER_TABLE} GSIs`, () => {
@@ -186,7 +187,7 @@ describe('DynamoDB GSI Utils', () => {
           ];
         }, []),
       });
-      expect(() => gsiUtils.addGsi(gsiItem, tableWithMaxGSI)).toThrowError(
+      expect(() => gsiUtils.addGSI(gsiItem, tableWithMaxGSI)).toThrowError(
         `DynamoDB ${tableWithMaxGSI.Properties.TableName} can have max of ${gsiUtils.MAX_GSI_PER_TABLE} GSIs`,
       );
     });
@@ -209,7 +210,7 @@ describe('DynamoDB GSI Utils', () => {
           },
         ],
       });
-      const updatedTable = gsiUtils.addGsi(gsiItem, tableWithGSI);
+      const updatedTable = gsiUtils.addGSI(gsiItem, tableWithGSI);
       expect(updatedTable).toBeDefined();
       expect(updatedTable).not.toEqual(tableWithGSI);
       expect(updatedTable.Properties.AttributeDefinitions).toEqual([
@@ -244,17 +245,17 @@ describe('DynamoDB GSI Utils', () => {
     };
     it('should throw error if there are no GSIs in the table', () => {
       const tableWithNoGSI = makeTableWithGSI({ gsis: [] });
-      expect(() => gsiUtils.removeGsi('missingGsi', tableWithNoGSI)).toThrowError('No GSIs are present in the table');
+      expect(() => gsiUtils.removeGSI('missingGsi', tableWithNoGSI)).toThrowError('No GSIs are present in the table');
     });
 
     it('should throw error when trying to remove index which does not exist', () => {
       const tableWitGSI = makeTableWithGSI(tableDefinition);
-      expect(() => gsiUtils.removeGsi('missingGsi', tableWitGSI)).toThrowError(`Table MyTable does not contain GSI missingGsi`);
+      expect(() => gsiUtils.removeGSI('missingGsi', tableWitGSI)).toThrowError(`Table MyTable does not contain GSI missingGsi`);
     });
     it('should remove index when the GSI is present', () => {
       const tableWitGSI = makeTableWithGSI(tableDefinition);
 
-      const updatedTable = gsiUtils.removeGsi('byTitle', tableWitGSI);
+      const updatedTable = gsiUtils.removeGSI('byTitle', tableWitGSI);
 
       expect(updatedTable).not.toEqual(tableWitGSI);
       expect(updatedTable.Properties.GlobalSecondaryIndexes).toBeUndefined();
@@ -288,7 +289,7 @@ describe('DynamoDB GSI Utils', () => {
           },
         ],
       });
-      const updatedTable = gsiUtils.removeGsi('byTitle', tableWitGSI);
+      const updatedTable = gsiUtils.removeGSI('byTitle', tableWitGSI);
 
       expect(updatedTable).not.toEqual(tableWitGSI);
       expect(updatedTable.Properties.GlobalSecondaryIndexes).toHaveLength(1);

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/gsi-diff-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/gsi-diff-helpers.test.ts
@@ -1,0 +1,484 @@
+import { GSIChange, getGSIDiffs } from '../../graphql-transformer/gsi-diff-helpers';
+import * as diffTestHelpers from './gsi-test-helpers';
+
+describe('gsi diff utils', () => {
+  let firstIndex;
+  let secondIndex;
+  let thirdIndex;
+  let fourthIndex;
+  beforeEach(() => {
+    firstIndex = {
+      indexName: 'firstIndex',
+      attributes: {
+        hash: {
+          name: 'foo',
+          type: 'S',
+        },
+      },
+    };
+
+    secondIndex = {
+      indexName: 'secondIndex',
+      attributes: {
+        hash: {
+          name: 'bar',
+          type: 'S',
+        },
+      },
+    };
+
+    thirdIndex = {
+      indexName: 'thirdIndex',
+      attributes: {
+        hash: {
+          name: 'baz',
+          type: 'S',
+        },
+      },
+    };
+
+    fourthIndex = {
+      indexName: 'fourthIndex',
+      attributes: {
+        hash: {
+          name: 'qux',
+          type: 'S',
+        },
+      },
+    };
+  });
+
+  describe('add index', () => {
+    it('Should return add when a new index is added', () => {
+      const change = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([], [firstIndex]));
+      expect(change).toHaveLength(1);
+      expect(change[0].type).toEqual(GSIChange.Add);
+      expect(change[0].indexName).toEqual('firstIndex');
+    });
+
+    it('should return add when an index is added to an table which already has another index', () => {
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex], [firstIndex, secondIndex]));
+      expect(changes).toMatchObject([{ type: GSIChange.Add, indexName: 'secondIndex' }]);
+    });
+
+    it('should return as add when multiple index are added to an table which already has another index', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex], [firstIndex, secondIndex, thirdIndex, fourthIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'fourthIndex',
+        },
+      ]);
+    });
+
+    it('should return add when multiple indexs are added in the middle of to an existing GSI array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, fourthIndex], [firstIndex, secondIndex, thirdIndex, fourthIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should return add when multiple indexes are added to end of GSI array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, fourthIndex], [firstIndex, fourthIndex, secondIndex, thirdIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should return add when multiple indexes are added in to begining of GSI the array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, fourthIndex], [secondIndex, thirdIndex, firstIndex, fourthIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+    it('should return add when multiple GSIs are added to a table with no GSI', () => {
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI(undefined, [firstIndex, secondIndex]));
+      expect(changes).toHaveLength(2);
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Add,
+          indexName: 'firstIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndex',
+        },
+      ]);
+    });
+  });
+  describe('delete index', () => {
+    it('should return delete when index is removed', () => {
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex], []));
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'firstIndex',
+        },
+      ]);
+    });
+
+    it('should return delete when there are more than 1 GSI exists in the table', () => {
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [firstIndex]));
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'secondIndex',
+        },
+      ]);
+    });
+
+    it('should return delete when multiple indexes are removed from the end of GSI array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex, thirdIndex, fourthIndex], [firstIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          indexName: 'secondIndex',
+          type: GSIChange.Delete,
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'thirdIndex',
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'fourthIndex',
+        },
+      ]);
+    });
+
+    it('should return delete when multiple indexes are removed from the middle of GSI array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex, thirdIndex, fourthIndex], [firstIndex, fourthIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          indexName: 'secondIndex',
+          type: GSIChange.Delete,
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should return delete when multiple index are removed from the begining of GSI array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex, thirdIndex, fourthIndex], [fourthIndex]),
+      );
+      expect(changes).toMatchObject([
+        {
+          indexName: 'firstIndex',
+          type: GSIChange.Delete,
+        },
+        {
+          indexName: 'secondIndex',
+          type: GSIChange.Delete,
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should do a batch delete when all the GSIs are deleted', () => {
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex, thirdIndex], undefined));
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'firstIndex',
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+  });
+  describe('update', () => {
+    it('should return an update when index gets sort key added', () => {
+      const firstIndexUpdated = {
+        ...firstIndex,
+        attributes: {
+          ...firstIndex.attributes,
+          sort: {
+            name: 'bar',
+            type: 'S',
+          },
+        },
+      };
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex], [firstIndexUpdated]));
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Update,
+          indexName: 'firstIndex',
+        },
+      ]);
+    });
+
+    it('should return an update when index gets its hash key changed', () => {
+      const firstIndex = {
+        indexName: 'firstIndex',
+        attributes: {
+          hash: {
+            name: 'foo',
+            type: 'S',
+          },
+          sort: {
+            name: 'bar',
+            type: 'S',
+          },
+        },
+      };
+      const firstIndexUpdated = {
+        ...firstIndex,
+        attributes: {
+          ...firstIndex.attributes,
+          hash: {
+            name: 'foo2',
+            type: 'S',
+          },
+        },
+      };
+
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex], [firstIndexUpdated]));
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Update,
+          indexName: 'firstIndex',
+        },
+      ]);
+    });
+
+    it('should return an remove and an add when index name is changed', () => {
+      const firstIndex = {
+        indexName: 'firstIndex',
+        attributes: {
+          hash: {
+            name: 'foo',
+            type: 'S',
+          },
+          sort: {
+            name: 'bar',
+            type: 'S',
+          },
+        },
+      };
+      const firstIndexUpdated = {
+        ...firstIndex,
+        indexName: 'firstIndexRenamed',
+      };
+
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex], [firstIndexUpdated]));
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'firstIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'firstIndexRenamed',
+        },
+      ]);
+    });
+
+    it('should update when GSI has multiple indexes and one of the index gets sort key added', () => {
+      const secondIndexWithSortKey = {
+        ...secondIndex,
+        attributes: {
+          ...secondIndex.attributes,
+          sort: {
+            name: 'secondBar',
+            type: 'N',
+          },
+        },
+      };
+
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [firstIndex, secondIndexWithSortKey]),
+      );
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Update,
+          indexName: 'secondIndex',
+        },
+      ]);
+    });
+
+    it('should update when GSI has multiple indexes and one of the index gets sort key added and the GSI array order changes', () => {
+      const secondIndexWithSortKey = {
+        ...secondIndex,
+        attributes: {
+          ...secondIndex.attributes,
+          sort: {
+            name: 'secondBar',
+            type: 'N',
+          },
+        },
+      };
+
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [secondIndexWithSortKey, firstIndex]),
+      );
+
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Update,
+          indexName: 'secondIndex',
+        },
+      ]);
+    });
+  });
+
+  describe('No op', () => {
+    it('should return an empty list if GSIs are re-ordered in the array', () => {
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex, thirdIndex], [secondIndex, firstIndex, thirdIndex]),
+      );
+      expect(changes).toHaveLength(0);
+    });
+  });
+
+  describe('Mixed opertaion', () => {
+    it('should support adding and deleting of indexes at once', () => {
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [thirdIndex]));
+
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'firstIndex',
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should support adding and updating of indexes at once', () => {
+      const secondIndexUpdated = {
+        ...secondIndex,
+        indexName: 'secondIndexUpdated',
+      };
+      const changes = getGSIDiffs(
+        ...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [firstIndex, secondIndexUpdated, thirdIndex]),
+      );
+
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndexUpdated',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should support deleting and updating of indexes at once', () => {
+      const secondIndexUpdated = {
+        ...secondIndex,
+        indexName: 'secondIndexUpdated',
+      };
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [secondIndexUpdated, thirdIndex]));
+
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'firstIndex',
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndexUpdated',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+
+    it('should support add, delete and updating of indexes at once', () => {
+      const secondIndexUpdated = {
+        ...secondIndex,
+        indexName: 'secondIndexUpdated',
+      };
+      const changes = getGSIDiffs(...diffTestHelpers.makeTablePairsWithGSI([firstIndex, secondIndex], [secondIndexUpdated, thirdIndex]));
+
+      expect(changes).toEqual([
+        {
+          type: GSIChange.Delete,
+          indexName: 'firstIndex',
+        },
+        {
+          type: GSIChange.Delete,
+          indexName: 'secondIndex',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'secondIndexUpdated',
+        },
+        {
+          type: GSIChange.Add,
+          indexName: 'thirdIndex',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/gsi-test-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/gsi-test-helpers.ts
@@ -1,0 +1,91 @@
+import { DynamoDB } from 'cloudform';
+import { GlobalSecondaryIndex, AttributeDefinition } from 'cloudform-types/types/dynamoDb/table';
+
+export type GSIDefinition = {
+  indexName: string;
+  attributes: {
+    hash: {
+      name: string;
+      type?: string;
+    };
+    sort?: {
+      name: string;
+      type?: string;
+    };
+  };
+};
+
+export const makeTableWithGSI = (props: { gsis?: GSIDefinition[] }): DynamoDB.Table => {
+  const gsis: GlobalSecondaryIndex[] | undefined = props.gsis?.map<GlobalSecondaryIndex>(gsi => {
+    const index: GlobalSecondaryIndex = {
+      IndexName: gsi.indexName,
+      Projection: {
+        ProjectionType: 'ALL',
+      },
+      KeySchema: [
+        {
+          AttributeName: gsi.attributes.hash.name,
+          KeyType: 'HASH',
+        },
+        ...(gsi.attributes.sort
+          ? [
+              {
+                AttributeName: gsi.attributes.sort.name,
+                KeyType: 'SORT',
+              },
+            ]
+          : []),
+      ],
+    };
+    return index;
+  });
+
+  const attributeSet = new Set(['id']);
+
+  const attrs = props.gsis?.reduce<AttributeDefinition[]>((acc, gsi) => {
+    if (!attributeSet.has(gsi.attributes.hash.name)) {
+      attributeSet.add(gsi.attributes.hash.name);
+      acc.push({
+        AttributeName: gsi.attributes.hash.name,
+        AttributeType: gsi.attributes.hash.type || 'S',
+      });
+    }
+
+    if (gsi.attributes.sort && !attributeSet.has(gsi.attributes.sort.name)) {
+      attributeSet.add(gsi.attributes.hash.name);
+
+      acc.push({
+        AttributeName: gsi.attributes.sort.name,
+        AttributeType: gsi.attributes.sort.type || 'S',
+      });
+    }
+
+    return acc;
+  }, []);
+
+  const table: DynamoDB.Table = new DynamoDB.Table({
+    TableName: 'MyTable',
+    KeySchema: [
+      {
+        AttributeName: 'id',
+        KeyType: 'HASH',
+      },
+    ],
+    AttributeDefinitions: [
+      {
+        AttributeName: 'id',
+        AttributeType: 'S',
+      },
+      ...(attrs ?? []),
+    ],
+    ...(gsis ? { GlobalSecondaryIndexes: gsis } : {}),
+  });
+  return table;
+};
+
+export const makeTablePairsWithGSI = (
+  gis1: GSIDefinition[] | undefined,
+  gis2: GSIDefinition[] | undefined,
+): [DynamoDB.Table, DynamoDB.Table] => {
+  return [makeTableWithGSI({ gsis: gis1 }), makeTableWithGSI({ gsis: gis2 })];
+};

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/deployment-state-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/deployment-state-manager.test.ts
@@ -1,0 +1,301 @@
+import { DeploymentStatus, DeploymentStepStatus, IDeploymentStateManager } from 'amplify-cli-core';
+import { DeploymentStateManager } from '../../iterative-deployment/deployment-state-manager';
+import { S3 } from '../../aws-utils/aws-s3';
+
+describe('deployment state manager', () => {
+  let deploymentStateManager: IDeploymentStateManager;
+
+  let s3Files: Record<string, string> = {};
+
+  const mockContext: any = {
+    amplify: {
+      getProjectDetails: () => ({
+        amplifyMeta: {
+          providers: {
+            awscloudformation: {
+              DeploymentBucketName: 'bucket',
+            },
+          },
+        },
+      }),
+      getEnvInfo: () => ({
+        envName: 'dev',
+      }),
+    },
+  };
+
+  beforeEach(async () => {
+    const getInstanceSpy = jest.spyOn(S3, 'getInstance');
+
+    getInstanceSpy.mockReturnValue(
+      new Promise((resolve, _) => {
+        resolve(({
+          uploadFile: async (s3Params: any, showSpinner: boolean): Promise<string> => {
+            return new Promise((resolve, _) => {
+              s3Files[s3Params.Key] = s3Params.Body;
+
+              resolve('');
+            });
+          },
+          getStringObjectFromBucket: async (bucketName: string, objectKey: string): Promise<string> => {
+            return new Promise((resolve, _) => {
+              resolve(s3Files[objectKey]);
+            });
+          },
+        } as unknown) as S3);
+      }),
+    );
+
+    deploymentStateManager = await DeploymentStateManager.createDeploymentStateManager(mockContext);
+  });
+
+  afterEach(async () => {
+    s3Files = {};
+  });
+
+  it('deployment in progress reflected correctly', async () => {
+    let isInProgress = await deploymentStateManager.isDeploymentInProgress();
+    expect(isInProgress).toBe(false);
+
+    const started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+
+    isInProgress = await deploymentStateManager.isDeploymentInProgress();
+    expect(isInProgress).toBe(true);
+
+    await deploymentStateManager.startCurrentStep();
+
+    let currentStatus = deploymentStateManager.getStatus();
+    expect(currentStatus.steps[0].status).toBe(DeploymentStepStatus.DEPLOYING);
+
+    await deploymentStateManager.advanceStep();
+
+    currentStatus = deploymentStateManager.getStatus();
+    expect(currentStatus.steps[0].status).toBe(DeploymentStepStatus.DEPLOYED);
+
+    isInProgress = await deploymentStateManager.isDeploymentInProgress();
+    expect(isInProgress).toBe(false);
+  });
+
+  it('should not advance forward without starting step', async () => {
+    let started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+
+    await expect(deploymentStateManager.advanceStep()).rejects.toThrow(
+      'Cannot advance step then the current step is in WAITING_FOR_DEPLOYMENT status.',
+    );
+  });
+
+  it('should not advance backward without starting step', async () => {
+    let started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+
+    await deploymentStateManager.startRollback();
+
+    await expect(deploymentStateManager.advanceStep()).rejects.toThrow(
+      'Cannot advance step then the current step is in WAITING_FOR_ROLLBACK status.',
+    );
+  });
+
+  it('second start fails if deployment is in progress', async () => {
+    let started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+
+    started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(false);
+  });
+
+  it('second start uses state from cloud', async () => {
+    let started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+  });
+
+  it('no deployment in progress when a deployment already finished previously present', async () => {
+    await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    const currentStatus = deploymentStateManager.getStatus();
+    expect(currentStatus.status).toBe(DeploymentStatus.DEPLOYED);
+
+    let isInProgress = await deploymentStateManager.isDeploymentInProgress();
+
+    expect(isInProgress).toBe(false);
+  });
+
+  it('multi step deployment succeeds', async () => {
+    const started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    const currentCloudState = await DeploymentStateManager.getStatusFromCloud(mockContext);
+
+    expect(currentCloudState.status).toBe(DeploymentStatus.DEPLOYED);
+    expect(currentCloudState.steps.filter(s => s.status === DeploymentStepStatus.DEPLOYED).length).toBe(3);
+
+    const currentStatus = deploymentStateManager.getStatus();
+    const cloudStatus = await DeploymentStateManager.getStatusFromCloud(mockContext);
+
+    expect(currentStatus).toMatchObject(cloudStatus);
+  });
+
+  it('multi step deployment with rollback succeeds', async () => {
+    const started = await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    expect(started).toBe(true);
+
+    await deploymentStateManager.startCurrentStep();
+
+    await deploymentStateManager.advanceStep();
+
+    await deploymentStateManager.startRollback();
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    const currentCloudState = await DeploymentStateManager.getStatusFromCloud(mockContext);
+
+    expect(currentCloudState.status).toBe(DeploymentStatus.ROLLED_BACK);
+    expect(currentCloudState.steps.filter(s => s.status === DeploymentStepStatus.WAITING_FOR_DEPLOYMENT).length).toBe(1);
+    expect(currentCloudState.steps.filter(s => s.status === DeploymentStepStatus.ROLLED_BACK).length).toBe(2);
+
+    const currentStatus = await deploymentStateManager.getStatus();
+    const cloudStatus = await DeploymentStateManager.getStatusFromCloud(mockContext);
+
+    expect(currentStatus).toMatchObject(cloudStatus);
+  });
+
+  it('cannot finish deployment twice', async () => {
+    await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    await expect(deploymentStateManager.advanceStep()).rejects.toThrow('Cannot advance a deployment when it was not started.');
+  });
+
+  it('cannot finish rolled back deployment twice', async () => {
+    await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    await deploymentStateManager.startRollback();
+
+    await deploymentStateManager.startCurrentStep();
+    await deploymentStateManager.advanceStep();
+
+    await expect(deploymentStateManager.advanceStep()).rejects.toThrow('Cannot advance a deployment when it was not started.');
+  });
+
+  it('can set FAILED status on in-progress deployments', async () => {
+    await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    await deploymentStateManager.failDeployment();
+
+    const currentStatus = deploymentStateManager.getStatus();
+
+    expect(currentStatus.status).toBe(DeploymentStatus.FAILED);
+  });
+
+  it('cannot rollback non-started deployment', async () => {
+    expect(deploymentStateManager.startRollback()).rejects.toThrow('Cannot rollback a non-deploying deployment');
+  });
+
+  it('cannot rollback an already rolled back deployment', async () => {
+    await deploymentStateManager.startDeployment([
+      {
+        status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+      },
+    ]);
+
+    await deploymentStateManager.startRollback();
+
+    expect(deploymentStateManager.startRollback()).rejects.toThrow('Cannot rollback a non-deploying deployment');
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/deployment-state-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/deployment-state-manager.test.ts
@@ -284,7 +284,9 @@ describe('deployment state manager', () => {
   });
 
   it('cannot rollback non-started deployment', async () => {
-    expect(deploymentStateManager.startRollback()).rejects.toThrow('Cannot rollback a non-deploying deployment');
+    expect(deploymentStateManager.startRollback()).rejects.toThrow(
+      'To rollback a deployment, the deployment must be in progress and not already rolling back.',
+    );
   });
 
   it('cannot rollback an already rolled back deployment', async () => {
@@ -296,6 +298,8 @@ describe('deployment state manager', () => {
 
     await deploymentStateManager.startRollback();
 
-    expect(deploymentStateManager.startRollback()).rejects.toThrow('Cannot rollback a non-deploying deployment');
+    expect(deploymentStateManager.startRollback()).rejects.toThrow(
+      'To rollback a deployment, the deployment must be in progress and not already rolling back.',
+    );
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/helper.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/helper.test.ts
@@ -1,0 +1,214 @@
+import * as helper from '../../iterative-deployment/helpers';
+import { DeployMachineContext, DeploymentMachineOp } from '../../iterative-deployment/state-machine';
+describe('deployment helpers', () => {
+  const baseDeploymentOp: DeploymentMachineOp = {
+    parameters: {
+      deploying: 'true',
+    },
+    region: 'us-east-2',
+    stackName: 'my-stack',
+    stackTemplatePath: 'stackTemplatePath',
+    stackTemplateUrl: 'stackTemplateUrl',
+    tableNames: ['table1'],
+    capabilities: [],
+  };
+
+  const deploymentContext: DeployMachineContext = {
+    currentIndex: -1,
+    deploymentBucket: 'my-bucket',
+    region: 'us-east-2',
+    stacks: [
+      {
+        deployment: {
+          ...baseDeploymentOp,
+        },
+        rollback: {
+          ...baseDeploymentOp,
+          parameters: { rollingBack: 'true' },
+        },
+      },
+    ],
+  };
+
+  describe('hasMoreDeployment', () => {
+    it('should return true when currentIndex is smaller than deployment steps', () => {
+      const context: DeployMachineContext = {
+        ...deploymentContext,
+        currentIndex: -1,
+      };
+      expect(helper.hasMoreDeployment(context)).toBeTruthy();
+    });
+
+    it('should return false when currentIndex is bigger than deployment steps', () => {
+      const context: DeployMachineContext = {
+        ...deploymentContext,
+        currentIndex: 1,
+      };
+      expect(helper.hasMoreDeployment(context)).toBeFalsy();
+    });
+  });
+
+  describe('hasMoreRollback', () => {
+    it('should return true when currentIndex is greater than -1', () => {
+      const context: DeployMachineContext = {
+        ...deploymentContext,
+        currentIndex: 1,
+      };
+      expect(helper.hasMoreRollback(context)).toBeTruthy();
+    });
+
+    it('should return false when currentIndex is smaller than 0', () => {
+      const context: DeployMachineContext = {
+        ...deploymentContext,
+        currentIndex: -1,
+      };
+      expect(helper.hasMoreRollback(context)).toBeFalsy();
+    });
+  });
+
+  describe('extractStackInfoFromContext', () => {
+    let deployFn;
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      deployFn = jest.fn();
+    });
+    describe('deploy', () => {
+      it('should extract deploy section when the deploying', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 0,
+        };
+        helper.extractStackInfoFromContext(deployFn, 'deploying')(context);
+        expect(deployFn).toHaveBeenCalledWith(context.stacks[0].deployment);
+      });
+      it('should be an no-op if the current index is greater than the number of stacks', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 2,
+        };
+        helper.extractStackInfoFromContext(deployFn, 'deploying')(context);
+        expect(deployFn).not.toHaveBeenCalled();
+      });
+
+      it('should be an no-op if the current index is less than 0', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: -1,
+        };
+        helper.extractStackInfoFromContext(deployFn, 'deploying')(context);
+        expect(deployFn).not.toHaveBeenCalled();
+      });
+    });
+    describe('rollback', () => {
+      it('should extract deploy section when the deploying', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 0,
+        };
+        helper.extractStackInfoFromContext(deployFn, 'rollingback')(context);
+        expect(deployFn).toHaveBeenCalledWith(context.stacks[0].rollback);
+      });
+      it('should be an no-op if the current index is greater than the number of stacks', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 2,
+        };
+        helper.extractStackInfoFromContext(deployFn, 'rollingback')(context);
+        expect(deployFn).not.toHaveBeenCalled();
+      });
+
+      it('should be an no-op if the current index is less than 0', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: -1,
+        };
+        helper.extractStackInfoFromContext(deployFn, 'rollingback')(context);
+        expect(deployFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('stackPollerActivity', () => {
+    let stackPoller;
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      stackPoller = jest.fn().mockImplementation(() => jest.fn);
+    });
+    describe('deploy', () => {
+      it('should extract deploy section when the deploying', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 0,
+        };
+        helper.stackPollerActivity(stackPoller, 'deploying')(context);
+        expect(stackPoller).toHaveBeenCalledWith(context.stacks[0].deployment);
+      });
+      it('should be an no-op if the current index is greater than the number of stacks', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 2,
+        };
+        helper.stackPollerActivity(stackPoller, 'deploying')(context);
+        expect(stackPoller).not.toHaveBeenCalled();
+      });
+
+      it('should be an no-op if the current index is less than 0', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: -1,
+        };
+        helper.stackPollerActivity(stackPoller, 'deploying')(context);
+        expect(stackPoller).not.toHaveBeenCalled();
+      });
+    });
+    describe('rollback', () => {
+      it('should extract deploy section when the deploying', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 0,
+        };
+        helper.stackPollerActivity(stackPoller, 'rollingback')(context);
+        expect(stackPoller).toHaveBeenCalledWith(context.stacks[0].rollback);
+      });
+      it('should be an no-op if the current index is greater than the number of stacks', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: 2,
+        };
+        helper.stackPollerActivity(stackPoller, 'rollingback')(context);
+        expect(stackPoller).not.toHaveBeenCalled();
+      });
+
+      it('should be an no-op if the current index is less than 0', () => {
+        const context: DeployMachineContext = {
+          ...deploymentContext,
+          currentIndex: -1,
+        };
+        helper.stackPollerActivity(stackPoller, 'rollingback')(context);
+        expect(stackPoller).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('getBucketKey', () => {
+    const bucketName = 'my-bucket';
+    it('should return bucket key from url', () => {
+      expect(helper.getBucketKey(`https://s3.amazon.com/${bucketName}/my-key`, bucketName)).toEqual('my-key');
+    });
+    it('should return bucket key key', () => {
+      expect(helper.getBucketKey(`my-key`, bucketName)).toEqual('my-key');
+    });
+  });
+
+  describe('getHttpUrl', () => {
+    const bucketName = 'my-bucket';
+    it('should return bucket key from url', () => {
+      expect(helper.getHttpUrl(`https://s3.amazonaws.com/${bucketName}/my-key`, bucketName)).toEqual(
+        `https://s3.amazonaws.com/${bucketName}/my-key`,
+      );
+    });
+    it('should return bucket key key', () => {
+      expect(helper.getHttpUrl(`my-key`, bucketName)).toEqual(`https://s3.amazonaws.com/${bucketName}/my-key`);
+    });
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/helper.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/helper.test.ts
@@ -1,5 +1,7 @@
 import * as helper from '../../iterative-deployment/helpers';
+
 import { DeployMachineContext, DeploymentMachineOp } from '../../iterative-deployment/state-machine';
+
 describe('deployment helpers', () => {
   const baseDeploymentOp: DeploymentMachineOp = {
     parameters: {
@@ -30,43 +32,43 @@ describe('deployment helpers', () => {
     ],
   };
 
-  describe('hasMoreDeployment', () => {
-    it('should return true when currentIndex is smaller than deployment steps', () => {
+  describe('isDeploymentComplete', () => {
+    it('should return false when currentIndex is smaller than deployment steps', () => {
       const context: DeployMachineContext = {
         ...deploymentContext,
         currentIndex: -1,
       };
-      expect(helper.hasMoreDeployment(context)).toBeTruthy();
+      expect(helper.isDeploymentComplete(context)).toBeFalsy();
     });
 
-    it('should return false when currentIndex is bigger than deployment steps', () => {
+    it('should return true when currentIndex is bigger than deployment steps', () => {
       const context: DeployMachineContext = {
         ...deploymentContext,
         currentIndex: 1,
       };
-      expect(helper.hasMoreDeployment(context)).toBeFalsy();
+      expect(helper.isDeploymentComplete(context)).toBeTruthy();
     });
   });
 
   describe('hasMoreRollback', () => {
-    it('should return true when currentIndex is greater than -1', () => {
+    it('should return false when currentIndex is greater than -1', () => {
       const context: DeployMachineContext = {
         ...deploymentContext,
         currentIndex: 1,
       };
-      expect(helper.hasMoreRollback(context)).toBeTruthy();
+      expect(helper.isRollbackComplete(context)).toBeFalsy();
     });
 
-    it('should return false when currentIndex is smaller than 0', () => {
+    it('should return true when currentIndex is smaller than 0', () => {
       const context: DeployMachineContext = {
         ...deploymentContext,
         currentIndex: -1,
       };
-      expect(helper.hasMoreRollback(context)).toBeFalsy();
+      expect(helper.isRollbackComplete(context)).toBeTruthy();
     });
   });
 
-  describe('extractStackInfoFromContext', () => {
+  describe('getDeploymentOperationHandler', () => {
     let deployFn;
     beforeEach(() => {
       jest.restoreAllMocks();
@@ -78,7 +80,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 0,
         };
-        helper.extractStackInfoFromContext(deployFn, 'deploying')(context);
+        helper.getDeploymentOperationHandler(deployFn)(context);
         expect(deployFn).toHaveBeenCalledWith(context.stacks[0].deployment);
       });
       it('should be an no-op if the current index is greater than the number of stacks', () => {
@@ -86,7 +88,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 2,
         };
-        helper.extractStackInfoFromContext(deployFn, 'deploying')(context);
+        helper.getDeploymentOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
 
@@ -95,7 +97,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: -1,
         };
-        helper.extractStackInfoFromContext(deployFn, 'deploying')(context);
+        helper.getDeploymentOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
     });
@@ -105,7 +107,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 0,
         };
-        helper.extractStackInfoFromContext(deployFn, 'rollingback')(context);
+        helper.getRollbackOperationHandler(deployFn)(context);
         expect(deployFn).toHaveBeenCalledWith(context.stacks[0].rollback);
       });
       it('should be an no-op if the current index is greater than the number of stacks', () => {
@@ -113,7 +115,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 2,
         };
-        helper.extractStackInfoFromContext(deployFn, 'rollingback')(context);
+        helper.getRollbackOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
 
@@ -122,7 +124,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: -1,
         };
-        helper.extractStackInfoFromContext(deployFn, 'rollingback')(context);
+        helper.getRollbackOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
     });
@@ -140,7 +142,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 0,
         };
-        helper.stackPollerActivity(stackPoller, 'deploying')(context);
+        helper.getDeploymentActivityPollerHandler(stackPoller)(context);
         expect(stackPoller).toHaveBeenCalledWith(context.stacks[0].deployment);
       });
       it('should be an no-op if the current index is greater than the number of stacks', () => {
@@ -148,7 +150,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 2,
         };
-        helper.stackPollerActivity(stackPoller, 'deploying')(context);
+        helper.getDeploymentActivityPollerHandler(stackPoller)(context);
         expect(stackPoller).not.toHaveBeenCalled();
       });
 
@@ -157,7 +159,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: -1,
         };
-        helper.stackPollerActivity(stackPoller, 'deploying')(context);
+        helper.getDeploymentActivityPollerHandler(stackPoller)(context);
         expect(stackPoller).not.toHaveBeenCalled();
       });
     });
@@ -167,7 +169,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 0,
         };
-        helper.stackPollerActivity(stackPoller, 'rollingback')(context);
+        helper.getRollbackActivityPollerHandler(stackPoller)(context);
         expect(stackPoller).toHaveBeenCalledWith(context.stacks[0].rollback);
       });
       it('should be an no-op if the current index is greater than the number of stacks', () => {
@@ -175,7 +177,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: 2,
         };
-        helper.stackPollerActivity(stackPoller, 'rollingback')(context);
+        helper.getRollbackActivityPollerHandler(stackPoller)(context);
         expect(stackPoller).not.toHaveBeenCalled();
       });
 
@@ -184,7 +186,7 @@ describe('deployment helpers', () => {
           ...deploymentContext,
           currentIndex: -1,
         };
-        helper.stackPollerActivity(stackPoller, 'rollingback')(context);
+        helper.getRollbackActivityPollerHandler(stackPoller)(context);
         expect(stackPoller).not.toHaveBeenCalled();
       });
     });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/state-machine.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/state-machine.test.ts
@@ -1,0 +1,210 @@
+import {
+  createDeploymentMachine,
+  DeployMachineContext,
+  DeploymentMachineOp,
+  StateMachineHelperFunctions,
+} from '../../iterative-deployment/state-machine';
+import { interpret } from 'xstate';
+describe('deployment state machine', () => {
+  const fns: StateMachineHelperFunctions = {
+    deployFn: jest.fn().mockResolvedValue(undefined),
+    deploymentWaitFn: jest.fn().mockResolvedValue(undefined),
+    rollbackFn: jest.fn().mockResolvedValue(undefined),
+    rollbackWaitFn: jest.fn().mockResolvedValue(undefined),
+    tableReadyWaitFn: jest.fn().mockResolvedValue(undefined),
+    startRollbackFn: jest.fn().mockResolvedValue(undefined),
+    stackEventPollFn: jest.fn().mockImplementation(() => {
+      return () => {};
+    }),
+  };
+
+  const baseDeploymentStep: Omit<DeploymentMachineOp, 'stackTemplateUrl'> = {
+    parameters: {},
+    stackName: 'amplify-multideploytest-dev-162313-apimultideploytest-1E3B7HVOV09VD',
+    stackTemplatePath: 'stack1/cfn.json',
+    tableNames: ['table1'],
+    region: 'us-east-2',
+    capabilities: [],
+  };
+  const initialContext: DeployMachineContext = {
+    currentIndex: -1,
+    region: 'us-east-2',
+    deploymentBucket: 'https://s3.amazonaws.com/amplify-multideploytest-dev-162313-deployment',
+    stacks: [
+      {
+        deployment: {
+          ...baseDeploymentStep,
+          stackTemplateUrl: 'step1.json',
+          tableNames: ['table1'],
+        },
+        rollback: {
+          ...baseDeploymentStep,
+          stackTemplateUrl: 'rollback1.json',
+          parameters: { rollback: 'true' },
+          tableNames: ['table1'],
+        },
+      },
+      {
+        deployment: {
+          ...baseDeploymentStep,
+          stackTemplateUrl: 'step2.json',
+          tableNames: ['table1', 'table2'],
+        },
+        rollback: {
+          ...baseDeploymentStep,
+          stackTemplateUrl: 'rollback2.json',
+          parameters: { rollback: 'true' },
+          tableNames: ['table1', 'table2'],
+        },
+      },
+      {
+        deployment: {
+          ...baseDeploymentStep,
+          stackTemplateUrl: 'step3.json',
+          tableNames: ['table1', 'table3'],
+        },
+        rollback: {
+          ...baseDeploymentStep,
+          stackTemplateUrl: 'rollback3.json',
+          parameters: { rollback: 'true' },
+          tableNames: ['table1', 'table3'],
+        },
+      },
+    ],
+  };
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (fns.deployFn as jest.Mock).mockResolvedValue(undefined);
+    (fns.deploymentWaitFn as jest.Mock).mockResolvedValue(undefined);
+    (fns.rollbackFn as jest.Mock).mockResolvedValue(undefined);
+    (fns.rollbackWaitFn as jest.Mock).mockResolvedValue(undefined);
+    (fns.startRollbackFn as jest.Mock).mockResolvedValue(undefined);
+    (fns.tableReadyWaitFn as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('should call deployment function multiple times when there are multiple stacks to be deployed', done => {
+    const machine = createDeploymentMachine(initialContext, fns);
+    interpret(machine)
+      .onTransition(state => {
+        if (state.value === 'deployed') {
+          expect(fns.deployFn).toHaveBeenCalledTimes(3);
+          expect(fns.deploymentWaitFn).toHaveBeenCalledTimes(3);
+          expect(fns.tableReadyWaitFn).toHaveBeenCalledTimes(3);
+
+          // 1st stack
+          const firstStackArg = initialContext.stacks[0].deployment;
+
+          expect((fns.deployFn as jest.Mock).mock.calls[0][0]).toEqual(firstStackArg);
+          expect((fns.deploymentWaitFn as jest.Mock).mock.calls[0][0]).toEqual(firstStackArg);
+          expect((fns.tableReadyWaitFn as jest.Mock).mock.calls[0][0]).toEqual(firstStackArg);
+
+          // second stack
+          const secondStackArg = initialContext.stacks[1].deployment;
+
+          expect((fns.deployFn as jest.Mock).mock.calls[1][0]).toEqual(secondStackArg);
+          expect((fns.deploymentWaitFn as jest.Mock).mock.calls[1][0]).toEqual(secondStackArg);
+          expect((fns.tableReadyWaitFn as jest.Mock).mock.calls[1][0]).toEqual(secondStackArg);
+
+          // third stack
+          const thirdStackArg = initialContext.stacks[2].deployment;
+
+          expect((fns.deployFn as jest.Mock).mock.calls[2][0]).toEqual(thirdStackArg);
+          expect((fns.deploymentWaitFn as jest.Mock).mock.calls[2][0]).toEqual(thirdStackArg);
+          expect((fns.tableReadyWaitFn as jest.Mock).mock.calls[2][0]).toEqual(thirdStackArg);
+
+          done();
+        }
+      })
+      .start()
+      .send('DEPLOY');
+  });
+
+  it('should rollback when one of the deployment fails in reverse order of deployment', done => {
+    //  mock deployment fn to fail for second deployment
+    (fns.deployFn as jest.Mock).mockImplementation(stack => {
+      if (stack.stackTemplateUrl === initialContext.stacks[2].deployment.stackTemplateUrl) {
+        return Promise.reject();
+      }
+      return Promise.resolve();
+    });
+
+    const firstStackDeploymentArg = initialContext.stacks[0].deployment;
+    const secondStackDeploymentArg = initialContext.stacks[1].deployment;
+    const thirdStackDeploymentArg = initialContext.stacks[2].deployment;
+
+    const firstStackRollbackArg = initialContext.stacks[0].rollback;
+    const secoondStackRollbackArg = initialContext.stacks[1].rollback;
+    const thirdStackRollbackArg = initialContext.stacks[2].rollback;
+
+    const machine = createDeploymentMachine(initialContext, fns);
+    interpret(machine)
+      .onTransition(state => {
+        if (state.value === 'rolledBack') {
+          const rollbackMock = fns.rollbackFn as jest.Mock;
+          const deployMock = fns.deployFn as jest.Mock;
+          const deployWaitMock = fns.deploymentWaitFn as jest.Mock;
+          const tableReadWaitMock = fns.tableReadyWaitFn as jest.Mock;
+
+          expect(deployMock).toHaveBeenCalledTimes(3);
+          expect(deployWaitMock).toHaveBeenCalledTimes(2);
+          expect(tableReadWaitMock).toHaveBeenCalledTimes(5); // 2 times for deploy and 2 times for rollback and 1 time for before starting rollback
+
+          // First stack deployed
+          expect(deployMock.mock.calls[0][0]).toEqual(firstStackDeploymentArg);
+          expect(deployWaitMock.mock.calls[0][0]).toEqual(firstStackDeploymentArg);
+          expect(tableReadWaitMock.mock.calls[0][0]).toEqual(firstStackDeploymentArg);
+
+          // second stack deployment
+          expect(deployMock.mock.calls[1][0]).toEqual(secondStackDeploymentArg);
+          expect(deployWaitMock.mock.calls[1][0]).toEqual(secondStackDeploymentArg);
+          expect(tableReadWaitMock.mock.calls[1][0]).toEqual(secondStackDeploymentArg);
+
+          // third stack deployment fails
+          expect(deployMock.mock.calls[2][0]).toEqual(thirdStackDeploymentArg);
+          // rollback kicks and waits for the table to be ready
+          expect(tableReadWaitMock.mock.calls[2][0]).toEqual(thirdStackRollbackArg);
+
+          expect(rollbackMock).toHaveBeenCalledTimes(2);
+
+          // rollback of second stack as the thrid stack is automatically rolled back by CFN
+          expect(rollbackMock.mock.calls[0][0]).toEqual(secoondStackRollbackArg);
+          expect(tableReadWaitMock.mock.calls[3]).toContainEqual(secoondStackRollbackArg);
+
+          // rollback of first stack after second one is complete
+          expect(rollbackMock.mock.calls[1][0]).toEqual(firstStackRollbackArg);
+          expect(tableReadWaitMock.mock.calls[4]).toContainEqual(firstStackRollbackArg);
+
+          // Notify rollback
+          expect(fns.startRollbackFn).toHaveBeenCalledTimes(1);
+
+          done();
+        }
+      })
+      .start()
+      .send('DEPLOY');
+  });
+
+  it('should go to failed state when rollback fails', done => {
+    const deployFn = fns.deployFn as jest.Mock;
+    deployFn.mockImplementation(stack => {
+      if (stack.stackTemplateUrl === initialContext.stacks[2].deployment.stackTemplateUrl) {
+        return Promise.reject();
+      }
+      return Promise.resolve();
+    });
+    const rollBackFn = fns.rollbackFn as jest.Mock;
+    rollBackFn.mockRejectedValue(undefined);
+
+    const machine = createDeploymentMachine(initialContext, fns);
+    interpret(machine)
+      .onTransition(state => {
+        if (state.value === 'failed') {
+          expect(deployFn).toHaveBeenCalledTimes(3);
+          expect(rollBackFn).toHaveBeenCalledTimes(1);
+          done();
+        }
+      })
+      .start()
+      .send('DEPLOY');
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/transformer-feature-flag-adapter.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/transformer-feature-flag-adapter.test.ts
@@ -1,4 +1,4 @@
-import { AmplifyCLIFeatureFlagAdapter } from '../../utils/transfomer-feature-flag-adapter';
+import { AmplifyCLIFeatureFlagAdapter } from '../../utils/amplify-cli-feature-flag-adapter';
 import { FeatureFlags } from 'amplify-cli-core';
 
 jest.mock('amplify-cli-core');

--- a/packages/amplify-provider-awscloudformation/src/amplify-state-manager/StateMachine.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-state-manager/StateMachine.ts
@@ -1,0 +1,6 @@
+export class StateMachine {
+  states: Array<string>;
+  constructor(states: Array<string>) {
+    this.states = states;
+  }
+}

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/CognitoUserPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/CognitoUserPoolService.ts
@@ -1,6 +1,4 @@
 import { $TSAny, $TSContext } from 'amplify-cli-core';
-import { ICognitoUserPoolService } from 'amplify-util-import';
-import { CognitoIdentityServiceProvider } from 'aws-sdk';
 import {
   GetUserPoolMfaConfigResponse,
   IdentityProviderType,
@@ -14,9 +12,12 @@ import {
   UserPoolDescriptionType,
   UserPoolType,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
+
+import { CognitoIdentityServiceProvider } from 'aws-sdk';
+import { ICognitoUserPoolService } from 'amplify-util-import';
 import configurationManager from '../configuration-manager';
-import { pagedAWSCall } from './paged-call';
 import { fileLogger } from '../utils/aws-logger';
+import { pagedAWSCall } from './paged-call';
 const logger = fileLogger('CognitoUserPoolService');
 
 export const createCognitoUserPoolService = async (context: $TSContext, options: $TSAny): Promise<CognitoUserPoolService> => {

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -202,10 +202,7 @@ class CloudFormation {
       .describeStack({ StackName: stackName })
       .promise()
       .then(data => {
-        return Promise.resolve(data.Parameters);
-      })
-      .catch(e => {
-        Promise.reject(e);
+        return data.Parameters;
       });
   }
 

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -197,6 +197,18 @@ class CloudFormation {
       });
   }
 
+  getStackParameters(stackName) {
+    return this.cfn
+      .describeStack({ StackName: stackName })
+      .promise()
+      .then(data => {
+        return Promise.resolve(data.Parameters);
+      })
+      .catch(e => {
+        Promise.reject(e);
+      });
+  }
+
   updateResourceStack(dir, cfnFile) {
     const filePath = path.normalize(path.join(dir, cfnFile));
     const projectDetails = this.context.amplify.getProjectDetails();

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
@@ -200,4 +200,23 @@ export class S3 {
       throw e;
     }
   }
+
+  public getStringObjectFromBucket = async (bucketName: string, objectKey: string): Promise<string | undefined> => {
+    try {
+      const result = await this.s3
+        .getObject({
+          Bucket: bucketName,
+          Key: objectKey,
+        })
+        .promise();
+
+      return result.Body.toString();
+    } catch (e) {
+      if (e.statusCode === 404) {
+        return undefined;
+      }
+
+      throw e;
+    }
+  };
 }

--- a/packages/amplify-provider-awscloudformation/src/build-resources.js
+++ b/packages/amplify-provider-awscloudformation/src/build-resources.js
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import { ServiceName } from 'amplify-category-function';
 
-async function run(context, category, resourceName) {
+export async function run(context, category, resourceName) {
   const { allResources } = await context.amplify.getResourceStatus(category, resourceName);
 
   const resources = allResources.filter(resource => resource.service === ServiceName.LambdaFunction).filter(resource => resource.build);
@@ -16,7 +16,7 @@ async function run(context, category, resourceName) {
 
 // This function is a translation layer around the previous buildResource
 // For legacy purposes, the method builds and packages the resource
-async function buildResource(context, resource) {
+export async function buildResource(context, resource) {
   const resourcePath = path.join(context.amplify.pathManager.getBackendDirPath(), resource.category, resource.resourceName);
   let breadcrumbs = context.amplify.readBreadcrumbs(context, resource.category, resource.resourceName);
 
@@ -82,8 +82,3 @@ async function buildResource(context, resource) {
       .catch(err => reject(new Error(`Package command failed with error [${err}]`)));
   });
 }
-
-module.exports = {
-  run,
-  buildResource,
-};

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
@@ -1,0 +1,274 @@
+import path from 'path';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import configurationManager from '../configuration-manager';
+import { Diff } from 'deep-diff';
+import {
+  cantAddAndRemoveGSIAtSameTimeRule,
+  cantBatchMutateGSIAtUpdateTimeRule,
+  cantEditGSIKeySchemaRule,
+  sanityCheckDiffs,
+} from 'graphql-transformer-core';
+import { Template, DynamoDB } from 'cloudform-types';
+import { $TSContext, JSONUtilities, pathManager } from 'amplify-cli-core';
+import { CloudFormation } from 'aws-sdk';
+import { getStackParameters, GSIRecord, TemplateState, getTableNames } from '../utils/amplify-resource-state-utils';
+import { hashDirectory, ROOT_APPSYNC_S3_KEY } from '../upload-appsync-files';
+import { DiffChanges, getGQLDiff, DiffableProject } from './utils';
+import { DeploymentStep, DeploymentOp } from '../iterative-deployment/deployment-manager';
+import { addGsi, removeGsi, getGSIDetails } from './dynamodb-gsi-helpers';
+import { GSIChange, getGSIDiffs } from './gsi-diff-helpers';
+
+export type GQLResourceManagerProps = {
+  cfnClient: CloudFormation;
+  resourceMeta: $ResourceMeta | null;
+  backendDir: string;
+  cloudBackendDir: string;
+};
+
+export type $ResourceMeta = {
+  category: string;
+  providerPlugin: string;
+  resourceName: string;
+  service: string;
+  output: any;
+  providerMetadata: {
+    s3TemplateURL: string;
+    logicalId: string;
+  };
+  stackId: string;
+  DeploymentBucketName: string;
+  [key: string]: any;
+};
+
+// TODO: Add unit testing
+export class GraphQLResourceManager {
+  static serviceName: string = 'AppSync';
+  static categoryName: string = 'api';
+  private cfnClient: CloudFormation;
+  private resourceMeta: $ResourceMeta;
+  private cloudBackendApiProjectRoot: string;
+  private backendApiProjectRoot: string;
+  private templateState: TemplateState;
+
+  public static createInstance = async (context: $TSContext, gqlResource: any, StackId: string) => {
+    try {
+      const cred = await configurationManager.loadConfiguration(context);
+      const cfn = new CloudFormation(cred);
+      const apiStack = await cfn
+        .describeStackResources({ StackName: StackId, LogicalResourceId: gqlResource.providerMetadata.logicalId })
+        .promise();
+      return new GraphQLResourceManager({
+        cfnClient: cfn,
+        resourceMeta: { ...gqlResource, stackId: apiStack.StackResources[0].PhysicalResourceId },
+        backendDir: pathManager.getBackendDirPath(),
+        cloudBackendDir: pathManager.getCurrentCloudBackendDirPath(),
+      });
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  constructor(props: GQLResourceManagerProps) {
+    if (!props.resourceMeta) {
+      throw Error('No GraphQL API enabled.');
+    }
+
+    this.cfnClient = props.cfnClient;
+
+    this.resourceMeta = props.resourceMeta;
+    this.backendApiProjectRoot = path.join(props.backendDir, GraphQLResourceManager.categoryName, this.resourceMeta.resourceName);
+    this.cloudBackendApiProjectRoot = path.join(props.cloudBackendDir, GraphQLResourceManager.categoryName, this.resourceMeta.resourceName);
+    this.templateState = new TemplateState();
+  }
+
+  run = async (): Promise<DeploymentStep[]> => {
+    const gqlDiff = getGQLDiff(this.backendApiProjectRoot, this.cloudBackendApiProjectRoot);
+
+    try {
+      const diffRules = [
+        // GSI
+        cantEditGSIKeySchemaRule,
+        cantBatchMutateGSIAtUpdateTimeRule,
+        cantAddAndRemoveGSIAtSameTimeRule,
+      ];
+
+      sanityCheckDiffs(gqlDiff.diff, gqlDiff.current, gqlDiff.next, diffRules);
+    } catch (err) {
+      if (err.name !== 'InvalidGSIMigrationError') {
+        throw err;
+      }
+    }
+
+    this.gsiManagement(gqlDiff.diff, gqlDiff.current, gqlDiff.next);
+
+    return await this.getDeploymentSteps();
+  };
+
+  // save states to build with a copy of build on every deploy
+  getDeploymentSteps = async (): Promise<DeploymentStep[]> => {
+    let count = 1;
+
+    const gqlSteps = new Array<DeploymentStep>();
+
+    const cloudBuildDir = path.join(this.cloudBackendApiProjectRoot, 'build');
+
+    const stateFileDir = this.getStateFilesDirectory();
+
+    const tableNameMap = await getTableNames(this.cfnClient, this.templateState.getKeys(), this.resourceMeta.stackId);
+
+    const parameters = await getStackParameters(this.cfnClient, this.resourceMeta.stackId);
+
+    const buildHash = await hashDirectory(this.backendApiProjectRoot);
+
+    // copy the last deployment state as current state
+    let previousStepPath = cloudBuildDir;
+    let rollbackStep: DeploymentOp = await this.getCurrentlyDeployedStackStep();
+
+    while (!this.templateState.isEmpty()) {
+      const stepNumber = count.toString().padStart(2, '0');
+      const stepPath = path.join(stateFileDir, `${stepNumber}`);
+
+      fs.copySync(previousStepPath, stepPath);
+      previousStepPath = stepPath;
+
+      const tables = this.templateState.getKeys();
+      const tableNames = [];
+      tables.forEach(tableName => {
+        tableNames.push(tableNameMap.get(tableName));
+        const filepath = path.join(stateFileDir, `${stepNumber}`, 'stacks', `${tableName}.json`);
+        fs.ensureDirSync(path.dirname(filepath));
+        JSONUtilities.writeJson(filepath, this.templateState.pop(tableName));
+      });
+
+      const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states/${stepNumber}`;
+      const deploymentStep: DeploymentOp = {
+        // stackTemplatePathOrUrl: this.resourceMeta.providerMetadata.s3TemplateURL,
+        stackTemplatePathOrUrl: `${deploymentRootKey}/cloudformation-template.json`,
+        parameters: { ...parameters, S3DeploymentRootKey: deploymentRootKey },
+        stackName: this.resourceMeta.stackId,
+        tableNames: tableNames,
+        // clientRequestToken: `${buildHash}-step-${stepNumber}`,
+      };
+
+      gqlSteps.push({
+        deployment: deploymentStep,
+        rollback: rollbackStep,
+      });
+
+      // Current deployment step is the rollback step for next step
+      rollbackStep = deploymentStep;
+      count++;
+    }
+
+    return gqlSteps;
+  };
+
+  /**
+   * get a copy of last deployed API nested stack to rollback to incase deployment fails
+   */
+  public getCurrentlyDeployedStackStep = async (): Promise<DeploymentOp> => {
+    const cloudBuildDir = path.join(this.cloudBackendApiProjectRoot, 'build');
+    const stateFileDir = this.getStateFilesDirectory();
+
+    const parameters = await getStackParameters(this.cfnClient, this.resourceMeta.stackId);
+    const buildHash = await hashDirectory(this.backendApiProjectRoot);
+
+    const stepNumber = 'initial-stack';
+    const stepPath = path.join(stateFileDir, `${stepNumber}`);
+
+    fs.copySync(cloudBuildDir, stepPath);
+
+    const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states/${stepNumber}`;
+    return {
+      // stackTemplatePathOrUrl: this.resourceMeta.providerMetadata.s3TemplateURL,
+      stackTemplatePathOrUrl: `${deploymentRootKey}/cloudformation-template.json`,
+      parameters: { ...parameters, S3DeploymentRootKey: deploymentRootKey },
+      stackName: this.resourceMeta.stackId,
+      tableNames: [],
+    };
+  };
+
+  public getStateFilesDirectory = (): string => {
+    const buildDir = path.join(this.backendApiProjectRoot, 'build');
+    return path.join(buildDir, 'states');
+  };
+
+  private gsiManagement = (diffs: DiffChanges<DiffableProject>, currentState: DiffableProject, nextState: DiffableProject) => {
+    const gsiChanges = _.filter(diffs, diff => {
+      return diff.path.includes('GlobalSecondaryIndexes');
+    });
+
+    const tableWithGSIChanges = _.uniqBy(gsiChanges, diff => diff.path?.slice(0, 3).join('/')).map(gsiChange => {
+      const tableName = gsiChange.path[3];
+
+      const stackName = gsiChange.path[1].split('.')[0];
+
+      const currentTable = this.getTable(gsiChange, currentState);
+      const nextTable = this.getTable(gsiChange, nextState);
+
+      return {
+        tableName,
+        stackName,
+        currentTable,
+        nextTable,
+      };
+    });
+
+    for (const gsiChange of tableWithGSIChanges) {
+      const changeSteps = getGSIDiffs(gsiChange.currentTable, gsiChange.nextTable);
+      const stackName = gsiChange.stackName;
+      const tableName = gsiChange.tableName;
+      for (const changeStep of changeSteps) {
+        const ddbResource = this.templateState.getLatest(stackName) || this.getStack(stackName, currentState);
+        let gsiRecord;
+        switch (changeStep.type) {
+          case GSIChange.Add:
+            gsiRecord = getGSIDetails(changeStep.indexName, gsiChange.nextTable);
+            this.addGSI(gsiRecord, tableName, ddbResource);
+            this.templateState.add(stackName, JSONUtilities.stringify(ddbResource));
+            break;
+
+          case GSIChange.Delete:
+            this.deleteGSI(changeStep.indexName, tableName, ddbResource);
+            this.templateState.add(stackName, JSONUtilities.stringify(ddbResource));
+            break;
+
+          case GSIChange.Update:
+            this.deleteGSI(changeStep.indexName, tableName, ddbResource);
+            this.templateState.add(stackName, JSONUtilities.stringify(ddbResource));
+            gsiRecord = getGSIDetails(changeStep.indexName, gsiChange.nextTable);
+            this.addGSI(gsiRecord, tableName, ddbResource);
+            this.templateState.add(stackName, JSONUtilities.stringify(ddbResource));
+            break;
+
+          default:
+            assertUnreachable(changeStep.type);
+        }
+      }
+    }
+  };
+
+  private getTable = (gsiChange: Diff<any, any>, proj: DiffableProject): DynamoDB.Table => {
+    return proj.stacks[gsiChange.path[1]].Resources[gsiChange.path[3]] as DynamoDB.Table;
+  };
+
+  private getStack(stackName: string, proj: DiffableProject): Template {
+    return proj.stacks[`${stackName}.json`];
+  }
+
+  private addGSI = (gsiRecord: GSIRecord, tableName: string, template: Template): void => {
+    const table = template.Resources[tableName] as DynamoDB.Table;
+    template.Resources[tableName] = addGsi(gsiRecord, table);
+  };
+
+  private deleteGSI = (indexName: string, tableName: string, template: Template): void => {
+    const table = template.Resources[tableName] as DynamoDB.Table;
+    template.Resources[tableName] = removeGsi(indexName, table);
+  };
+}
+
+// https://stackoverflow.com/questions/39419170/how-do-i-check-that-a-switch-block-is-exhaustive-in-typescript
+export const assertUnreachable = (_: never): never => {
+  throw new Error('Default case should never reach');
+};

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
@@ -143,7 +143,6 @@ export class GraphQLResourceManager {
 
       const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states/${stepNumber}`;
       const deploymentStep: DeploymentOp = {
-        // stackTemplatePathOrUrl: this.resourceMeta.providerMetadata.s3TemplateURL,
         stackTemplatePathOrUrl: `${deploymentRootKey}/cloudformation-template.json`,
         parameters: { ...parameters, S3DeploymentRootKey: deploymentRootKey },
         stackName: this.resourceMeta.stackId,
@@ -181,7 +180,6 @@ export class GraphQLResourceManager {
 
     const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states/${stepNumber}`;
     return {
-      // stackTemplatePathOrUrl: this.resourceMeta.providerMetadata.s3TemplateURL,
       stackTemplatePathOrUrl: `${deploymentRootKey}/cloudformation-template.json`,
       parameters: { ...parameters, S3DeploymentRootKey: deploymentRootKey },
       stackName: this.resourceMeta.stackId,

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
@@ -5,7 +5,7 @@ import { DynamoDB, Template } from 'cloudform-types';
 import { GSIChange, getGSIDiffs } from './gsi-diff-helpers';
 import { GSIRecord, TemplateState, getStackParameters, getTableNames } from '../utils/amplify-resource-state-utils';
 import { ROOT_APPSYNC_S3_KEY, hashDirectory } from '../upload-appsync-files';
-import { addGsi, getGSIDetails, removeGsi } from './dynamodb-gsi-helpers';
+import { addGSI, getGSIDetails, removeGSI } from './dynamodb-gsi-helpers';
 import {
   cantAddAndRemoveGSIAtSameTimeRule,
   cantBatchMutateGSIAtUpdateTimeRule,
@@ -258,12 +258,12 @@ export class GraphQLResourceManager {
 
   private addGSI = (gsiRecord: GSIRecord, tableName: string, template: Template): void => {
     const table = template.Resources[tableName] as DynamoDB.Table;
-    template.Resources[tableName] = addGsi(gsiRecord, table);
+    template.Resources[tableName] = addGSI(gsiRecord, table);
   };
 
   private deleteGSI = (indexName: string, tableName: string, template: Template): void => {
     const table = template.Resources[tableName] as DynamoDB.Table;
-    template.Resources[tableName] = removeGsi(indexName, table);
+    template.Resources[tableName] = removeGSI(indexName, table);
   };
 }
 

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/dynamodb-gsi-helpers.ts
@@ -1,0 +1,138 @@
+import _ from 'lodash';
+
+import { AttributeDefinition, GlobalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
+import { GSIRecord } from '../utils/amplify-resource-state-utils';
+import { DynamoDB, IntrinsicFunction } from 'cloudform';
+import { KeySchema } from 'cloudform-types/types/dynamoDb/table';
+export const MAX_GSI_PER_TABLE = 20;
+/**
+ * Extract the GlobalSecondaryIndex information and required Attributes from an Table
+ * @param indexName name of the global secondary index of which detail is extracted
+ * @param table DynamoDB Table with GSI
+ */
+export const getGSIDetails = (indexName: string, table: DynamoDB.Table): GSIRecord | undefined => {
+  const gsis = table.Properties.GlobalSecondaryIndexes ?? [];
+
+  assertNotIntrinsicFunction<GlobalSecondaryIndex>(gsis);
+
+  const indexItems = _.filter(gsis, {
+    IndexName: indexName,
+  });
+
+  if (indexItems.length) {
+    const addedGSI = indexItems[0];
+    const keySchema = addedGSI.KeySchema;
+
+    assertNotIntrinsicFunction<KeySchema>(keySchema);
+
+    const attributesUsedInKey = keySchema.reduce((acc, attr) => {
+      acc.push(attr.AttributeName);
+      return acc;
+    }, []);
+
+    const existingAttrDefinition = table.Properties.AttributeDefinitions;
+    assertNotIntrinsicFunction(existingAttrDefinition);
+
+    const attributeDefinition = _.filter(existingAttrDefinition, defs => {
+      return attributesUsedInKey.includes(defs.AttributeName);
+    });
+
+    return { gsi: addedGSI, attributeDefinition: attributeDefinition };
+  }
+};
+
+/**
+ * Helper method to add new GSI and attribute definitions
+ * @param index GSIRecord with the index  and attribute definition
+ * @param table DynamoDB table to which the new GSI is added
+ */
+export const addGsi = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table => {
+  const updatedTable = _.cloneDeep(table);
+
+  const gsis = updatedTable.Properties.GlobalSecondaryIndexes ?? [];
+  assertNotIntrinsicFunction<GlobalSecondaryIndex>(gsis);
+
+  const existingIndices = getExistingIndexNames(table);
+
+  if (existingIndices.length + 1 > MAX_GSI_PER_TABLE) {
+    throw new Error(`DynamoDB ${table.Properties.TableName || '{UnNamedTable}'} can have max of ${MAX_GSI_PER_TABLE} GSIs`);
+  }
+
+  const indexName = index.gsi.IndexName;
+  assertNotIntrinsicFunction(indexName);
+
+  if (existingIndices.includes(indexName)) {
+    throw new Error(`An index with name ${indexName} already exists`);
+  }
+
+  gsis.push(index.gsi);
+
+  updatedTable.Properties.GlobalSecondaryIndexes = gsis;
+
+  const attrDefs = (updatedTable.Properties.AttributeDefinitions ?? []) as AttributeDefinition[];
+  updatedTable.Properties.AttributeDefinitions = _.unionBy(attrDefs, index.attributeDefinition, 'AttributeName');
+
+  return updatedTable;
+};
+
+/**
+ * Remove an specified index and attribute definition of the fields used in given index
+ * @param indexName Name of the Index
+ * @param table DynamoDB table from which the index is removed
+ */
+export const removeGsi = (indexName: string, table: DynamoDB.Table): DynamoDB.Table => {
+  const updatedTable = _.cloneDeep(table);
+  const gsis = updatedTable.Properties.GlobalSecondaryIndexes;
+  assertNotIntrinsicFunction(gsis);
+
+  if (!gsis || gsis.length === 0) {
+    throw new Error(`No GSIs are present in the table`);
+  }
+
+  const indexNames = gsis.map(g => g.IndexName);
+  if (!indexNames.includes(indexName)) {
+    throw new Error(`Table ${table.Properties.TableName || '{UnnamedTable}'} does not contain GSI ${indexName}`);
+  }
+
+  const attrDefs = updatedTable.Properties.AttributeDefinitions;
+  assertNotIntrinsicFunction(attrDefs);
+
+  const removedIndices = _.remove(gsis, { IndexName: indexName });
+  assertNotIntrinsicFunction(removedIndices);
+  const currentKeySchemas = gsis.reduce((acc, gsi) => {
+    acc.push(...(gsi.KeySchema as Array<KeySchema>));
+    return acc;
+  }, []);
+
+  // Remove the property as it does not have any child
+  if (gsis.length == 0) {
+    delete updatedTable.Properties.GlobalSecondaryIndexes;
+  }
+
+  if (removedIndices?.length) {
+    const removedIndex = removedIndices[0];
+
+    const removedKeySchema = removedIndex.KeySchema;
+    assertNotIntrinsicFunction(removedKeySchema);
+
+    const attrToRemove = _.differenceBy(removedKeySchema, currentKeySchemas, 'AttributeName');
+    _.pullAllBy(attrDefs, attrToRemove, 'AttributeName');
+  }
+
+  return updatedTable;
+};
+/**
+ * Asserts a List is not an intrinsic function which is not generated and supported by transformer
+ * @param x record
+ */
+export function assertNotIntrinsicFunction<A>(x: A[] | A | IntrinsicFunction): asserts x is A[] | A {
+  if (x instanceof IntrinsicFunction) {
+    throw new Error('Intrinsic functions are not supported in KeySchema and GlobalSecondaryIndex');
+  }
+}
+
+export const getExistingIndexNames = (table: DynamoDB.Table): string[] => {
+  const gsis = table.Properties.GlobalSecondaryIndexes ?? [];
+  assertNotIntrinsicFunction(gsis);
+  return gsis.reduce((acc, idx) => [...acc, idx.IndexName], []);
+};

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/dynamodb-gsi-helpers.ts
@@ -47,7 +47,7 @@ export const getGSIDetails = (indexName: string, table: DynamoDB.Table): GSIReco
  * @param index GSIRecord with the index  and attribute definition
  * @param table DynamoDB table to which the new GSI is added
  */
-export const addGsi = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table => {
+export const addGSI = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table => {
   const updatedTable = _.cloneDeep(table);
 
   const gsis = updatedTable.Properties.GlobalSecondaryIndexes ?? [];
@@ -81,7 +81,7 @@ export const addGsi = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table 
  * @param indexName Name of the Index
  * @param table DynamoDB table from which the index is removed
  */
-export const removeGsi = (indexName: string, table: DynamoDB.Table): DynamoDB.Table => {
+export const removeGSI = (indexName: string, table: DynamoDB.Table): DynamoDB.Table => {
   const updatedTable = _.cloneDeep(table);
   const gsis = updatedTable.Properties.GlobalSecondaryIndexes;
   assertNotIntrinsicFunction(gsis);

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/dynamodb-gsi-helpers.ts
@@ -1,12 +1,13 @@
+import { AttributeDefinition, GlobalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
+import { DynamoDB, IntrinsicFunction } from 'cloudform';
+
+import { GSIRecord } from '../utils/amplify-resource-state-utils';
+import { KeySchema } from 'cloudform-types/types/dynamoDb/table';
 import _ from 'lodash';
 
-import { AttributeDefinition, GlobalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
-import { GSIRecord } from '../utils/amplify-resource-state-utils';
-import { DynamoDB, IntrinsicFunction } from 'cloudform';
-import { KeySchema } from 'cloudform-types/types/dynamoDb/table';
 export const MAX_GSI_PER_TABLE = 20;
 /**
- * Extract the GlobalSecondaryIndex information and required Attributes from an Table
+ * Extract the GlobalSecondaryIndex information and required Attributes from a Table
  * @param indexName name of the global secondary index of which detail is extracted
  * @param table DynamoDB Table with GSI
  */

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
@@ -1,0 +1,107 @@
+import { DynamoDB, IntrinsicFunction } from 'cloudform';
+import * as _ from 'lodash';
+import { GlobalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
+import Table from 'cloudform-types/types/glue/table';
+import { diff as getDiffs } from 'deep-diff';
+
+export enum GSIChange {
+  Add = 'ADD',
+  Update = 'UPDATE',
+  Delete = 'DELETE',
+}
+
+export type IndexChange = {
+  type: GSIChange;
+  indexName: string;
+};
+
+/**
+ * Generate a list of GSI changes that needs to be pushed to update the
+ * GSIs
+ * @param current DynamoDB table represnting currently deployed
+ * @param next DynamoDB table configuration that needs to be deployed
+ */
+export const getGSIDiffs = (current: DynamoDB.Table, next: DynamoDB.Table): IndexChange[] => {
+  if (
+    current.Properties.GlobalSecondaryIndexes instanceof IntrinsicFunction ||
+    next.Properties.GlobalSecondaryIndexes instanceof IntrinsicFunction
+  ) {
+    return [];
+  }
+
+  const currentIndexes = current.Properties.GlobalSecondaryIndexes ?? [];
+  const nextIndexes = next.Properties.GlobalSecondaryIndexes ?? [];
+
+  return generateGSIChangeList(currentIndexes, nextIndexes);
+};
+
+/**
+ * Generates a list of operation that needs to be performed in iterative push to update
+ * the DynamoDB tables GSIs
+ * @param currentIndexes DynamoDB GlobalSecondaryIndexes represnting currently deployed table
+ * @param nextIndexes DynamoDB GlobalSecondaryIndexes that needs to be deployed in next push
+ */
+export const generateGSIChangeList = (currentIndexes: GlobalSecondaryIndex[], nextIndexes: GlobalSecondaryIndex[]): IndexChange[] => {
+  // Create  Record<IndexName, Index>
+  const currentIndexByIndexName = _.keyBy(currentIndexes, 'IndexName');
+  // create an array of indexes
+  const currentIndexNames = Object.keys(currentIndexByIndexName);
+
+  // Create  Record<IndexName, Index>
+  const nextIndexByIndexName = _.keyBy(nextIndexes, 'IndexName');
+  // create an array of indexes
+  const nextIndexNames = Object.keys(nextIndexByIndexName);
+
+  // Get the indexes which are not in both current and next indexes
+  const addedOrRemovedIndexNames = _.xor(currentIndexNames, nextIndexNames);
+
+  // Partition them as added/removed indexes
+  const [indexToRemove, indexToAdd] = _.partition(addedOrRemovedIndexNames, indexName => currentIndexNames.includes(indexName));
+
+  // Get all the indexes that are in bot current and next indexes
+  const possiblyModifiedIndexNames = _.xor([...currentIndexNames, ...nextIndexNames], addedOrRemovedIndexNames);
+
+  const modifiedIndexes = possiblyModifiedIndexNames
+    .map(indexName => {
+      return getUpdatedIndexDiff(currentIndexByIndexName[indexName], nextIndexByIndexName[indexName]);
+    })
+    .filter(change => Boolean(change));
+
+  return [
+    ...indexToRemove.map(idx => ({
+      type: GSIChange.Delete,
+      indexName: idx,
+    })),
+    ...indexToAdd.map(idx => ({
+      type: GSIChange.Add,
+      indexName: idx,
+    })),
+    ...modifiedIndexes,
+  ];
+};
+
+/**
+ * Returns the type of iterative change needed to the index to support index updating
+ * @param currentIndex DynamoDB GlobalSecondaryIndex in currently deployed table
+ * @param nextIndex updated DynamoDB GlobalSecondaryIndex to be deployed in the next push
+ */
+export const getUpdatedIndexDiff = (currentIndex: GlobalSecondaryIndex, nextIndex: GlobalSecondaryIndex): IndexChange | undefined => {
+  const diffs = getDiffs(currentIndex, nextIndex);
+  if (currentIndex.IndexName instanceof IntrinsicFunction) {
+    return;
+  }
+  const isModeifed = diffs?.some(diff => {
+    const leaf = diff.path?.slice(-1)[0];
+    return [
+      'IndexName',
+      'KeySchema',
+      'AttributeName',
+      'AttributeType',
+      'KeyType',
+      'NonKeyAttributes',
+      'Projection',
+      'ProjectionType',
+    ].includes(leaf);
+  });
+  return isModeifed ? { type: GSIChange.Update, indexName: currentIndex.IndexName } : undefined;
+};

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
@@ -1,7 +1,6 @@
 import { DynamoDB, IntrinsicFunction } from 'cloudform';
 import * as _ from 'lodash';
 import { GlobalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
-import Table from 'cloudform-types/types/glue/table';
 import { diff as getDiffs } from 'deep-diff';
 
 export enum GSIChange {

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
@@ -63,7 +63,7 @@ export const generateGSIChangeList = (currentIndexes: GlobalSecondaryIndex[], ne
   const possiblyModifiedIndexNames = _.xor([...currentIndexNames, ...nextIndexNames], addedOrRemovedIndexNames);
 
   const modifiedIndexes = possiblyModifiedIndexNames
-    .filter(indexName => isIdexModified(currentIndexByIndexName[indexName], nextIndexByIndexName[indexName]))
+    .filter(indexName => isIndexModified(currentIndexByIndexName[indexName], nextIndexByIndexName[indexName]))
     .map(indexName => ({
       type: GSIChange.Update,
       indexName,
@@ -87,7 +87,7 @@ export const generateGSIChangeList = (currentIndexes: GlobalSecondaryIndex[], ne
  * @param currentIndex DynamoDB GlobalSecondaryIndex in currently deployed table
  * @param nextIndex updated DynamoDB GlobalSecondaryIndex to be deployed in the next push
  */
-export const isIdexModified = (currentIndex: GlobalSecondaryIndex, nextIndex: GlobalSecondaryIndex): boolean => {
+export const isIndexModified = (currentIndex: GlobalSecondaryIndex, nextIndex: GlobalSecondaryIndex): boolean => {
   const diffs = getDiffs(currentIndex, nextIndex);
   if (currentIndex.IndexName instanceof IntrinsicFunction) {
     return;

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/gsi-diff-helpers.ts
@@ -89,7 +89,7 @@ export const getUpdatedIndexDiff = (currentIndex: GlobalSecondaryIndex, nextInde
   if (currentIndex.IndexName instanceof IntrinsicFunction) {
     return;
   }
-  const isModeifed = diffs?.some(diff => {
+  const isModified = diffs?.some(diff => {
     const leaf = diff.path?.slice(-1)[0];
     return [
       'IndexName',
@@ -102,5 +102,5 @@ export const getUpdatedIndexDiff = (currentIndex: GlobalSecondaryIndex, nextInde
       'ProjectionType',
     ].includes(leaf);
   });
-  return isModeifed ? { type: GSIChange.Update, indexName: currentIndex.IndexName } : undefined;
+  return isModified ? { type: GSIChange.Update, indexName: currentIndex.IndexName } : undefined;
 };

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/index.ts
@@ -1,0 +1,1 @@
+export { GraphQLResourceManager } from './amplify-graphql-resource-manager';

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -3,9 +3,85 @@ import * as path from 'path';
 import { DeploymentResources } from '@aws-amplify/graphql-transformer-core';
 import rimraf from 'rimraf';
 import { JSONUtilities } from 'amplify-cli-core';
+import { Template } from 'cloudform';
+import { Diff, diff as getDiffs } from 'deep-diff';
 
-
+const ROOT_STACK_FILE_NAME = 'cloudformation-template.json';
 const PARAMETERS_FILE_NAME = 'parameters.json';
+export interface DiffableProject {
+  stacks: {
+    [stackName: string]: Template;
+  };
+  root: Template;
+}
+
+export type DiffChanges<T> = Array<Diff<DiffableProject, DiffableProject>>;
+
+export interface GQLDiff {
+  diff: DiffChanges<DiffableProject>;
+  next: DiffableProject;
+  current: DiffableProject;
+}
+
+export const getGQLDiff = (currentBackendDir: string, cloudBackendDir: string): GQLDiff => {
+  const currentBuildDir = path.join(currentBackendDir, 'build');
+  const cloudBuildDir = path.join(cloudBackendDir, 'build');
+  if (fs.existsSync(cloudBuildDir) && fs.existsSync(currentBuildDir)) {
+    const current = loadDiffableProject(cloudBuildDir, ROOT_STACK_FILE_NAME);
+    const next = loadDiffableProject(currentBuildDir, ROOT_STACK_FILE_NAME);
+    return { current, next, diff: getDiffs(current, next) };
+  }
+  return null;
+};
+
+export const getGqlUpdatedResource = (resources: any[]) => {
+  if (resources.length > 0) {
+    const resource = resources[0];
+    if (
+      resource.service === 'AppSync' &&
+      resource.providerMetadata &&
+      resource.providerMetadata.logicalId &&
+      resource.providerPlugin === 'awscloudformation'
+    ) {
+      return resource;
+    }
+  }
+  return null;
+};
+
+export function loadDiffableProject(path: string, rootStackName: string): DiffableProject {
+  const project = readFromPath(path);
+  const currentStacks = project.stacks || {};
+  const diffableProject: DiffableProject = {
+    stacks: {},
+    root: {},
+  };
+  for (const key of Object.keys(currentStacks)) {
+    diffableProject.stacks[key] = JSON.parse(project.stacks[key]);
+  }
+  diffableProject.root = JSON.parse(project[rootStackName]);
+  return diffableProject;
+}
+
+export function readFromPath(directory: string): any {
+  const pathExists = fs.pathExistsSync(directory);
+  if (!pathExists) {
+    return;
+  }
+  const dirStats = fs.lstatSync(directory);
+  if (!dirStats.isDirectory()) {
+    const buf = fs.readFileSync(directory);
+    return buf.toString();
+  }
+  const files = fs.readdirSync(directory);
+  const accum = {};
+  for (const fileName of files) {
+    const fullPath = path.join(directory, fileName);
+    const value = readFromPath(fullPath);
+    accum[fileName] = value;
+  }
+  return accum;
+}
 
 /**
  * Writes a deployment to disk at a path.

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -1,0 +1,311 @@
+import * as aws from 'aws-sdk';
+import assert from 'assert';
+import throttle from 'lodash.throttle';
+import {
+  createDeploymentMachine,
+  DeploymentMachineOp,
+  DeploymentMachineStep,
+  StateMachineHelperFunctions,
+  DeployMachineContext,
+} from './state-machine';
+import { interpret } from 'xstate';
+import { IStackProgressPrinter, StackEventMonitor } from './stack-event-monitor';
+import { StackProgressPrinter } from './stack-progress-printer';
+import ora from 'ora';
+import configurationManager from '../configuration-manager';
+import { $TSContext, IDeploymentStateManager } from 'amplify-cli-core';
+import { ConfigurationOptions } from 'aws-sdk/lib/config-base';
+import { getBucketKey, getHttpUrl } from './helpers';
+interface DeploymentManagerOptions {
+  throttleDelay?: number;
+  eventPollingDelay?: number;
+}
+
+export type DeploymentOp = Omit<DeploymentMachineOp, 'region' | 'stackTemplatePath' | 'stackTemplateUrl'> & {
+  stackTemplatePathOrUrl: string;
+};
+
+export type DeploymentStep = {
+  deployment: DeploymentOp;
+  rollback: DeploymentOp;
+};
+
+export class DeploymentManager {
+  /**
+   * Helper method to get an instance of the Deployment manager with the right credentials
+   */
+
+  public static createInstance = async (
+    context: $TSContext,
+    deploymentBucket: string,
+    spinner: ora.Ora,
+    printer?: IStackProgressPrinter,
+    options?: DeploymentManagerOptions,
+  ) => {
+    try {
+      const cred = await configurationManager.loadConfiguration(context);
+      assert(cred.region);
+      return new DeploymentManager(cred, cred.region, deploymentBucket, spinner, printer, options);
+    } catch (e) {
+      throw new Error('Could not load the credentials');
+    }
+  };
+
+  private deployment: DeploymentMachineStep[] = [];
+  private options: Required<DeploymentManagerOptions>;
+  private cfnClient: aws.CloudFormation;
+  private s3Client: aws.S3;
+  private deploymentStateManager?: IDeploymentStateManager;
+
+  private constructor(
+    creds: ConfigurationOptions,
+    private region: string,
+    private deploymentBucket: string,
+    private spinner: ora.Ora,
+    // private deployedTemplatePath: string,
+    private printer: IStackProgressPrinter = new StackProgressPrinter(),
+    options: DeploymentManagerOptions = {},
+  ) {
+    this.options = {
+      throttleDelay: 1_000,
+      eventPollingDelay: 1_000,
+      ...options,
+    };
+
+    this.s3Client = new aws.S3(creds);
+    this.cfnClient = new aws.CloudFormation({ ...creds, maxRetries: 10 });
+  }
+
+  public deploy = async (deploymentStateManager: IDeploymentStateManager): Promise<void> => {
+    this.deploymentStateManager = deploymentStateManager;
+
+    // sanity check before deployment
+    const deploymentTemplates = this.deployment.reduce<Set<string>>((acc, step) => {
+      acc.add(step.deployment.stackTemplatePath);
+      acc.add(step.rollback.stackTemplatePath);
+      return acc;
+    }, new Set());
+    await Promise.all(Array.from(deploymentTemplates.values()).map(path => this.ensureTemplateExists(path)));
+
+    const fns: StateMachineHelperFunctions = {
+      deployFn: this.doDeploy,
+      deploymentWaitFn: this.waitForDeployment,
+      rollbackFn: this.rollBackStack,
+      tableReadyWaitFn: this.waitForIndices,
+      rollbackWaitFn: this.waitForDeployment,
+      stackEventPollFn: this.stackPollFn,
+      startRollbackFn: this.startRollBackFn,
+    };
+
+    const machine = createDeploymentMachine(
+      {
+        currentIndex: -1,
+        deploymentBucket: this.deploymentBucket,
+        region: this.region,
+        stacks: this.deployment,
+      },
+      fns,
+    );
+
+    let maxDeployed = 0;
+
+    return new Promise(async (resolve, reject) => {
+      const service = interpret(machine)
+        .onTransition(async state => {
+          if (state.changed) {
+            maxDeployed = Math.max(maxDeployed, state.context.currentIndex + 1);
+            if (state.matches('idle')) {
+              this.spinner.text = `Starting deployment`;
+            } else if (state.matches('deploy')) {
+              this.spinner.text = `Deploying stack (${maxDeployed} of ${state.context.stacks.length})`;
+            } else if (state.matches('rollback')) {
+              this.spinner.text = `Rolling back (${maxDeployed - state.context.currentIndex} of ${maxDeployed})`;
+            } else if (state.matches('deployed')) {
+              this.spinner.succeed(`Deployed`);
+            }
+          }
+
+          switch (state.value) {
+            case 'deployed':
+              return resolve();
+            case 'rolledBack':
+            case 'failed':
+              return reject(new Error('Deployment failed'));
+              break;
+            default:
+            // intentionally left blank as we don't care about intermediate states
+          }
+        })
+        .start();
+      service.send({ type: 'DEPLOY' });
+    });
+  };
+
+  public addStep = (deploymentStep: DeploymentStep): void => {
+    const deploymentStackTemplateUrl = getHttpUrl(deploymentStep.deployment.stackTemplatePathOrUrl, this.deploymentBucket);
+    const deploymentStackTemplatePath = getBucketKey(deploymentStep.deployment.stackTemplatePathOrUrl, this.deploymentBucket);
+
+    const rollbackStackTemplateUrl = getHttpUrl(deploymentStep.rollback.stackTemplatePathOrUrl, this.deploymentBucket);
+    const rollbackStackTemplatePath = getBucketKey(deploymentStep.rollback.stackTemplatePathOrUrl, this.deploymentBucket);
+
+    this.deployment.push({
+      deployment: {
+        ...deploymentStep.deployment,
+        stackTemplatePath: deploymentStackTemplatePath,
+        stackTemplateUrl: deploymentStackTemplateUrl,
+        region: this.region,
+        clientRequestToken: deploymentStep.deployment.clientRequestToken
+          ? `deploy-${deploymentStep.deployment.clientRequestToken}`
+          : undefined,
+      },
+      rollback: {
+        ...deploymentStep.rollback,
+        stackTemplatePath: rollbackStackTemplatePath,
+        stackTemplateUrl: rollbackStackTemplateUrl,
+        region: this.region,
+        clientRequestToken: deploymentStep.rollback.clientRequestToken
+          ? `rollback-${deploymentStep.rollback.clientRequestToken}`
+          : undefined,
+      },
+    });
+  };
+
+  public setPrinter = (printer: IStackProgressPrinter) => {
+    this.printer = printer;
+  };
+
+  /**
+   * Called when an deployment is failed and rolling back is started
+   * @param context deployment machie context
+   */
+  private startRollBackFn = async (_: Readonly<DeployMachineContext>): Promise<void> => {
+    try {
+      await this.deploymentStateManager?.startRollback();
+      await this.deploymentStateManager?.startCurrentStep();
+    } catch {
+      // ignore, rollback should not fail because updating the deployment status fails
+    }
+  };
+
+  /**
+   * Ensure that the stack is present and can be deployed
+   * @param stackName name of the stack
+   */
+  private ensureStack = async (stackName: string): Promise<boolean> => {
+    const result = await this.cfnClient.describeStacks({ StackName: stackName }).promise();
+    return result.Stacks[0].StackStatus.endsWith('_COMPLETE');
+  };
+
+  /**
+   * Checks the file exists in the path
+   * @param templatePath path of the cloudformation file
+   */
+  private ensureTemplateExists = async (templatePath: string): Promise<boolean> => {
+    try {
+      const bucketKey = getBucketKey(templatePath, this.deploymentBucket);
+      await this.s3Client.headObject({ Bucket: this.deploymentBucket, Key: bucketKey }).promise();
+      return true;
+    } catch (e) {
+      if (e.ccode === 'NotFound') {
+        throw new Error(`The cloudformation template ${templatePath} was not found in deployment bucket ${this.deploymentBucket}`);
+      }
+      throw e;
+    }
+  };
+
+  private getTableStatus = async (tableName: string, region: string): Promise<boolean> => {
+    assert(tableName, 'table name should be passed');
+
+    const dbClient = new aws.DynamoDB({ region });
+
+    const response = await dbClient.describeTable({ TableName: tableName }).promise();
+    const gsis = response.Table?.GlobalSecondaryIndexes;
+
+    return gsis ? gsis.every(idx => idx.IndexStatus === 'ACTIVE') : true;
+  };
+
+  private waitForIndices = async (stackParams: DeploymentMachineOp) => {
+    if (stackParams.tableNames.length) console.log('\nWaiting for DynamoDB table indices to be ready');
+    const throttledGetTableStatus = throttle(this.getTableStatus, this.options.throttleDelay);
+
+    const waiters = stackParams.tableNames.map(name => {
+      return new Promise(resolve => {
+        let interval = setInterval(async () => {
+          const areIndexesReady = await throttledGetTableStatus(name, this.region);
+          if (areIndexesReady) {
+            clearInterval(interval);
+            resolve(undefined);
+          }
+        }, this.options.throttleDelay);
+      });
+    });
+
+    await Promise.all(waiters);
+    try {
+      await this.deploymentStateManager?.advanceStep();
+    } catch {
+      // deployment should not fail because saving status failed
+    }
+    return Promise.resolve();
+  };
+
+  private stackPollFn = (deploymentStep: DeploymentMachineOp): (() => void) => {
+    let monitor: StackEventMonitor;
+    assert(deploymentStep.stackName, 'stack name should be passed to stackPollFn');
+    if (this.printer) {
+      monitor = new StackEventMonitor(this.cfnClient, deploymentStep.stackName, this.printer);
+      monitor.start();
+    }
+    return () => {
+      if (monitor) {
+        monitor.stop();
+      }
+    };
+  };
+
+  private doDeploy = async (currentStack: DeploymentMachineOp): Promise<void> => {
+    try {
+      await this.deploymentStateManager?.startCurrentStep();
+    } catch {
+      // deployment should not fail because status could not be saved
+    }
+    const cfn = this.cfnClient;
+
+    assert(currentStack.stackName, 'stack name should be passed to doDeploy');
+    assert(currentStack.stackTemplateUrl, 'stackTemplateUrl must be passed to doDeploy');
+
+    await this.ensureStack(currentStack.stackName);
+
+    const parameters = Object.entries(currentStack.parameters).map(([key, val]) => {
+      return {
+        ParameterKey: key,
+        ParameterValue: val.toString(),
+      };
+    });
+
+    await cfn
+      .updateStack({
+        StackName: currentStack.stackName,
+        Parameters: parameters,
+        TemplateURL: currentStack.stackTemplateUrl,
+        Capabilities: currentStack.capabilities,
+        ClientRequestToken: currentStack.clientRequestToken,
+      })
+      .promise();
+  };
+
+  private waitForDeployment = async (stackParams: DeploymentMachineOp): Promise<void> => {
+    const cfnClient = this.cfnClient;
+    assert(stackParams.stackName, 'stackName should be passed to waitForDeployment');
+
+    await cfnClient
+      .waitFor('stackUpdateComplete', {
+        StackName: stackParams.stackName,
+      })
+      .promise();
+  };
+
+  private rollBackStack = async (currentStack: Readonly<DeploymentMachineOp>): Promise<void> => {
+    await this.doDeploy(currentStack);
+  };
+}

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -19,6 +19,7 @@ import { getBucketKey, getHttpUrl } from './helpers';
 interface DeploymentManagerOptions {
   throttleDelay?: number;
   eventPollingDelay?: number;
+  userAgent?: string;
 }
 
 export type DeploymentOp = Omit<DeploymentMachineOp, 'region' | 'stackTemplatePath' | 'stackTemplateUrl'> & {
@@ -39,8 +40,8 @@ export class DeploymentManager {
     context: $TSContext,
     deploymentBucket: string,
     spinner: ora.Ora,
-    printer?: IStackProgressPrinter,
     options?: DeploymentManagerOptions,
+    printer?: IStackProgressPrinter,
   ) => {
     try {
       const cred = await configurationManager.loadConfiguration(context);
@@ -69,11 +70,12 @@ export class DeploymentManager {
     this.options = {
       throttleDelay: 1_000,
       eventPollingDelay: 1_000,
+      userAgent: undefined,
       ...options,
     };
 
     this.s3Client = new aws.S3(creds);
-    this.cfnClient = new aws.CloudFormation({ ...creds, maxRetries: 10 });
+    this.cfnClient = new aws.CloudFormation({ ...creds, maxRetries: 10, customUserAgent: this.options.userAgent });
   }
 
   public deploy = async (deploymentStateManager: IDeploymentStateManager): Promise<void> => {

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -1,21 +1,23 @@
 import * as aws from 'aws-sdk';
-import assert from 'assert';
-import throttle from 'lodash.throttle';
+
+import { $TSContext, IDeploymentStateManager } from 'amplify-cli-core';
 import {
-  createDeploymentMachine,
+  DeployMachineContext,
   DeploymentMachineOp,
   DeploymentMachineStep,
   StateMachineHelperFunctions,
-  DeployMachineContext,
+  createDeploymentMachine,
 } from './state-machine';
-import { interpret } from 'xstate';
 import { IStackProgressPrinter, StackEventMonitor } from './stack-event-monitor';
-import { StackProgressPrinter } from './stack-progress-printer';
-import ora from 'ora';
-import configurationManager from '../configuration-manager';
-import { $TSContext, IDeploymentStateManager } from 'amplify-cli-core';
-import { ConfigurationOptions } from 'aws-sdk/lib/config-base';
 import { getBucketKey, getHttpUrl } from './helpers';
+
+import { ConfigurationOptions } from 'aws-sdk/lib/config-base';
+import { StackProgressPrinter } from './stack-progress-printer';
+import assert from 'assert';
+import configurationManager from '../configuration-manager';
+import { interpret } from 'xstate';
+import ora from 'ora';
+import throttle from 'lodash.throttle';
 interface DeploymentManagerOptions {
   throttleDelay?: number;
   eventPollingDelay?: number;
@@ -63,7 +65,6 @@ export class DeploymentManager {
     private region: string,
     private deploymentBucket: string,
     private spinner: ora.Ora,
-    // private deployedTemplatePath: string,
     private printer: IStackProgressPrinter = new StackProgressPrinter(),
     options: DeploymentManagerOptions = {},
   ) {

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
@@ -1,0 +1,210 @@
+import {
+  $TSContext,
+  DeploymentState,
+  DeploymentStatus,
+  DeploymentStepState,
+  DeploymentStepStatus,
+  IDeploymentStateManager,
+  JSONUtilities,
+} from 'amplify-cli-core';
+import { S3 } from '../aws-utils/aws-s3';
+import { ProviderName } from '../constants';
+
+export class DeploymentStateManager implements IDeploymentStateManager {
+  private static stateFileName: string = 'deployment-state.json';
+
+  // The direction of advance step, in case of rollback it is reversed.
+  private direction: number = 1;
+  private currentState: DeploymentState;
+
+  public static createDeploymentStateManager = async (context: $TSContext): Promise<IDeploymentStateManager> => {
+    const projectDetails = context.amplify.getProjectDetails();
+    const { envName } = context.amplify.getEnvInfo();
+    const deploymentBucketName = projectDetails.amplifyMeta.providers
+      ? projectDetails.amplifyMeta.providers[ProviderName].DeploymentBucketName
+      : projectDetails.teamProviderInfo[envName][ProviderName].DeploymentBucketName;
+
+    const s3 = await S3.getInstance(context);
+    const deploymentStateManager = new DeploymentStateManager(s3, deploymentBucketName, envName);
+
+    await deploymentStateManager.loadOrCreateState();
+
+    return deploymentStateManager;
+  };
+
+  public static getStatusFromCloud = async (context: $TSContext): Promise<DeploymentState | null> => {
+    const deploymentStateManager = await DeploymentStateManager.createDeploymentStateManager(context);
+
+    return await deploymentStateManager.getStatus();
+  };
+
+  private constructor(private readonly s3: S3, private readonly deploymentBucketName: string, private readonly envName: string) {}
+
+  public startDeployment = async (steps: DeploymentStepState[]): Promise<boolean> => {
+    // Before starting a deployment do a reload on the persisted state in the cloud, to minimize the chance
+    // of concurrently starting a deployment.
+    const persistedState = await this.loadState();
+
+    if (persistedState) {
+      if (persistedState.status === DeploymentStatus.DEPLOYING || persistedState.status === DeploymentStatus.ROLLING_BACK) {
+        return false;
+      }
+
+      // Use the freshly loaded state as current state
+      this.currentState = persistedState;
+    }
+
+    this.currentState.startedAt = new Date().toISOString();
+    this.currentState.finishedAt = undefined;
+    this.currentState.currentStepIndex = 0;
+    this.currentState.status = DeploymentStatus.DEPLOYING;
+    this.currentState.steps = steps;
+
+    this.currentState.steps.forEach(s => {
+      s.status = DeploymentStepStatus.WAITING_FOR_DEPLOYMENT;
+    });
+
+    await this.saveState();
+
+    return true;
+  };
+
+  public failDeployment = async (): Promise<void> => {
+    if (this.currentState.status !== DeploymentStatus.ROLLED_BACK && this.currentState.status !== DeploymentStatus.DEPLOYED) {
+      this.currentState.finishedAt = new Date().toISOString();
+      this.currentState.status = DeploymentStatus.FAILED;
+
+      await this.saveState();
+    }
+  };
+
+  public updateCurrentStepStatus = async (status: DeploymentStepStatus): Promise<void> => {
+    this.currentState.steps[this.currentState.currentStepIndex].status = status;
+
+    await this.saveState();
+  };
+
+  public startCurrentStep = async (): Promise<void> => {
+    if (this.direction === 1) {
+      if (this.currentState.steps[this.currentState.currentStepIndex].status !== DeploymentStepStatus.WAITING_FOR_DEPLOYMENT) {
+        throw new Error(
+          `Cannot start step then the current step is in ${this.currentState.steps[this.currentState.currentStepIndex].status} status.`,
+        );
+      }
+
+      this.currentState.steps[this.currentState.currentStepIndex].status = DeploymentStepStatus.DEPLOYING;
+    } else if (this.direction === -1) {
+      if (this.currentState.steps[this.currentState.currentStepIndex].status !== DeploymentStepStatus.WAITING_FOR_ROLLBACK) {
+        throw new Error(
+          `Cannot start step then the current step is in ${this.currentState.steps[this.currentState.currentStepIndex].status} status.`,
+        );
+      }
+
+      this.currentState.steps[this.currentState.currentStepIndex].status = DeploymentStepStatus.ROLLING_BACK;
+    }
+
+    await this.saveState();
+  };
+
+  public advanceStep = async (): Promise<void> => {
+    if (!(await this.isDeploymentInProgress())) {
+      throw new Error(`Cannot advance a deployment when it was not started.`);
+    }
+
+    if (this.direction === 1 && this.currentState.steps[this.currentState.currentStepIndex].status !== DeploymentStepStatus.DEPLOYING) {
+      throw new Error(
+        `Cannot advance step then the current step is in ${this.currentState.steps[this.currentState.currentStepIndex].status} status.`,
+      );
+    } else if (
+      this.direction === -1 &&
+      this.currentState.steps[this.currentState.currentStepIndex].status !== DeploymentStepStatus.ROLLING_BACK
+    ) {
+      throw new Error(
+        `Cannot advance step then the current step is in ${this.currentState.steps[this.currentState.currentStepIndex].status} status.`,
+      );
+    }
+
+    // Check if we are finishing the deployment or just advancing a step
+    if (this.direction === 1 && this.currentState.currentStepIndex === this.currentState.steps.length - 1) {
+      this.currentState.steps[this.currentState.currentStepIndex].status = DeploymentStepStatus.DEPLOYED;
+
+      this.currentState.currentStepIndex = 0;
+      this.currentState.finishedAt = new Date().toISOString();
+      this.currentState.status = DeploymentStatus.DEPLOYED;
+    } else if (this.direction === -1 && this.currentState.currentStepIndex === 0) {
+      this.currentState.steps[this.currentState.currentStepIndex].status = DeploymentStepStatus.ROLLED_BACK;
+
+      this.currentState.currentStepIndex = 0;
+      this.currentState.finishedAt = new Date().toISOString();
+      this.currentState.status = DeploymentStatus.ROLLED_BACK;
+    } else {
+      // Regular advance step
+      if (this.direction === 1) {
+        this.currentState.steps[this.currentState.currentStepIndex].status = DeploymentStepStatus.DEPLOYED;
+      } else if (this.direction === -1) {
+        this.currentState.steps[this.currentState.currentStepIndex].status = DeploymentStepStatus.ROLLED_BACK;
+      }
+
+      this.currentState.currentStepIndex += this.direction;
+    }
+
+    await this.saveState();
+  };
+
+  public startRollback = async (): Promise<void> => {
+    if (!(await this.isDeploymentInProgress()) || this.direction !== 1) {
+      throw new Error('Cannot rollback a non-deploying deployment');
+    }
+
+    this.direction = -1;
+
+    for (let i = 0; i <= this.currentState.currentStepIndex; i++) {
+      this.currentState.steps[i].status = DeploymentStepStatus.WAITING_FOR_ROLLBACK;
+    }
+
+    this.currentState.status = DeploymentStatus.ROLLING_BACK;
+
+    await this.saveState();
+  };
+
+  public isDeploymentInProgress = async (): Promise<boolean> =>
+    this.currentState.status === DeploymentStatus.DEPLOYING || this.currentState.status === DeploymentStatus.ROLLING_BACK;
+
+  public getStatus = (): DeploymentState | undefined => {
+    return this.currentState;
+  };
+
+  private loadOrCreateState = async (): Promise<void> => {
+    const persistedState = await this.loadState();
+
+    if (persistedState) {
+      this.currentState = persistedState;
+    } else {
+      this.currentState = {
+        version: '1',
+        startedAt: '',
+        finishedAt: undefined,
+        status: DeploymentStatus.IDLE,
+        currentStepIndex: 0,
+        steps: [],
+      };
+    }
+  };
+
+  private loadState = async (): Promise<DeploymentState | undefined> => {
+    const stateFileContent = await this.s3.getStringObjectFromBucket(this.deploymentBucketName, DeploymentStateManager.stateFileName);
+
+    if (stateFileContent) {
+      return JSONUtilities.parse<DeploymentState>(stateFileContent);
+    }
+
+    return undefined;
+  };
+
+  private saveState = async (): Promise<void> => {
+    await this.s3.uploadFile({
+      Key: DeploymentStateManager.stateFileName,
+      Body: JSONUtilities.stringify(this.currentState),
+    });
+  };
+}

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/helpers.ts
@@ -1,0 +1,50 @@
+import { DeployMachineContext, DeploymentMachineOp } from './state-machine';
+import * as path from 'path';
+
+export const hasMoreRollback = (context: DeployMachineContext) => {
+  return context.currentIndex >= 0;
+};
+
+export const hasMoreDeployment = (context: DeployMachineContext) => {
+  return context.stacks.length > context.currentIndex;
+};
+
+export const stackPollerActivity = (
+  stackEventPollFn: (stack: Readonly<DeploymentMachineOp>) => () => void,
+  operation: 'deploying' | 'rollingback',
+) => {
+  return (context: Readonly<DeployMachineContext>) => {
+    if (context.currentIndex >= 0 && context.currentIndex < context.stacks.length) {
+      const stack = context.stacks[context.currentIndex];
+      const step = operation == 'deploying' ? stack.deployment : stack.rollback;
+
+      return stackEventPollFn(step);
+    }
+    return () => {};
+  };
+};
+
+export const extractStackInfoFromContext = (
+  fn: (stack: Readonly<DeploymentMachineOp>) => Promise<void>,
+  operation: 'deploying' | 'rollingback',
+): ((context: Readonly<DeployMachineContext>) => Promise<void>) => {
+  return (context: DeployMachineContext) => {
+    if (context.currentIndex >= 0 && context.currentIndex < context.stacks.length) {
+      const stack = context.stacks[context.currentIndex];
+      const step = operation == 'deploying' ? stack.deployment : stack.rollback;
+      return fn(step);
+    }
+    return Promise.resolve();
+  };
+};
+
+export const getBucketKey = (keyOrUrl: string, bucketName: string): string => {
+  if (keyOrUrl.startsWith('https://') && keyOrUrl.includes(bucketName)) {
+    return keyOrUrl.substring(keyOrUrl.indexOf(bucketName) + bucketName.length + 1);
+  }
+  return keyOrUrl;
+};
+
+export const getHttpUrl = (keyOrUrl: string, bucketName: string): string => {
+  return keyOrUrl.startsWith('https://') ? keyOrUrl : `https://s3.amazonaws.com/${path.join(bucketName, keyOrUrl)}`;
+};

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentManager } from './deployment-manager';

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
@@ -1,0 +1,184 @@
+import { StackEvent } from 'aws-sdk/clients/cloudformation';
+import * as aws from 'aws-sdk';
+export interface StackEventMonitorOptions {
+  pollDelay: number;
+}
+export interface IStackProgressPrinter {
+  addActivity(activity: StackEvent): void;
+  print(): void;
+  start(): void;
+  stop(): void;
+}
+export class StackEventMonitor {
+  private active: boolean = false;
+  private tickTimer?: NodeJS.Timeout;
+  private options: StackEventMonitorOptions;
+  private readPromise?: Promise<any>;
+  private startTime: number = Date.now();
+  private activity: Record<string, StackEvent> = {};
+  private completedStacks: Set<string> = new Set();
+  private stacksBeingMonitored: string[] = [this.stackName];
+  private lastPolledStackIndex: number = 0;
+
+  constructor(
+    private cfn: aws.CloudFormation,
+    private stackName: string,
+    private printer: IStackProgressPrinter,
+    options?: StackEventMonitor,
+  ) {
+    this.options = { pollDelay: 5_000, ...options };
+  }
+
+  public start() {
+    this.active = true;
+    this.printer.start();
+    this.scheduleNextTick();
+    return this;
+  }
+
+  public async stop() {
+    this.active = false;
+    this.printer.stop();
+    if (this.tickTimer) {
+      clearTimeout(this.tickTimer);
+    }
+
+    // Do a final poll for all events. This is to handle the situation where DescribeStackStatus
+    // already returned an error, but the monitor hasn't seen all the events yet and we'd end
+    // up not printing the failure reason to users.
+    await this.finalPollToEnd();
+  }
+
+  private scheduleNextTick() {
+    if (!this.active) {
+      return;
+    }
+
+    this.tickTimer = setTimeout(() => this.tick(), this.options.pollDelay);
+  }
+
+  private async tick() {
+    if (!this.active) {
+      return;
+    }
+
+    try {
+      this.readPromise = this.readNewEvents();
+      await this.readPromise;
+      this.readPromise = undefined;
+
+      // We might have been stop()ped while the network call was in progress.
+      if (!this.active) {
+        return;
+      }
+
+      this.printer.print();
+    } catch (e) {
+      if (e && e.code !== 'Throttling') e.message = 'Error occurred while monitoring stack:' + e.message;
+      throw e;
+    }
+    this.scheduleNextTick();
+  }
+
+  /**
+   * Reads all new events from the stack history
+   *
+   * The events are returned in reverse chronological order; we continue to the next page if we
+   * see a next page and the last event in the page is new to us (and within the time window).
+   * haven't seen the final event
+   */
+  private async readNewEvents(): Promise<void> {
+    const events: StackEvent[] = [];
+    this.lastPolledStackIndex = (this.lastPolledStackIndex + 1) % this.stacksBeingMonitored.length;
+    const stackName = this.stacksBeingMonitored[this.lastPolledStackIndex];
+    if (!stackName) {
+      return;
+    }
+    try {
+      let nextToken: string | undefined;
+      let finished = false;
+      while (!finished) {
+        const response = await this.cfn
+          .describeStackEvents({
+            StackName: stackName,
+            NextToken: nextToken,
+          })
+          .promise();
+        const eventPage = response?.StackEvents ?? [];
+
+        for (const event of eventPage) {
+          // Event from before we were interested in 'em
+          if (event.Timestamp.valueOf() < this.startTime) {
+            finished = true;
+            break;
+          }
+
+          // Already seen this one
+          if (event.EventId in this.activity) {
+            finished = true;
+            break;
+          }
+
+          if (event.ResourceType === 'AWS::CloudFormation::Stack') {
+            this.processNestedStack(event);
+            // Dont' render info about the stack itself
+            continue;
+          }
+
+          // Fresh event
+          events.push((this.activity[event.EventId] = event));
+        }
+
+        // We're also done if there's nothing left to read
+        nextToken = response?.NextToken;
+        if (nextToken === undefined) {
+          finished = true;
+        }
+      }
+    } catch (e) {
+      if (e.code === 'ValidationError' && e.message === `Stack [${this.stackName}] does not exist`) {
+        return;
+      }
+      throw e;
+    }
+
+    events.reverse();
+    for (const event of events) {
+      this.printer.addActivity(event);
+    }
+  }
+
+  private processNestedStack(event: StackEvent) {
+    if (event.ResourceType === 'AWS::CloudFormation::Stack') {
+      const physicalResourceId = event.PhysicalResourceId!;
+      const idx = this.stacksBeingMonitored.indexOf(physicalResourceId);
+      if (idx >= 0 && event.ResourceStatus!.endsWith('_COMPLETE') && physicalResourceId !== this.stackName) {
+        this.stacksBeingMonitored.splice(idx, 1);
+        this.completedStacks.add(physicalResourceId);
+      } else if (!this.completedStacks.has(physicalResourceId)) {
+        this.stacksBeingMonitored.push(physicalResourceId);
+      }
+    }
+  }
+
+  /**
+   * Perform a final poll to the end and flush out all events to the printer
+   *
+   * Finish any poll currently in progress, then do a final one until we've
+   * reached the last page.
+   */
+  private async finalPollToEnd() {
+    // If we were doing a poll, finish that first. It was started before
+    // the moment we were sure we weren't going to get any new events anymore
+    // so we need to do a new one anyway. Need to wait for this one though
+    // because our state is single-threaded.
+    if (this.readPromise) {
+      await this.readPromise;
+    }
+
+    await this.readNewEvents();
+
+    // Final print
+    this.printer.print();
+  }
+}

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-progress-printer.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-progress-printer.ts
@@ -1,0 +1,56 @@
+import { StackEvent, StackEvents } from 'aws-sdk/clients/cloudformation';
+import { IStackProgressPrinter } from './stack-event-monitor';
+import columnify from 'columnify';
+import chalk from 'chalk';
+import ora, { Ora } from 'ora';
+
+const CFN_SUCCESS_STATUS = ['UPDATE_COMPLETE', 'CREATE_COMPLETE', 'DELETE_COMPLETE', 'DELETE_SKIPPED'];
+
+const CNF_ERROR_STATUS = ['CREATE_FAILED', 'DELETE_FAILED', 'UPDATE_FAILED'];
+export class StackProgressPrinter implements IStackProgressPrinter {
+  private events: StackEvents = [];
+  private isRunning: boolean = true;
+  private spinner: Ora = ora('Deploying');
+  addActivity = (event: StackEvent) => {
+    this.events.push(event);
+  };
+  print = () => {
+    if (this.events.length > 0 && this.isRunning) {
+      console.log('\n');
+      const COLUMNS = ['ResourceStatus', 'LogicalResourceId', 'ResourceType', 'Timestamp', 'ResourceStatusReason'];
+
+      const e = this.events.map(ev => {
+        const res: Record<string, string> = {};
+        const { ResourceStatus: resourceStatus } = ev;
+
+        let colorFn = chalk.reset;
+        if (CNF_ERROR_STATUS.includes(resourceStatus!)) {
+          colorFn = chalk.red;
+        } else if (CFN_SUCCESS_STATUS.includes(resourceStatus!)) {
+          colorFn = chalk.green;
+        }
+
+        Object.entries(ev)
+          .filter(([name, value]) => COLUMNS.includes(name))
+          .forEach(([name, value]) => {
+            res[name] = colorFn(value);
+          });
+
+        return res;
+      });
+      console.log(
+        columnify(e, {
+          columns: COLUMNS,
+          showHeaders: false,
+        }),
+      );
+      this.events = [];
+    }
+  };
+  start = () => {
+    this.isRunning = true;
+  };
+  stop = () => {
+    this.spinner.stop();
+  };
+}

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/state-machine.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/state-machine.ts
@@ -1,0 +1,226 @@
+import { Machine, assign, EventObject, State } from 'xstate';
+import { send } from 'xstate/lib/actions';
+import { extractStackInfoFromContext, hasMoreDeployment, hasMoreRollback, stackPollerActivity } from './helpers';
+
+export type DeploymentMachineOp = {
+  stackTemplatePath: string;
+  parameters: Record<string, string>;
+  tableNames: string[];
+  stackName: string;
+  capabilities?: string[];
+  stackTemplateUrl: string;
+  region: string;
+  clientRequestToken?: string;
+};
+
+export type DeploymentMachineStep = {
+  deployment: DeploymentMachineOp;
+  rollback: DeploymentMachineOp;
+};
+
+export type DeployMachineContext = {
+  deploymentBucket: string;
+  region: string;
+  stacks: DeploymentMachineStep[];
+  currentIndex: number;
+};
+
+export type DeploymentMachineEvents = 'IDLE' | 'DEPLOY' | 'ROLLBACK' | 'INDEX' | 'DONE' | 'NEXT';
+
+export type DeploymentMachineState = State<
+  DeployMachineContext,
+  { type: DeploymentMachineEvents },
+  DeployMachineSchema,
+  {
+    value: any;
+    context: DeployMachineContext;
+  }
+>;
+export interface DeployMachineSchema {
+  states: {
+    idle: {};
+    deploy: {
+      states: {
+        triggerDeploy: {};
+        deploying: {};
+        waitingForDeployment: {};
+        waitForTablesToBeReady: {};
+      };
+    };
+    rollback: {
+      states: {
+        triggerRollback: {};
+        rollingBack: {};
+        waitingForRollback: {};
+        waitForTablesToBeReady: {};
+      };
+    };
+    deployed: {};
+    rolledBack: {};
+    failed: {};
+  };
+}
+
+interface DeployMachineEvent extends EventObject {
+  type: DeploymentMachineEvents;
+}
+
+export type StateMachineHelperFunctions = {
+  deploymentWaitFn: (stack: Readonly<DeploymentMachineOp>) => Promise<void>;
+  deployFn: (stack: Readonly<DeploymentMachineOp>) => Promise<void>;
+  rollbackFn: (stack: Readonly<DeploymentMachineOp>) => Promise<void>;
+  rollbackWaitFn: (stack: Readonly<DeploymentMachineOp>) => Promise<void>;
+  tableReadyWaitFn: (stack: Readonly<DeploymentMachineOp>) => Promise<void>;
+  stackEventPollFn: (stack: Readonly<DeploymentMachineOp>) => () => void;
+  startRollbackFn: (context: Readonly<DeployMachineContext>) => Promise<void>;
+};
+
+export function createDeploymentMachine(initialContext: DeployMachineContext, helperFns: StateMachineHelperFunctions) {
+  const machine = Machine<DeployMachineContext, DeployMachineSchema, DeployMachineEvent>(
+    {
+      id: 'DeployManager',
+      initial: 'idle',
+      context: initialContext,
+      states: {
+        idle: {
+          on: {
+            DEPLOY: {
+              target: 'deploy',
+              actions: send('NEXT'),
+            },
+          },
+        },
+        deploy: {
+          id: 'deploy',
+          initial: 'triggerDeploy',
+          states: {
+            triggerDeploy: {
+              entry: assign(context => {
+                return {
+                  ...context,
+                  currentIndex: context.currentIndex + 1,
+                };
+              }),
+              on: {
+                NEXT: [{ target: 'deploying', cond: 'hasMoreDeployment' }, { target: '#deployed' }],
+              },
+            },
+            deploying: {
+              invoke: {
+                id: 'deploy-stack',
+                src: extractStackInfoFromContext(helperFns.deployFn, 'deploying'),
+                onDone: {
+                  target: 'waitingForDeployment',
+                },
+                onError: {
+                  target: '#rollback',
+                },
+              },
+            },
+            waitingForDeployment: {
+              invoke: {
+                id: 'wait-for-deploy-stack',
+                src: extractStackInfoFromContext(helperFns.deploymentWaitFn, 'deploying'),
+                onDone: {
+                  target: 'waitForTablesToBeReady',
+                },
+                onError: {
+                  target: '#rollback',
+                },
+              },
+              activities: ['deployPoll'],
+            },
+            waitForTablesToBeReady: {
+              invoke: {
+                id: 'wait-for-table-to-be-ready',
+                src: extractStackInfoFromContext(helperFns.tableReadyWaitFn, 'deploying'),
+                onDone: {
+                  target: 'triggerDeploy',
+                  actions: send('NEXT'),
+                },
+              },
+            },
+          },
+        },
+        rollback: {
+          id: 'rollback',
+          initial: 'waitForTablesToBeReady',
+          invoke: {
+            id: 'enter-rollback',
+            src: helperFns.startRollbackFn,
+          },
+          states: {
+            triggerRollback: {
+              entry: assign((context: DeployMachineContext) => {
+                return {
+                  ...context,
+                  currentIndex: context.currentIndex - 1,
+                };
+              }),
+              on: {
+                NEXT: [{ target: 'rollingBack', cond: 'hasMoreRollback' }, { target: '#rolledBack' }],
+              },
+            },
+            rollingBack: {
+              invoke: {
+                id: 'rollback-stack',
+                src: extractStackInfoFromContext(helperFns.rollbackFn, 'rollingback'),
+                onDone: {
+                  target: 'waitingForRollback',
+                },
+                onError: {
+                  target: '#failed',
+                },
+              },
+            },
+            waitingForRollback: {
+              invoke: {
+                id: 'wait-for-deployment',
+                src: extractStackInfoFromContext(helperFns.rollbackWaitFn, 'rollingback'),
+                onDone: {
+                  target: 'waitForTablesToBeReady',
+                },
+                onError: {
+                  target: '#failed',
+                },
+              },
+              activities: ['rollbackPoll'],
+            },
+            waitForTablesToBeReady: {
+              invoke: {
+                id: 'wait-for-table-to-be-ready',
+                src: extractStackInfoFromContext(helperFns.tableReadyWaitFn, 'rollingback'),
+                onDone: {
+                  target: 'triggerRollback',
+                  actions: send('NEXT'),
+                },
+              },
+            },
+          },
+        },
+        deployed: {
+          id: 'deployed',
+          type: 'final',
+        },
+        rolledBack: {
+          id: 'rolledBack',
+        },
+        failed: {
+          id: 'failed',
+          type: 'final',
+        },
+      },
+    },
+    {
+      guards: {
+        hasMoreDeployment,
+        hasMoreRollback,
+      },
+      activities: {
+        deployPoll: stackPollerActivity(helperFns.stackEventPollFn, 'deploying'),
+        rollbackPoll: stackPollerActivity(helperFns.stackEventPollFn, 'rollingback'),
+      },
+    },
+  );
+  return machine;
+}

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/state-machine.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/state-machine.ts
@@ -222,8 +222,8 @@ export function createDeploymentMachine(initialContext: DeployMachineContext, he
     },
     {
       guards: {
-        isDeploymentComplete: isDeploymentComplete,
-        isRollbackComplete: isRollbackComplete,
+        isDeploymentComplete,
+        isRollbackComplete,
       },
       activities: {
         deployPoll: getDeploymentActivityPollerHandler(helperFns.stackEventPollFn),

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1,51 +1,74 @@
-const _ = require('lodash');
-const fs = require('fs-extra');
-const path = require('path');
-const cfnLint = require('cfn-lint');
-const glob = require('glob');
-const { pathManager, PathConstants } = require('amplify-cli-core');
-const ora = require('ora');
-const { S3 } = require('./aws-utils/aws-s3');
-const Cloudformation = require('./aws-utils/aws-cfn');
-const providerName = require('./constants').ProviderName;
-const { buildResource } = require('./build-resources');
-const { uploadAppSyncFiles } = require('./upload-appsync-files');
-const { prePushGraphQLCodegen, postPushGraphQLCodegen } = require('./graphql-codegen');
-const { prePushAuthTransform } = require('./auth-transform');
-const { transformGraphQLSchema } = require('./transform-graphql-schema');
-const { displayHelpfulURLs } = require('./display-helpful-urls');
-const { downloadAPIModels } = require('./download-api-models');
-const { loadResourceParameters } = require('./resourceParams');
-const { uploadAuthTriggerFiles } = require('./upload-auth-trigger-files');
-const archiver = require('./utils/archiver');
-const amplifyServiceManager = require('./amplify-service-manager');
-const { stateManager } = require('amplify-cli-core');
-const { isAmplifyAdminApp } = require('./utils/admin-helpers');
-const { fileLogger } = require('./utils/aws-logger');
+import _ from 'lodash';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { validateFile } from 'cfn-lint';
+import glob from 'glob';
+import {
+  pathManager,
+  PathConstants,
+  stateManager,
+  FeatureFlags,
+  JSONUtilities,
+  $TSContext,
+  $TSObject,
+  $TSMeta,
+  DeploymentStepState,
+  DeploymentStepStatus,
+} from 'amplify-cli-core';
+import ora from 'ora';
+import { S3 } from './aws-utils/aws-s3';
+import Cloudformation from './aws-utils/aws-cfn';
+import { ProviderName as providerName } from './constants';
+import { buildResource } from './build-resources';
+import { uploadAppSyncFiles } from './upload-appsync-files';
+import { prePushGraphQLCodegen, postPushGraphQLCodegen } from './graphql-codegen';
+import { prePushAuthTransform } from './auth-transform';
+import { transformGraphQLSchema } from './transform-graphql-schema';
+import { displayHelpfulURLs } from './display-helpful-urls';
+import { downloadAPIModels } from './download-api-models';
+import { GraphQLResourceManager } from './graphql-transformer';
+import { loadResourceParameters } from './resourceParams';
+import { uploadAuthTriggerFiles } from './upload-auth-trigger-files';
+import archiver from './utils/archiver';
+import amplifyServiceManager from './amplify-service-manager';
+import { DeploymentManager } from './iterative-deployment';
+import { Template } from 'cloudform-types';
+import { getGqlUpdatedResource } from './graphql-transformer/utils';
+import { DeploymentStep, DeploymentOp } from './iterative-deployment/deployment-manager';
+import { DeploymentStateManager } from './iterative-deployment/deployment-state-manager';
+import { isAmplifyAdminApp } from './utils/admin-helpers';
+import { fileLogger } from './utils/aws-logger';
+
 const logger = fileLogger('push-resources');
 
 // keep in sync with ServiceName in amplify-category-function, but probably it will not change
 const FunctionServiceNameLambdaLayer = 'LambdaLayer';
 
 const spinner = ora('Updating resources in the cloud. This may take a few minutes...');
+const rootStackFileName = 'rootStackTemplate.json';
 const nestedStackFileName = 'nested-cloudformation-stack.yml';
 const optionalBuildDirectoryName = 'build';
 const cfnTemplateGlobPattern = '*template*.+(yaml|yml|json)';
 const parametersJson = 'parameters.json';
 
-async function run(context, resourceDefinition) {
+export async function run(context, resourceDefinition) {
+  const deploymentStateManager = await DeploymentStateManager.createDeploymentStateManager(context);
+  let iterativeDeploymentWasInvoked = false;
+
   try {
     const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeSynced, resourcesToBeDeleted, allResources } = resourceDefinition;
+    const clousformationMeta = context.amplify.getProjectMeta().providers.awscloudformation;
     const {
       parameters: { options },
     } = context;
-    let resources;
+
+    let resources: $TSObject[];
+
     if (context.exeInfo && context.exeInfo.forcePush) {
       resources = allResources;
     } else {
       resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
     }
-    let projectDetails = context.amplify.getProjectDetails();
 
     validateCfnTemplates(context, resources);
 
@@ -56,23 +79,104 @@ async function run(context, resourceDefinition) {
       minify: options['minify'],
     });
 
+    // If there is a deployment already in progress we have to fail the push operation as another
+    // push in between could lead non-recoverable stacks and files.
+    if (await deploymentStateManager.isDeploymentInProgress()) {
+      context.print.error('A deployment is already in progress for the project, cannot push resources until it finishes.');
+
+      return;
+    }
+
+    let deploymentSteps: DeploymentStep[] = [];
+
+    // location where the intermediate deployment steps are stored
+    let stateFolder: string;
+
+    // Check if iterative updates are enabled or not and generate the required deployment steps if needed.
+    if (FeatureFlags.getBoolean('graphQLTransformer.enableIterativeGSIUpdates')) {
+      const gqlResource = getGqlUpdatedResource(resourcesToBeUpdated);
+
+      if (gqlResource) {
+        const gqlManager = await GraphQLResourceManager.createInstance(context, gqlResource, clousformationMeta.StackId);
+        deploymentSteps = await gqlManager.run();
+
+        if (deploymentSteps.length > 1) {
+          iterativeDeploymentWasInvoked = true;
+
+          // Initialize deployment state to signal a new iterative deployment
+          // When using iterative push, the deployment steps provided by GraphQLResourceManager does not include the last step
+          // where the root stack is pushed
+          const deploymentStepStates: DeploymentStepState[] = new Array(deploymentSteps.length + 1).fill(true).map(() => ({
+            status: DeploymentStepStatus.WAITING_FOR_DEPLOYMENT,
+          }));
+
+          // If start cannot update because a deployment has started between the start of this method and this point
+          // we have to return before uploading any artifacts that could fail the other deployment.
+          if (!(await deploymentStateManager.startDeployment(deploymentStepStates))) {
+            context.print.error('A deployment is already in progress for the project, cannot push resources until it finishes.');
+
+            return;
+          }
+        }
+
+        stateFolder = gqlManager.getStateFilesDirectory();
+      }
+    }
+
     await uploadAppSyncFiles(context, resources, allResources);
     await prePushAuthTransform(context, resources);
     await prePushGraphQLCodegen(context, resourcesToBeCreated, resourcesToBeUpdated);
+
+    let projectDetails = context.amplify.getProjectDetails();
     await updateS3Templates(context, resources, projectDetails.amplifyMeta);
-
-    spinner.start();
-
-    projectDetails = context.amplify.getProjectDetails();
 
     // We do not need CloudFormation update if only syncable resources are the changes.
     if (resourcesToBeCreated.length > 0 || resourcesToBeUpdated.length > 0 || resourcesToBeDeleted.length > 0) {
-      await updateCloudFormationNestedStack(
-        context,
-        await formNestedStack(context, projectDetails),
-        resourcesToBeCreated,
-        resourcesToBeUpdated,
-      );
+      // If there is an API change, there will be one deployment step. But when there needs an iterative update the step count is > 1
+      if (deploymentSteps.length > 1) {
+        // create deployment manager
+        const deploymentManager = await DeploymentManager.createInstance(context, clousformationMeta.DeploymentBucketName, spinner);
+
+        deploymentSteps.forEach(step => deploymentManager.addStep(step));
+
+        // generate nested stack
+        const backEndDir = pathManager.getBackendDirPath();
+        const nestedStackFilepath = path.normalize(path.join(backEndDir, providerName, nestedStackFileName));
+        await generateAndUploadRootStack(context, nestedStackFilepath, nestedStackFileName);
+
+        // Use state manager to do the final deployment. The final deployment include not just API change but the whole Amplify Project
+        const finalStep: DeploymentOp = {
+          stackTemplatePathOrUrl: nestedStackFileName,
+          tableNames: [],
+          stackName: clousformationMeta.StackName,
+          parameters: {
+            DeploymentBucketName: clousformationMeta.DeploymentBucketName,
+            AuthRoleName: clousformationMeta.AuthRoleName,
+            UnauthRoleName: clousformationMeta.UnauthRoleName,
+          },
+          capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
+        };
+
+        deploymentManager.addStep({
+          deployment: finalStep,
+          rollback: deploymentSteps[deploymentSteps.length - 1].deployment,
+        });
+
+        spinner.start();
+        await deploymentManager.deploy(deploymentStateManager);
+
+        // delete the intermidiate states as it is ephemeral
+        if (stateFolder && fs.existsSync(stateFolder)) {
+          fs.removeSync(stateFolder);
+        }
+      } else {
+        // Non iterative update
+        spinner.start();
+
+        const nestedStack = await formNestedStack(context, context.amplify.getProjectDetails());
+
+        await updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated);
+      }
     }
 
     await postPushGraphQLCodegen(context);
@@ -83,8 +187,8 @@ async function run(context, resourceDefinition) {
     }
 
     if (resourcesToBeSynced.length > 0) {
-      const importResources = resourcesToBeSynced.filter(r => r.sync === 'import');
-      const unlinkedResources = resourcesToBeSynced.filter(r => r.sync === 'unlink');
+      const importResources = resourcesToBeSynced.filter((r: { sync: string }) => r.sync === 'import');
+      const unlinkedResources = resourcesToBeSynced.filter((r: { sync: string }) => r.sync === 'unlink');
 
       if (importResources.length > 0) {
         await context.amplify.updateamplifyMetaAfterPush(importResources);
@@ -107,7 +211,7 @@ async function run(context, resourceDefinition) {
 
     const newAPIresources = [];
 
-    updatedAllResources = updatedAllResources.filter(resource => resource.service === 'API Gateway');
+    updatedAllResources = updatedAllResources.filter((resource: { service: string }) => resource.service === 'API Gateway');
 
     for (let i = 0; i < updatedAllResources.length; i++) {
       if (resources.findIndex(resource => resource.resourceName === updatedAllResources[i].resourceName) > -1) {
@@ -118,14 +222,14 @@ async function run(context, resourceDefinition) {
     // Check if there was any imported auth resource and if there was we have to refresh the
     // COGNITO_USER_POOLS configuration for AppSync APIs in meta if we have any
     if (resourcesToBeSynced.length > 0) {
-      const importResources = resourcesToBeSynced.filter(r => r.sync === 'import');
+      const importResources = resourcesToBeSynced.filter((r: { sync: string }) => r.sync === 'import');
 
       if (importResources.length > 0) {
         const { imported, userPoolId } = context.amplify.getImportedAuthProperties(context);
 
         // Sanity check it will always be true in this case
         if (imported) {
-          const appSyncAPIs = allResources.filter(resource => resource.service === 'AppSync');
+          const appSyncAPIs = allResources.filter((resource: { service: string }) => resource.service === 'AppSync');
           const meta = stateManager.getMeta(undefined);
           let hasChanges = false;
 
@@ -137,6 +241,7 @@ async function run(context, resourceDefinition) {
 
               if (defaultAuthentication && defaultAuthentication.authenticationType === 'AMAZON_COGNITO_USER_POOLS') {
                 defaultAuthentication.userPoolConfig.userPoolId = userPoolId;
+
                 hasChanges = true;
               }
 
@@ -148,6 +253,7 @@ async function run(context, resourceDefinition) {
                   additionalAuthenticationProvider.authenticationType === 'AMAZON_COGNITO_USER_POOLS'
                 ) {
                   additionalAuthenticationProvider.userPoolConfig.userPoolId = userPoolId;
+
                   hasChanges = true;
                 }
               }
@@ -166,27 +272,36 @@ async function run(context, resourceDefinition) {
     // Store current cloud backend in S3 deployment bcuket
     await storeCurrentCloudBackend(context);
     await amplifyServiceManager.storeArtifactsForAmplifyService(context);
+
     //check for auth resources and remove deployment secret for push
     const authResources = resources.filter(
       resource => resource.category === 'auth' && resource.service === 'Cognito' && resource.providerPlugin === 'awscloudformation',
     );
+
     if (authResources.length > 0) {
       for (let i = 0; i < authResources.length; i++) {
         const authResource = authResources[i];
+
         context.amplify.removeDeploymentSecrets(context, authResource.category, authResource.resourceName);
       }
     }
+
     spinner.succeed('All resources are updated in the cloud');
 
     await displayHelpfulURLs(context, resources);
-  } catch (err) {
+  } catch (error) {
+    if (iterativeDeploymentWasInvoked) {
+      await deploymentStateManager.failDeployment();
+    }
     spinner.fail('An error occurred when pushing the resources to the cloud');
-    logger('run', [resourceDefinition])(err);
-    throw err;
+
+    logger('run', [resourceDefinition])(error);
+
+    throw error;
   }
 }
 
-async function updateStackForAPIMigration(context, category, resourceName, options) {
+export async function updateStackForAPIMigration(context, category, resourceName, options) {
   const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = await context.amplify.getResourceStatus(
     category,
     resourceName,
@@ -194,6 +309,7 @@ async function updateStackForAPIMigration(context, category, resourceName, optio
   );
 
   const { isReverting, isCLIMigration } = options;
+
   let resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
   let projectDetails = context.amplify.getProjectDetails();
 
@@ -201,61 +317,65 @@ async function updateStackForAPIMigration(context, category, resourceName, optio
 
   resources = allResources.filter(resource => resource.service === 'AppSync');
 
-  return packageResources(context, resources)
-    .then(() =>
-      uploadAppSyncFiles(context, resources, allResources, {
-        useDeprecatedParameters: isReverting,
-        defaultParams: {
-          CreateAPIKey: 0,
-          APIKeyExpirationEpoch: -1,
-          authRoleName: {
-            Ref: 'AuthRoleName',
-          },
-          unauthRoleName: {
-            Ref: 'UnauthRoleName',
-          },
-        },
-      }),
-    )
-    .then(() => updateS3Templates(context, resources, projectDetails.amplifyMeta))
-    .then(async () => {
-      if (!isCLIMigration) {
-        spinner.start();
+  await packageResources(context, resources);
+
+  await uploadAppSyncFiles(context, resources, allResources, {
+    useDeprecatedParameters: isReverting,
+    defaultParams: {
+      CreateAPIKey: 0,
+      APIKeyExpirationEpoch: -1,
+      authRoleName: {
+        Ref: 'AuthRoleName',
+      },
+      unauthRoleName: {
+        Ref: 'UnauthRoleName',
+      },
+    },
+  });
+
+  await updateS3Templates(context, resources, projectDetails.amplifyMeta);
+
+  try {
+    if (!isCLIMigration) {
+      spinner.start();
+    }
+
+    projectDetails = context.amplify.getProjectDetails();
+
+    if (resources.length > 0 || resourcesToBeDeleted.length > 0) {
+      // isCLIMigration implies a top level CLI migration is underway.
+      // We do not inject an env in such situations so we pass a resourceName.
+      // When it is an API level migration, we do pass an env so omit the resourceName.
+      let nestedStack: Template;
+
+      if (isReverting && isCLIMigration) {
+        // When this is a CLI migration and we are rolling back, we do not want to inject
+        // an [env] for any templates.
+        nestedStack = await formNestedStack(context, projectDetails, category, resourceName, 'AppSync', true);
+      } else if (isCLIMigration) {
+        nestedStack = await formNestedStack(context, projectDetails, category, resourceName, 'AppSync');
+      } else {
+        nestedStack = await formNestedStack(context, projectDetails, category);
       }
-      projectDetails = context.amplify.getProjectDetails();
-      if (resources.length > 0 || resourcesToBeDeleted.length > 0) {
-        // isCLIMigration implies a top level CLI migration is underway.
-        // We do not inject an env in such situations so we pass a resourceName.
-        // When it is an API level migration, we do pass an env so omit the resourceName.
-        let nestedStack;
-        if (isReverting && isCLIMigration) {
-          // When this is a CLI migration and we are rolling back, we do not want to inject
-          // an [env] for any templates.
-          nestedStack = await formNestedStack(context, projectDetails, category, resourceName, 'AppSync', true);
-        } else if (isCLIMigration) {
-          nestedStack = await formNestedStack(context, projectDetails, category, resourceName, 'AppSync');
-        } else {
-          nestedStack = await formNestedStack(context, projectDetails, category);
-        }
-        return updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated);
-      }
-    })
-    .then(async res => {
-      await context.amplify.updateamplifyMetaAfterPush(resources);
-      if (!isCLIMigration) {
-        spinner.stop();
-      }
-      return res;
-    })
-    .catch(err => {
-      if (!isCLIMigration) {
-        spinner.fail('An error occurred when migrating the API project.');
-      }
-      throw err;
-    });
+
+      await updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated);
+    }
+
+    await context.amplify.updateamplifyMetaAfterPush(resources);
+
+    if (!isCLIMigration) {
+      spinner.stop();
+    }
+  } catch (error) {
+    if (!isCLIMigration) {
+      spinner.fail('An error occurred when migrating the API project.');
+    }
+
+    throw error;
+  }
 }
 
-function storeCurrentCloudBackend(context) {
+export async function storeCurrentCloudBackend(context) {
   const zipFilename = '#current-cloud-backend.zip';
   const backendDir = context.amplify.pathManager.getBackendDirPath();
   const tempDir = path.join(backendDir, '.temp');
@@ -272,27 +392,27 @@ function storeCurrentCloudBackend(context) {
 
   const zipFilePath = path.normalize(path.join(tempDir, zipFilename));
   let log = null;
-  return archiver
-    .run(currentCloudBackendDir, zipFilePath, undefined, cliJSONFiles)
-    .then(result => {
-      const s3Key = `${result.zipFilename}`;
-      return S3.getInstance(context).then(s3 => {
-        const s3Params = {
-          Body: fs.createReadStream(result.zipFilePath),
-          Key: s3Key,
-        };
-        log = logger('storeCurrentcoudBackend.s3.uploadFile', [{ Key: s3Key }]);
-        log();
-        return s3.uploadFile(s3Params);
-      });
-    })
-    .catch(ex => {
-      log(ex);
-      throw ex;
-    })
-    .then(() => {
-      fs.removeSync(tempDir);
-    });
+  const result = await archiver.run(currentCloudBackendDir, zipFilePath, undefined, cliJSONFiles);
+
+  const s3Key = `${result.zipFilename}`;
+
+  const s3 = await S3.getInstance(context);
+
+  const s3Params = {
+    Body: fs.createReadStream(result.zipFilePath),
+    Key: s3Key,
+  };
+
+  log = logger('storeCurrentcoudBackend.s3.uploadFile', [{ Key: s3Key }]);
+  log();
+  try {
+    await s3.uploadFile(s3Params);
+  } catch (error) {
+    log(error);
+    throw error;
+  }
+
+  fs.removeSync(tempDir);
 }
 
 function validateCfnTemplates(context, resourcesToBeUpdated) {
@@ -304,113 +424,129 @@ function validateCfnTemplates(context, resourcesToBeUpdated) {
       cwd: resourceDir,
       ignore: [parametersJson],
     });
+
     for (let j = 0; j < cfnFiles.length; j += 1) {
       const filePath = path.normalize(path.join(resourceDir, cfnFiles[j]));
+
       try {
-        cfnLint.validateFile(filePath);
+        validateFile(filePath);
       } catch (err) {
         context.print.error(`Invalid CloudFormation template: ${filePath}`);
+
         throw err;
       }
     }
   }
 }
 
-function packageResources(context, resources) {
+async function packageResources(context, resources) {
   // Only build and package resources which are required
   resources = resources.filter(resource => resource.build);
+
   let log = null;
-  const packageResource = (context, resource) => {
-    let s3Key;
-    return (resource.service === FunctionServiceNameLambdaLayer
-      ? context.amplify.invokePluginMethod(context, 'function', undefined, 'packageLayer', [context, resource])
-      : buildResource(context, resource)
-    )
-      .then(result => {
-        // Upload zip file to S3
-        s3Key = `amplify-builds/${result.zipFilename}`;
-        return S3.getInstance(context).then(s3 => {
-          const s3Params = {
-            Body: fs.createReadStream(result.zipFilePath),
-            Key: s3Key,
-          };
-          log = logger('packageResources.s3.uploadFile', [{ Key: s3Key }]);
-          log();
-          return s3.uploadFile(s3Params);
+
+  const packageResource = async (context, resource) => {
+    let result;
+
+    if (resource.service === FunctionServiceNameLambdaLayer) {
+      result = await context.amplify.invokePluginMethod(context, 'function', undefined, 'packageLayer', [context, resource]);
+    } else {
+      result = await buildResource(context, resource);
+    }
+
+    // Upload zip file to S3
+    const s3Key = `amplify-builds/${result.zipFilename}`;
+
+    const s3 = await S3.getInstance(context);
+
+
+    const s3Params = {
+      Body: fs.createReadStream(result.zipFilePath),
+      Key: s3Key,
+    };
+    log = logger('packageResources.s3.uploadFile', [{ Key: s3Key }]);
+    log();
+    let s3Bucket;
+    try {
+
+      s3Bucket = await s3.uploadFile(s3Params);
+    } catch(error) {
+      log(error);
+      throw error;
+    }
+
+    // Update cfn template
+    const { category, resourceName } = resource;
+    const backEndDir = context.amplify.pathManager.getBackendDirPath();
+    const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
+
+    const cfnFiles = glob.sync(cfnTemplateGlobPattern, {
+      cwd: resourceDir,
+      ignore: [parametersJson],
+    });
+
+    if (cfnFiles.length !== 1) {
+      const errorMessage =
+        cfnFiles.length > 1
+          ? 'Only one CloudFormation template is allowed in the resource directory'
+          : 'CloudFormation template is missing in the resource directory';
+      context.print.error(errorMessage);
+      context.print.error(resourceDir);
+
+      throw new Error(errorMessage);
+    }
+
+    const cfnFile = cfnFiles[0];
+    const cfnFilePath = path.normalize(path.join(resourceDir, cfnFile));
+    const cfnMeta = context.amplify.readJsonFile(cfnFilePath);
+
+    if (resource.service === FunctionServiceNameLambdaLayer) {
+      const isMultiEnvLayer = await context.amplify.invokePluginMethod(context, 'function', undefined, 'isMultiEnvLayer', [
+        context,
+        resourceName,
+      ]);
+
+      if (isMultiEnvLayer) {
+        const amplifyMeta = stateManager.getMeta();
+        const teamProviderInfo = stateManager.getTeamProviderInfo();
+
+        _.set(teamProviderInfo, [context.amplify.getEnvInfo().envName, 'categories', 'function', resourceName], {
+          deploymentBucketName: s3Bucket,
+          s3Key,
         });
-      })
-      .catch(ex => {
-        log(ex);
-        throw ex;
-      })
-      .then(async s3Bucket => {
-        // Update cfn template
-        const { category, resourceName } = resource;
-        const backEndDir = context.amplify.pathManager.getBackendDirPath();
-        const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
 
-        const cfnFiles = glob.sync(cfnTemplateGlobPattern, {
-          cwd: resourceDir,
-          ignore: [parametersJson],
+        _.set(amplifyMeta, ['function', resourceName, 's3Bucket'], {
+          deploymentBucketName: s3Bucket,
+          s3Key,
         });
 
-        if (cfnFiles.length !== 1) {
-          const errorMessage =
-            cfnFiles.length > 1
-              ? 'Only one CloudFormation template is allowed in the resource directory'
-              : 'CloudFormation template is missing in the resource directory';
-          context.print.error(errorMessage);
-          context.print.error(resourceDir);
-          throw new Error(errorMessage);
-        }
+        stateManager.setMeta(undefined, amplifyMeta);
+        stateManager.setTeamProviderInfo(undefined, teamProviderInfo);
+      } else {
+        cfnMeta.Resources.LambdaLayer.Properties.Content = {
+          S3Bucket: s3Bucket,
+          S3Key: s3Key,
+        };
+      }
+    } else {
+      if (cfnMeta.Resources.LambdaFunction.Type === 'AWS::Serverless::Function') {
+        cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
+          Bucket: s3Bucket,
+          Key: s3Key,
+        };
+      } else {
+        cfnMeta.Resources.LambdaFunction.Properties.Code = {
+          S3Bucket: s3Bucket,
+          S3Key: s3Key,
+        };
+      }
+    }
 
-        const cfnFile = cfnFiles[0];
-        const cfnFilePath = path.normalize(path.join(resourceDir, cfnFile));
-        const cfnMeta = context.amplify.readJsonFile(cfnFilePath);
-
-        if (resource.service === FunctionServiceNameLambdaLayer) {
-          const isMultiEnvLayer = await context.amplify.invokePluginMethod(context, 'function', undefined, 'isMultiEnvLayer', [
-            context,
-            resourceName,
-          ]);
-
-          if (isMultiEnvLayer) {
-            const amplifyMeta = stateManager.getMeta();
-            const teamProviderInfo = stateManager.getTeamProviderInfo();
-            _.set(teamProviderInfo, [context.amplify.getEnvInfo().envName, 'categories', 'function', resourceName], {
-              deploymentBucketName: s3Bucket,
-              s3Key,
-            });
-            _.set(amplifyMeta, ['function', resourceName, 's3Bucket'], {
-              deploymentBucketName: s3Bucket,
-              s3Key,
-            });
-            stateManager.setMeta(undefined, amplifyMeta);
-            stateManager.setTeamProviderInfo(undefined, teamProviderInfo);
-          } else {
-            cfnMeta.Resources.LambdaLayer.Properties.Content = {
-              S3Bucket: s3Bucket,
-              S3Key: s3Key,
-            };
-          }
-        } else {
-          if (cfnMeta.Resources.LambdaFunction.Type === 'AWS::Serverless::Function') {
-            cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
-              Bucket: s3Bucket,
-              Key: s3Key,
-            };
-          } else {
-            cfnMeta.Resources.LambdaFunction.Properties.Code = {
-              S3Bucket: s3Bucket,
-              S3Key: s3Key,
-            };
-          }
-        }
-        context.amplify.writeObjectAsJson(cfnFilePath, cfnMeta, true);
-      });
+    context.amplify.writeObjectAsJson(cfnFilePath, cfnMeta, true);
   };
 
   const promises = [];
+
   for (let resource of resources) {
     promises.push(packageResource(context, resource));
   }
@@ -422,9 +558,23 @@ async function updateCloudFormationNestedStack(context, nestedStack, resourcesTo
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
   const nestedStackFilepath = path.normalize(path.join(backEndDir, providerName, nestedStackFileName));
 
+  JSONUtilities.writeJson(nestedStackFilepath, nestedStack);
+
+  const cfnItem = await new Cloudformation(context, generateUserAgentAction(resourcesToBeCreated, resourcesToBeUpdated));
+  const providerDirectory = path.normalize(path.join(backEndDir, providerName));
+
+  const log = logger('updateCloudFormationNestedStack', [providerDirectory, nestedStackFilepath]);
+  try {
+    log();
+    await cfnItem.updateResourceStack(path.normalize(path.join(backEndDir, providerName)), nestedStackFileName);
+  } catch (error) {
+    log(error);
+  }
+}
+
+function generateUserAgentAction(resourcesToBeCreated, resourcesToBeUpdated) {
   const uniqueCategoriesAdded = getAllUniqueCategories(resourcesToBeCreated);
   const uniqueCategoriesUpdated = getAllUniqueCategories(resourcesToBeUpdated);
-
   let userAgentAction = '';
 
   if (uniqueCategoriesAdded.length > 0) {
@@ -442,27 +592,14 @@ async function updateCloudFormationNestedStack(context, nestedStack, resourcesTo
       if (category.length >= 2) {
         category = category.substring(0, 2);
       }
+
       userAgentAction += `${category}:u `;
     });
   }
-
-  const jsonString = JSON.stringify(nestedStack, null, '\t');
-  context.filesystem.write(nestedStackFilepath, jsonString);
-
-  const cfnItem = await new Cloudformation(context, userAgentAction);
-  const dir = path.normalize(path.join(backEndDir, providerName));
-  const cfnFileName = nestedStackFileName;
-  const log = logger('updateCloudFormationNestedStack', [dir, cfnFileName]);
-  try {
-    log();
-    await cfnItem.updateResourceStack(dir, cfnFileName);
-  } catch (ex) {
-    log(ex);
-    throw ex;
-  }
+  return userAgentAction;
 }
 
-function getAllUniqueCategories(resources) {
+function getAllUniqueCategories(resources: $TSObject[]): $TSObject[] {
   const categories = new Set();
 
   resources.forEach(resource => categories.add(resource.category));
@@ -474,6 +611,7 @@ function getCfnFiles(context, category, resourceName) {
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
   const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
   const resourceBuildDir = path.join(resourceDir, optionalBuildDirectoryName);
+
   /**
    * The API category w/ GraphQL builds into a build/ directory.
    * This looks for a build directory and uses it if one exists.
@@ -492,10 +630,12 @@ function getCfnFiles(context, category, resourceName) {
       };
     }
   }
+
   const cfnFiles = glob.sync(cfnTemplateGlobPattern, {
     cwd: resourceDir,
     ignore: [parametersJson],
   });
+
   return {
     resourceDir,
     cfnFiles,
@@ -508,6 +648,7 @@ function updateS3Templates(context, resourcesToBeUpdated, amplifyMeta) {
   for (let i = 0; i < resourcesToBeUpdated.length; i += 1) {
     const { category, resourceName } = resourcesToBeUpdated[i];
     const { resourceDir, cfnFiles } = getCfnFiles(context, category, resourceName);
+
     for (let j = 0; j < cfnFiles.length; j += 1) {
       promises.push(uploadTemplateToS3(context, resourceDir, cfnFiles[j], category, resourceName, amplifyMeta));
     }
@@ -516,37 +657,50 @@ function updateS3Templates(context, resourcesToBeUpdated, amplifyMeta) {
   return Promise.all(promises);
 }
 
-function uploadTemplateToS3(context, resourceDir, cfnFile, category, resourceName, amplifyMeta) {
+async function uploadTemplateToS3(
+  context: $TSContext,
+  resourceDir: string,
+  cfnFile: string,
+  category: string,
+  resourceName: string,
+  amplifyMeta: $TSMeta,
+) {
   const filePath = path.normalize(path.join(resourceDir, cfnFile));
-  let log = null;
+  const s3 = await S3.getInstance(context);
 
-  return S3.getInstance(context)
-    .then(s3 => {
-      const s3Params = {
-        Body: fs.createReadStream(filePath),
-        Key: `amplify-cfn-templates/${category}/${cfnFile}`,
-      };
-      log = logger('uploadTemplateToS3.s3.uploadFile', [{ Key: s3Params.Key }]);
-      return s3.uploadFile(s3Params, false);
-    })
-    .catch(ex => {
-      log(ex);
-      throw ex;
-    })
-    .then(projectBucket => {
-      const templateURL = `https://s3.amazonaws.com/${projectBucket}/amplify-cfn-templates/${category}/${cfnFile}`;
-      const providerMetadata = amplifyMeta[category][resourceName].providerMetadata || {};
-      providerMetadata.s3TemplateURL = templateURL;
-      providerMetadata.logicalId = category + resourceName;
-      context.amplify.updateamplifyMetaAfterResourceUpdate(category, resourceName, 'providerMetadata', providerMetadata);
-    });
+  const s3Params = {
+    Body: fs.createReadStream(filePath),
+    Key: `amplify-cfn-templates/${category}/${cfnFile}`,
+  };
+
+  const log = logger('uploadTemplateToS3.s3.uploadFile', [{ Key: s3Params.Key }]);
+  try {
+    const projectBucket = await s3.uploadFile(s3Params, false);
+  } catch (error) {
+    log(error);
+    throw error;
+  }
+
+  const templateURL = `https://s3.amazonaws.com/${projectBucket}/amplify-cfn-templates/${category}/${cfnFile}`;
+  const providerMetadata = amplifyMeta[category][resourceName].providerMetadata || {};
+
+  providerMetadata.s3TemplateURL = templateURL;
+  providerMetadata.logicalId = category + resourceName;
+
+  context.amplify.updateamplifyMetaAfterResourceUpdate(category, resourceName, 'providerMetadata', providerMetadata);
 }
 
-/* eslint-disable */
-async function formNestedStack(context, projectDetails, categoryName, resourceName, serviceName, skipEnv) {
-  /* eslint-enable */
-  const initTemplateFilePath = path.join(__dirname, '..', 'resources', 'rootStackTemplate.json');
-  const nestedStack = context.amplify.readJsonFile(initTemplateFilePath);
+async function formNestedStack(
+  context: $TSContext,
+  projectDetails: $TSObject,
+  categoryName?: string,
+  resourceName?: string,
+  serviceName?: string,
+  skipEnv?: boolean,
+) {
+  const initTemplateFilePath = path.join(__dirname, '..', 'resources', rootStackFileName);
+  const nestedStack = JSONUtilities.readJson<Template>(initTemplateFilePath);
+
   // Track Amplify Console generated stacks
   try {
     const amplifyMeta = stateManager.getMeta();
@@ -559,20 +713,27 @@ async function formNestedStack(context, projectDetails, categoryName, resourceNa
   }
 
   const { amplifyMeta } = projectDetails;
-  let authResourceName;
+
+  let authResourceName: string;
   let categories = Object.keys(amplifyMeta);
+
   categories = categories.filter(category => category !== 'provider');
+
   categories.forEach(category => {
     const resources = Object.keys(amplifyMeta[category]);
+
     resources.forEach(resource => {
       const resourceDetails = amplifyMeta[category][resource];
+
       if (category === 'auth' && resource !== 'userPoolGroups') {
         authResourceName = resource;
       }
+
       const resourceKey = category + resource;
       let templateURL;
+
       if (resourceDetails.providerPlugin) {
-        const parameters = loadResourceParameters(context, category, resource);
+        const parameters = <$TSObject>loadResourceParameters(context, category, resource);
         const { dependsOn } = resourceDetails;
 
         if (dependsOn) {
@@ -604,6 +765,7 @@ async function formNestedStack(context, projectDetails, categoryName, resourceNa
                 parameterValue = outputAttributeValue;
               } else {
                 const dependsOnStackName = dependsOn[i].category + dependsOn[i].resourceName;
+
                 parameterValue = { 'Fn::GetAtt': [dependsOnStackName, `Outputs.${dependsOn[i].attributes[j]}`] };
               }
 
@@ -624,6 +786,7 @@ async function formNestedStack(context, projectDetails, categoryName, resourceNa
 
         const values = Object.values(parameters);
         const keys = Object.keys(parameters);
+
         for (let a = 0; a < values.length; a += 1) {
           if (Array.isArray(values[a])) {
             parameters[keys[a]] = values[a].join();
@@ -676,6 +839,7 @@ async function formNestedStack(context, projectDetails, categoryName, resourceNa
 
         if (resourceDetails.providerMetadata) {
           templateURL = resourceDetails.providerMetadata.s3TemplateURL;
+
           nestedStack.Resources[resourceKey] = {
             Type: 'AWS::CloudFormation::Stack',
             Properties: {
@@ -694,6 +858,7 @@ async function formNestedStack(context, projectDetails, categoryName, resourceNa
     // If auth is imported we cannot update the IDP as it is not part of the stack resources we deploy.
     if (importedAuth && importedAuth.serviceType !== 'imported') {
       const authParameters = loadResourceParameters(context, 'auth', authResourceName);
+
       if (authParameters.identityPoolName) {
         updateIdPRolesInNestedStack(context, nestedStack, authResourceName);
       }
@@ -706,7 +871,7 @@ async function formNestedStack(context, projectDetails, categoryName, resourceNa
 function updateIdPRolesInNestedStack(context, nestedStack, authResourceName) {
   const authLogicalResourceName = `auth${authResourceName}`;
   const idpUpdateRoleCfnFilePath = path.join(__dirname, '..', 'resources', 'update-idp-roles-cfn.json');
-  const idpUpdateRoleCfn = context.amplify.readJsonFile(idpUpdateRoleCfnFilePath);
+  const idpUpdateRoleCfn = JSONUtilities.readJson<$TSObject>(idpUpdateRoleCfnFilePath);
 
   idpUpdateRoleCfn.UpdateRolesWithIDPFunction.DependsOn.push(authLogicalResourceName);
   idpUpdateRoleCfn.UpdateRolesWithIDPFunctionOutputs.Properties.idpId['Fn::GetAtt'].unshift(authLogicalResourceName);
@@ -714,8 +879,18 @@ function updateIdPRolesInNestedStack(context, nestedStack, authResourceName) {
   Object.assign(nestedStack.Resources, idpUpdateRoleCfn);
 }
 
-module.exports = {
-  run,
-  updateStackForAPIMigration,
-  storeCurrentCloudBackend,
-};
+export async function generateAndUploadRootStack(context: $TSContext, destinationPath: string, destinationS3Key: string) {
+  const projectDetails = context.amplify.getProjectDetails();
+  const nestedStack = await formNestedStack(context, projectDetails);
+
+  JSONUtilities.writeJson(destinationPath, nestedStack);
+
+  // upload the nested stack
+  const s3Client = await S3.getInstance(context);
+  const s3Params = {
+    Body: Buffer.from(JSONUtilities.stringify(nestedStack)),
+    Key: destinationS3Key,
+  };
+
+  await s3Client.uploadFile(s3Params, false);
+}

--- a/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
@@ -498,7 +498,7 @@ async function getPreviousDeploymentRootKey(previouslyDeployedBackendDir) {
   // this is the function
   let parameters;
   try {
-    const parametersPath = path.join(previouslyDeployedBackendDir, `build/${parametersFileName}`);
+    const parametersPath = path.join(previouslyDeployedBackendDir, 'build', parametersFileName);
     const parametersExists = fs.existsSync(parametersPath);
     if (parametersExists) {
       const parametersString = await fs.readFile(parametersPath);

--- a/packages/amplify-provider-awscloudformation/src/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/src/upload-appsync-files.js
@@ -241,6 +241,7 @@ async function hashDirectory(directory) {
 }
 
 module.exports = {
+  ROOT_APPSYNC_S3_KEY,
   uploadAppSyncFiles,
   hashDirectory,
 };

--- a/packages/amplify-provider-awscloudformation/src/utils/amplify-resource-state-utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/amplify-resource-state-utils.ts
@@ -1,0 +1,94 @@
+import { Template } from 'cloudform-types';
+import { GlobalSecondaryIndex, AttributeDefinition } from 'cloudform-types/types/dynamoDb/table';
+import { CloudFormation } from 'aws-sdk';
+import _ from 'lodash';
+
+export interface GSIRecord {
+  attributeDefinition: AttributeDefinition[];
+  gsi: GlobalSecondaryIndex;
+}
+
+export const getStackParameters = async (cfnClient: CloudFormation, StackId: string): Promise<any> => {
+  const apiStackInfo = await cfnClient
+    .describeStacks({
+      StackName: StackId,
+    })
+    .promise();
+  return apiStackInfo.Stacks[0].Parameters.reduce((acc, param) => {
+    acc[param.ParameterKey] = param.ParameterValue;
+    return acc;
+  }, {});
+};
+
+export const getTableNames = async (cfnClient: CloudFormation, tables: string[], StackId: string): Promise<Map<string, string>> => {
+  const tableNameMap: Map<string, string> = new Map();
+  const apiResources = await cfnClient
+    .describeStackResources({
+      StackName: StackId,
+    })
+    .promise();
+  for (const resource of apiResources.StackResources) {
+    if (tables.includes(resource.LogicalResourceId)) {
+      const tableStack = await cfnClient
+        .describeStacks({
+          StackName: resource.PhysicalResourceId,
+        })
+        .promise();
+      const tableName = tableStack.Stacks[0].Outputs.reduce((acc, out) => {
+        if (out.OutputKey === `GetAtt${resource.LogicalResourceId}TableName`) {
+          acc.push(out.OutputValue);
+        }
+        return acc;
+      }, []);
+      tableNameMap.set(resource.LogicalResourceId, tableName[0]);
+    }
+  }
+  return tableNameMap;
+};
+
+export class TemplateState {
+  private changes: { [key: string]: string[] } = {};
+
+  public has(key: string) {
+    return Boolean(key in this.changes);
+  }
+
+  public isEmpty(): Boolean {
+    return !Object.keys(this.changes).length;
+  }
+
+  public get(key: string): string[] {
+    return this.changes[key];
+  }
+
+  public getLatest(key: string): Template | null {
+    if (this.changes[key]) {
+      const length = this.changes[key].length;
+      return length ? JSON.parse(this.changes[key][length - 1]) : null;
+    }
+    return null;
+  }
+
+  public pop(key: string): Template {
+    const template = this.changes[key].shift();
+    if (_.isEmpty(this.changes[key])) {
+      delete this.changes[key];
+    }
+    return JSON.parse(template);
+  }
+
+  public add(key: string, val: string): void {
+    if (!(key in this.changes)) {
+      this.changes[key] = [];
+    }
+    this.changes[key].push(val);
+  }
+
+  public getChangeCount(key: string): number {
+    return this.changes[key].length;
+  }
+
+  public getKeys(): Array<string> {
+    return Object.keys(this.changes);
+  }
+}

--- a/packages/amplify-provider-awscloudformation/src/utils/amplify-resource-state-utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/amplify-resource-state-utils.ts
@@ -2,6 +2,7 @@ import { Template } from 'cloudform-types';
 import { GlobalSecondaryIndex, AttributeDefinition } from 'cloudform-types/types/dynamoDb/table';
 import { CloudFormation } from 'aws-sdk';
 import _ from 'lodash';
+import { JSONUtilities } from 'amplify-cli-core';
 
 export interface GSIRecord {
   attributeDefinition: AttributeDefinition[];
@@ -64,7 +65,7 @@ export class TemplateState {
   public getLatest(key: string): Template | null {
     if (this.changes[key]) {
       const length = this.changes[key].length;
-      return length ? JSON.parse(this.changes[key][length - 1]) : null;
+      return length ? JSONUtilities.parse(this.changes[key][length - 1]) : null;
     }
     return null;
   }
@@ -74,7 +75,7 @@ export class TemplateState {
     if (_.isEmpty(this.changes[key])) {
       delete this.changes[key];
     }
-    return JSON.parse(template);
+    return JSONUtilities.parse(template);
   }
 
   public add(key: string, val: string): void {

--- a/packages/amplify-provider-awscloudformation/src/utils/aws-logger.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/aws-logger.ts
@@ -1,6 +1,8 @@
-const { logger, Redactor } = require('amplify-cli-logger');
+import { Redactor, logger } from 'amplify-cli-logger';
+
 const mainModule = 'amplify-provider-awscloudformation';
-export const fileLogger = file => (crumb, args) => error => {
+
+export const fileLogger = file => (crumb, args) => (error?) => {
   const message = `${mainModule}.${file}.${crumb}(${Redactor(JSON.stringify(args))})`;
   if (!error) {
     logger.logInfo({ message });

--- a/packages/amplify-provider-awscloudformation/tsconfig.json
+++ b/packages/amplify-provider-awscloudformation/tsconfig.json
@@ -10,6 +10,7 @@
   },
   "exclude": [
     "lib",
+    "coverage",
     "src/__tests__",
   ],
   "references": [

--- a/packages/graphql-transformer-core/src/errors.ts
+++ b/packages/graphql-transformer-core/src/errors.ts
@@ -59,6 +59,15 @@ InvalidMigrationError.prototype.toString = function() {
   return `${this.message}\nCause: ${this.cause}\nHow to fix: ${this.fix}`;
 };
 
+export class InvalidGSIMigrationError extends InvalidMigrationError {
+  fix: string;
+  cause: string;
+  constructor(message: string, cause: string, fix: string) {
+    super(message, cause, fix);
+    this.name = 'InvalidGSIMigrationError';
+  }
+}
+
 export class InvalidDirectiveError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -79,7 +79,6 @@ export async function buildProject(opts: ProjectOptions) {
           // GSI
           cantEditGSIKeySchemaRule,
           cantAddAndRemoveGSIAtSameTimeRule,
-          cantBatchMutateGSIAtUpdateTimeRule,
         ];
 
         projectRules = [cantHaveMoreThan500ResourcesRule, cantMutateMultipleGSIAtUpdateTimeRule];

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -18,8 +18,8 @@ import {
   DiffRule,
   sanityCheckProject,
   ProjectRule,
+  cantMutateMultipleGSIAtUpdateTimeRule,
 } from './sanity-check';
-import { cantMutateMultipleGSIAtUpdateTimeRule } from '..';
 
 export const CLOUDFORMATION_FILE_NAME = 'cloudformation-template.json';
 export const PARAMETERS_FILE_NAME = 'parameters.json';

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -11,7 +11,6 @@ import { FeatureFlagProvider } from '../FeatureFlags';
 import {
   cantAddAndRemoveGSIAtSameTimeRule,
   cantAddLSILaterRule,
-  cantBatchMutateGSIAtUpdateTimeRule,
   cantEditGSIKeySchemaRule,
   cantEditKeySchemaRule,
   cantEditLSIKeySchemaRule,

--- a/packages/graphql-transformer-core/src/util/index.ts
+++ b/packages/graphql-transformer-core/src/util/index.ts
@@ -3,3 +3,4 @@ export * from './getFieldArguments';
 export * from './gql';
 export * from './transformConfig';
 export * from './syncUtils';
+export * from './sanity-check';

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -50,7 +50,6 @@ export const sanityCheckDiffs = (
   projectRules: ProjectRule[] = [cantHaveMoreThan500ResourcesRule],
 ): void => {
   // Project rules run on the full set of diffs, the current build, and the next build.
-  // Todo: confirm if , cantMutateMultipleGSIAtUpdateTimeRule is needed as project rule as the diffRule should include it already
 
   // Loop through the diffs and call each DiffRule.
   // We loop once so each rule does not need to loop.

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -34,6 +34,7 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/hosting.test.ts',
   'src/__tests__/analytics.test.ts',
   'src/__tests__/feature-flags.test.ts',
+  'src/__tests__/schema-iterative-update-2.test.ts',
   //<20m
   'src/__tests__/predictions.test.ts',
   'src/__tests__/hostingPROD.test.ts',
@@ -43,6 +44,7 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/auth_1.test.ts',
   'src/__tests__/auth_5.test.ts',
   'src/__tests__/function_3.test.ts',
+  'src/__tests__/schema-iterative-update-1.test.ts',
   //<30m
   'src/__tests__/schema-auth-3.test.ts',
   'src/__tests__/delete.test.ts',
@@ -76,6 +78,7 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/migration/api.connection.migration.test.ts',
   'src/__tests__/schema-connection.test.ts',
   'src/__tests__/schema-auth-6.test.ts',
+  'src/__tests__/schema-iterative-update-3.test.ts',
   //<50m
   'src/__tests__/schema-auth-2.test.ts',
   'src/__tests__/api_1.test.ts',
@@ -83,6 +86,7 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   //<55m
   'src/__tests__/storage.test.ts',
   'src/__tests__/api_2.test.ts',
+  'src/__tests__/schema-iterative-update-4.test.ts',
 ];
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,6 +6103,17 @@ amplify-cli-core@1.3.0:
     hjson "^3.2.1"
     lodash "^4.17.19"
 
+amplify-cli-core@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/amplify-cli-core/-/amplify-cli-core-1.5.1.tgz#7c5d2b460ef5cc6ec23292d864378098bed5503b"
+  integrity sha512-gzUNO/AiPGtowYgyVO20ofMZXukcbyK5908QlBYaStsUOqL71zzeK8H+S5n6nHAgiMAB/C+hr51mVlzCaoqp5Q==
+  dependencies:
+    ajv "^6.12.3"
+    dotenv "^8.2.0"
+    fs-extra "^8.1.0"
+    hjson "^3.2.1"
+    lodash "^4.17.19"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5187,6 +5187,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/columnify@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@types/columnify/-/columnify-1.5.0.tgz#94bb31f14c66bab6d968caa455ff13af1f0e7632"
+  integrity sha512-f39gUbf4NuSTVG9XEUJzYQ8L9e3l91jwywbJdU0fJixCRHKzQnyWxa9KfRPEuC3PhH5TIAi79kX2sAkXXSTB9Q==
+
 "@types/common-tags@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.0.tgz#79d55e748d730b997be5b7fce4b74488d8b26a6b"
@@ -5215,6 +5220,11 @@
   integrity sha512-sOdDRU3oRS7LBNTIqwDkPJyq0lpHYcbMTt0TrjzsXbk/e37hcLTH6eZX7CdbDeN0yJJvzw9hFBZkbtCSbk/jAQ==
   dependencies:
     "@types/express" "*"
+
+"@types/deep-diff@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.0.tgz#7eba3202a99b3a207f758f351f7f86387269fc40"
+  integrity sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -5365,6 +5375,18 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/lodash.throttle@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz#f5ba2c22244ee42ff6c2c49e614401a870c1009c"
+  integrity sha512-/UIH96i/sIRYGC60NoY72jGkCJtFN5KVPhEMMMTjol65effe1gPn0tycJqV5tlSwMTzX8FqzB5yAj0rfGHTPNg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
 
 "@types/lodash@^4.14.149":
   version "4.14.161"
@@ -8239,7 +8261,7 @@ clone@^2.1.1:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-cloudform-types@4.2.0, cloudform-types@^4.1.0, cloudform-types@^4.2.0:
+cloudform-types@^4.1.0, cloudform-types@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/cloudform-types/-/cloudform-types-4.2.0.tgz#698c98a1468bd8fe9c1c275b2e65720f572ca401"
   integrity sha512-i7fmpsOtrMzF4z3Ltpqn9Khi6pgSxNCMqqsXLXWbaZsczky7vA9mkq/Z2bdMUu5x4Eaj5wvvKc95ENZ0dtN/Uw==
@@ -15535,6 +15557,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash.toarray@^4.4.0:
   version "4.4.0"
@@ -22934,6 +22961,11 @@ xregexp@^4.3.0:
   integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
   dependencies:
     "@babel/runtime-corejs3" "^7.8.3"
+
+xstate@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.14.0.tgz#dd9f3f0af4acd04a01b3ad60d3d4c66c51ac1b5d"
+  integrity sha512-nz+T5rlPl0Vu1L9NZdI7JYVq57k/pKpyLwmztqgcj/HqUVsopnMKBP6cQJCb4Op9TC8kffyJSMwHDFthuRpooQ==
 
 xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Updated CLI to support multiple changes to @key directive in same @model during update. The CLI will
split the cloudformation stack into mulitple batches of update such that GSIs are added and removed
in separate pushes which out causing any cloudfomration deployment error. This change is behind
FeatureFlage `graphqltransformer.enableIterativeGSIUpdates` which is turned off by default.

The changes supported after enabling this GSI are
1. Rename of @key
2. Add and Remove multiple @keys at the same time in a single model
3. Add and remove fileds to @key

The change only helps in deployment of key changes and does not backfill the data if
the key is a composite key or remove column from Dynamo DB records when a key removed

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.