### PR TITLE
Revert "fix: #6108 - add proper AWSJSON mapping in generated filter input types"

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -70,11 +70,6 @@ input ModelBooleanFilterInput {
   eq: Boolean
 }
 
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
-}
-
 input ModelPostFilterInput {
   id: ModelIDFilterInput
   content: ModelStringFilterInput

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
@@ -89,13 +89,6 @@ input ModelBooleanInput {
   attributeType: ModelAttributeTypes
 }
 
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
 input ModelSizeInput {
   ne: Int
   eq: Int
@@ -219,13 +212,6 @@ input ModelFloatInput {
 input ModelBooleanInput {
   ne: Boolean
   eq: Boolean
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
   attributeExists: Boolean
   attributeType: ModelAttributeTypes
 }

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
@@ -110,13 +110,6 @@ input ModelBooleanInput {
   attributeType: ModelAttributeTypes
 }
 
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
 input ModelSizeInput {
   ne: Int
   eq: Int
@@ -405,13 +398,6 @@ input ModelFloatInput {
 input ModelBooleanInput {
   ne: Boolean
   eq: Boolean
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
   attributeExists: Boolean
   attributeType: ModelAttributeTypes
 }

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -146,8 +146,6 @@ test('Test DynamoDBModelTransformer with multiple model directives', () => {
   expect(floatInputType).toBeDefined();
   const idInputType = getInputType(parsed, 'ModelIDFilterInput');
   expect(idInputType).toBeDefined();
-  const awsJSONInputType = getInputType(parsed, 'ModelAWSJSONFilterInput');
-  expect(awsJSONInputType).toBeDefined();
   const postInputType = getInputType(parsed, 'ModelPostFilterInput');
   expect(postInputType).toBeDefined();
   const userInputType = getInputType(parsed, 'ModelUserFilterInput');
@@ -158,7 +156,6 @@ test('Test DynamoDBModelTransformer with multiple model directives', () => {
   expect(verifyInputCount(parsed, 'ModelIntFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy();
-  expect(verifyInputCount(parsed, 'ModelAWSJSONFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelUserFilterInput', 1)).toBeTruthy();
 });
@@ -192,7 +189,6 @@ test('Test DynamoDBModelTransformer with filter', () => {
   expect(verifyInputCount(parsed, 'ModelIntFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy();
-  expect(verifyInputCount(parsed, 'ModelAWSJSONFilterInput', 1)).toBeTruthy();
   expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy();
 });
 

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -81,13 +81,6 @@ input ModelBooleanInput {
   attributeType: ModelAttributeTypes
 }
 
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
 input ModelSizeInput {
   ne: Int
   eq: Int
@@ -267,11 +260,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {
@@ -563,11 +551,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {
@@ -862,11 +845,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {
@@ -1167,13 +1145,6 @@ input ModelBooleanInput {
   attributeType: ModelAttributeTypes
 }
 
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
 input ModelSizeInput {
   ne: Int
   eq: Int
@@ -1279,11 +1250,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {
@@ -1573,11 +1539,6 @@ input ModelBooleanFilterInput {
   eq: Boolean
 }
 
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
-}
-
 input ModelPostFilterInput {
   id: ModelIDFilterInput
   content: ModelStringFilterInput
@@ -1696,13 +1657,6 @@ input ModelFloatInput {
 input ModelBooleanInput {
   ne: Boolean
   eq: Boolean
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
-input ModelAWSJSONInput {
-  ne: AWSJSON
-  eq: AWSJSON
   attributeExists: Boolean
   attributeType: ModelAttributeTypes
 }

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -42,14 +42,12 @@ const INT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
 const FLOAT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
 const BOOLEAN_CONDITIONS = ['ne', 'eq'];
 const SIZE_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
-const AWSJSON_CONDITIONS = ['ne', 'eq'];
 
 const STRING_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType', 'size']);
 const ID_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType', 'size']);
 const INT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
 const FLOAT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
 const BOOLEAN_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
-const AWSJSON_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
 
 const ATTRIBUTE_TYPES = ['binary', 'binarySet', 'bool', 'list', 'map', 'number', 'numberSet', 'string', 'stringSet', '_null'];
 
@@ -618,8 +616,6 @@ function getScalarConditions(type: string): string[] {
       return FLOAT_CONDITIONS;
     case 'Boolean':
       return BOOLEAN_CONDITIONS;
-    case 'AWSJSON':
-      return AWSJSON_CONDITIONS;
     default:
       throw new Error('Valid types are String, ID, Int, Float, Boolean');
   }
@@ -663,8 +659,6 @@ function getFunctionListForType(typeName: string): Set<string> {
       return FLOAT_FUNCTIONS;
     case 'Boolean':
       return BOOLEAN_FUNCTIONS;
-    case 'AWSJSON':
-      return AWSJSON_FUNCTIONS;
     default:
       throw new Error('Valid types are String, ID, Int, Float, Boolean');
   }
@@ -787,7 +781,6 @@ export function makeScalarFilterInputs(supportsConditions: Boolean): InputObject
     makeModelScalarFilterInputObject('Int', supportsConditions),
     makeModelScalarFilterInputObject('Float', supportsConditions),
     makeModelScalarFilterInputObject('Boolean', supportsConditions),
-    makeModelScalarFilterInputObject('AWSJSON', supportsConditions),
   ];
 
   if (supportsConditions) {

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
@@ -124,11 +124,6 @@ input ModelBooleanFilterInput {
   eq: Boolean
 }
 
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
-}
-
 input ModelPostFilterInput {
   id: ModelIDFilterInput
   title: ModelStringFilterInput
@@ -343,11 +338,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {
@@ -619,11 +609,6 @@ input ModelBooleanFilterInput {
   eq: Boolean
 }
 
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
-}
-
 input ModelPostFilterInput {
   id: ModelIDFilterInput
   title: ModelStringFilterInput
@@ -816,11 +801,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {
@@ -1030,11 +1010,6 @@ input ModelFloatFilterInput {
 input ModelBooleanFilterInput {
   ne: Boolean
   eq: Boolean
-}
-
-input ModelAWSJSONFilterInput {
-  ne: AWSJSON
-  eq: AWSJSON
 }
 
 input ModelPostFilterInput {

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -22,7 +22,7 @@ import {
 } from 'graphql';
 
 type ScalarMap = {
-  [k: string]: 'String' | 'Int' | 'Float' | 'Boolean' | 'ID' | 'AWSJSON';
+  [k: string]: 'String' | 'Int' | 'Float' | 'Boolean' | 'ID';
 };
 export const STANDARD_SCALARS: ScalarMap = {
   String: 'String',
@@ -43,7 +43,7 @@ export const APPSYNC_DEFINED_SCALARS: ScalarMap = {
   AWSDateTime: 'String',
   AWSTimestamp: 'Int',
   AWSEmail: 'String',
-  AWSJSON: 'AWSJSON',
+  AWSJSON: 'String',
   AWSURL: 'String',
   AWSPhone: 'String',
   AWSIPAddress: 'String',


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#6112