### PR TITLE
test(amplify-e2e-tests): fix api key lsi migration e2e

### DIFF
--- a/packages/amplify-e2e-tests/schemas/migrations_key/cant_add_lsi.graphql
+++ b/packages/amplify-e2e-tests/schemas/migrations_key/cant_add_lsi.graphql
@@ -8,5 +8,5 @@ type Todo
   id2: ID!
   name: String!
   name2: String!
-  version: Int!
+  version: String!
 }

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration1.test.ts
@@ -20,8 +20,10 @@ describe('amplify add api', () => {
 
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+    // testing this with old behavior with named lsi key
+    addFeatureFlag(projRoot, 'graphqltransformer', 'secondarykeyasgsi', false);
 
-    await addApiWithSchema(projRoot, initialSchema);
+    await addApiWithSchema(projRoot, initialSchema, { apiKeyExpirationDays: 2 });
     await amplifyPush(projRoot);
 
     updateApiSchema(projRoot, projectName, nextSchema1);


### PR DESCRIPTION
schema fix to use the same type as initial and add ff to keep old lsi

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.