### PR TITLE
feat: app client secret omission

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -49,6 +49,7 @@ Parameters:
 
 Conditions:
   ShouldNotCreateEnvResources: !Equals [ !Ref env, NONE ]
+  ShouldOutputAppClientSecrets: !Equals [!Ref userpoolClientGenerateSecret, true ]
 
 Resources:
   <%if (props.verificationBucketName) { %>
@@ -1161,6 +1162,7 @@ Outputs :
     Description: The user pool app client id
   AppClientSecret:
     Value: !GetAtt UserPoolClientInputs.appSecret
+    Condition: ShouldOutputAppClientSecrets
   <%if (props.mfaConfiguration != 'OFF') { %>
   CreatedSNSRole:
     Value: !GetAtt SNSRole.Arn

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -36,7 +36,7 @@ const userPoolDefaults = projectName => {
     passwordPolicyMinLength: 8,
     passwordPolicyCharacters: [],
     requiredAttributes: ['email'],
-    userpoolClientGenerateSecret: true,
+    userpoolClientGenerateSecret: false,
     userpoolClientRefreshTokenValidity: 30,
     userpoolClientWriteAttributes: ['email'],
     userpoolClientReadAttributes: ['email'],

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -49,6 +49,10 @@ function getCloudBackendConfig(projectRoot: string) {
   return JSON.parse(fs.readFileSync(currentCloudPath, 'utf8'));
 }
 
+function getParameterPath(projRoot: string, category: string, resourceName: string) {
+  return path.join(projRoot, 'amplify', 'backend', category, resourceName, 'parameters.json');
+}
+
 function getTeamProviderInfo(projectRoot: string) {
   const teamProviderFilePath: string = path.join(projectRoot, 'amplify', 'team-provider-info.json');
   return JSON.parse(fs.readFileSync(teamProviderFilePath, 'utf8'));
@@ -99,6 +103,16 @@ function isDeploymentSecretForEnvExists(projRoot: string, envName: string): bool
   return false;
 }
 
+function getParameters(projRoot: string, category: string, resourceName: string): any {
+  const parametersPath = getParameterPath(projRoot, category, resourceName);
+  return JSONUtilities.parse(fs.readFileSync(parametersPath, 'utf8'));
+}
+
+function setParameters(projRoot: string, category: string, resourceName: string, parameters: any) {
+  const parametersPath = getParameterPath(projRoot, category, resourceName);
+  JSONUtilities.writeJson(parametersPath, parameters);
+}
+
 export {
   getProjectMeta,
   getProjectTags,
@@ -116,5 +130,7 @@ export {
   getAmplifyDirPath,
   getBackendConfig,
   getTeamProviderInfo,
+  getParameters,
   getCloudBackendConfig,
+  setParameters,
 };

--- a/packages/amplify-e2e-tests/src/__tests__/auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_1.test.ts
@@ -5,19 +5,16 @@ import {
   initFlutterProjectWithProfile,
   deleteProject,
   amplifyPushAuth,
-  amplifyPush,
+  getAwsIOSConfig,
+  getUserPoolClients,
+  getParameters,
+  setParameters,
+  initIosProjectWithProfile,
+  getAwsAndroidConfig,
+  initAndroidProjectWithProfile,
 } from 'amplify-e2e-core';
-import {
-  addAuthWithDefault,
-  runAmplifyAuthConsole,
-  removeAuthWithDefault,
-} from 'amplify-e2e-core';
-import {
-  createNewProjectDir,
-  deleteProjectDir,
-  getProjectMeta,
-  getUserPool
-} from 'amplify-e2e-core';
+import { addAuthWithDefault, runAmplifyAuthConsole, removeAuthWithDefault } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool } from 'amplify-e2e-core';
 
 const defaultsSettings = {
   name: 'authTest',
@@ -43,6 +40,65 @@ describe('amplify add auth...', () => {
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
+  });
+  it('...should init an IOS project and add default auth', async () => {
+    await initIosProjectWithProfile(projRoot, defaultsSettings);
+    await addAuthWithDefault(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    let config = await getAwsIOSConfig(projRoot);
+    expect(config.CognitoUserPool.Default.AppClientSecret).toBeUndefined();
+    let meta = getProjectMeta(projRoot);
+    let id = Object.keys(meta.auth)[0];
+    let authMeta = meta.auth[id];
+    let clientIds = [authMeta.output.AppClientID];
+    let clients = await getUserPoolClients(authMeta.output.UserPoolId, clientIds, meta.providers.awscloudformation.Region);
+    expect(clients[0].UserPoolClient.ClientSecret).toBeUndefined();
+
+    //update parameter to generate client Secret
+    const parameters = getParameters(projRoot, 'auth', id);
+    parameters.userpoolClientGenerateSecret = true;
+    setParameters(projRoot, 'auth', id, parameters);
+
+    await amplifyPushAuth(projRoot);
+
+    config = await getAwsIOSConfig(projRoot);
+    expect(config.CognitoUserPool.Default.AppClientSecret).toBeDefined();
+    meta = getProjectMeta(projRoot);
+    id = Object.keys(meta.auth)[0];
+    authMeta = meta.auth[id];
+    clientIds = [authMeta.output.AppClientID];
+    clients = await getUserPoolClients(authMeta.output.UserPoolId, clientIds, meta.providers.awscloudformation.Region);
+    expect(clients[0].UserPoolClient.ClientSecret).toBeDefined();
+  });
+
+  it('...should init an Android project and add default auth', async () => {
+    await initAndroidProjectWithProfile(projRoot, defaultsSettings);
+    await addAuthWithDefault(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    let config = await getAwsAndroidConfig(projRoot);
+    expect(config.CognitoUserPool.Default.AppClientSecret).toBeUndefined();
+    let meta = getProjectMeta(projRoot);
+    let id = Object.keys(meta.auth)[0];
+    let authMeta = meta.auth[id];
+    let clientIds = [authMeta.output.AppClientID];
+    let clients = await getUserPoolClients(authMeta.output.UserPoolId, clientIds, meta.providers.awscloudformation.Region);
+
+    expect(clients[0].UserPoolClient.ClientSecret).toBeUndefined();
+    const parameters = getParameters(projRoot, 'auth', id);
+    parameters.userpoolClientGenerateSecret = true;
+    setParameters(projRoot, 'auth', id, parameters);
+
+    await amplifyPushAuth(projRoot);
+
+    config = await getAwsAndroidConfig(projRoot);
+    expect(config.CognitoUserPool.Default.AppClientSecret).toBeDefined();
+    meta = getProjectMeta(projRoot);
+    id = Object.keys(meta.auth)[0];
+    authMeta = meta.auth[id];
+    clientIds = [authMeta.output.AppClientID];
+    clients = await getUserPoolClients(authMeta.output.UserPoolId, clientIds, meta.providers.awscloudformation.Region);
+
+    expect(clients[0].UserPoolClient.ClientSecret).toBeDefined();
   });
 
   it('should init with a long env name and add default auth', async () => {

--- a/packages/amplify-e2e-tests/src/import-helpers/expects.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/expects.ts
@@ -7,7 +7,6 @@ export const expectAuthProjectDetailsMatch = (projectDetails: AuthProjectDetails
 
   expect(projectDetails.meta.UserPoolId).toEqual(ogProjectDetails.meta.UserPoolId);
   expect(projectDetails.meta.AppClientID).toEqual(ogProjectDetails.meta.AppClientID);
-  expect(projectDetails.meta.AppClientSecret).toEqual(ogProjectDetails.meta.AppClientSecret);
   expect(projectDetails.meta.AppClientIDWeb).toEqual(ogProjectDetails.meta.AppClientIDWeb);
   expect(projectDetails.meta.HostedUIDomain).toEqual(ogProjectDetails.meta.HostedUIDomain);
 
@@ -48,7 +47,6 @@ export const expectAuthLocalAndOGMetaFilesOutputMatching = (projectRoot: string,
 
   expect(authMeta.output.AppClientID).toEqual(ogAuthMeta.output.AppClientID);
   expect(authMeta.output.AppClientIDWeb).toEqual(ogAuthMeta.output.AppClientIDWeb);
-  expect(authMeta.output.AppClientSecret).toEqual(ogAuthMeta.output.AppClientSecret);
   expect(authMeta.output.HostedUIDomain).toEqual(ogAuthMeta.output.HostedUIDomain);
   expect(authMeta.output.UserPoolId).toEqual(ogAuthMeta.output.UserPoolId);
 };

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -1,6 +1,7 @@
 const constants = require('./constants');
 const path = require('path');
 const fs = require('fs-extra');
+const _ = require('lodash');
 const graphQLConfig = require('graphql-config');
 const amplifyConfigHelper = require('./amplify-config-helper');
 
@@ -193,14 +194,17 @@ function getCognitoConfig(cognitoResources, projectRegion) {
   }
 
   if (cognitoResource.output.UserPoolId) {
+    const defaultPool = {
+      PoolId: cognitoResource.output.UserPoolId,
+      AppClientId: cognitoResource.output.AppClientID,
+      Region: projectRegion,
+    };
+    if (cognitoResource.output.AppClientSecret) {
+      _.set(defaultPool, 'AppClientSecret', cognitoResource.output.AppClientSecret);
+    }
     Object.assign(cognitoConfig, {
       CognitoUserPool: {
-        Default: {
-          PoolId: cognitoResource.output.UserPoolId,
-          AppClientId: cognitoResource.output.AppClientID,
-          AppClientSecret: cognitoResource.output.AppClientSecret,
-          Region: projectRegion,
-        },
+        Default: defaultPool,
       },
     });
   }

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -1,4 +1,5 @@
 const constants = require('./constants');
+const _ = require('lodash');
 const path = require('path');
 const fs = require('fs-extra');
 const graphQLConfig = require('graphql-config');
@@ -170,14 +171,17 @@ function getCognitoConfig(cognitoResources, projectRegion) {
   }
 
   if (cognitoResource.output.UserPoolId) {
+    const defaultPool = {
+      PoolId: cognitoResource.output.UserPoolId,
+      AppClientId: cognitoResource.output.AppClientID,
+      Region: projectRegion,
+    };
+    if (cognitoResource.output.AppClientSecret) {
+      _.set(defaultPool, 'AppClientSecret', cognitoResource.output.AppClientSecret);
+    }
     Object.assign(cognitoConfig, {
       CognitoUserPool: {
-        Default: {
-          PoolId: cognitoResource.output.UserPoolId,
-          AppClientId: cognitoResource.output.AppClientID,
-          AppClientSecret: cognitoResource.output.AppClientSecret,
-          Region: projectRegion,
-        },
+        Default: defaultPool,
       },
     });
   }


### PR DESCRIPTION

*Description of changes:*
Rework off reverted previous change https://github.com/aws-amplify/amplify-cli/pull/5992. This change sets the cognito default to generate the AppClientSecret to false and writes the secret to the native config files when the secret is configured in the app client.

The previous change did not take into consideration of an existing appClient with a configure client. In the new change the configuration files will possess the secret only if it's configured

*New Projects*
There will be two app clients same as before but the native app client will not be configured to generate a secret and the configuration file for IOS/Android will contain the secret either.

*Existing Projects with Auth Enabled*
The change will not affect any existing configuration of their app clients in Cognito. 

*Steps to test*

`yarn setup-dev`
`cd <project-folder>`

```
amplify-dev init
? Enter a name for the project testProject
? Enter a name for the environment dev
? Choose your default editor: Visual Studio Code
? Choose the type of app that you're building ios
Using default provider  awscloudformation

For more information on AWS Profiles, see:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

? Do you want to use an AWS profile? Yes
? Please choose the profile you want to use default
```
### add auth
```
amplify-dev add auth
Using service: Cognito, provided by: awscloudformation
 
 The current configured provider is Amazon Cognito. 
 
 Do you want to use the default authentication and security configuration? Default configuration
 Warning: you will not be able to edit these selections. 
 How do you want users to be able to sign in? Username
 Do you want to configure advanced settings? No, I am done.
```

### push

```
amplify-dev push  
✔ Successfully pulled backend environment dev from the cloud.

Current Environment: dev

| Category | Resource name | Operation | Provider plugin   |
| -------- | ------------- | --------- | ----------------- |
| Auth     | tagsf536171d  | Create    | awscloudformation |
? Are you sure you want to continue? (Y/n) y
```

Auth is ready to use in your project

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.