### PR TITLE
fix(amplify-provider-awscloudformation): pass assumeRoleRequest

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.js
@@ -136,7 +136,7 @@ async function getRoleCredentials(context, profileName, profileConfig) {
     const log = logger('getRoleCredentials.sts.assumeRole', [assumeRoleRequest]);
     try {
       log();
-      const roleData = await sts.assumeRole().promise();
+      const roleData = await sts.assumeRole(assumeRoleRequest).promise();
       roleCredentials = {
         accessKeyId: roleData.Credentials.AccessKeyId,
         secretAccessKey: roleData.Credentials.SecretAccessKey,


### PR DESCRIPTION
The constructed request parameter for `assumeRole` wasn't used. Thus, AWS profile using `role_arn`
never succeeded. This commit fixes it and now the parameter is passed to `assumeRole`.

Fixes #6233 , Fixes #6220

### Testing
I have confirmed by `amplify-dev`:

```shell
$ amplify-dev pull --appId aaaaaaaa

For more information on AWS Profiles, see:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

? Do you want to use an AWS profile? Yes
? Please choose the profile you want to use dev
Amplify AppID found: aaaaaaaa. Amplify App name is: SampleApp
```

Without this change:

```shell
$ amplify --version
4.40.1

$ amplify pull --appId aaaaaaaa

For more information on AWS Profiles, see:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

? Do you want to use an AWS profile? Yes
? Please choose the profile you want to use dev
Failed to pull the backend.
App aaaaaaaa not found. Check that the region of the Amplify App is matching the configured region.
```

Logs:

```
2020-12-26T12:01:39.950Z|info : amplify-provider-awscloudformation.system-config-manager.getRoleCredentials.sts.assumeRole([{"RoleArn":"[***]4469718:role/[***]ntAccessRole","RoleSessionName":"[***]ify"}])
2020-12-26T12:01:39.954Z|error : amplify-provider-awscloudformation.system-config-manager.getRoleCredentials.sts.assumeRole([{"RoleArn":"[***]4469718:role/[***]ntAccessRole","RoleSessionName":"[***]ify"}])
MultipleValidationErrors: There were 2 validation errors:
* MissingRequiredParameter: Missing required key 'RoleArn' in params
* MissingRequiredParameter: Missing required key 'RoleSessionName' in params
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.