### PR TITLE
fix: correct function resource name validation

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
@@ -19,8 +19,8 @@ function generalQuestions(context: any): object[] {
       message: 'Provide an AWS Lambda function name:',
       validate: context.amplify.inputValidation({
         operator: 'regex',
-        value: '^[a-zA-Z0-9._-]+$',
-        onErrorMsg: 'You can use the following characters: a-z A-Z 0-9 . - _',
+        value: '^[a-zA-Z0-9]+$',
+        onErrorMsg: 'You can use the following characters: a-z A-Z 0-9',
         required: true,
       }),
       default: () => {


### PR DESCRIPTION
*Issue #, if available:*
#6064

*Description of changes:*
Since we are using the function name as the resource name as well, it must conform to the more restrictive CFN logicId requirements of [a-zA-Z0-9]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.