### PR TITLE
test: update e2e tests to support auth import

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
@@ -129,7 +129,7 @@ describe('auth import userpool only', () => {
 
   it('status should reflect correct values for imported auth', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     let projectDetails = getAuthProjectDetails(projectRoot);
 
@@ -157,7 +157,7 @@ describe('auth import userpool only', () => {
 
   it('imported auth with graphql api and cognito should push', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' }); // space at to make sure its not web client
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' }); // space at to make sure its not web client
     await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectRoot);
     await amplifyPush(projectRoot);
 
@@ -166,7 +166,7 @@ describe('auth import userpool only', () => {
 
   it('imported auth with function and crud on auth should push', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     const functionName = randomizedFunctionName('authimpfunc');
     const authResourceName = getCognitoResourceName(projectRoot);
@@ -224,7 +224,7 @@ describe('auth import userpool only', () => {
 
   it('imported userpool only auth, s3 storage add should fail with error', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     // Imported auth resources cannot be used together with \'storage\' category\'s authenticated and unauthenticated access.
     await expect(addS3WithAuthConfigurationMismatchErrorExit(projectRoot, {})).rejects.toThrowError(
@@ -237,7 +237,7 @@ describe('auth import userpool only', () => {
       ...projectSettings,
       disableAmplifyAppCreation: false,
     });
-    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     const functionName = randomizedFunctionName('authimpfunc');
     const authResourceName = getCognitoResourceName(projectRoot);
@@ -280,7 +280,7 @@ describe('auth import userpool only', () => {
 
   it('imported auth, create prod env, files should match', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     await amplifyPushAuth(projectRoot);
 
@@ -340,9 +340,9 @@ describe('auth import userpool only', () => {
     } as any);
 
     // The previously configured Cognito User Pool: '${userPoolName}' (${userPoolId}) cannot be found.
-    await expect(await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ' })).rejects.toThrowError(
-      'Process exited with non zero exit code 1',
-    );
+    await expect(
+      await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' }),
+    ).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   // Used for creating custom app clients. This should match with web app client setting for import to work

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_2.test.ts
@@ -26,7 +26,7 @@ import {
   importIdentityPoolAndUserPool,
 } from '../import-helpers';
 
-const profileName = 'amplify-integ-test-user';
+const profileName = 'default';
 
 describe('auth import identity pool and userpool', () => {
   const projectPrefix = 'auimpidup';
@@ -107,7 +107,7 @@ describe('auth import identity pool and userpool', () => {
 
   it('auth import identitypool and userpool', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     let projectDetails = getAuthProjectDetails(projectRoot);
 
@@ -125,7 +125,7 @@ describe('auth import identity pool and userpool', () => {
       ...projectSettings,
       disableAmplifyAppCreation: false,
     });
-    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     await amplifyPushAuth(projectRoot);
 
@@ -153,7 +153,7 @@ describe('auth import identity pool and userpool', () => {
       disableAmplifyAppCreation: false,
     });
 
-    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     await amplifyPushAuth(projectRoot);
 
@@ -194,7 +194,7 @@ describe('auth import identity pool and userpool', () => {
       disableAmplifyAppCreation: false,
     });
 
-    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     await amplifyPushAuth(projectRoot);
 
@@ -240,7 +240,7 @@ describe('auth import identity pool and userpool', () => {
 
   it('auth import, storage auth/guest access, push successful', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
-    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ' });
+    await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
     await addS3Storage(projectRoot);
     await amplifyPushAuth(projectRoot);
 


### PR DESCRIPTION
updated the e2e tests to support auth import to use the correct app client for web

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.