### PR TITLE
chore: add cli team to github codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @aws-amplify/amplify-cli


### PR DESCRIPTION
> You can use a CODEOWNERS file to define individuals or teams that are
> responsible for code in a repository.
    
This will cause the "Amplify CLI" team to automatically be included to
the "Reviewers" list on all incoming Pull Requests.

Refer: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.