### PR TITLE
fix: change to new docs url in some messages

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -38,7 +38,7 @@ function warnOnAuth(context, map) {
   if (unAuthModelTypes.length) {
     context.print.warning("\nThe following types do not have '@auth' enabled. Consider using @auth with @model");
     context.print.warning(unAuthModelTypes.map(type => `\t - ${type}`).join('\n'));
-    context.print.info('Learn more about @auth here: https://docs.amplify.aws/cli/graphql-transformer/directives#auth\n');
+    context.print.info('Learn more about @auth here: https://docs.amplify.aws/cli/graphql-transformer/auth\n');
   }
 }
 

--- a/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
@@ -51,7 +51,7 @@ function warnOnAuth(context, map) {
   if (unAuthModelTypes.length) {
     context.print.warning("\nThe following types do not have '@auth' enabled. Consider using @auth with @model");
     context.print.warning(unAuthModelTypes.map(type => `\t - ${type}`).join('\n'));
-    context.print.info('Learn more about @auth here: https://docs.amplify.aws/cli/graphql-transformer/directives#auth\n');
+    context.print.info('Learn more about @auth here: https://docs.amplify.aws/cli/graphql-transformer/auth\n');
   }
 }
 
@@ -160,9 +160,9 @@ function getTransformerFactory(context, resourceDir, authConfig?) {
  */
 async function transformerVersionCheck(context, resourceDir, cloudBackendDirectory, updatedResources, usedDirectives) {
   const versionChangeMessage =
-    'The default behavior for @auth has changed in the latest version of Amplify\nRead here for details: https://docs.amplify.aws/cli/graphql-transformer/directives#authorizing-subscriptions';
+    'The default behavior for @auth has changed in the latest version of Amplify\nRead here for details: https://docs.amplify.aws/cli/graphql-transformer/auth#authorizing-subscriptions';
   const warningESMessage =
-    'The behavior for @searchable has changed after version 4.14.1.\nRead here for details: https://docs.amplify.aws/cli/graphql-transformer/directives#searchable';
+    'The behavior for @searchable has changed after version 4.14.1.\nRead here for details: https://docs.amplify.aws/cli/graphql-transformer/searchable';
   const checkVersionExist = config => config && config.Version;
   const checkESWarningExists = config => config && config.ElasticsearchWarning;
   let writeToConfig = false;

--- a/packages/amplify-util-mock/src/api/lambda-arn-to-config.ts
+++ b/packages/amplify-util-mock/src/api/lambda-arn-to-config.ts
@@ -6,7 +6,7 @@ import { keys } from 'lodash';
  */
 export const lambdaArnToConfig = (arn: any, provisionedLambdas: LambdaFunctionConfig[]): LambdaFunctionConfig => {
   const errorSuffix =
-    '\nSee https://docs.amplify.aws/cli/graphql-transformer/directives#function for information on how to configure Lambda resolvers.';
+    '\nSee https://docs.amplify.aws/cli/graphql-transformer/function for information on how to configure Lambda resolvers.';
   let searchString = '';
   if (typeof arn === 'string') {
     searchString = arn;


### PR DESCRIPTION
*Issue #, if available:*
#6280 

*Description of changes:*
Some messages output "old-docs-url" like
"https://docs.amplify.aws/cli/graphql-transformer/directives#auth".
So, modify it to "new-docs-url" like
"https://docs.amplify.aws/cli/graphql-transformer/auth".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.