### PR TITLE
fix: correctly initialize Array when values contain a single integer element

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/array.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/array.ts
@@ -7,7 +7,14 @@ export class JavaArray extends Array<any> {
       // splice sends a single object
       values = [values];
     }
-    super(...values);
+    if (values.length > 1) {
+      super(...values);
+    } else {
+      super();
+      for (const v of values) {
+        this.push(v);
+      }
+    }
     Object.setPrototypeOf(this, Object.create(JavaArray.prototype));
     this.mapper = mapper;
   }

--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/array.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/array.ts
@@ -7,13 +7,11 @@ export class JavaArray extends Array<any> {
       // splice sends a single object
       values = [values];
     }
-    if (values.length > 1) {
+    if (values.length !== 1) {
       super(...values);
     } else {
       super();
-      for (const v of values) {
-        this.push(v);
-      }
+      this.push(values[0]);
     }
     Object.setPrototypeOf(this, Object.create(JavaArray.prototype));
     this.mapper = mapper;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a request to an external data source returns a single value that is of type number, the array is incorrectly initialized. This scenario means that all requests to ElasticSearch with results sorted by date fail.

For example, when querying a locally running ElasticSearch instance with results sorted by date, the date is always returned is in milliseconds: 1608657312744. Since that value is a number, the call to 

`super(...values)` 

becomes 

`super(1608657312744)`

Which tries to initialize an array of length 1608657312744. See the documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array

> A JavaScript array is initialized with the given elements, except in the case where a single argument is passed to the Array constructor and that argument is a number (see the arrayLength parameter below). Note that this special case only applies to JavaScript arrays created with the Array constructor, not array literals created with the bracket syntax.

This pull request correctly initializes the array when the length is 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.