### PR TITLE
fix: enables cors support for lambda proxy integrations for python

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
@@ -46,7 +46,18 @@ describe('go function tests', () => {
 });
 
 describe('python function tests', () => {
-  const helloWorldSuccessOutput = '{"message":"Hello from your new Amplify Python lambda!"}';
+  const statusCode: number = 200;
+  const headers = {
+    'Access-Control-Allow-Headers': '*',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
+  };
+  const message: string = 'Hello from your new Amplify Python lambda!';
+  const helloWorldSuccessOutput = {
+    statusCode: statusCode,
+    headers: headers,
+    body: message,
+  };
 
   let projRoot: string;
   let funcName: string;
@@ -76,7 +87,7 @@ describe('python function tests', () => {
   it('add python hello world and mock locally', async () => {
     await functionMockAssert(projRoot, {
       funcName,
-      successString: helloWorldSuccessOutput,
+      successString: helloWorldSuccessOutput.body,
       eventFile: 'src/event.json',
     }); // will throw if successString is not in output
   });
@@ -85,7 +96,7 @@ describe('python function tests', () => {
     const payload = '{"test":"event"}';
     await amplifyPushAuth(projRoot);
     const response = await functionCloudInvoke(projRoot, { funcName, payload });
-    expect(JSON.parse(response.Payload.toString())).toEqual(JSON.parse(helloWorldSuccessOutput));
+    expect(JSON.parse(response.Payload.toString())).toEqual(JSON.parse(JSON.stringify(helloWorldSuccessOutput)));
   });
 });
 

--- a/packages/amplify-python-function-template-provider/resources/hello-world/index.py
+++ b/packages/amplify-python-function-template-provider/resources/hello-world/index.py
@@ -2,5 +2,11 @@ def handler(event, context):
   print('received event:')
   print(event)
   return {
-    'message': 'Hello from your new Amplify Python lambda!'
+      'statusCode': 200,
+      'headers': {
+          'Access-Control-Allow-Headers': '*',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
+      },
+      'body': "Hello from your new Amplify Python lambda!"
   }


### PR DESCRIPTION
*Issue #5914 *

*Description of changes:*

* enables cors support for lambda proxy integrations for python
* Added tests for the same

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.