### PR TITLE
ci: update circle ci build to include tags

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -874,6 +874,7 @@ workflows:
                 - iterative-update
                 - release
                 - compute-functions
+                - ci-build-tag-update
           requires:
             - build
       - build_pkg_binaries:
@@ -893,6 +894,7 @@ workflows:
                 - master
                 - compute-functions
                 - iterative-update
+                - ci-build-tag-update
           requires:
             - publish_to_local_registry
       - done_with_node_e2e_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2130,6 +2130,7 @@ workflows:
                 - iterative-update
                 - release
                 - compute-functions
+                - ci-build-tag-update
           requires:
             - build
       - build_pkg_binaries:
@@ -2281,6 +2282,7 @@ workflows:
                 - master
                 - compute-functions
                 - iterative-update
+                - ci-build-tag-update
           requires:
             - publish_to_local_registry
       - tags-amplify_e2e_tests:

--- a/packages/amplify-cli-core/src/__tests__/tags.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/tags.test.ts
@@ -21,10 +21,49 @@ describe('tags-validation:', () => {
     ];
 
     it('tags-validation should throw an error stating that the tags.json file has exceeded the tags amount limit', () => {
-      expect(() => validate(json)).toThrowError(new Error('Tag thould be of type Key: string, Value: string'));
+      expect(() => validate(json)).toThrowError(new Error('Tag should be of type Key: string, Value: string'));
     });
   });
 
