### PR TITLE
feat(amplify-appsync-simulator): implement new utils

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/list-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/list-utils.test.ts
@@ -1,0 +1,83 @@
+import { create } from '../../../velocity/util/index';
+import { GraphQLResolveInfo } from 'graphql';
+import { map, random } from 'lodash';
+
+const stubInfo = {} as unknown;
+export const mockInfo = stubInfo as GraphQLResolveInfo;
+var util;
+
+beforeEach(() => {
+  util = create(undefined, undefined, mockInfo);
+});
+
+describe('$utils.list.copyAndRetainAll', () => {
+  it('should retain', () => {
+    const myList = [1, 2, 3, 4, 5];
+    expect(util.list.copyAndRetainAll(myList, [2, 4])).toEqual([2, 4]);
+  });
+});
+
+describe('$utils.list.copyAndRemoveAll', () => {
+  it('should remove', () => {
+    const myList = [1, 2, 3, 4, 5];
+    expect(util.list.copyAndRemoveAll(myList, [2, 4])).toEqual([1, 3, 5]);
+  });
+});
+
+describe('$utils.list.sortList', () => {
+  it('should sort a list of objects asc', () => {
+    const myList = [
+      { description: 'youngest', age: 5 },
+      { description: 'middle', age: 45 },
+      { description: 'oldest', age: 85 },
+    ];
+    expect(util.list.sortList(myList, false, 'description')).toEqual([
+      { description: 'middle', age: 45 },
+      { description: 'oldest', age: 85 },
+      { description: 'youngest', age: 5 },
+    ]);
+  });
+
+  it('should sort a list of objects desc', () => {
+    const myList = [
+      { description: 'youngest', age: 5 },
+      { description: 'middle', age: 45 },
+      { description: 'oldest', age: 85 },
+    ];
+    expect(util.list.sortList(myList, true, 'description')).toEqual([
+      { description: 'youngest', age: 5 },
+      { description: 'oldest', age: 85 },
+      { description: 'middle', age: 45 },
+    ]);
+  });
+
+  it('should sort a list of strings asc', () => {
+    const myList = ['youngest', 'middle', 'oldest'];
+    expect(util.list.sortList(myList, false, 'any')).toEqual(['middle', 'oldest', 'youngest']);
+  });
+
+  it('should sort a list of strings desc', () => {
+    const myList = ['youngest', 'middle', 'oldest'];
+    expect(util.list.sortList(myList, true, 'any')).toEqual(['youngest', 'oldest', 'middle']);
+  });
+
+  it('should sort a list of integers asc', () => {
+    const myList = [10, 1, 5];
+    expect(util.list.sortList(myList, false, 'any')).toEqual([1, 5, 10]);
+  });
+
+  it('should sort a list of integers desc', () => {
+    const myList = [10, 1, 5];
+    expect(util.list.sortList(myList, true, 'any')).toEqual([10, 5, 1]);
+  });
+
+  it('should not sort mixed content', () => {
+    const myList = [{ name: 'foo' }, 1, 'bar'];
+    expect(util.list.sortList(myList, true, 'any')).toEqual(myList);
+  });
+
+  it('should not sort list > 1000 elements', () => {
+    const myList = map(Array(1100), () => random(0, 100));
+    expect(util.list.sortList(myList, true, 'any')).toEqual(myList);
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/math.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/math.test.ts
@@ -17,14 +17,26 @@ describe('$utils.math.round', () => {
   });
 });
 
-describe('$utils.str.minVal', () => {
+describe('$utils.math.minVal', () => {
   it('should get the min value', () => {
     expect(util.math.minVal(13.45, 45.67)).toEqual(13.45);
   });
 });
 
-describe('$utils.str.maxVal', () => {
+describe('$utils.math.maxVal', () => {
   it('get the max value', () => {
     expect(util.math.maxVal(13.45, 45.67)).toEqual(45.67);
+  });
+});
+
+describe('$utils.math.random', () => {
+  it('get a random value', () => {
+    expect(typeof util.math.randomDouble()).toBe('number');
+  });
+});
+
+describe('$utils.math.randomWithinRange', () => {
+  it('get a randomWithinRange value', () => {
+    expect(typeof util.math.randomWithinRange(10, 20)).toBe('number');
   });
 });

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/math.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/math.test.ts
@@ -1,0 +1,30 @@
+import { create } from '../../../velocity/util/index';
+import { GraphQLResolveInfo } from 'graphql';
+
+const stubInfo = {} as unknown;
+export const mockInfo = stubInfo as GraphQLResolveInfo;
+var util;
+
+beforeEach(() => {
+  util = create(undefined, undefined, mockInfo);
+});
+
+describe('$utils.math.round', () => {
+  it('should round a double', () => {
+    expect(util.math.roundNum(10.2)).toEqual(10);
+    expect(util.math.roundNum(10.8)).toEqual(11);
+    expect(util.math.roundNum(10)).toEqual(10);
+  });
+});
+
+describe('$utils.str.minVal', () => {
+  it('should get the min value', () => {
+    expect(util.math.minVal(13.45, 45.67)).toEqual(13.45);
+  });
+});
+
+describe('$utils.str.maxVal', () => {
+  it('get the max value', () => {
+    expect(util.math.maxVal(13.45, 45.67)).toEqual(45.67);
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/str.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/str.test.ts
@@ -1,0 +1,41 @@
+import { create } from '../../../velocity/util/index';
+import { GraphQLResolveInfo } from 'graphql';
+
+const stubInfo = {} as unknown;
+export const mockInfo = stubInfo as GraphQLResolveInfo;
+var util;
+
+beforeEach(() => {
+  util = create(undefined, undefined, mockInfo);
+});
+
+describe('$utils.str.toLower', () => {
+  it('should chnage a string to lowercase', () => {
+    expect(util.str.toLower('HELLO WORLD')).toEqual('hello world');
+    expect(util.str.toLower('hello world')).toEqual('hello world');
+    expect(util.str.toLower('HeLlo WorlD')).toEqual('hello world');
+  });
+});
+
+describe('$utils.str.toUpper', () => {
+  it('should chnage a string to uppercase', () => {
+    expect(util.str.toUpper('HELLO WORLD')).toEqual('HELLO WORLD');
+    expect(util.str.toUpper('hello world')).toEqual('HELLO WORLD');
+    expect(util.str.toUpper('HeLlo WorlD')).toEqual('HELLO WORLD');
+  });
+});
+
+describe('$utils.str.toReplace', () => {
+  it('should replace a string', () => {
+    expect(util.str.toReplace('hello world, hello!', 'hello', 'mellow')).toEqual('mellow world, mellow!');
+  });
+});
+
+describe('$utils.str.normalize', () => {
+  it('should normalize a string', () => {
+    expect(util.str.normalize('\u0041\u006d\u0065\u0301\u006c\u0069\u0065', 'nfc')).toEqual('Amélie');
+    expect(util.str.normalize('\u0041\u006d\u0065\u0301\u006c\u0069\u0065', 'nfc')).toEqual('Amélie');
+    expect(util.str.normalize('\u00F1', 'nfd')).toEqual('ñ');
+    expect(util.str.normalize('\u006E\u0303', 'nfd')).toEqual('ñ');
+  });
+});

--- a/packages/amplify-appsync-simulator/src/velocity/util/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/index.ts
@@ -5,6 +5,8 @@ import { listUtils } from './list-utils';
 import { mapUtils } from './map-utils';
 import { transformUtils } from './transform';
 import { time } from './time';
+import { str } from './str';
+import { math } from './math';
 import { GraphQLResolveInfo } from 'graphql';
 
 export function create(errors = [], now: Date = new Date(), info: GraphQLResolveInfo) {
@@ -18,5 +20,7 @@ export function create(errors = [], now: Date = new Date(), info: GraphQLResolve
     errors,
     info,
     time: time(),
+    str,
+    math,
   };
 }

--- a/packages/amplify-appsync-simulator/src/velocity/util/list-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/list-utils.ts
@@ -1,8 +1,26 @@
+import { identity, isObject, negate, orderBy, some } from 'lodash';
+
 export const listUtils = {
   copyAndRetainAll(list: any[], intersect: any[]) {
     return list.filter(value => intersect.indexOf(value) !== -1);
   },
   copyAndRemoveAll(list: any[], toRemove: any[]) {
     return list.filter(value => toRemove.indexOf(value) === -1);
+  },
+  sortList(list: any[], desc: boolean, property: string) {
+    if (list.length === 0 || list.length > 1000) {
+      return list;
+    }
+
+    const type = typeof list[0];
+    const isMixedTypes = some(list.slice(1), i => typeof i !== type);
+
+    if (isMixedTypes) {
+      return list;
+    }
+
+    const isScalarList = some(list, negate(isObject));
+
+    return orderBy(list, isScalarList ? identity : property, desc ? 'desc' : 'asc');
   },
 };

--- a/packages/amplify-appsync-simulator/src/velocity/util/math.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/math.ts
@@ -1,0 +1,9 @@
+import { random } from 'lodash';
+
+export const math = {
+  roundNum: Math.round,
+  minVal: Math.min,
+  maxVal: Math.max,
+  randomDouble: Math.random,
+  randomWithinRange: random,
+};

--- a/packages/amplify-appsync-simulator/src/velocity/util/str.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/str.ts
@@ -1,0 +1,14 @@
+export const str = {
+  toUpper(str: string) {
+    return str.toUpperCase();
+  },
+  toLower(str: string) {
+    return str.toLowerCase();
+  },
+  toReplace(str: string, substr: string, newSubstr: string) {
+    return str.replace(new RegExp(substr, 'g'), newSubstr);
+  },
+  normalize(str: string, form: string) {
+    return str.normalize(form.toUpperCase());
+  },
+};


### PR DESCRIPTION
Implements new utils as described in doc:
https://docs.aws.amazon.com/appsync/latest/devguide/resolver-util-reference.html#list-helpers-in-util-list
and
https://docs.aws.amazon.com/appsync/latest/devguide/resolver-util-reference.html#str-helpers-in-util-str

`$utils.list.sortList()`
`$utils.str.toUpper()`
`$utils.str.toLower()`
`$utils.str.toReplace()`
`$utils.str.normalize()`
`$util.math.roundNum()`
`$util.math.roundNum()`
`$util.math.maxVal()`
`$util.math.minVal()`
`$util.math.randomWithinRange()`
`$util.math.randomDouble()`

Note concerning `$utils.list.sortList()`:
I have honoured what the documentation states in the simulator:
> Only lists containing a maximum of 1000 objects are supported.

However, during my tests in a real AppSync API, it worked fine with > 1000 elements. (tested with > 3k). I will leave the limit, just in case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.