### PR TITLE
fix: download s3 file to reject on network errors

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/zip-util.js
+++ b/packages/amplify-provider-awscloudformation/src/zip-util.js
@@ -35,7 +35,7 @@ function downloadZip(s3, tempDir, zipFileName, envName) {
       })
       .catch(err => {
         log(err);
-        resolve(err);
+        reject(err);
       });
   });
 }


### PR DESCRIPTION
Downloading current cloud backend from S3 did not reject the promise on error. Updated the code to reject on network error

fix #6198  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.