### PR TITLE
fix: apply empty arrays as default values but not undefined values

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
@@ -1,12 +1,16 @@
 import { ServiceQuestionsResult } from '../../../../provider-utils/awscloudformation/service-walkthrough-types';
 import { structureOAuthMetadata } from '../../../../provider-utils/awscloudformation/service-walkthroughs/auth-questions';
-import { getUpdateAuthDefaultsApplier } from '../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers';
+import {
+  getAddAuthDefaultsApplier,
+  getUpdateAuthDefaultsApplier,
+} from '../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers';
 
 jest.mock(`../../../../provider-utils/awscloudformation/assets/cognito-defaults.js`, () => ({
   functionMap: {
     userPoolOnly: () => ({ some: 'default value' }),
   },
   getAllDefaults: jest.fn(),
+  generalDefaults: jest.fn().mockReturnValue({ requiredAttributes: ['email'] }),
 }));
 
 jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/auth-questions', () => ({
@@ -40,5 +44,29 @@ describe('update auth defaults applier', () => {
     const result = await getUpdateAuthDefaultsApplier({}, 'cognito-defaults.js', {} as ServiceQuestionsResult)(stubResult);
     expect(result).toMatchSnapshot();
     expect(structureOAuthMetadata_mock.mock.calls.length).toBe(1);
+  });
+
+  it('overwrites default parameters', async () => {
+    const stubResult = {
+      useDefault: 'manual',
+      authSelections: 'userPoolOnly',
+      requiredAttributes: [] as string[],
+    } as ServiceQuestionsResult;
+
+    const result = await getUpdateAuthDefaultsApplier({}, 'cognito-defaults.js', {} as ServiceQuestionsResult)(stubResult);
+    expect(result.requiredAttributes).toEqual([]);
+  });
+});
+
+describe('add auth defaults applier', () => {
+  it('overwrites default parameters', async () => {
+    const stubResult: ServiceQuestionsResult = {
+      useDefault: 'manual',
+      authSelections: 'userPoolOnly',
+      requiredAttributes: [] as string[],
+    } as ServiceQuestionsResult;
+
+    const result = await getAddAuthDefaultsApplier({}, 'cognito-defaults.js', 'testProjectName')(stubResult);
+    expect(result.requiredAttributes).toEqual([]);
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -1,6 +1,6 @@
 import { ServiceQuestionsResult } from '../service-walkthrough-types';
 import { verificationBucketName } from './verification-bucket-name';
-import { isEmpty, merge } from 'lodash';
+import _ from 'lodash';
 import { structureOAuthMetadata } from '../service-walkthroughs/auth-questions';
 import { removeDeprecatedProps } from './synthesize-resources';
 import { immutableAttributes, safeDefaults } from '../constants';
@@ -18,7 +18,7 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
   result: ServiceQuestionsResult,
 ): Promise<ServiceQuestionsResult> => {
   const { functionMap, generalDefaults, roles, getAllDefaults } = await import(`../assets/${defaultValuesFilename}`);
-  result = merge(generalDefaults(projectName), result);
+  result = assignDefaults({}, generalDefaults(projectName), result);
 
   await verificationBucketName(result);
 
@@ -32,7 +32,7 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
 
   /* merge actual answers object into props object,
    * ensuring that manual entries override defaults */
-  return merge(functionMap[result.authSelections](result.resourceName), result, roles);
+  return assignDefaults({}, functionMap[result.authSelections](result.resourceName), result, roles);
 };
 
 export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename: string, previousResult: ServiceQuestionsResult) => async (
@@ -57,8 +57,14 @@ export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename
   structureOAuthMetadata(result, context, getAllDefaults, context.amplify); // adds "oauthMetadata" to result
 
   // If there are new trigger selections, make sure they overwrite the previous selections
-  if (!isEmpty(result.triggers)) {
+  if (!_.isEmpty(result.triggers)) {
     previousResult.triggers = Object.assign({}, result.triggers);
   }
-  return merge(defaults, removeDeprecatedProps(previousResult), result);
+  return assignDefaults({}, defaults, removeDeprecatedProps(previousResult), result);
 };
+
+// same as _.assign except undefined values won't overwrite existing values
+// typed to accept up to 4 params but could be typed to accept any number of params
+const assignDefaults = _.partialRight(_.assignWith, (objValue: unknown, srcValue: unknown) =>
+  _.isUndefined(srcValue) ? objValue : srcValue,
+) as <T, U, V, W>(a: T, b: U, c?: V, d?: W) => T & U & V & W;


### PR DESCRIPTION
*Issue #, if available:*
#5681

fixes an issue that caused some tests to fail in PR #6071 which were reverted in #6179

*Description of changes:*
Use _.assignWith with a customizer to not assign undefined values instead of using _.merge which would not overwrite empty arrays

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.