### PR TITLE
fix: #6067 - nodejs mock return error from lambda

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
@@ -61,7 +61,7 @@ describe('VelocityTemplate', () => {
           info,
         );
         expect(result.errors).toEqual([]);
-        expect(result.result).toEqual('some unexpected error, UnknowErrorType');
+        expect(result.result).toEqual('some unexpected error, UnknownErrorType');
       });
     });
 
@@ -88,7 +88,7 @@ describe('VelocityTemplate', () => {
           info,
         );
         expect(result.errors).toEqual([]);
-        expect(result.result).toEqual('Error: my string as error, UnknowErrorType');
+        expect(result.result).toEqual('Error: my string as error, UnknownErrorType');
       });
     });
 

--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -117,7 +117,7 @@ export class VelocityTemplate {
       error: error
         ? {
             ...error,
-            type: error.extensions?.errorType || 'UnknowErrorType',
+            type: error.type || error.extensions?.errorType || 'UnknownErrorType',
             message: error.message || `Error: ${error}`,
           }
         : error,

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/execute.ts
@@ -95,16 +95,16 @@ process.on('message', async options => {
     process.stdout.write('\n');
     process.stdout.write(JSON.stringify({ result, error: null }));
   } catch (error) {
-    process.send!(
+    process.stdout.write('\n');
+    process.stdout.write(
       JSON.stringify({
         result: null,
         error: {
           type: 'Lambda:Unhandled',
-          message: error.message,
+          message: error.message || typeof error === 'string' ? error : 'Unknown error', // In case of callback('error'), it is only a string
         },
       }),
     );
-    exit(1);
   }
   exit(0);
 });

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
@@ -25,8 +25,9 @@ export function invoke(options: InvokeOptions): Promise<any> {
           const result = JSON.parse(lastLine);
           if (result.error) {
             reject(result.error);
+          } else {
+            resolve(result.result);
           }
-          resolve(result.result);
         } catch {
           resolve(lastLine);
         }


### PR DESCRIPTION
*Issue #, if available:*

fix: #6067

*Description of changes:*

This fixes the error scenarios with mock when Lambda resolvers are used, either with `throw` or the `callback('error')` way.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.