### PR TITLE
test: fix casing for AppSync options when adding function

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -37,7 +37,7 @@ const pythonTemplateChoices = ['Hello World'];
 
 const crudOptions = ['create', 'read', 'update', 'delete'];
 
-const appSyncOptions = ['query', 'mutation', 'subscription'];
+const appSyncOptions = ['Query', 'Mutation', 'Subscription'];
 
 const additionalPermissions = (cwd: string, chain: ExecutionContext, settings: any) => {
   multiSelect(

--- a/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
@@ -1,13 +1,24 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, amplifyPush } from 'amplify-e2e-core';
-import { addFunction, updateFunction } from 'amplify-e2e-core';
-import { addSimpleDDB, addDDBWithTrigger } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, overrideFunctionSrc, getFunctionSrc } from 'amplify-e2e-core';
-import { addApiWithSchema } from 'amplify-e2e-core';
-import { getBackendAmplifyMeta } from 'amplify-e2e-core';
-import { invokeFunction } from 'amplify-e2e-core';
+import {
+  addApiWithSchema,
+  addDDBWithTrigger,
+  addFunction,
+  addSimpleDDB,
+  amplifyPush,
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getBackendAmplifyMeta,
+  getFunctionSrc,
+  getProjectMeta,
+  initJSProjectWithProfile,
+  invokeFunction,
+  overrideFunctionSrc,
+  readJsonFile,
+  updateFunction,
+} from 'amplify-e2e-core';
 import fs from 'fs-extra';
 import path from 'path';
-import { readJsonFile } from 'amplify-e2e-core';
 import _ from 'lodash';
 
 describe('nodejs', () => {


### PR DESCRIPTION
*Description of changes:*
E2E tests got stuck due to case mistmatch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.