### PR TITLE
fix: removes nodeModules from curBackend

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -79,6 +79,7 @@
     "figlet": "^1.2.4",
     "folder-hash": "^3.3.0",
     "fs-extra": "^8.1.0",
+    "glob": "^7.1.6",
     "global-prefix": "^3.0.0",
     "graphql-transformer-core": "6.25.1",
     "gunzip-maybe": "^1.4.2",
@@ -96,8 +97,7 @@
     "tar-fs": "^2.1.1",
     "update-notifier": "^4.1.0",
     "which": "^2.0.2",
-    "winston": "^3.3.3",
-    "glob": "^7.1.6"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/ci-info": "^2.0.0",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -96,7 +96,8 @@
     "tar-fs": "^2.1.1",
     "update-notifier": "^4.1.0",
     "which": "^2.0.2",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "glob": "^7.1.6"
   },
   "devDependencies": {
     "@types/ci-info": "^2.0.0",

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { hashElement } from 'folder-hash';
+import glob from 'glob';
 import { updateBackendConfigAfterResourceAdd, updateBackendConfigAfterResourceUpdate } from './update-backend-config';
 import { JSONUtilities, $TSMeta, pathManager, stateManager } from 'amplify-cli-core';
 
@@ -56,6 +57,7 @@ function moveBackendResourcesToCurrentCloudBackend(resources) {
     // in the case that the resource is being deleted, the sourceDir won't exist
     if (fs.pathExistsSync(sourceDir)) {
       fs.copySync(sourceDir, targetDir);
+      removeNodeModulesDir(targetDir);
     }
   }
 
@@ -65,6 +67,18 @@ function moveBackendResourcesToCurrentCloudBackend(resources) {
   // if project hasn't been initialized after tags has been released
   if (fs.existsSync(tagFilePath)) {
     fs.copySync(tagFilePath, tagCloudFilePath, { overwrite: true });
+  }
+}
+
+function removeNodeModulesDir(currentCloudBackendDir) {
+  const nodeModulesDirs = glob.sync('**/node_modules', {
+    cwd: currentCloudBackendDir,
+    absolute: true,
+  });
+  for (const nodeModulesPath of nodeModulesDirs) {
+    if (fs.existsSync(nodeModulesPath)) {
+      fs.removeSync(nodeModulesPath);
+    }
   }
 }
 

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -475,7 +475,7 @@ const getRuntimeDisplayName = (runtime: FunctionRuntimes) => {
   }
 };
 
