### PR TITLE
Codegen fix

### DIFF
--- a/packages/amplify-app/src/framework-config-mapping.js
+++ b/packages/amplify-app/src/framework-config-mapping.js
@@ -36,7 +36,7 @@ const vueConfig = {
 };
 
 const emberConfig = {
-  SourceDir: '/',
+  SourceDir: './',
   DistributionDir: 'dist',
   BuildCommand: `${npm} run-script build -- -e production`,
   StartCommand: `${npm} run-script start`,

--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -13,27 +13,32 @@ async function postPushCallback(context, graphQLConfig) {
     return;
   }
 
-  if (!graphQLConfig.gqlConfig.schema) {
-    const config = loadConfig(context);
+  try {
+    if (!graphQLConfig.gqlConfig.schema) {
+      const config = loadConfig(context);
 
-    const projectPath = pathManager.findProjectRoot() || process.cwd();
-    const schemaLocation = path.join(projectPath, getSchemaDownloadLocation(context));
+      const projectPath = pathManager.findProjectRoot() || process.cwd();
+      const schemaLocation = path.join(projectPath, getSchemaDownloadLocation(context));
 
-    const newProject = graphQLConfig.gqlConfig;
-    newProject.schema = schemaLocation;
-    config.addProject(newProject);
-    config.save();
-  }
-  const apis = getAppSyncAPIDetails(context);
+      const newProject = graphQLConfig.gqlConfig;
+      newProject.schema = schemaLocation;
+      config.addProject(newProject);
+      config.save();
+    }
+    const apis = getAppSyncAPIDetails(context);
 
-  await downloadIntrospectionSchema(context, apis[0].id, graphQLConfig.gqlConfig.schema);
-  if (graphQLConfig.shouldGenerateDocs) {
-    await generateStatements(context);
+    await downloadIntrospectionSchema(context, apis[0].id, graphQLConfig.gqlConfig.schema);
+    if (graphQLConfig.shouldGenerateDocs) {
+      await generateStatements(context);
+    }
+    if (graphQLConfig.shouldGenerateModels) {
+      await generateModels(context);
+    }
+    await generateTypes(context);
+  } catch (error) {
+    // Code Generation failure should not result in actual push failure
+    context.print.warning(`Code generation failed with the following error \n${error.message}.`);
   }
-  if (graphQLConfig.shouldGenerateModels) {
-    await generateModels(context);
-  }
-  await generateTypes(context);
 }
 
 module.exports = postPushCallback;

--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const { pathManager } = require('amplify-cli-core');
+
 const loadConfig = require('../codegen-config');
 const generateStatements = require('../commands/statements');
 const generateTypes = require('../commands/types');
@@ -10,12 +13,17 @@ async function postPushCallback(context, graphQLConfig) {
     return;
   }
 
+  const projectPath = pathManager.findProjectRoot();
+  if (!projectPath) {
+    return;
+  }
+
   if (!graphQLConfig.gqlConfig.schema) {
     const config = loadConfig(context);
     const schemaLocation = getSchemaDownloadLocation(context);
 
     const newProject = graphQLConfig.gqlConfig;
-    newProject.schema = schemaLocation;
+    newProject.schema = path.join(projectPath, schemaLocation);
     config.addProject(newProject);
     config.save();
   }

--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -13,17 +13,14 @@ async function postPushCallback(context, graphQLConfig) {
     return;
   }
 
-  const projectPath = pathManager.findProjectRoot();
-  if (!projectPath) {
-    return;
-  }
-
   if (!graphQLConfig.gqlConfig.schema) {
     const config = loadConfig(context);
-    const schemaLocation = getSchemaDownloadLocation(context);
+
+    const projectPath = pathManager.findProjectRoot() || process.cwd();
+    const schemaLocation = path.join(projectPath, getSchemaDownloadLocation(context));
 
     const newProject = graphQLConfig.gqlConfig;
-    newProject.schema = path.join(projectPath, schemaLocation);
+    newProject.schema = schemaLocation;
     config.addProject(newProject);
     config.save();
   }

--- a/packages/amplify-codegen/src/utils/getSchemaDownloadLocation.js
+++ b/packages/amplify-codegen/src/utils/getSchemaDownloadLocation.js
@@ -1,8 +1,13 @@
 const path = require('path');
+const { pathManager } = require('amplify-cli-core');
 
 const getAndroidResDir = require('./getAndroidResDir');
 const getFrontEndHandler = require('./getFrontEndHandler');
 
+function isSubDirectory(parent, pathToCheck) {
+  const relative = path.relative(parent, pathToCheck);
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
 function getSchemaDownloadLocation(context) {
   let downloadDir;
   try {
@@ -18,6 +23,10 @@ function getSchemaDownloadLocation(context) {
     const outputPath = frontEnd === 'javascript' ? sourceDir : '';
     downloadDir = path.join(outputPath, 'graphql');
   }
+
+  const projectRoot = pathManager.findProjectRoot();
+  // Downloaded schema should always be inside the project dir so the project is self contained
+  downloadDir = isSubDirectory(projectRoot, path.resolve(downloadDir)) ? downloadDir : path.join(projectRoot, downloadDir);
   return path.join(downloadDir, 'schema.json');
 }
 

--- a/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
+++ b/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
@@ -40,7 +40,7 @@ const vueConfig = {
 };
 
 const emberConfig = {
-  SourceDir: '/',
+  SourceDir: './',
   DistributionDir: 'dist',
   BuildCommand: `${npm} run-script build -- -e production`,
   StartCommand: `${npm} run-script start`,


### PR DESCRIPTION
Description of changes:
This is based off of #5654. Creating a new PR as I dont have permission to push to MLH fork

#5334 c630145 changed amplify-codegen from hard coding src to using SourceDir in the config file.
This resulted in the default sourceDir value / (system root) for reactnative being used. The PR ensures the schema download location is always with in the project root and mitigates permission issues.

Also the `push` command will show an warning if codegen fails instead failing the whole push operation

fix #5483
Other:
Docs PR: aws-amplify/docs#2581