### PR TITLE
Allow use of existing pipeline resolver for @function directive

### DIFF
--- a/packages/graphql-function-transformer/src/FunctionTransformer.ts
+++ b/packages/graphql-function-transformer/src/FunctionTransformer.ts
@@ -176,7 +176,7 @@ export class FunctionTransformer extends Transformer {
         compoundExpression([qref(`$ctx.stash.put("typeName", "${type}")`), qref(`$ctx.stash.put("fieldName", "${field}")`), obj({})])
       ),
       ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
-    }).dependsOn(FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region));
+    });
   };
 
   appendFunctionToResolver(resolver: any, functionId: string) {
@@ -186,6 +186,7 @@ export class FunctionTransformer extends Transformer {
       Array.isArray(resolver.Properties.PipelineConfig.Functions)
     ) {
       resolver.Properties.PipelineConfig.Functions.push(Fn.GetAtt(functionId, 'FunctionId'));
+      resolver.dependsOn(functionId)
     }
     return resolver;
   }


### PR DESCRIPTION
Move `dependsOn` to the append function instead of the resolver, to allow usage with existing pipeline resolvers.

*Description of changes:*
By moving the dependency injection out of the resolver's template and into the function's template, the `@function` directive should work nicely with existing pipeline resolvers not generated by the `@function` directive. It will just add the dependency. It should have no effect on pipeline resolvers generated with `@function`, but it would make it more interoperable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.