### PR TITLE
fix: adding JSON stringify to example python function

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
@@ -52,7 +52,7 @@ describe('python function tests', () => {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'OPTIONS,POST,GET',
   };
-  const message: string = 'Hello from your new Amplify Python lambda!';
+  const message: string = JSON.stringify('Hello from your new Amplify Python lambda!');
   const helloWorldSuccessOutput = {
     statusCode: statusCode,
     headers: headers,

--- a/packages/amplify-python-function-template-provider/resources/hello-world/index.py
+++ b/packages/amplify-python-function-template-provider/resources/hello-world/index.py
@@ -1,6 +1,9 @@
+import json
+
 def handler(event, context):
   print('received event:')
   print(event)
+  
   return {
       'statusCode': 200,
       'headers': {
@@ -8,5 +11,5 @@ def handler(event, context):
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
       },
-      'body': "Hello from your new Amplify Python lambda!"
+      'body': json.dumps('Hello from your new Amplify Python lambda!')
   }


### PR DESCRIPTION
We need a JSON string for the body in order to access it in our response message. See this comment: https://github.com/aws-amplify/amplify-js/issues/6390#issuecomment-740757548

I had this issue with my own function which was returning null on my JSON.stringify(response). I found the above comment and it made it work! i.e. I could access the return body.

*Issue #, if available:*
No issue created as it's a one-line change.

*Description of changes:*
Adding `json` library import and `json.dumps()` call in `packages/amplify-python-function-template-provider/resources/hello-world/index.py`

Updating relevant unit test in `packages/amplify-e2e-tests/src/__tests__/function_3.test.ts` by adding a `JSON.stringify()` call to match the `json.dumps()` call in the source file.

If there's an issue with this PR let me know - this is my first open-source contribution!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.