### PR TITLE
fix: #4175 - enable Cognito case insensitive usernames for new projects and new auth resources

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -7,11 +7,11 @@ Parameters:
     Type: String
   unauthRoleArn:
     Type: String
-  
+
   <% if (props.dependsOn && props.dependsOn.length > 0) { %>
   <% for(var i=0; i < props.dependsOn.length; i++) { %>
   <% for(var j=0; j < props.dependsOn[i].attributes.length; j++) { %>
-  <%= props.dependsOn[i].category %><%= props.dependsOn[i].resourceName %><%= props.dependsOn[i].attributes[j] %>: 
+  <%= props.dependsOn[i].category %><%= props.dependsOn[i].resourceName %><%= props.dependsOn[i].attributes[j] %>:
     Type: String
     Default: <%= props.dependsOn[i].category %><%= props.dependsOn[i].resourceName %><%= props.dependsOn[i].attributes[j] %>
   <% } %>
@@ -63,9 +63,9 @@ Resources:
         ErrorDocument: "index.html"
       CorsConfiguration:
         CorsRules:
-          - 
+          -
             AllowedHeaders:
-              - "Authorization" 
+              - "Authorization"
               - "Content-Length"
             AllowedMethods:
               - "GET"
@@ -75,32 +75,32 @@ Resources:
   <% } %>
   <%if (props.authSelections !== 'identityPoolOnly') { %>
   # BEGIN SNS ROLE RESOURCE
-  SNSRole: 
+  SNSRole:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
     Type: AWS::IAM::Role
     Properties:
       RoleName: !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_sns-role`%>', !Join ['',[ 'sns', '<%=`${props.sharedId}`%>', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
-      AssumeRolePolicyDocument: 
+      AssumeRolePolicyDocument:
         Version: "2012-10-17"
-        Statement: 
+        Statement:
           - Sid: ""
             Effect: "Allow"
-            Principal: 
+            Principal:
               Service: "cognito-idp.amazonaws.com"
-            Action: 
+            Action:
               - "sts:AssumeRole"
-            Condition: 
+            Condition:
               StringEquals:
                 sts:ExternalId: <%=`${props.resourceNameTruncated}_role_external_id`%>
-      Policies: 
-        - 
+      Policies:
+        -
           PolicyName: <%=`${props.resourceNameTruncated}-sns-policy`%>
-          PolicyDocument: 
+          PolicyDocument:
             Version: "2012-10-17"
-            Statement: 
-              - 
+            Statement:
+              -
                 Effect: "Allow"
-                Action: 
+                Action:
                   - "sns:Publish"
                 Resource: "*"
   # BEGIN USER POOL RESOURCES
@@ -112,7 +112,11 @@ Resources:
     Properties:
       UserPoolName: !If [ShouldNotCreateEnvResources, !Ref userPoolName, !Join ['',[!Ref userPoolName, '-', !Ref env]]]
       <%if (props.requiredAttributes && props.requiredAttributes.length > 0) { %>
-      Schema: 
+      <%if (props.usernameCaseSensitive !== undefined) { %>
+      UsernameConfiguration:
+        CaseSensitive: <%= props.usernameCaseSensitive %>
+      <% } %>
+      Schema:
         <% for(var i=0; i < props.requiredAttributes.length; i++) { %>
         -
           Name: <%= props.requiredAttributes[i] %>
@@ -156,7 +160,7 @@ Resources:
       <%if (props.autoVerifiedAttributes.includes('email')) { %>
       EmailVerificationMessage: !Ref emailVerificationMessage
       EmailVerificationSubject: !Ref emailVerificationSubject
-      <% } %>      
+      <% } %>
       Policies:
         PasswordPolicy:
           MinimumLength: !Ref passwordPolicyMinLength
@@ -166,106 +170,106 @@ Resources:
           RequireUppercase: <%= props.passwordPolicyCharacters.includes('Requires Uppercase') %>
       <% if (props.usernameAttributes && props.usernameAttributes !== 'username') { %>
       UsernameAttributes: !Ref usernameAttributes
-      <% } %>    
+      <% } %>
       MfaConfiguration: !Ref mfaConfiguration
       SmsVerificationMessage: !Ref smsVerificationMessage
-      SmsConfiguration: 
+      SmsConfiguration:
         SnsCallerArn: !GetAtt SNSRole.Arn
         ExternalId: <%=`${props.resourceNameTruncated}_role_external_id`%>
-    <%if (props.mfaConfiguration != 'OFF') { %>      
+    <%if (props.mfaConfiguration != 'OFF') { %>
     DependsOn: SNSRole
     <% } %>
   <%if (props.triggers && props.dependsOn) { %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('CreateAuthChallenge'))) { %>
-  UserPoolCreateAuthChallengeLambdaInvokePermission: 
+  UserPoolCreateAuthChallengeLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>CreateAuthChallengeName
       SourceArn: !GetAtt UserPool.Arn
-  <% } %>  
+  <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('CustomMessage'))) { %>
-  UserPoolCustomMessageLambdaInvokePermission: 
+  UserPoolCustomMessageLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>CustomMessageName
       SourceArn: !GetAtt UserPool.Arn
-  <% } %>  
+  <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('DefineAuthChallenge'))) { %>
-  UserPoolDefineAuthChallengeLambdaInvokePermission: 
+  UserPoolDefineAuthChallengeLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>DefineAuthChallengeName
       SourceArn: !GetAtt UserPool.Arn
   <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('PostAuthentication'))) { %>
-  UserPoolPostAuthenticationLambdaInvokePermission: 
+  UserPoolPostAuthenticationLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>PostAuthenticationName
       SourceArn: !GetAtt UserPool.Arn
-  <% } %>  
+  <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('PostConfirmation'))) { %>
-  UserPoolPostConfirmationLambdaInvokePermission: 
+  UserPoolPostConfirmationLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>PostConfirmationName
       SourceArn: !GetAtt UserPool.Arn
-  <% } %>  
+  <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('PreAuthentication'))) { %>
-  UserPoolPreAuthenticationLambdaInvokePermission: 
+  UserPoolPreAuthenticationLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>PreAuthenticationName
       SourceArn: !GetAtt UserPool.Arn
   <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('PreSignup'))) { %>
-  UserPoolPreSignupLambdaInvokePermission: 
+  UserPoolPreSignupLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>PreSignupName
       SourceArn: !GetAtt UserPool.Arn
   <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('PreTokenGeneration'))) { %>
-  UserPoolPreTokenGenerationLambdaInvokePermission: 
+  UserPoolPreTokenGenerationLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>PreTokenGenerationName
       SourceArn: !GetAtt UserPool.Arn
-  <% } %> 
+  <% } %>
   <%if (props.dependsOn.find(i => i.resourceName.includes('VerifyAuthChallengeResponse'))) { %>
-  UserPoolVerifyAuthChallengeResponseLambdaInvokePermission: 
+  UserPoolVerifyAuthChallengeResponseLambdaInvokePermission:
     Type: "AWS::Lambda::Permission"
     DependsOn: UserPool
-    Properties: 
+    Properties:
       Action: "lambda:invokeFunction"
       Principal: "cognito-idp.amazonaws.com"
       FunctionName: !Ref function<%=props.resourceName%>VerifyAuthChallengeResponseName
       SourceArn: !GetAtt UserPool.Arn
-  <% } %>  
+  <% } %>
   # Updating lambda role with permissions to Cognito
   <% if (props.permissions && props.permissions.length > 0) { %>
   <% for(var i=0; i < props.permissions.length; i++) { %>
@@ -349,7 +353,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        ZipFile: !Join 
+        ZipFile: !Join
           - |+
           - - 'const response = require(''cfn-response'');'
             - 'const aws = require(''aws-sdk'');'
@@ -365,7 +369,7 @@ Resources:
             - '   };'
             - '   identity.describeUserPoolClient(params).promise()'
             - '     .then((res) => {'
-            - '       response.send(event, context, response.SUCCESS, {''appSecret'': res.UserPoolClient.ClientSecret});'   
+            - '       response.send(event, context, response.SUCCESS, {''appSecret'': res.UserPoolClient.ClientSecret});'
             - '     })'
             - '     .catch((err) => {'
             - '       response.send(event, context, response.FAILED, {err});'
@@ -375,7 +379,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Timeout: '300'
-      Role: !GetAtt 
+      Role: !GetAtt
         - UserPoolClientRole
         - Arn
     DependsOn: UserPoolClientRole
@@ -386,7 +390,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_userpoolclient_lambda_iam_policy`%>
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
@@ -403,7 +407,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_userpoolclient_lambda_log_policy`%>
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
@@ -413,10 +417,10 @@ Resources:
               - 'logs:CreateLogGroup'
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
               - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref UserPoolClientLambda}
-    DependsOn: UserPoolClientLambdaPolicy  
+    DependsOn: UserPoolClientLambdaPolicy
   UserPoolClientInputs:
   # Values passed to Userpool client Lambda
   # Depends on UserPool for Id
@@ -433,7 +437,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        ZipFile: !Join 
+        ZipFile: !Join
           - |+
           - - 'const response = require(''cfn-response'');'
             - 'const aws = require(''aws-sdk'');'
@@ -452,7 +456,7 @@ Resources:
             - ' }'
             - ' if (event.RequestType == ''Update'' || event.RequestType == ''Create'') {'
             - '  let checkDomainAvailability = (domainName) => {'
-            - '  let params = { Domain: domainName };'   
+            - '  let params = { Domain: domainName };'
             - '  return identity.describeUserPoolDomain(params).promise().then((res) => {'
             - '   if (res.DomainDescription && res.DomainDescription.UserPool) {'
             - '    return false;'
@@ -501,7 +505,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Timeout: '300'
-      Role: !GetAtt 
+      Role: !GetAtt
         - UserPoolClientRole
         - Arn
     DependsOn: UserPoolClientRole
@@ -510,7 +514,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUI']]
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
@@ -530,7 +534,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUILogPolicy']]
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
@@ -540,7 +544,7 @@ Resources:
               - 'logs:CreateLogGroup'
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
               - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref HostedUICustomResource}
     DependsOn: HostedUICustomResourcePolicy
@@ -558,7 +562,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        ZipFile: !Join 
+        ZipFile: !Join
           - |+
           - - 'const response = require(''cfn-response'');'
             - 'const aws = require(''aws-sdk'');'
@@ -576,7 +580,7 @@ Resources:
             - ' }'
             - ' if (event.RequestType == ''Update'' || event.RequestType == ''Create'') {'
             - '  let getRequestParams = (providerName) => {'
-            - '   let providerMetaIndex = hostedUIProviderMeta.findIndex((provider) => provider.ProviderName === providerName);'   
+            - '   let providerMetaIndex = hostedUIProviderMeta.findIndex((provider) => provider.ProviderName === providerName);'
             - '   let providerMeta =  hostedUIProviderMeta[providerMetaIndex];'
             - '   let providerCredsIndex = hostedUIProviderCreds.findIndex((provider) => provider.ProviderName === providerName);'
             - '   let providerCreds = hostedUIProviderCreds[providerCredsIndex];'
@@ -633,7 +637,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Timeout: '300'
-      Role: !GetAtt 
+      Role: !GetAtt
         - UserPoolClientRole
         - Arn
     DependsOn: UserPoolClientRole
@@ -642,7 +646,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUIProvider']]
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
@@ -660,7 +664,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'hostedUIProviderLogPolicy']]
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
@@ -670,7 +674,7 @@ Resources:
               - 'logs:CreateLogGroup'
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
               - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref HostedUIProvidersCustomResource}
     DependsOn: HostedUIProvidersCustomResourcePolicy
@@ -689,7 +693,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        ZipFile: !Join 
+        ZipFile: !Join
           - |+
           - - 'const response = require(''cfn-response'');'
             - 'const aws = require(''aws-sdk'');'
@@ -708,7 +712,7 @@ Resources:
             - ' }'
             - ' if (event.RequestType == ''Update'' || event.RequestType == ''Create'') {'
             - '  let params = {'
-            - '   UserPoolId: userPoolId,'   
+            - '   UserPoolId: userPoolId,'
             - '   AllowedOAuthFlows: oAuthMetadata.AllowedOAuthFlows,'
             - '   AllowedOAuthFlowsUserPoolClient: true,'
             - '   AllowedOAuthScopes: oAuthMetadata.AllowedOAuthScopes,'
@@ -732,7 +736,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Timeout: '300'
-      Role: !GetAtt 
+      Role: !GetAtt
         - UserPoolClientRole
         - Arn
     DependsOn: HostedUIProvidersCustomResourceInputs
@@ -741,7 +745,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'OAuth']]
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
@@ -756,7 +760,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: !Join ['-',[!Ref UserPool, 'OAuthLogPolicy']]
-      Roles: 
+      Roles:
         - !Ref UserPoolClientRole
       PolicyDocument:
         Version: 2012-10-17
@@ -766,7 +770,7 @@ Resources:
               - 'logs:CreateLogGroup'
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
               - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref OAuthCustomResource}
     DependsOn: OAuthCustomResourcePolicy
@@ -814,7 +818,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        ZipFile: !Join 
+        ZipFile: !Join
           - |+
           - - 'const response = require(''cfn-response'');'
             - 'const aws = require(''aws-sdk'');'
@@ -843,7 +847,7 @@ Resources:
             - '   };'
             - '   identity.setUserPoolMfaConfig(totpParams).promise()'
             - '     .then((res) => {'
-            - '       response.send(event, context, response.SUCCESS, {res});'   
+            - '       response.send(event, context, response.SUCCESS, {res});'
             - '     })'
             - '     .catch((err) => {'
             - '       response.send(event, context, response.FAILED, {err});'
@@ -853,7 +857,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Timeout: '300'
-      Role: !GetAtt 
+      Role: !GetAtt
         - MFALambdaRole
         - Arn
     DependsOn: MFALambdaRole
@@ -864,7 +868,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_totp_lambda_iam_policy`%>
-      Roles: 
+      Roles:
         - !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_totp_lambda_role`%>', !Join ['',['<%=`${props.resourceNameTruncated}_totp_lambda_role`%>', '-', !Ref env]]]
       PolicyDocument:
         Version: '2012-10-17'
@@ -880,7 +884,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_totp_lambda_log_policy`%>
-      Roles: 
+      Roles:
         - !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_totp_lambda_role`%>', !Join ['',['<%=`${props.resourceNameTruncated}_totp_lambda_role`%>', '-', !Ref env]]]
       PolicyDocument:
         Version: 2012-10-17
@@ -890,10 +894,10 @@ Resources:
               - 'logs:CreateLogGroup'
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
               - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref MFALambda}
-    DependsOn: MFALambdaPolicy  
+    DependsOn: MFALambdaPolicy
   MFALambdaInputs:
   # Values passed to MFA Lambda
   # Depends on UserPool for Arn
@@ -944,7 +948,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        ZipFile: !Join 
+        ZipFile: !Join
           - |+
           - - 'const response = require(''cfn-response'');'
             - 'const aws = require(''aws-sdk'');'
@@ -956,7 +960,7 @@ Resources:
             - ' if (event.RequestType == ''Update'' || event.RequestType == ''Create'') {'
             - '   const params = {'
             - '     ClientIDList: event.ResourceProperties.clientIdList.split('',''),'
-            - '     ThumbprintList: ["0000000000000000000000000000000000000000"],'   
+            - '     ThumbprintList: ["0000000000000000000000000000000000000000"],'
             - '     Url: event.ResourceProperties.url'
             - '   };'
             - '   let exists = false;'
@@ -971,7 +975,7 @@ Resources:
             - '     }'
             - '     if (!existingValue) {'
             - '       iam.createOpenIDConnectProvider(params).promise().then((data) => {'
-            - '         response.send(event, context, response.SUCCESS, {providerArn: data.OpenIDConnectProviderArn, providerIds: params.ClientIDList});'   
+            - '         response.send(event, context, response.SUCCESS, {providerArn: data.OpenIDConnectProviderArn, providerIds: params.ClientIDList});'
             - '       })'
             - '       .catch((err) => {'
             - '         response.send(event, context, response.FAILED, {err});'
@@ -994,7 +998,7 @@ Resources:
             - '           }'
             - '         });'
             - '         Promise.all(updateCalls).then(function(values) {'
-            - '           response.send(event, context, response.SUCCESS, {providerArn: existingValue, providerIds: params.ClientIDList});'   
+            - '           response.send(event, context, response.SUCCESS, {providerArn: existingValue, providerIds: params.ClientIDList});'
             - '         })'
             - '         .catch((err3) => {'
             - '           response.send(event, context, response.FAILED, {err3});'
@@ -1013,7 +1017,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Timeout: '300'
-      Role: !GetAtt 
+      Role: !GetAtt
         - OpenIdLambdaRole
         - Arn
     DependsOn: OpenIdLambdaRole
@@ -1024,7 +1028,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_openid_lambda_iam_policy`%>
-      Roles: 
+      Roles:
         - !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_openid_lambda_role`%>', !Join ['',['<%=`${props.resourceNameTruncated}_openid_lambda_role`%>', '-', !Ref env]]]
       PolicyDocument:
         Version: '2012-10-17'
@@ -1034,13 +1038,13 @@ Resources:
               - 'iam:CreateOpenIDConnectProvider'
               - 'iam:GetOpenIDConnectProvider'
               - 'iam:AddClientIDToOpenIDConnectProvider'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:iam::${account}:oidc-provider/accounts.google.com
               - { account: !Ref "AWS::AccountId"}
           - Effect: Allow
             Action:
               - 'iam:ListOpenIDConnectProviders'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:iam::${account}:oidc-provider/${selector}
               - { account: !Ref "AWS::AccountId", selector: '*'}
     DependsOn: OpenIdLambda
@@ -1051,7 +1055,7 @@ Resources:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyName: <%=`${props.resourceNameTruncated}_openid_lambda_log_policy`%>
-      Roles: 
+      Roles:
         - !If [ShouldNotCreateEnvResources, '<%=`${props.resourceNameTruncated}_openid_lambda_role`%>', !Join ['',['<%=`${props.resourceNameTruncated}_openid_lambda_role`%>', '-', !Ref env]]]
       PolicyDocument:
         Version: 2012-10-17
@@ -1061,10 +1065,10 @@ Resources:
               - 'logs:CreateLogGroup'
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
-            Resource: !Sub  
+            Resource: !Sub
               - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
               - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref OpenIdLambda}
-    DependsOn: OpenIdLambdaIAMPolicy  
+    DependsOn: OpenIdLambdaIAMPolicy
   OpenIdLambdaInputs:
   # Values passed to OpenId Lambda
   # Depends on OpenId for Arn
@@ -1076,11 +1080,11 @@ Resources:
       url: 'https://accounts.google.com'
     DependsOn: OpenIdLogPolicy
   <% } %>
- 
+
   IdentityPool:
   # Always created
     Type: AWS::Cognito::IdentityPool
-    Properties: 
+    Properties:
       IdentityPoolName: !If [ShouldNotCreateEnvResources, '<%= props.identityPoolName %>', !Join ['',['<%= props.identityPoolName %>', '__', !Ref env]]]
       <%if (props.authSelections !== 'identityPoolOnly') { %>
       CognitoIdentityProviders:
@@ -1094,7 +1098,7 @@ Resources:
             - { region: !Ref "AWS::Region",  client: !Ref UserPool}
       <% } -%>
       <%if (props.authProviders && Object.keys(props.authProviders).length > 0 && props.authProviders !== '{}' && !(Object.keys(props.authProviders).length === 1 && props.authProviders[0] === 'accounts.google.com' && props.audiences)) { %>
-      SupportedLoginProviders: 
+      SupportedLoginProviders:
         <%if (props.authProviders.indexOf('graph.facebook.com') !== -1) { %>
         graph.facebook.com: !Ref facebookAppId
         <% } %>
@@ -1110,16 +1114,16 @@ Resources:
       OpenIdConnectProviderARNs:
         - !GetAtt OpenIdLambdaInputs.providerArn
     DependsOn: OpenIdLambdaInputs
-      <% } %> 
-    <%if ((!props.audiences || props.audiences.length === 0) && props.authSelections !== 'identityPoolOnly') { %>   
-    DependsOn: UserPoolClientInputs 
+      <% } %>
+    <%if ((!props.audiences || props.audiences.length === 0) && props.authSelections !== 'identityPoolOnly') { %>
+    DependsOn: UserPoolClientInputs
     <% } %>
-  
+
   IdentityPoolRoleMap:
   # Created to map Auth and Unauth roles to the identity pool
   # Depends on Identity Pool for ID ref
     Type: AWS::Cognito::IdentityPoolRoleAttachment
-    Properties: 
+    Properties:
       IdentityPoolId: !Ref IdentityPool
       Roles:
           unauthenticated: !Ref unauthRoleArn
@@ -1133,7 +1137,7 @@ Outputs :
     Value: !Ref 'IdentityPool'
     Description:  Id for the identity pool
   IdentityPoolName:
-    Value: !GetAtt IdentityPool.Name 
+    Value: !GetAtt IdentityPool.Name
   <% } %>
   <%if (props.hostedUIDomainName) { %>
   HostedUIDomain:
@@ -1158,18 +1162,18 @@ Outputs :
   AppClientSecret:
     Value: !GetAtt UserPoolClientInputs.appSecret
   <%if (props.mfaConfiguration != 'OFF') { %>
-  CreatedSNSRole: 
+  CreatedSNSRole:
     Value: !GetAtt SNSRole.Arn
     Description: role arn
   <% } %>
   <%if (props.googleClientId) { %>
   GoogleWebClient:
     Value: !Ref googleClientId
-  <% } %> 
+  <% } %>
   <%if (props.googleIos) { %>
   GoogleIOSClient:
     Value: !Ref googleIos
-  <% } %> 
+  <% } %>
   <%if (props.googleAndroid) { %>
   GoogleAndroidClient:
     Value: !Ref googleAndroid
@@ -1177,9 +1181,9 @@ Outputs :
   <%if (props.facebookAppId) { %>
   FacebookWebClient:
     Value: !Ref facebookAppId
-  <% } %> 
+  <% } %>
   <%if (props.amazonAppId) { %>
   AmazonWebClient:
     Value: !Ref amazonAppId
-  <% } %> 
+  <% } %>
   <% } %>

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
@@ -35,7 +35,14 @@ export const safeDefaults = [
 ];
 
 // These attributes cannot be modified once the auth resource is created
-export const immutableAttributes = ['resourceName', 'userPoolName', 'identityPoolName', 'usernameAttributes', 'requiredAttributes'];
+export const immutableAttributes = [
+  'resourceName',
+  'userPoolName',
+  'identityPoolName',
+  'usernameAttributes',
+  'requiredAttributes',
+  'usernameCaseSensitive',
+];
 
 export const privateKeys = [
   'facebookAppIdUserPool',

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
@@ -24,6 +24,7 @@ export interface ServiceQuestionsBaseResult {
   userpoolClientRefreshTokenValidity?: number;
   userpoolClientReadAttributes: string[];
   userpoolClientWriteAttributes: string[];
+  usernameCaseSensitive?: boolean;
 }
 
 export interface OAuthResult {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -4,6 +4,7 @@ import { isEmpty, merge } from 'lodash';
 import { structureOAuthMetadata } from '../service-walkthroughs/auth-questions';
 import { removeDeprecatedProps } from './synthesize-resources';
 import { immutableAttributes, safeDefaults } from '../constants';
+import { FeatureFlags } from 'amplify-cli-core';
 
 /**
  * Factory function that returns a function that applies default values to a ServiceQuestionsResult request.
@@ -22,6 +23,12 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
   await verificationBucketName(result);
 
   structureOAuthMetadata(result, context, getAllDefaults, context.amplify); // adds "oauthMetadata" to result
+
+  // Make the usernames for Cognito case-insensitive by default when it is created, if feature flag
+  // is enabled.
+  if (FeatureFlags.getBoolean('auth.enableCaseInsensitivity')) {
+    result.usernameCaseSensitive = false;
+  }
 
   /* merge actual answers object into props object,
    * ensuring that manual entries override defaults */

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -505,5 +505,14 @@ export class FeatureFlags {
         defaultValueForNewProjects: false,
       },
     ]);
+
+    this.registerFlag('auth', [
+      {
+        name: 'enableCaseInsensitivity',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
+    ]);
   };
 }


### PR DESCRIPTION
*Issue #, if available:*

fix: #4175 - enable Cognito case insensitive usernames for new projects behind a feature flag.

*Description of changes:*

`auth.enableCaseInsensitivity` feature flag was added to not to break existing deployment. When a new auth resource is added and the flag's value is true case insensitivity for Cognito User Pools will be enabled.

New projects created will have this enabled by default.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.