-export function validateRemovalNodeModulesDir(projRoot) {
+export function validateNodeModulesDirRemoval(projRoot) {
   let functionDir = path.join(projRoot, 'amplify', '#current-cloud-backend', 'function');
   const nodeModulesDirs = glob.sync('**/node_modules', {
     cwd: functionDir,

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -1,6 +1,8 @@
 import { nspawn as spawn, ExecutionContext, KEY_DOWN_ARROW, getCLIPath, getProjectMeta, invokeFunction } from '..';
 import { Lambda } from 'aws-sdk';
 import { singleSelect, multiSelect, moveUp, moveDown } from '../utils/selectors';
+import * as glob from 'glob';
+import * as path from 'path';
 
 type FunctionActions = 'create' | 'update';
 
@@ -472,3 +474,12 @@ const getRuntimeDisplayName = (runtime: FunctionRuntimes) => {
       throw new Error(`Invalid runtime value: ${runtime}`);
   }
 };
+
+export function validateRemovalNodeModulesDir(projRoot) {
+  let functionDir = path.join(projRoot, 'amplify', '#current-cloud-backend', 'function');
+  const nodeModulesDirs = glob.sync('**/node_modules', {
+    cwd: functionDir,
+    absolute: true,
+  });
+  expect(nodeModulesDirs.length).toBe(0);
+}

--- a/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
@@ -1,4 +1,4 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush, validateRemovalNodeModulesDir } from 'amplify-e2e-core';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush, validateNodeModulesDirRemoval } from 'amplify-e2e-core';
 import { addAuthWithDefaultSocial, addAuthWithGroupTrigger, addAuthWithRecaptchaTrigger, addAuthViaAPIWithTrigger } from 'amplify-e2e-core';
 import {
   createNewProjectDir,
@@ -40,7 +40,7 @@ describe('amplify add auth...', () => {
 
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
-    validateRemovalNodeModulesDir(projRoot);
+    validateNodeModulesDirRemoval(projRoot);
     expect(clients[0].UserPoolClient.CallbackURLs[0]).toEqual('https://www.google.com/');
     expect(clients[0].UserPoolClient.LogoutURLs[0]).toEqual('https://www.nytimes.com/');
     expect(clients[0].UserPoolClient.SupportedIdentityProviders).toHaveLength(4);
@@ -61,7 +61,7 @@ describe('amplify add auth...', () => {
     const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
 
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
-    validateRemovalNodeModulesDir(projRoot);
+    validateNodeModulesDirRemoval(projRoot);
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
     expect(lambdaFunction).toBeDefined();
@@ -83,7 +83,7 @@ describe('amplify add auth...', () => {
 
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
-    validateRemovalNodeModulesDir(projRoot);
+    validateNodeModulesDirRemoval(projRoot);
     expect(clients).toHaveLength(2);
     expect(lambdaFunction).toBeDefined();
     expect(lambdaFunction.Configuration.Environment.Variables.GROUP).toEqual('mygroup');
@@ -110,7 +110,7 @@ describe('amplify add auth...', () => {
     const verifyFunction = await getLambdaFunction(verifyFunctionName, meta.providers.awscloudformation.Region);
 
     expect(userPool.UserPool).toBeDefined();
-    validateRemovalNodeModulesDir(projRoot);
+    validateNodeModulesDirRemoval(projRoot);
     expect(clients).toHaveLength(2);
     expect(createFunction).toBeDefined();
     expect(defineFunction).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
@@ -1,4 +1,4 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush } from 'amplify-e2e-core';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush, validateRemovalNodeModulesDir } from 'amplify-e2e-core';
 import { addAuthWithDefaultSocial, addAuthWithGroupTrigger, addAuthWithRecaptchaTrigger, addAuthViaAPIWithTrigger } from 'amplify-e2e-core';
 import {
   createNewProjectDir,
@@ -40,6 +40,7 @@ describe('amplify add auth...', () => {
 
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
+    validateRemovalNodeModulesDir(projRoot);
     expect(clients[0].UserPoolClient.CallbackURLs[0]).toEqual('https://www.google.com/');
     expect(clients[0].UserPoolClient.LogoutURLs[0]).toEqual('https://www.nytimes.com/');
     expect(clients[0].UserPoolClient.SupportedIdentityProviders).toHaveLength(4);
@@ -60,6 +61,7 @@ describe('amplify add auth...', () => {
     const clients = await getUserPoolClients(id, clientIds, meta.providers.awscloudformation.Region);
 
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
+    validateRemovalNodeModulesDir(projRoot);
     expect(userPool.UserPool).toBeDefined();
     expect(clients).toHaveLength(2);
     expect(lambdaFunction).toBeDefined();
@@ -81,6 +83,7 @@ describe('amplify add auth...', () => {
 
     const lambdaFunction = await getLambdaFunction(functionName, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
+    validateRemovalNodeModulesDir(projRoot);
     expect(clients).toHaveLength(2);
     expect(lambdaFunction).toBeDefined();
     expect(lambdaFunction.Configuration.Environment.Variables.GROUP).toEqual('mygroup');
@@ -107,6 +110,7 @@ describe('amplify add auth...', () => {
     const verifyFunction = await getLambdaFunction(verifyFunctionName, meta.providers.awscloudformation.Region);
 
     expect(userPool.UserPool).toBeDefined();
+    validateRemovalNodeModulesDir(projRoot);
     expect(clients).toHaveLength(2);
     expect(createFunction).toBeDefined();
     expect(defineFunction).toBeDefined();


### PR DESCRIPTION
*Description of changes:*

Removing NodeModules folder from the #currentcloudbackend

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.