### PR TITLE
fix(amplify-provider-awscloudformation): don't overwrite team-provider params

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -565,9 +565,9 @@ function storeS3BucketInfo(category: string, deploymentBucketName: string, envNa
   const amplifyMeta = stateManager.getMeta();
   const teamProviderInfo = stateManager.getTeamProviderInfo();
 
-  _.set(teamProviderInfo, [envName, 'categories', category, resourceName], { deploymentBucketName, s3Key });
+  _.assign(teamProviderInfo, [envName, 'categories', category, resourceName], { deploymentBucketName, s3Key });
 
-  _.set(amplifyMeta, [category, resourceName, 's3Bucket'], { deploymentBucketName, s3Key });
+  _.assign(amplifyMeta, [category, resourceName, 's3Bucket'], { deploymentBucketName, s3Key });
   stateManager.setMeta(undefined, amplifyMeta);
   stateManager.setTeamProviderInfo(undefined, teamProviderInfo);
 }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -545,18 +545,20 @@ async function packageResource(context: $TSContext, resource: $TSAny) {
     const cfnParamsFilePath = path.normalize(path.join(resourceDir, 'parameters.json'));
     JSONUtilities.writeJson(cfnParamsFilePath, cfnParams);
   } else {
+    cfnMeta.Parameters.deploymentBucketName = paramType;
+    cfnMeta.Parameters.s3Key = paramType;
     if (cfnMeta.Resources.LambdaFunction.Type === 'AWS::Serverless::Function') {
-      cfnMeta.Parameters.deploymentBucketName = paramType;
-      cfnMeta.Parameters.s3Key = paramType;
       cfnMeta.Resources.LambdaFunction.Properties.CodeUri = {
         Bucket: Fn.Ref('deploymentBucketName'),
         Key: Fn.Ref('s3Key'),
       };
     } else {
-      cfnMeta.Parameters.deploymentBucketName = paramType;
-      cfnMeta.Parameters.s3Key = paramType;
-      storeS3BucketInfo(category, s3Bucket, envName, resourceName, s3Key);
+      cfnMeta.Resources.LambdaFunction.Properties.Code = {
+        S3Bucket: Fn.Ref('deploymentBucketName'),
+        S3Key: Fn.Ref('s3Key'),
+      };
     }
+    storeS3BucketInfo(category, s3Bucket, envName, resourceName, s3Key);
   }
   JSONUtilities.writeJson(cfnFilePath, cfnMeta);
 }
@@ -565,9 +567,11 @@ function storeS3BucketInfo(category: string, deploymentBucketName: string, envNa
   const amplifyMeta = stateManager.getMeta();
   const teamProviderInfo = stateManager.getTeamProviderInfo();
 
-  _.assign(teamProviderInfo, [envName, 'categories', category, resourceName], { deploymentBucketName, s3Key });
+  const tpiResourceParams: $TSAny = _.get(teamProviderInfo, [envName, 'categories', category, resourceName], {});
+  _.assign(tpiResourceParams, { deploymentBucketName, s3Key });
+  _.set(teamProviderInfo, [envName, 'categories', category, resourceName], tpiResourceParams);
 
-  _.assign(amplifyMeta, [category, resourceName, 's3Bucket'], { deploymentBucketName, s3Key });
+  _.set(amplifyMeta, [category, resourceName, 's3Bucket'], { deploymentBucketName, s3Key });
   stateManager.setMeta(undefined, amplifyMeta);
   stateManager.setTeamProviderInfo(undefined, teamProviderInfo);
 }


### PR DESCRIPTION
*Description of changes:*
Fixes regression from #6358 where team-provider-info parameters would be overwritten


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.