### PR TITLE
fix(graphql-connection-transformer): store graphql float as java double

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/scalars/index.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/scalars/index.ts
@@ -4,7 +4,7 @@ export const JAVA_SCALAR_MAP: NormalizedScalarsMap = {
   ID: 'String',
   String: 'String',
   Int: 'Integer',
-  Float: 'Float',
+  Float: 'Double',
   Boolean: 'Boolean',
   AWSDate: 'java.util.Date',
   AWSDateTime: 'java.util.Date',


### PR DESCRIPTION
According to the [GraphQL spec](https://graphql.org/learn/schema/#scalar-types), a `Float` type is:
> Float: A signed double-precision floating-point value

The CLI maps GraphQL's `Float` to a `Double` in Swift, and a `double` in TypeScript, respectively. However, the codegen maps  the GraphQL type to __Java `Float`__, which is a single-precision value. In a perfect world, this would have always been the Java double-precision type, `java.lang.Double`.

Android customers have existing models in the field that use the `Float` we've generated for them. As a result, the Android library has been updated to support _both_. This compat support was released in Amplify Android 1.6.7 (See https://github.com/aws-amplify/amplify-android/pull/1040.)

After #6145, _Double_ will be generated for all _new_ models. The Java Float support in the Android library will eventually be deprecated.

Proper support for GraphQL `Float` is important since the other platforms may use it to store large values. When the Android client receives them over subscription or sync, it would crash - or worse - truncate and improperly store large values.

Resolves: https://github.com/aws-amplify/amplify-android/issues/1031

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.