### PR TITLE
fix: bump min version of cli required by amplify-app

### DIFF
--- a/packages/amplify-app/package.json
+++ b/packages/amplify-app/package.json
@@ -25,7 +25,7 @@
   },
   "engines": {
     "node": ">=10.0.0",
-    "@aws-amplify/cli": ">=4.27.2"
+    "@aws-amplify/cli": ">=4.37.0"
   },
   "dependencies": {
     "amplify-frontend-android": "2.14.2",


### PR DESCRIPTION
*Issue #, if available:*
#6039

*Description of changes:*
Bump min CLI version required by amplify-app

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.