### PR TITLE
fix: update aws.exports file on amplify push

### DIFF
--- a/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
@@ -40,8 +40,8 @@ export async function generateFiles(context: $TSContext) {
     throwIfNotExist: false,
     default: {},
   });
-
-  await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta);
+  const localMeta = stateManager.getMeta();
+  await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta, localMeta);
 
   return context;
 }

--- a/packages/amplify-cli/src/config-steps/c9-onSuccess.ts
+++ b/packages/amplify-cli/src/config-steps/c9-onSuccess.ts
@@ -5,8 +5,10 @@ export async function onSuccess(context) {
 
   stateManager.setProjectConfig(projectPath, context.exeInfo.projectConfig);
   stateManager.setLocalEnvInfo(undefined, context.exeInfo.localEnvInfo);
+  const localMeta = stateManager.getMeta();
+  const currentMeta = stateManager.getCurrentMeta();
 
-  await context.amplify.onCategoryOutputsChange(context);
+  await context.amplify.onCategoryOutputsChange(context, currentMeta, localMeta);
 
   printWelcomeMessage(context);
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -10,7 +10,7 @@ export async function pushResources(
   context: $TSContext,
   category?: string,
   resourceName?: string,
-  filteredResources?: { category: string, resourceName: string }[],
+  filteredResources?: { category: string; resourceName: string }[],
 ) {
   if (context.parameters.options.env) {
     const envName: string = context.parameters.options.env;
@@ -64,7 +64,8 @@ export async function pushResources(
       const currentAmplifyMeta = stateManager.getCurrentMeta();
 
       await providersPush(context, category, resourceName, filteredResources);
-      await onCategoryOutputsChange(context, currentAmplifyMeta);
+      const localMeta = stateManager.getMeta();
+      await onCategoryOutputsChange(context, currentAmplifyMeta, localMeta);
     } catch (err) {
       // Handle the errors and print them nicely for the user.
       context.print.error(`\n${err.message}`);

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -95,9 +95,9 @@ export async function initializeEnv(context: $TSContext, currentAmplifyMeta?: $T
 
       await sequential(providerPushTasks);
     }
-
+    const localMeta = stateManager.getMeta();
     // Generate AWS exports/configurtion file
-    await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta);
+    await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta, localMeta);
 
     context.print.success(isPulling ? '' : 'Initialized your environment successfully.');
   } catch (e) {

--- a/packages/amplify-e2e-tests/src/__tests__/env.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env.test.ts
@@ -12,7 +12,11 @@ import {
   amplifyPushAuth,
   addAuthWithRecaptchaTrigger,
   addAuthWithDefaultSocial,
+  addApiWithoutSchema,
+  amplifyPushWithoutCodegen,
+  amplifyPush,
 } from 'amplify-e2e-core';
+import { getAWSExports } from '../aws-exports/awsExports';
 import {
   addEnvironment,
   checkoutEnvironment,
@@ -186,5 +190,30 @@ describe('environment commands with HostedUI params', () => {
     await pullEnvironment(projRoot);
     const meta = getProjectMeta(projRoot);
     await validate(meta);
+  });
+});
+
+describe('environment and push commands for aws exports', () => {
+  let projRoot: string;
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('env-test');
+    await initJSProjectWithProfile(projRoot, { envName: 'enva' });
+    await addAuthWithDefault(projRoot, {});
+    await amplifyPushWithoutCodegen(projRoot);
+  });
+
+  afterAll(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('add api and push should update aws exports', async () => {
+    await addEnvironment(projRoot, { envName: 'envb' });
+    await addApiWithoutSchema(projRoot, { apiName: 'testing' });
+    await amplifyPush(projRoot);
+    const awsExports: any = getAWSExports(projRoot).default;
+    const { aws_appsync_graphqlEndpoint, aws_appsync_region } = awsExports;
+    expect(aws_appsync_graphqlEndpoint).toBeDefined();
+    expect(aws_appsync_region).toBeDefined();
   });
 });

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -75,28 +75,18 @@ function createAmplifyConfig(context, amplifyResources) {
   }
 }
 
-async function createAWSExports(context, amplifyResources, cloudAmplifyResources) {
+async function createAWSExports(context, amplifyResources) {
   const newAWSExports = getAWSExportsObject(amplifyResources);
-  const cloudAWSExports = getAWSExportsObject(cloudAmplifyResources);
-  const currentAWSExports = await getCurrentAWSExports(context);
-
-  const customConfigs = getCustomConfigs(cloudAWSExports, currentAWSExports);
-
+  const customConfigs = removeCustomConfigs(newAWSExports);
   Object.assign(newAWSExports, customConfigs);
   generateAWSExportsFile(context, newAWSExports);
   return context;
 }
 
-function getCustomConfigs(cloudAWSExports, currentAWSExports) {
+function removeCustomConfigs(newAWSExports) {
   const customConfigs = {};
-  if (currentAWSExports) {
-    Object.keys(currentAWSExports)
-      .filter(key => !CUSTOM_CONFIG_DENY_LIST.includes(key))
-      .forEach(key => {
-        if (!cloudAWSExports[key]) {
-          customConfigs[key] = currentAWSExports[key];
-        }
-      });
+  if (newAWSExports) {
+    Object.keys(newAWSExports).filter(key => !CUSTOM_CONFIG_BLACK_LIST.includes(key));
   }
   return customConfigs;
 }


### PR DESCRIPTION
*Issue #6292 *

*Description of changes:*
* added localMeta obj to generate current AWSexports
* Removed logic to copy cloudMeta and oldAWSexports file
* added tests for the same

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.