### PR TITLE
fix: correct given_name fb attribute mapping

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/string-maps.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/string-maps.js
@@ -186,7 +186,7 @@ const attributeProviderMap = {
   },
   given_name: {
     facebook: {
-      attr: 'given_name',
+      attr: 'first_name',
       scope: 'public_profile',
     },
     google: {


### PR DESCRIPTION
*Issue #, if available:*
#4981

*Description of changes:*
Update Facebook Cognito attribute mapping to be "given_name" => "last_name" instead of "given_name" => "given_name"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.