### PR TITLE
feat(amplify-frontend-javascript): add envName to awsExports

### DIFF
--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -80,7 +80,11 @@ function getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources)
 
   const customConfigs = getCustomConfigs(cloudAWSConfig, currentAWSConfig);
 
+  const { envName } = context.amplify.getEnvInfo();
+  const environmentConfig = { envName };
+
   Object.assign(newAWSConfig, customConfigs);
+  Object.assign(newAWSConfig, environmentConfig);
   return newAWSConfig;
 }
 

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -62,7 +62,11 @@ function getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources)
 
   const customConfigs = getCustomConfigs(cloudAWSConfig, currentAWSConfig);
 
+  const { envName } = context.amplify.getEnvInfo();
+  const environmentConfig = { envName };
+
   Object.assign(newAWSConfig, customConfigs);
+  Object.assign(newAWSConfig, environmentConfig);
   return newAWSConfig;
 }
 

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -82,7 +82,11 @@ async function createAWSExports(context, amplifyResources, cloudAmplifyResources
 
   const customConfigs = getCustomConfigs(cloudAWSExports, currentAWSExports);
 
+  const { envName } = context.amplify.getEnvInfo();
+  const environmentConfig = { envName };
+
   Object.assign(newAWSExports, customConfigs);
+  Object.assign(newAWSExports, environmentConfig);
   generateAWSExportsFile(context, newAWSExports);
   return context;
 }


### PR DESCRIPTION
*Issue #, if available:*
#672 #6429

*Description of changes:*
To allow developers to access their current environment name on their frontend

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.