+  describe('case: tags-validatation recives a JSON file that contains invalid char in tag Key', () => {
+    const json = [{ Key: 'user:Stack,', Value: 'dev' }];
+
+    it('tags-validation should throw an error stating that the tags.json file has exceeded the tags amount limit', () => {
+      expect(() => validate(json)).toThrowError(
+        new Error(
+          'Invalid character found in Tag Key. Tag Key may only contain unicode letters, digits, whitespace, or one of these symbols: _ . : / = + - @',
+        ),
+      );
+    });
+  });
+
+  describe('case: tags-validatation recives a JSON file that contains tag key length greater than 128', () => {
+    const json = [{ Key: 'a'.repeat(129), Value: 'dev' }];
+
+    it('tags-validation should throw an error stating that the tags.json file has exceeded the tags amount limit', () => {
+      expect(() => validate(json)).toThrowError(new Error('Tag key can be up to 128 characters but found 129'));
+    });
+  });
+
+  describe('case: tags-validatation recives a JSON file that contains invalid char in tag Value', () => {
+    const json = [{ Key: 'user:Stack', Value: 'dev,123' }];
+
+    it('tags-validation should throw an error stating that the tags.json file has exceeded the tags amount limit', () => {
+      expect(() => validate(json)).toThrowError(
+        new Error(
+          'Invalid character found in Tag Value. Tag values may only contain unicode letters, digits, whitespace, or one of these symbols: _ . : / = + - @',
+        ),
+      );
+    });
+  });
+
+  describe('case: tags-validatation recives a JSON file that contains tag value length greater than 256', () => {
+    const json = [{ Key: 'a'.repeat(128), Value: 'd'.repeat(257) }];
+
+    it('tags-validation should throw an error stating that the tags.json file has exceeded the tags amount limit', () => {
+      expect(() => validate(json)).toThrowError(new Error('Tag value can be up to 256 characters but found 257'));
+    });
+  });
   describe('case: tags-validation receives a JSON file that contains more than 50 key-value pairs', () => {
     const jsonObjects: any = [];
 

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -4,7 +4,7 @@ import { $TSMeta, $TSTeamProviderInfo, $TSAny, DeploymentSecrets } from '..';
 import { JSONUtilities } from '../jsonUtilities';
 import _ from 'lodash';
 import { SecretFileMode } from '../cliConstants';
-import { Tag, ReadValidateTags, HydrateTags } from '../tags';
+import { Tag, ReadTags, HydrateTags } from '../tags';
 
 export type GetOptions<T> = {
   throwIfNotExist?: boolean;
@@ -54,9 +54,9 @@ export class StateManager {
     );
   };
 
-  getProjectTags = (projectPath?: string): Tag[] => ReadValidateTags(pathManager.getTagFilePath(projectPath));
+  getProjectTags = (projectPath?: string): Tag[] => ReadTags(pathManager.getTagFilePath(projectPath));
 
-  getCurrentProjectTags = (projectPath?: string): Tag[] => ReadValidateTags(pathManager.getCurrentTagFilePath(projectPath));
+  getCurrentProjectTags = (projectPath?: string): Tag[] => ReadTags(pathManager.getCurrentTagFilePath(projectPath));
 
   teamProviderInfoExists = (projectPath?: string): boolean => this.doesExist(pathManager.getTeamProviderInfoFilePath, projectPath);
 

--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -1,7 +1,9 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { nspawn as spawn, getCLIPath, createNewProjectDir, KEY_DOWN_ARROW, readJsonFile } from '..';
+import _ from 'lodash';
 import { spawnSync } from 'child_process';
+import { getBackendAmplifyMeta } from '../utils';
 
 export function addDEVHosting(cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -136,4 +138,9 @@ export function resetBuildCommand(projectDir: string, newBuildCommand: string): 
   projectConfig.javascript.config.BuildCommand = newBuildCommand;
   fs.writeFileSync(projectConfigFilePath, JSON.stringify(projectConfig, null, 4));
   return currentBuildCommand;
+}
+
+export function extractHostingBucketInfo(projectDir: string) {
+  const meta = getBackendAmplifyMeta(projectDir);
+  return _.get(meta, ['hosting', 'S3AndCloudFront', 'output', 'HostingBucketName']);
 }

--- a/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
+++ b/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
@@ -1,7 +1,17 @@
 import { stateManager } from 'amplify-cli-core';
 
+declare global {
+  namespace NodeJS {
+    interface Global {
+      getTestName?: () => string;
+      getHookName?: () => string;
+      getDescibeBlocks?: () => string[];
+    }
+  }
+}
+
 export const addCircleCITags = (projectPath: string): void => {
-  if (process.env && process.env['CIRCLE_CI']) {
+  if (process.env && process.env['CIRCLECI']) {
     const tags = stateManager.getProjectTags(projectPath);
 
     const addTagIfNotExist = (key: string, value: string): void => {
@@ -13,10 +23,25 @@ export const addCircleCITags = (projectPath: string): void => {
       }
     };
 
-    addTagIfNotExist('circleci', process.env['CIRCLE_CI'] || 'N/A');
+    addTagIfNotExist('circleci', process.env['CIRCLECI'] || 'N/A');
     addTagIfNotExist('circleci:branch', process.env['CIRCLE_BRANCH'] || 'N/A');
     addTagIfNotExist('circleci:sha1', process.env['CIRCLE_SHA1'] || 'N/A');
     addTagIfNotExist('circleci:workflow_id', process.env['CIRCLE_WORKFLOW_ID'] || 'N/A');
+    addTagIfNotExist('circleci:build_id', process.env['CIRCLE_BUILD_NUM'] || 'N/A');
+    addTagIfNotExist('circleci:build_url', process.env['CIRCLE_BUILD_URL'] || 'N/A');
+    addTagIfNotExist('circleci:job', process.env['CIRCLE_JOB'] || 'N/A');
+    // exposed by custom CLI test environment
+    if (global.getTestName) {
+      addTagIfNotExist('jest:test_name', global.getTestName().substr(0, 255) || 'N/A');
+    }
+    if (global.getHookName) {
+      addTagIfNotExist('jest:hook_name', global.getHookName().substr(0, 255) || 'N/A');
+    }
+    if (global.getDescibeBlocks) {
+      global.getDescibeBlocks().forEach((blockName, i) => {
+        addTagIfNotExist(`jest:describe_${i + 1}`, blockName.substr(0, 255) || 'N/A');
+      });
+    }
 
     stateManager.setProjectFileTags(projectPath, tags);
   }

--- a/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
+++ b/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
@@ -23,26 +23,30 @@ export const addCircleCITags = (projectPath: string): void => {
       }
     };
 
-    addTagIfNotExist('circleci', process.env['CIRCLECI'] || 'N/A');
-    addTagIfNotExist('circleci:branch', process.env['CIRCLE_BRANCH'] || 'N/A');
-    addTagIfNotExist('circleci:sha1', process.env['CIRCLE_SHA1'] || 'N/A');
-    addTagIfNotExist('circleci:workflow_id', process.env['CIRCLE_WORKFLOW_ID'] || 'N/A');
-    addTagIfNotExist('circleci:build_id', process.env['CIRCLE_BUILD_NUM'] || 'N/A');
-    addTagIfNotExist('circleci:build_url', process.env['CIRCLE_BUILD_URL'] || 'N/A');
-    addTagIfNotExist('circleci:job', process.env['CIRCLE_JOB'] || 'N/A');
+    addTagIfNotExist('circleci', sanitizeTagValue(process.env['CIRCLECI'] || 'N/A'));
+    addTagIfNotExist('circleci:branch', sanitizeTagValue(process.env['CIRCLE_BRANCH'] || 'N/A'));
+    addTagIfNotExist('circleci:sha1', sanitizeTagValue(process.env['CIRCLE_SHA1'] || 'N/A'));
+    addTagIfNotExist('circleci:workflow_id', sanitizeTagValue(process.env['CIRCLE_WORKFLOW_ID'] || 'N/A'));
+    addTagIfNotExist('circleci:build_id', sanitizeTagValue(process.env['CIRCLE_BUILD_NUM'] || 'N/A'));
+    addTagIfNotExist('circleci:build_url', sanitizeTagValue(process.env['CIRCLE_BUILD_URL'] || 'N/A'));
+    addTagIfNotExist('circleci:job', sanitizeTagValue(process.env['CIRCLE_JOB'] || 'N/A'));
     // exposed by custom CLI test environment
     if (global.getTestName) {
-      addTagIfNotExist('jest:test_name', global.getTestName().substr(0, 255) || 'N/A');
+      addTagIfNotExist('jest:test_name', sanitizeTagValue(global.getTestName().substr(0, 255) || 'N/A'));
     }
     if (global.getHookName) {
-      addTagIfNotExist('jest:hook_name', global.getHookName().substr(0, 255) || 'N/A');
+      addTagIfNotExist('jest:hook_name', sanitizeTagValue(global.getHookName().substr(0, 255) || 'N/A'));
     }
     if (global.getDescibeBlocks) {
       global.getDescibeBlocks().forEach((blockName, i) => {
-        addTagIfNotExist(`jest:describe_${i + 1}`, blockName.substr(0, 255) || 'N/A');
+        addTagIfNotExist(`jest:describe_${i + 1}`, sanitizeTagValue(blockName.substr(0, 255) || 'N/A'));
       });
     }
 
     stateManager.setProjectFileTags(projectPath, tags);
   }
 };
+
+export function sanitizeTagValue(value: string): string {
+  return value.replace(/[^ a-z0-9_.:/=+\-@]/gi, '');
+}

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -107,7 +107,7 @@ function chain(context: Context): ExecutionContext {
 
       return chain(context);
     },
-    expect: function(expectation: string | RegExp): ExecutionContext {
+    expect: function (expectation: string | RegExp): ExecutionContext {
       let _expect: ExecutionStep = {
         fn: data => {
           return testExpectation(data, expectation, context);
@@ -123,7 +123,7 @@ function chain(context: Context): ExecutionContext {
       return chain(context);
     },
 
-    wait: function(expectation: string | RegExp, callback = (data: string) => {}): ExecutionContext {
+    wait: function (expectation: string | RegExp, callback = (data: string) => {}): ExecutionContext {
       let _wait: ExecutionStep = {
         fn: data => {
           var val = testExpectation(data, expectation, context);
@@ -141,7 +141,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_wait);
       return chain(context);
     },
-    sendLine: function(line: string): ExecutionContext {
+    sendLine: function (line: string): ExecutionContext {
       let _sendline: ExecutionStep = {
         fn: () => {
           context.process.write(`${line}${EOL}`);
@@ -155,7 +155,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_sendline);
       return chain(context);
     },
-    sendCarriageReturn: function(): ExecutionContext {
+    sendCarriageReturn: function (): ExecutionContext {
       let _sendline: ExecutionStep = {
         fn: () => {
           context.process.write(EOL);
@@ -169,7 +169,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_sendline);
       return chain(context);
     },
-    send: function(line: string): ExecutionContext {
+    send: function (line: string): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
           context.process.write(line);
@@ -183,7 +183,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_send);
       return chain(context);
     },
-    sendKeyDown: function(repeat?: number): ExecutionContext {
+    sendKeyDown: function (repeat?: number): ExecutionContext {
       const repeatitions = repeat ? Math.max(1, repeat) : 1;
       var _send: ExecutionStep = {
         fn: () => {
@@ -200,7 +200,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_send);
       return chain(context);
     },
-    sendKeyUp: function(repeat?: number): ExecutionContext {
+    sendKeyUp: function (repeat?: number): ExecutionContext {
       const repeatitions = repeat ? Math.max(1, repeat) : 1;
       var _send: ExecutionStep = {
         fn: () => {
@@ -217,7 +217,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_send);
       return chain(context);
     },
-    sendConfirmYes: function(): ExecutionContext {
+    sendConfirmYes: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
           context.process.write(`Y${EOL}`);
@@ -231,7 +231,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_send);
       return chain(context);
     },
-    sendConfirmNo: function(): ExecutionContext {
+    sendConfirmNo: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
           context.process.write(`N${EOL}`);
@@ -245,7 +245,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_send);
       return chain(context);
     },
-    sendEof: function(): ExecutionContext {
+    sendEof: function (): ExecutionContext {
       var _sendEof: ExecutionStep = {
         fn: () => {
           context.process.write('');
@@ -259,7 +259,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_sendEof);
       return chain(context);
     },
-    delay: function(milliseconds: number): ExecutionContext {
+    delay: function (milliseconds: number): ExecutionContext {
       var _delay: ExecutionStep = {
         fn: () => {
           const startCallback = Date.now();
@@ -276,7 +276,7 @@ function chain(context: Context): ExecutionContext {
       context.queue.push(_delay);
       return chain(context);
     },
-    run: function(callback: (err: any, code?: number, signal?: string | number) => void): ExecutionContext {
+    run: function (callback: (err: any, code?: number, signal?: string | number) => void): ExecutionContext {
       let errState: any = null;
       let responded = false;
       let stdout: string[] = [];
@@ -289,8 +289,9 @@ function chain(context: Context): ExecutionContext {
         if (code !== 0) {
           if (code === EXIT_CODE_TIMEOUT) {
             const err = new Error(
-              `Killed the process as no output receive for ${context.noOutputTimeout /
-                1000} Sec. The no output timeout is set to ${context.noOutputTimeout / 1000}`,
+              `Killed the process as no output receive for ${context.noOutputTimeout / 1000} Sec. The no output timeout is set to ${
+                context.noOutputTimeout / 1000
+              }`,
             );
             return onError(err, true);
           } else if (code === 127) {
@@ -441,7 +442,7 @@ function chain(context: Context): ExecutionContext {
           data = strip(data);
         }
 
-        var lines = data.split(EOL).filter(function(line) {
+        var lines = data.split(EOL).filter(function (line) {
           return line.length > 0 && line !== '\r';
         });
         stdout = stdout.concat(lines);
@@ -540,7 +541,7 @@ function testExpectation(data: string, expectation: string | RegExp, context: Co
 }
 
 function createUnexpectedEndError(message: string, remainingQueue: ExecutionStep[]) {
-  const desc: string[] = remainingQueue.map(function(it) {
+  const desc: string[] = remainingQueue.map(function (it) {
     return it.description;
   });
   var msg = message + '\n' + desc.join('\n');

--- a/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
@@ -1,7 +1,7 @@
 import { amplifyPublishWithoutUpdate, createReactTestProject, resetBuildCommand } from 'amplify-e2e-core';
 
 import { initJSProjectWithProfile, deleteProject } from 'amplify-e2e-core';
-import { addDEVHosting, removeHosting, amplifyPushWithoutCodegen } from 'amplify-e2e-core';
+import { addDEVHosting, removeHosting, amplifyPushWithoutCodegen, extractHostingBucketInfo, deleteS3Bucket } from 'amplify-e2e-core';
 import { deleteProjectDir, getProjectMeta } from 'amplify-e2e-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -17,9 +17,15 @@ describe('amplify add hosting', () => {
   });
 
   afterAll(async () => {
+    const hostingBucket = extractHostingBucketInfo(projRoot);
     await removeHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
     await deleteProject(projRoot);
+    if (hostingBucket) {
+      try {
+        await deleteS3Bucket(hostingBucket);
+      } catch {}
+    }
     deleteProjectDir(projRoot);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7064,6 +7064,18 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+amplify-cli-core@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-1.14.1.tgz#7bdf82b00f82cdb4f83895349a0963abb797ada7"
+  integrity sha512-iHeFaePbG24sZX/oJi/d+k1b74sFor5NJREMa7am2YLbdq9TsiPAgcVXNjzYbfESJoaQLUdBYpQsJYr10XEOUw==
+  dependencies:
+    ajv "^6.12.3"
+    amplify-cli-logger "1.1.0"
+    dotenv "^8.2.0"
+    fs-extra "^8.1.0"
+    hjson "^3.2.1"
+    lodash "^4.17.19"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"


### PR DESCRIPTION
1. Added tags to resources created by CircleCI. These tags include build number and build url
2. Updated hosting test to delete the hosting buckets after running the tests

The e2e tests get tags like below:
![image](https://user-images.githubusercontent.com/511386/107456112-7ad8c580-6b04-11eb-9c32-c1fbcbd3ff58.png)

This change will help identifying which tests are not cleaning up after themselves.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.