### PR TITLE
fix: undefined appId destructuring

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.js
@@ -405,7 +405,7 @@ function validateConfig(context) {
 
 function persistLocalEnvConfig(context) {
   let { awsConfigInfo } = context.exeInfo;
-  const { appId } = _.get(context, ['exeInfo', 'inputParams', 'amplify'], undefined);
+  const { appId } = _.get(context, ['exeInfo', 'inputParams', 'amplify'], {});
   if (appId && doAdminCredentialsExist(appId)) {
     awsConfigInfo = {
       configLevel: 'amplifyAdmin',


### PR DESCRIPTION
*Issue #, if available:*
fixes #6087
*Description of changes:*
Default to {} instead of undefined in _.get() appId

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.