### PR TITLE
fix: set default sourceDir for react-native projects to 'src'

### DIFF
--- a/packages/amplify-app/src/framework-config-mapping.js
+++ b/packages/amplify-app/src/framework-config-mapping.js
@@ -8,7 +8,7 @@ const reactConfig = {
 };
 
 const reactNativeConfig = {
-  SourceDir: '/',
+  SourceDir: 'src',
   DistributionDir: '/',
   BuildCommand: `${npm} run-script build`,
   StartCommand: `${npm} run-script start`,

--- a/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
+++ b/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
@@ -12,7 +12,7 @@ const reactConfig = {
 };
 
 const reactNativeConfig = {
-  SourceDir: '/',
+  SourceDir: 'src',
   DistributionDir: '/',
   BuildCommand: `${npm} run-script build`,
   StartCommand: `${npm} run-script start`,


### PR DESCRIPTION
*Issue #, if available:*
#6269

*Description of changes:*
change default SourceDir from `/` to `src` for react-native projects. This is consistent with other project structures and removes a disparity between where types were generated and where the CLI tries to locate them by default.

Tested in projects initialized using expo and react-native CLI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.