### PR TITLE
fix: ensure auth selections overwrite defaults

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
@@ -1,12 +1,16 @@
 import { ServiceQuestionsResult } from '../../../../provider-utils/awscloudformation/service-walkthrough-types';
 import { structureOAuthMetadata } from '../../../../provider-utils/awscloudformation/service-walkthroughs/auth-questions';
-import { getUpdateAuthDefaultsApplier } from '../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers';
+import {
+  getAddAuthDefaultsApplier,
+  getUpdateAuthDefaultsApplier,
+} from '../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers';
 
 jest.mock(`../../../../provider-utils/awscloudformation/assets/cognito-defaults.js`, () => ({
   functionMap: {
     userPoolOnly: () => ({ some: 'default value' }),
   },
   getAllDefaults: jest.fn(),
+  generalDefaults: jest.fn().mockReturnValue({ requiredAttributes: ['email'] }),
 }));
 
 jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/auth-questions', () => ({
@@ -25,5 +29,29 @@ describe('update auth defaults applier', () => {
     const result = await getUpdateAuthDefaultsApplier({}, 'cognito-defaults.js', {} as ServiceQuestionsResult)(stubResult);
     expect(result).toMatchSnapshot();
     expect(structureOAuthMetadata_mock.mock.calls.length).toBe(1);
+  });
+
+  it('overwrites default parameters', async () => {
+    const stubResult = {
+      useDefault: 'manual',
+      authSelections: 'userPoolOnly',
+      requiredAttributes: [] as string[],
+    } as ServiceQuestionsResult;
+
+    const result = await getUpdateAuthDefaultsApplier({}, 'cognito-defaults.js', {} as ServiceQuestionsResult)(stubResult);
+    expect(result.requiredAttributes).toEqual([]);
+  });
+});
+
+describe('add auth defaults applier', () => {
+  it('overwrites default parameters', async () => {
+    const stubResult: ServiceQuestionsResult = {
+      useDefault: 'manual',
+      authSelections: 'userPoolOnly',
+      requiredAttributes: [] as string[],
+    } as ServiceQuestionsResult;
+
+    const result = await getAddAuthDefaultsApplier({}, 'cognito-defaults.js', 'testProjectName')(stubResult);
+    expect(result.requiredAttributes).toEqual([]);
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -1,6 +1,6 @@
 import { ServiceQuestionsResult } from '../service-walkthrough-types';
 import { verificationBucketName } from './verification-bucket-name';
-import { isEmpty, merge } from 'lodash';
+import { assign, isEmpty } from 'lodash';
 import { structureOAuthMetadata } from '../service-walkthroughs/auth-questions';
 import { removeDeprecatedProps } from './synthesize-resources';
 import { immutableAttributes, safeDefaults } from '../constants';
@@ -17,7 +17,7 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
   result: ServiceQuestionsResult,
 ): Promise<ServiceQuestionsResult> => {
   const { functionMap, generalDefaults, roles, getAllDefaults } = await import(`../assets/${defaultValuesFilename}`);
-  result = merge(generalDefaults(projectName), result);
+  result = assign(generalDefaults(projectName), result);
 
   await verificationBucketName(result);
 
@@ -25,7 +25,7 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
 
   /* merge actual answers object into props object,
    * ensuring that manual entries override defaults */
-  return merge(functionMap[result.authSelections](result.resourceName), result, roles);
+  return assign(functionMap[result.authSelections](result.resourceName), result, roles);
 };
 
 export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename: string, previousResult: ServiceQuestionsResult) => async (
@@ -53,5 +53,5 @@ export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename
   if (!isEmpty(result.triggers)) {
     previousResult.triggers = Object.assign({}, result.triggers);
   }
-  return merge(defaults, removeDeprecatedProps(previousResult), result);
+  return assign(defaults, removeDeprecatedProps(previousResult), result);
 };


### PR DESCRIPTION
*Issue #, if available:*
#5681
*Description of changes:*
Switch from lodash merge to lodash assign when overwriting defaults with walkthrough selections. merge will append to lists (in the case of the issue above causing the default requiredAttribute 'email' to stick around even when deselecting all attributes in the walkthrough). assign will overwrite any defined field with the new value (so [] overwrites ['email'])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.