### PR TITLE
fix(amplify-nodejs-function-runtime-provider): handle lambda pkg errors

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -1,8 +1,10 @@
-import path from 'path';
+import { BuildRequest, BuildResult } from 'amplify-function-plugin-interface';
+
+import { ExecOptions } from 'child_process';
+import execa from 'execa';
 import fs from 'fs-extra';
 import glob from 'glob';
-import childProcess from 'child_process';
-import { BuildRequest, BuildResult } from 'amplify-function-plugin-interface';
+import path from 'path';
 
 // copied from the existing build-resources.js file in amplify-cli with changes for new interface
 export async function buildResource(request: BuildRequest): Promise<BuildResult> {
@@ -39,19 +41,24 @@ function installDependencies(resourceDir: string) {
 }
 
 function runPackageManager(cwd: string, scriptName?: string) {
-  const isWindows = /^win/.test(process.platform);
-  const npm = isWindows ? 'npm.cmd' : 'npm';
-  const yarn = isWindows ? 'yarn.cmd' : 'yarn';
   const useYarn = fs.existsSync(`${cwd}/yarn.lock`);
-  const packageManager = useYarn ? yarn : npm;
+  const packageManager = useYarn ? 'yarn' : 'npm';
   const args = toPackageManagerArgs(useYarn, scriptName);
-  const childProcessResult = childProcess.spawnSync(packageManager, args, {
-    cwd,
-    stdio: 'pipe',
-    encoding: 'utf-8',
-  });
-  if (childProcessResult.status !== 0) {
-    throw new Error(childProcessResult.output.join());
+  try {
+    const { stdout, exitCode } = execa.commandSync(`${packageManager} ${args.join(' ')}`, {
+      cwd,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+    if (exitCode !== 0) {
+      throw new Error(stdout);
+    }
+  } catch (error) {
+    if ((error as any).code === 'ENOENT') {
+      throw new Error(`Packaging lambda failed function failed. Could not find ${packageManager} executable in the PATH.`);
+    } else {
+      throw new Error(`Packaging lambda failed function failed with the error \n${error.message}`);
+    }
   }
 }
 

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -44,7 +44,7 @@ function runPackageManager(cwd: string, scriptName?: string) {
   const packageManager = useYarn ? 'yarn' : 'npm';
   const args = toPackageManagerArgs(useYarn, scriptName);
   try {
-    const { stdout, stderr, exitCode } = execa.sync(packageManager, args, {
+    execa.sync(packageManager, args, {
       cwd,
       stdio: 'pipe',
       encoding: 'utf-8',

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -1,6 +1,5 @@
 import { BuildRequest, BuildResult } from 'amplify-function-plugin-interface';
 
-import { ExecOptions } from 'child_process';
 import execa from 'execa';
 import fs from 'fs-extra';
 import glob from 'glob';
@@ -45,14 +44,11 @@ function runPackageManager(cwd: string, scriptName?: string) {
   const packageManager = useYarn ? 'yarn' : 'npm';
   const args = toPackageManagerArgs(useYarn, scriptName);
   try {
-    const { stdout, exitCode } = execa.commandSync(`${packageManager} ${args.join(' ')}`, {
+    const { stdout, stderr, exitCode } = execa.sync(packageManager, args, {
       cwd,
       stdio: 'pipe',
       encoding: 'utf-8',
     });
-    if (exitCode !== 0) {
-      throw new Error(stdout);
-    }
   } catch (error) {
     if ((error as any).code === 'ENOENT') {
       throw new Error(`Packaging lambda failed function failed. Could not find ${packageManager} executable in the PATH.`);


### PR DESCRIPTION
Update the package script to handle error when package manager is mising and child process returns
with NOENT error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.