### PR TITLE
fix(amplify-appsync-simulator): allow token.iss ending with slash

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/utils/auth-helpers/helpers.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/auth-helpers/helpers.test.ts
@@ -62,6 +62,11 @@ describe('auth helpers', () => {
       expect(isValidOIDCToken(token, configuredAuthTypes)).toBeTruthy();
     });
 
+    it('should return true when token has allowed issuer ending with slash', () => {
+      token.iss = 'http://amazon.com/';
+      expect(isValidOIDCToken(token, configuredAuthTypes)).toBeTruthy();
+    });
+
     it('should return false when token does not have valid issuer', () => {
       token.iss = 'invalid-issuer';
       expect(isValidOIDCToken(token, configuredAuthTypes)).toBeFalsy();

--- a/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
+++ b/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
@@ -34,7 +34,9 @@ export function isValidOIDCToken(token: JWTToken, configuredAuthTypes: AmplifyAp
         : auth.openIDConnectConfig.Issuer,
     );
 
-  return oidcIssuers.length > 0 && oidcIssuers.includes(token.iss);
+  const tokenIssuer = token.iss.endsWith('/') ? token.iss.substring(0, token.iss.length - 1) : token.iss;
+
+  return oidcIssuers.length > 0 && oidcIssuers.includes(tokenIssuer);
 }
 export function extractHeader(headers: Record<string, string | string[]>, name: string): string {
   const headerName = Object.keys(headers).find(header => header.toLowerCase() === name.toLowerCase());


### PR DESCRIPTION
*Issue:* https://github.com/aws-amplify/amplify-cli/issues/6368

https://github.com/aws-amplify/amplify-cli/issues/5372#issuecomment-758247839

*Description of changes:*

- Improved isValidOIDCToken(): Added support for token.iss ending with slash. (Auth0)
- Added unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.