### PR TITLE
fix(graphql-dynamodb-transformer): make primary key non null on del

### DIFF
--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -98,7 +98,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
@@ -164,7 +164,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
   _version: Int
 }
 
@@ -229,7 +229,7 @@ input UpdatePostEditorInput {
 }
 
 input DeletePostEditorInput {
-  id: ID
+  id: ID!
   _version: Int
 }
 
@@ -268,7 +268,7 @@ input UpdateUserInput {
 }
 
 input DeleteUserInput {
-  id: ID
+  id: ID!
   _version: Int
 }
 
@@ -440,7 +440,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -487,7 +487,7 @@ input UpdatePostEditorInput {
 }
 
 input DeletePostEditorInput {
-  id: ID
+  id: ID!
 }
 
 input ModelPostEditorConditionInput {
@@ -522,7 +522,7 @@ input UpdateUserInput {
 }
 
 input DeleteUserInput {
-  id: ID
+  id: ID!
 }
 
 input ModelUserConditionInput {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -128,7 +128,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -292,7 +292,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -577,7 +577,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -877,7 +877,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -1276,7 +1276,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -1563,7 +1563,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -1708,7 +1708,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -266,7 +266,7 @@ export function makeDeleteInputObject(obj: ObjectTypeDefinitionNode, isSync: boo
     {
       kind: Kind.INPUT_VALUE_DEFINITION,
       name: { kind: 'Name', value: 'id' },
-      type: makeNamedType('ID'),
+      type: wrapNonNull(makeNamedType('ID')),
       // TODO: Service does not support new style descriptions so wait.
       // description: {
       //     kind: 'StringValue',

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
@@ -155,7 +155,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -374,7 +374,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -419,7 +419,7 @@ input UpdateUserInput {
 }
 
 input DeleteUserInput {
-  id: ID
+  id: ID!
 }
 
 input SearchableStringFilterInput {
@@ -834,7 +834,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {
@@ -1043,7 +1043,7 @@ input UpdatePostInput {
 }
 
 input DeletePostInput {
-  id: ID
+  id: ID!
 }
 
 type Mutation {


### PR DESCRIPTION
*Issue #, if available:*
fix #2564 
*Description of changes:*
make primary key non nullable on delete input

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.