### PR TITLE
fix: #6097 - check for root stack when loading projects for sanity check

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -57,9 +57,11 @@ export function loadDiffableProject(path: string, rootStackName: string): Diffab
     root: {},
   };
   for (const key of Object.keys(currentStacks)) {
-    diffableProject.stacks[key] = JSON.parse(project.stacks[key]);
+    diffableProject.stacks[key] = JSONUtilities.parse(project.stacks[key]);
   }
-  diffableProject.root = JSON.parse(project[rootStackName]);
+  if (project[rootStackName]) {
+    diffableProject.root = JSONUtilities.parse(project[rootStackName]);
+  }
   return diffableProject;
 }
 

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -363,7 +363,9 @@ const loadDiffableProject = async (path: string, rootStackName: string): Promise
     diffableProject.stacks[key] = JSONUtilities.parse(project.stacks[key]);
   }
 
-  diffableProject.root = JSONUtilities.parse(project[rootStackName]);
+  if (project[rootStackName]) {
+    diffableProject.root = JSONUtilities.parse(project[rootStackName]);
+  }
 
   return diffableProject;
 };


### PR DESCRIPTION
*Issue #, if available:*

fix: #6097 - check for root stack when loading projects for sanity check

*Description of changes:*

This fix adds an additional check to sanity check project loading in case if the `cloudformation-template.json` file is not present in the `#current-cloud-backend/api/<apiname>/build` folder. This enables api gql-compile to succeed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.