### PR TITLE
feat(amplify-category-auth): add HostedUI custom domain in metadata

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/import/index.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/import/index.ts
@@ -781,6 +781,7 @@ const createMetaOutput = (answers: ImportAnswers, hasOAuthConfig: boolean): Meta
     ...(answers.appClientNative!.ClientSecret ? { AppClientSecret: answers.appClientNative!.ClientSecret } : {}),
     AppClientIDWeb: answers.appClientWeb!.ClientId,
     HostedUIDomain: userPool.Domain,
+    HostedUICustomDomain: userPool.CustomDomain,
   };
 
   if (answers.authSelections === 'identityPoolAndUserPool') {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/import/types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/import/types.ts
@@ -46,6 +46,7 @@ export type MetaOutput = {
   GoogleWebClient?: string;
   AppleWebClient?: string;
   HostedUIDomain?: string;
+  HostedUICustomDomain?: string;
   OAuthMetadata?: string;
   CreatedSNSRole?: string;
 };

--- a/packages/amplify-e2e-tests/src/import-helpers/expects.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/expects.ts
@@ -12,6 +12,7 @@ export const expectAuthProjectDetailsMatch = (projectDetails: AuthProjectDetails
   expect(projectDetails.meta.AppClientID).toEqual(ogProjectDetails.meta.AppClientID);
   expect(projectDetails.meta.AppClientIDWeb).toEqual(ogProjectDetails.meta.AppClientIDWeb);
   expect(projectDetails.meta.HostedUIDomain).toEqual(ogProjectDetails.meta.HostedUIDomain);
+  expect(projectDetails.meta.HostedUICustomDomain).toEqual(ogProjectDetails.meta.HostedUICustomDomain);
 
   if (projectDetails.meta.OAuthMetadata) {
     expect(ogProjectDetails.meta.OAuthMetadata).toBeDefined();
@@ -51,6 +52,7 @@ export const expectAuthLocalAndOGMetaFilesOutputMatching = (projectRoot: string,
   expect(authMeta.output.AppClientID).toEqual(ogAuthMeta.output.AppClientID);
   expect(authMeta.output.AppClientIDWeb).toEqual(ogAuthMeta.output.AppClientIDWeb);
   expect(authMeta.output.HostedUIDomain).toEqual(ogAuthMeta.output.HostedUIDomain);
+  expect(authMeta.output.HostedUICustomDomain).toEqual(ogAuthMeta.output.HostedUICustomDomain);
   expect(authMeta.output.UserPoolId).toEqual(ogAuthMeta.output.UserPoolId);
 };
 

--- a/packages/amplify-e2e-tests/src/import-helpers/types.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/types.ts
@@ -22,6 +22,7 @@ export type AuthProjectDetails = {
     AppClientSecret?: string;
     AppClientIDWeb?: string;
     HostedUIDomain?: string;
+    HostedUICustomDomain?: string;
     OAuthMetadata?: $TSObject;
     IdentityPoolId?: string;
     IdentityPoolName?: string;

--- a/packages/amplify-e2e-tests/src/import-helpers/utilities.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/utilities.ts
@@ -49,6 +49,7 @@ export const getAuthProjectDetails = (projectRoot: string): AuthProjectDetails =
       AppClientSecret: authMeta.output.AppClientSecret,
       AppClientIDWeb: authMeta.output.AppClientIDWeb,
       HostedUIDomain: authMeta.output.HostedUIDomain,
+      HostedUICustomDomain: authMeta.output.HostedUICustomDomain,
       OAuthMetadata: authMeta.output.OAuthMetadata ? JSON.parse(authMeta.output.OAuthMetadata) : undefined,
     },
     team: {
@@ -114,6 +115,7 @@ export const getOGAuthProjectDetails = (projectRoot: string): AuthProjectDetails
       AppClientSecret: authMeta.output.AppClientSecret,
       AppClientIDWeb: authMeta.output.AppClientIDWeb,
       HostedUIDomain: authMeta.output.HostedUIDomain,
+      HostedUICustomDomain: authMeta.output.HostedUICustomDomain,
       OAuthMetadata: authMeta.output.OAuthMetadata ? JSON.parse(authMeta.output.OAuthMetadata) : undefined,
       IdentityPoolId: authMeta.output.IdentityPoolId,
       IdentityPoolName: authMeta.output.IdentityPoolName,

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -246,7 +246,8 @@ function getCognitoConfig(cognitoResources, projectRegion) {
   let redirectSignOut;
 
   if (cognitoResource.output.HostedUIDomain) {
-    domain = `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
+    domain =
+      cognitoResource.output.HostedUICustomDomain || `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
   }
 
   if (cognitoResource.output.OAuthMetadata) {

--- a/packages/amplify-frontend-flutter/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-flutter/lib/frontend-config-creator.js
@@ -227,7 +227,8 @@ function getCognitoConfig(cognitoResources, projectRegion) {
   let redirectSignOut;
 
   if (cognitoResource.output.HostedUIDomain) {
-    domain = `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
+    domain =
+      cognitoResource.output.HostedUICustomDomain || `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
   }
 
   if (cognitoResource.output.OAuthMetadata) {

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -237,7 +237,8 @@ function getCognitoConfig(cognitoResources, projectRegion) {
   let redirectSignOut;
 
   if (cognitoResource.output.HostedUIDomain) {
-    domain = `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
+    domain =
+      cognitoResource.output.HostedUICustomDomain || `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
   }
 
   if (cognitoResource.output.OAuthMetadata) {

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -352,7 +352,8 @@ function getCognitoConfig(cognitoResources, projectRegion) {
 
   if (cognitoResource.output.HostedUIDomain) {
     // eslint-disable-next-line spellcheck/spell-checker
-    domain = `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
+    domain =
+      cognitoResource.output.HostedUICustomDomain || `${cognitoResource.output.HostedUIDomain}.auth.${projectRegion}.amazoncognito.com`;
   }
   if (cognitoResource.output.OAuthMetadata) {
     const oAuthMetadata = JSON.parse(cognitoResource.output.OAuthMetadata);

--- a/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
+++ b/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
@@ -160,17 +160,19 @@ const showHostedUIURLs = (context, resourcesToBeCreated): void => {
     }
     const { Region } = amplifyMeta.providers.awscloudformation;
 
-    const { HostedUIDomain, AppClientIDWeb, OAuthMetadata } = amplifyMeta[category][resourceName].output;
+    const { HostedUIDomain, HostedUICustomDomain, AppClientIDWeb, OAuthMetadata } = amplifyMeta[category][resourceName].output;
 
     if (OAuthMetadata) {
       const oAuthMetadata = JSON.parse(OAuthMetadata);
-      const hostedUIEndpoint = `https://${HostedUIDomain}.auth.${Region}.amazoncognito.com/`;
+      const hostedUIEndpoint = HostedUICustomDomain
+        ? `https://${HostedUICustomDomain}`
+        : `https://${HostedUIDomain}.auth.${Region}.amazoncognito.com/`;
       printer.info(`Hosted UI Endpoint: ${chalk.blue.underline(hostedUIEndpoint)}`);
       const redirectURIs = oAuthMetadata.CallbackURLs.concat(oAuthMetadata.LogoutURLs);
       if (redirectURIs.length > 0) {
         const [responseType] = oAuthMetadata.AllowedOAuthFlows;
 
-        const testHostedUIEndpoint = `https://${HostedUIDomain}.auth.${Region}.amazoncognito.com/login?response_type=${
+        const testHostedUIEndpoint = `${hostedUIEndpoint}/login?response_type=${
           responseType === 'implicit' ? 'token' : 'code'
         }&client_id=${AppClientIDWeb}&redirect_uri=${redirectURIs[0]}\n`;
         printer.info(`Test Your Hosted UI Endpoint: ${chalk.blue.underline(testHostedUIEndpoint)}`);


### PR DESCRIPTION
Fix #1880

HostedUIDomain equals to either the domain prefix or the custom domain defined in the user pool.
However we need to differentiate a custom domain from a domain prefix for the config put in aws-exports.js

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.