### PR TITLE
fix(cli): update plugin type details url

### DIFF
--- a/packages/amplify-cli/src/plugin-helpers/create-new-plugin.ts
+++ b/packages/amplify-cli/src/plugin-helpers/create-new-plugin.ts
@@ -132,7 +132,7 @@ generation of all the configuration files required by the frontend framework.`);
   context.print.green(`${AmplifyPluginType.util} plugins are general purpose utility plugins, \
 they provide utility functions for other plugins.`);
   context.print.green('For more information please read - \
-  https://docs.amplify.aws/cli/usage/plugin');
+  https://docs.amplify.aws/cli/plugins/architecture#plugin-types');
 }
 
 async function promptForEventSubscription(context: Context): Promise<string[]> {


### PR DESCRIPTION
*Description of changes:*
Replacing https://docs.amplify.aws/cli/usage/plugin which is 404 with https://docs.amplify.aws/cli/plugins/architecture#plugin-types at `amplify plugin init`.

Fixes https://github.com/aws-amplify/amplify-cli/issues/6196.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.