### PR TITLE
fix(amplify-util-mock): off-by-one array reference and general refactor

### DIFF
--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -28,6 +28,7 @@
     "@hapi/topo": "^5.0.0",
     "amplify-appsync-simulator": "1.25.0",
     "amplify-category-function": "2.28.4",
+    "amplify-cli-core": "1.14.1",
     "amplify-codegen": "2.20.5",
     "amplify-dynamodb-simulator": "1.17.6",
     "amplify-storage-simulator": "1.5.1",

--- a/packages/amplify-util-mock/src/CFNParser/lambda-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/lambda-resource-processor.ts
@@ -40,8 +40,8 @@ export function lambdaFunctionHandler(resourceName, resource, cfnContext: CloudF
   };
 }
 
-export function processResources(resources: { [key: string]: any }, params = {}): LambdaFunctionConfig | undefined {
-  const definition = Object.entries(resources).find((entry: [string, any]) => entry[1].Type === 'AWS::Lambda::Function');
+export function processResources(resources: $TSObject, params = {}): LambdaFunctionConfig | undefined {
+  const definition = Object.entries(resources).find((entry: [string, $TSAny]) => entry[1].Type === 'AWS::Lambda::Function');
   if (definition) {
     return lambdaFunctionHandler(definition[0], definition[1], {
       conditions: CFN_DEFAULT_CONDITIONS,

--- a/packages/amplify-util-mock/src/CFNParser/lambda-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/lambda-resource-processor.ts
@@ -1,3 +1,4 @@
+import { $TSAny, $TSObject } from 'amplify-cli-core';
 import { CloudFormationParseContext } from './types';
 import { parseValue } from './field-parser';
 
@@ -39,7 +40,7 @@ export function lambdaFunctionHandler(resourceName, resource, cfnContext: CloudF
   };
 }
 
-export function processResources(resources: { [key: string]: any }, transformResult: any, params = {}): LambdaFunctionConfig | undefined {
+export function processResources(resources: { [key: string]: any }, params = {}): LambdaFunctionConfig | undefined {
   const definition = Object.entries(resources).find((entry: [string, any]) => entry[1].Type === 'AWS::Lambda::Function');
   if (definition) {
     return lambdaFunctionHandler(definition[0], definition[1], {

--- a/packages/amplify-util-mock/src/__tests__/func/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/func/index.test.ts
@@ -1,3 +1,4 @@
+import { $TSAny } from 'amplify-cli-core';
 import { start } from '../../func';
 
 jest.mock('../../utils/lambda/loadMinimal', () => ({
@@ -5,6 +6,14 @@ jest.mock('../../utils/lambda/loadMinimal', () => ({
 }));
 jest.mock('../../utils', () => ({
   hydrateAllEnvVars: jest.fn(),
+}));
+jest.mock('amplify-cli-core', () => ({
+  JSONUtilities: {
+    readJson: jest.fn(),
+  },
+  pathManager: {
+    getBackendDirPath: () => 'fake-backend-path',
+  },
 }));
 jest.mock('amplify-category-function', () => ({
   getInvoker: () => () => new Promise(resolve => setTimeout(() => resolve('lambda value'), 1000 * 19)),
@@ -17,7 +26,7 @@ describe('function start', () => {
     jest.clearAllMocks();
   });
 
-  const context_stub = {
+  const context_stub: $TSAny = {
     input: {
       subCommands: ['funcName'],
       options: {
@@ -26,9 +35,6 @@ describe('function start', () => {
       },
     },
     amplify: {
-      pathManager: {
-        getBackendDirPath: jest.fn(() => 'backend-path'),
-      },
       inputValidation: () => () => true,
       readJsonFile: jest.fn(),
       getResourceStatus: () => ({ allResources: [] }),

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -1,3 +1,4 @@
+import { JSONUtilities, pathManager, $TSContext } from 'amplify-cli-core';
 import { getInvoker, category, isMockable } from 'amplify-category-function';
 import * as path from 'path';
 import * as inquirer from 'inquirer';
@@ -6,7 +7,7 @@ import { hydrateAllEnvVars } from '../utils';
 
 const DEFAULT_TIMEOUT_SECONDS = 10;
 
-export async function start(context) {
+export async function start(context: $TSContext) {
   if (!context.input.subCommands || context.input.subCommands.length < 1) {
     throw new Error('Specify the function name to invoke with "amplify mock function <function name>"');
   }
@@ -18,7 +19,7 @@ export async function start(context) {
     throw new Error(`Unable to mock ${resourceName}. ${mockable.reason}`);
   }
   const { amplify } = context;
-  const resourcePath = path.join(amplify.pathManager.getBackendDirPath(), category, resourceName);
+  const resourcePath = path.join(pathManager.getBackendDirPath(), category, resourceName);
   const eventNameValidator = amplify.inputValidation({
     operator: 'regex',
     value: '^[a-zA-Z0-9/._-]+?\\.json$',
@@ -51,8 +52,8 @@ export async function start(context) {
     eventName = resourceAnswers.eventName as string;
   }
 
-  const event = amplify.readJsonFile(path.resolve(path.join(resourcePath, eventName)));
-  const lambdaConfig = loadMinimalLambdaConfig(context, resourceName, { env: context.amplify.getEnvInfo().envName });
+  const event = JSONUtilities.readJson(path.resolve(path.join(resourcePath, eventName)));
+  const lambdaConfig = loadMinimalLambdaConfig(resourceName, { env: context.amplify.getEnvInfo().envName });
   if (!lambdaConfig || !lambdaConfig.handler) {
     throw new Error(`Could not parse handler for ${resourceName} from cloudformation file`);
   }

--- a/packages/amplify-util-mock/src/utils/lambda/execute.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/execute.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs-extra';
-import _ = require('lodash');
+import * as _ from 'lodash';
 import * as path from 'path';
 
 function loadFunction(fileName: string) {

--- a/packages/amplify-util-mock/src/utils/lambda/execute.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/execute.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'fs-extra';
 import _ = require('lodash');
-const path = require('path');
+import * as path from 'path';
 
-function loadFunction(fileName) {
+function loadFunction(fileName: string) {
   return require(path.resolve(fileName));
 }
 

--- a/packages/amplify-util-mock/src/utils/lambda/hydrate-env-vars.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/hydrate-env-vars.ts
@@ -15,6 +15,7 @@ export type ApiDetails = {
     type: string;
   }[];
 };
+
 export function hydrateAllEnvVars(
   resources: Resources,
   sourceEnvVars: Record<string, string>,

--- a/packages/amplify-util-mock/src/utils/lambda/load.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/load.ts
@@ -19,7 +19,7 @@ export function getAllLambdaFunctions(context: $TSContext, backendPath: string):
         const cfnParams = path.join(lambdaDir, 'function-parameters.json');
         try {
           const lambdaCfn = JSONUtilities.readJson<$TSAny>(cfnPath);
-          const lambdaCfnParams = fs.existsSync(cfnParams) ? JSONUtilities.readJson<$TSAny>(cfnParams) : {};
+          const lambdaCfnParams = JSONUtilities.readJson<$TSAny>(cfnParams, { throwIfNotExist: false }) || {};
           const lambdaConfig = processResources(lambdaCfn.Resources, { ...lambdaCfnParams, env: 'NONE' });
           lambdaConfig.basePath = lambdaDir;
           lambdas.push(lambdaConfig);

--- a/packages/amplify-util-mock/src/utils/lambda/load.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/load.ts
@@ -1,8 +1,9 @@
+import { JSONUtilities, $TSAny, $TSContext } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { LambdaFunctionConfig, processResources } from '../../CFNParser/lambda-resource-processor';
 
-export function getAllLambdaFunctions(context, backendPath: string): LambdaFunctionConfig[] {
+export function getAllLambdaFunctions(context: $TSContext, backendPath: string): LambdaFunctionConfig[] {
   const lambdas: LambdaFunctionConfig[] = [];
   const lambdaCategoryPath = path.join(backendPath, 'function');
   if (fs.existsSync(lambdaCategoryPath) && fs.lstatSync(lambdaCategoryPath).isDirectory) {
@@ -17,9 +18,9 @@ export function getAllLambdaFunctions(context, backendPath: string): LambdaFunct
         const cfnPath = path.join(lambdaDir, `${resourceName}-cloudformation-template.json`);
         const cfnParams = path.join(lambdaDir, 'function-parameters.json');
         try {
-          const lambdaCfn = context.amplify.readJsonFile(cfnPath);
-          const lambdaCfnParams = fs.existsSync(cfnParams) ? context.amplify.readJsonFile(cfnParams) : {};
-          const lambdaConfig = processResources(lambdaCfn.Resources, {}, { ...lambdaCfnParams, env: 'NONE' });
+          const lambdaCfn = JSONUtilities.readJson<$TSAny>(cfnPath);
+          const lambdaCfnParams = fs.existsSync(cfnParams) ? JSONUtilities.readJson<$TSAny>(cfnParams) : {};
+          const lambdaConfig = processResources(lambdaCfn.Resources, { ...lambdaCfnParams, env: 'NONE' });
           lambdaConfig.basePath = lambdaDir;
           lambdas.push(lambdaConfig);
         } catch (e) {

--- a/packages/amplify-util-mock/src/utils/lambda/loadMinimal.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/loadMinimal.ts
@@ -1,12 +1,13 @@
+import { JSONUtilities, pathManager, stateManager, $TSAny } from 'amplify-cli-core';
 import { LambdaFunctionConfig, processResources } from '../../CFNParser/lambda-resource-processor';
 import * as path from 'path';
 
 // Performs a minimal parsing of a lambda CFN.
-export function loadMinimalLambdaConfig(context: any, resourceName: string, params: { [key: string]: string } = {}): LambdaFunctionConfig {
-  const resourcePath = path.join(context.amplify.pathManager.getBackendDirPath(), 'function', resourceName);
-  const cfn = context.amplify.readJsonFile(path.join(resourcePath, `${resourceName}-cloudformation-template.json`));
-  const projectMeta = context.amplify.getProjectMeta();
-  let extendedParams: any = {};
+export function loadMinimalLambdaConfig(resourceName: string, params: { [key: string]: string } = {}): LambdaFunctionConfig {
+  const resourcePath = path.join(pathManager.getBackendDirPath(), 'function', resourceName);
+  const cfn = JSONUtilities.readJson<$TSAny>(path.join(resourcePath, `${resourceName}-cloudformation-template.json`));
+  const projectMeta = stateManager.getMeta();
+  let extendedParams: $TSAny = {};
   if (projectMeta.function[resourceName].dependsOn) {
     extendedParams = projectMeta.function[resourceName].dependsOn.reduce((ini, depend) => {
       depend.attributes.forEach(attribute => {
@@ -16,5 +17,5 @@ export function loadMinimalLambdaConfig(context: any, resourceName: string, para
       return ini;
     }, {});
   }
-  return processResources(cfn.Resources, {}, { ...params, ...extendedParams });
+  return processResources(cfn.Resources, { ...params, ...extendedParams });
 }


### PR DESCRIPTION
Removes deprecated `util` functions: https://nodejs.org/docs/latest-v8.x/api/util.html#util_util_isstring_object

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.