### PR TITLE
fix: #6123 - add missing amplify-cli-core dependencies to packages

### DIFF
--- a/packages/amplify-category-analytics/package.json
+++ b/packages/amplify-category-analytics/package.json
@@ -15,6 +15,7 @@
     "aws"
   ],
   "dependencies": {
+    "amplify-cli-core": "1.11.0",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.3.3",
     "open": "^7.0.0",

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@graphql-tools/merge": "^6.0.18",
+    "amplify-cli-core": "1.11.0",
     "amplify-util-headless-input": "1.4.2",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -23,6 +23,7 @@
     "clean": "rimraf ./lib"
   },
   "dependencies": {
+    "amplify-cli-core": "1.11.0",
     "cloudform-types": "^4.2.0",
     "deep-diff": "^1.0.2",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
*Issue #, if available:*

fix: #6123 - add missing `amplify-cli-core` dependencies to packages

*Description of changes:*

`amplify-cli-core` dependency was missing from some packages where it is referenced, this PR adds those entries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.