### PR TITLE
feat: use default values in DynamoDB VTLs

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -95,7 +95,11 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test "create", "update", "delete" auth operations 4`] = `
-"## [Start] Determine request authentication mode **
+"## [Start] Set default values. **
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+## [End] Set default values. **
+## [Start] Determine request authentication mode **
 #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
   #set( $authMode = \\"userPools\\" )
 #end
@@ -220,8 +224,6 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -740,7 +742,11 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test that operation overwrites queries in auth operations 4`] = `
-"## [Start] Determine request authentication mode **
+"## [Start] Set default values. **
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+## [End] Set default values. **
+## [Start] Determine request authentication mode **
 #if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
   #set( $authMode = \\"userPools\\" )
 #end
@@ -865,8 +871,6 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -371,6 +371,13 @@ export class DynamoDBModelTransformer extends Transformer {
         timestamps: timestampFields,
       });
       const resourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName);
+      this.addInitalizationMetadata(ctx, resourceId, () => {
+        const inputObj = ctx.getType(updateInput.name.value) as InputObjectTypeDefinitionNode;
+        if (inputObj) {
+          return this.resources.initalizeDefaultInputForUpdateMutation(inputObj, timestampFields);
+        }
+      });
+
       ctx.setResource(resourceId, updateResolver);
       ctx.mapResourceToStack(typeName, resourceId);
       const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(updateInput.name.value)))];

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -352,7 +352,11 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"## [Start] Set default values. **
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+## [End] Set default values. **
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -388,8 +392,6 @@ exports[`Test create and update mutation input should have timestamps as nullabl
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -632,7 +634,10 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"## [Start] Set default values. **
+
+## [End] Set default values. **
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -932,7 +937,10 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"## [Start] Set default values. **
+
+## [End] Set default values. **
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -1336,7 +1344,11 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test timestamp parameters when generating resolvers and output schema 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"## [Start] Set default values. **
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $util.time.nowISO8601())))
+## [End] Set default values. **
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -1372,8 +1384,6 @@ exports[`Test timestamp parameters when generating resolvers and output schema 3
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -140,7 +140,11 @@ $util.error($ctx.error.message, $ctx.error.type)
 #else
 $util.toJson($ctx.result)
 #end",
-  "Mutation.updateItem.req.vtl": "
+  "Mutation.updateItem.req.vtl": "## [Start] Set default values. **
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+## [End] Set default values. **
+
 
 
 
@@ -194,8 +198,6 @@ $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )
@@ -748,7 +750,11 @@ $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
 $util.toJson($ctx.result)
 #end",
-  "Mutation.updateItem.req.vtl": "
+  "Mutation.updateItem.req.vtl": "## [Start] Set default values. **
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+## [End] Set default values. **
+
 
 
 
@@ -802,8 +808,6 @@ $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}
 } )
   #end
 #end
-## Automatically set the updatedAt timestamp. **
-$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
 ## Update condition if type is @versioned **
 #if( $versionedCondition )


### PR DESCRIPTION
See https://github.com/aws/aws-appsync-community/issues/59 for a related discussion.

*Description of changes:*

Translate default values defined in `input` models into default values when generating DynamoDB VTLs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.