### PR TITLE
fix: update pre-pkg babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
     "pkg-install": "cd pkg && yarn install --production",
     "pkg-prune": "cd pkg && rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md",
-    "pkg-transpile": "cd pkg && babel node_modules --copy-files -d ../build/node_modules",
+    "pkg-transpile": "cd pkg && babel node_modules --extensions '.js,.jsx,.es6,.es,.ts' --copy-files -d ../build/node_modules",
     "pkg-build": "cp pkg/package.json build/node_modules/package.json && pkg -t node12-macos-x64,node12-linux-x64,node12-win-x64 build/node_modules --out-path out",
     "pkg-all": "yarn pkg-install && yarn pkg-prune && yarn pkg-transpile && yarn pkg-build",
     "publish:master": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --yes",

--- a/pkg/babel.config.json
+++ b/pkg/babel.config.json
@@ -9,13 +9,15 @@
         "@babel/plugin-proposal-numeric-separator"
       ],
       "only": [
+        "**/amplify-category-analytics/**/*",
+        "**/amplify-category-interactions/**/*",
         "**/amplify-category-predictions/**/*",
+        "**/amplify-category-storage/**/*",
         "**/amplify-console-hosting/**/*",
+        "**/amplify-container-hosting/**/*",
         "**/amplify-provider-awscloudformation/**/*",
         "**/amplify-util-mock/**/*",
-        "**/amplify-category-analytics/**/*",
-        "**/amplify-category-storage/**/*",
-        "**/amplify-category-interactions/**/*"
+        "**/@octokit/openapi-types/**/*"
       ]
     }
   ]


### PR DESCRIPTION
Fix pkg cli build failures as a result of pulling in octokit as a dependency: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/3256/workflows/bedb748a-1663-4d09-8e2b-8ee3402e1546/jobs/45374

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.