### PR TITLE
fix: check for local env file and then fall back on exeinfo

### DIFF
--- a/packages/amplify-cli/src/__tests__/get-tags.test.ts
+++ b/packages/amplify-cli/src/__tests__/get-tags.test.ts
@@ -11,6 +11,7 @@ describe('getTags', () => {
   jest.setMock('amplify-cli-core', {
     stateManager: {
       isTagFilePresent: jest.fn().mockReturnValue(false),
+      localEnvInfoExists: jest.fn().mockReturnValue(false),
     },
     HydrateTags,
   });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-tags.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-tags.ts
@@ -1,14 +1,25 @@
-import { stateManager, Tag, HydrateTags } from 'amplify-cli-core';
+import { stateManager, Tag, HydrateTags, $TSAny } from 'amplify-cli-core';
 import { Context } from '../../domain/context';
 
 export function getTags(context: Context): Tag[] {
+  let tags: Tag[];
+  let envInfo: $TSAny;
+  let projectConfig: $TSAny;
   if (stateManager.isTagFilePresent()) {
-    return stateManager.getHydratedTags();
+    tags = stateManager.getProjectTags();
   } else {
-    const { envName } = context.exeInfo.localEnvInfo;
-    const { projectName } = context.exeInfo.projectConfig;
-    return HydrateTags(initialTags, { envName, projectName });
+    tags = initialTags;
   }
+  if (stateManager.localEnvInfoExists() && stateManager.projectConfigExists()) {
+    envInfo = stateManager.getLocalEnvInfo();
+    projectConfig = stateManager.getProjectConfig();
+  } else {
+    envInfo = context.exeInfo.localEnvInfo;
+    projectConfig = context.exeInfo.projectConfig;
+  }
+  const { envName } = envInfo;
+  const { projectName } = projectConfig;
+  return HydrateTags(tags, { envName, projectName });
 }
 
 const initialTags: Tag[] = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The local env file is not present when the root stack is initialized on an existing project. The envName and projectName are extracted from the exeInfo as a fall back

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.