### PR TITLE
chore: removed pending triage from stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,6 @@ exemptLabels:
   - documentation
   - enhancement
   - feature-request
-  - pending-triage
   - pinned
   - question
   - RFC


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed the pending triage from exempt labels

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.