### PR TITLE
fix(amplify-codegen): correct docFilePath in codegen add and configure

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -29,6 +29,7 @@
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "glob-all": "^3.1.0",
+    "glob-parent": "5.1.1",
     "graphql": "^14.5.8",
     "graphql-config": "^2.2.1",
     "graphql-transformer-core": "6.25.1",

--- a/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
+++ b/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
@@ -5,7 +5,6 @@ function getGraphQLDocPath(frontend, graphQLDirectory, includePathGlob) {
   if (frontend === 'android') {
     return join(graphQLDirectory, 'com/amazonaws/amplify/generated/graphql');
   }
-  //TODO
   return includePathGlob ? globParent(includePathGlob) : graphQLDirectory;
 }
 

--- a/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
+++ b/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
@@ -1,17 +1,11 @@
-const { join, dirname } = require('path');
+const { join } = require('path');
+const globParent = require('glob-parent');
 
-function getGraphQLDocPath(frontend, schemaLocation) {
-  const graphQLDirectory = dirname(schemaLocation);
-  let subDirectory;
-  switch (frontend) {
-    case 'android':
-      subDirectory = 'com/amazonaws/amplify/generated/graphql';
-      break;
-    default:
-      subDirectory = '';
+function getGraphQLDocPath(frontend, graphQLDirectory, includePathGlob) {
+  if (frontend === 'android') {
+    return join(graphQLDirectory, 'com/amazonaws/amplify/generated/graphql');
   }
-
-  return join(graphQLDirectory, subDirectory);
+  return includePathGlob ? globParent(includePathGlob) : graphQLDirectory;
 }
 
 module.exports = getGraphQLDocPath;

--- a/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
+++ b/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
@@ -5,6 +5,7 @@ function getGraphQLDocPath(frontend, graphQLDirectory, includePathGlob) {
   if (frontend === 'android') {
     return join(graphQLDirectory, 'com/amazonaws/amplify/generated/graphql');
   }
+  //TODO
   return includePathGlob ? globParent(includePathGlob) : graphQLDirectory;
 }
 

--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -57,6 +57,7 @@ async function addWalkThrough(context, skip = [], withoutInit, decoupleFrontend,
 
   const includePatternDefault = getIncludePattern(targetLanguage, schemaLocation);
   const includePathGlob = join(includePatternDefault.graphQLDirectory, '**', includePatternDefault.graphQLExtension);
+  const docsFilePathDefault = includePatternDefault.graphQLDirectory;
 
   if (!skip.includes('includePattern')) {
     answers.includePattern = await determineValue(inputParams, yesFlag, 'includePattern', [includePathGlob], () =>
@@ -65,7 +66,7 @@ async function addWalkThrough(context, skip = [], withoutInit, decoupleFrontend,
   }
   if (!skip.includes('shouldGenerateDocs')) {
     answers.shouldGenerateDocs = await determineValue(inputParams, yesFlag, 'generateDocs', true, () => askShouldGenerateDocs());
-    answers.docsFilePath = getGraphQLDocPath(frontend, schemaLocation);
+    answers.docsFilePath = getGraphQLDocPath(frontend, docsFilePathDefault, answers.includePattern);
   }
 
   if (answers.shouldGenerateDocs && !skip.includes('maxDepth')) {

--- a/packages/amplify-codegen/src/walkthrough/configure.js
+++ b/packages/amplify-codegen/src/walkthrough/configure.js
@@ -5,7 +5,7 @@ const askCodeGenTargetLanguage = require('./questions/languageTarget');
 const askCodeGeneQueryFilePattern = require('./questions/queryFilePattern');
 const askTargetFileName = require('./questions/generatedFileName');
 const askMaxDepth = require('./questions/maxDepth');
-const { getFrontEndHandler, getIncludePattern } = require('../utils/');
+const { getFrontEndHandler, getIncludePattern, getGraphQLDocPath } = require('../utils/');
 
 function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
@@ -55,7 +55,7 @@ async function configureProjectWalkThrough(context, amplifyConfig, withoutInit =
     amplifyExtension.generatedFileName = '';
   }
   amplifyExtension.codeGenTarget = targetLanguage;
-
+  amplifyExtension.docsFilePath = getGraphQLDocPath(frontend, includePatternDefault.graphQLDirectory, selectedProjectConfig.includes)
   amplifyExtension.maxDepth = await askMaxDepth(amplifyExtension.maxDepth);
 
   return selectedProjectConfig;

--- a/packages/amplify-codegen/tests/utils/getGraphQLDocPath.test.js
+++ b/packages/amplify-codegen/tests/utils/getGraphQLDocPath.test.js
@@ -1,13 +1,21 @@
 const getGraphQLDocPath = require('../../src/utils/getGraphQLDocPath');
+const getIncludePatterns = require('../../src/utils/getIncludePattern')
 
 describe('getGraphQLDocPath', () => {
   it('should return com/amplify/generated/graphql when used in android project', () => {
-    const SCHEMA_LOCATION = 'app/src/main/graphql/scheam.json';
-    expect(getGraphQLDocPath('android', SCHEMA_LOCATION)).toEqual('app/src/main/graphql/com/amazonaws/amplify/generated/graphql');
+    const SCHEMA_LOCATION = 'app/src/main/graphql/schema.json';
+    const graphQLDirectory = getIncludePatterns('android', SCHEMA_LOCATION).graphQLDirectory;
+    expect(getGraphQLDocPath('android', graphQLDirectory)).toEqual('app/src/main/graphql/com/amazonaws/amplify/generated/graphql');
   });
 
-  it('should return graphql folder when frontend is not android', () => {
-    const SCHEMA_LOCATION = 'src/scheam.json';
-    expect(getGraphQLDocPath('ios', SCHEMA_LOCATION)).toEqual('src');
+  it('should return default folder when frontend is not android and include path not defined', () => {
+    const graphQLDirectory = getIncludePatterns('javascript').graphQLDirectory;
+    expect(getGraphQLDocPath('javascript', graphQLDirectory)).toEqual('src/graphql');
+  });
+
+  it('should return parent folder for include glob path when frontend is not android and include path is defined', () => {
+    const graphQLDirectory = getIncludePatterns('javascript').graphQLDirectory;
+    const includePathGlob = 'path/to/graphql/**/*.js';
+    expect(getGraphQLDocPath('javascript', graphQLDirectory, includePathGlob)).toEqual('path/to/graphql');
   });
 });

--- a/packages/amplify-codegen/tests/walkthrough/add.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/add.test.js
@@ -49,7 +49,7 @@ describe('Add walk-through', () => {
     expect(askCodegenTargetLanguage).toHaveBeenCalledWith(MOCK_CONTEXT, undefined, undefined, undefined, undefined);
     expect(askCodegneQueryFilePattern).toHaveBeenCalledWith(['src/graphql/**/*.js']);
     expect(askGeneratedFileName).toHaveBeenCalledWith('API', MOCK_TARGET_LANGUAGE);
-    expect(getGraphQLDocPath).toHaveBeenCalledWith(MOCK_FRONTEND_HANDLER, MOCK_DOWNLOAD_LOCATION);
+    expect(getGraphQLDocPath).toHaveBeenCalledWith(MOCK_FRONTEND_HANDLER, 'src/graphql', MOCK_INCLUDE_PATTERN);
     expect(results).toEqual({
       target: MOCK_TARGET_LANGUAGE,
       includePattern: MOCK_INCLUDE_PATTERN,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12618,6 +12618,13 @@ glob-base@^0.3.0:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
 
+glob-parent@5.1.1, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-parent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
@@ -12632,13 +12639,6 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
-
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob-to-regexp@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
*Issue #, if available:*
fix #6468 
fix #5835 
fix #4147
*Description of changes:*
The generation path for doc files are now correctly configured by sync up with user's prompt glob expression in `includes` field. The fix applies to the following commands.

- `amplify codegen add`
![image](https://user-images.githubusercontent.com/20614187/106533247-9e699380-64a6-11eb-8955-eb8b96c63779.png)

- `amplify codegen configure`
![image](https://user-images.githubusercontent.com/20614187/106533191-8a259680-64a6-11eb-903c-f4fc4885b01a.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.