### PR TITLE
 build: compile test files before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint-fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "clean": "lerna run clean && lerna exec yarn rimraf tsconfig.tsbuildinfo && lerna clean --yes && yarn rimraf node_modules",
     "build": "lerna run build",
+    "build-tests": "lerna run build-tests",
     "production-build": "yarn --frozen-lockfile && lerna run build --concurrency 3 --stream",
     "dev-build": "yarn && lerna run build",
     "link-aa-dev": "cd packages/amplify-app && ln -s $(pwd)/bin/amplify-app $(yarn global bin)/amplify-app-dev && cd -",
@@ -57,7 +58,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "npm run lint && npm run test-changed",
+      "pre-push": "yarn build-tests && yarn run lint && yarn run test-changed",
       "pre-commit": "yarn split-e2e-tests && pretty-quick --staged"
     }
   },

--- a/packages/amplify-category-predictions/package.json
+++ b/packages/amplify-category-predictions/package.json
@@ -15,7 +15,7 @@
     "aws"
   ],
   "dependencies": {
-    "amplify-cli-core": "1.14.1",
+    "amplify-cli-core": "1.15.0",
     "aws-sdk": "^2.765.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-category-xr/package.json
+++ b/packages/amplify-category-xr/package.json
@@ -19,7 +19,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "amplify-cli-core": "1.14.1",
+    "amplify-cli-core": "1.15.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.3.3"

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -17,6 +17,7 @@
   ],
   "private": true,
   "scripts": {
+    "build-tests": "tsc --build tsconfig.tests.json",
     "migration_v4.0.0": "npm run setup-profile 4.0.0 && jest --testPathIgnorePatterns=.*auth.deployment.secrets.test.ts --verbose",
     "migration_v4.30.0_auth": "npm run setup-profile 4.30.0 && jest src/__tests__/migration_tests/auth-deployment-migration/auth.deployment.secrets.test.ts --verbose",
     "migration": "npm run setup-profile latest && jest --testPathIgnorePatterns=.*auth.deployment.secrets.test.ts --verbose",

--- a/packages/amplify-migration-tests/src/migration-helpers/check-version.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/check-version.ts
@@ -1,6 +1,6 @@
 import { getCLIPath, nspawn as spawn } from 'amplify-e2e-core';
 
-export function versionCheck(cwd: string, testingWithLatestCodebase = false) {
+export function versionCheck(cwd: string, testingWithLatestCodebase = false): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(testingWithLatestCodebase), ['-v'], { cwd, stripColors: true }).run((err: Error) => {
       if (!err) {

--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -17,7 +17,7 @@ const defaultSettings = {
   disableAmplifyAppCreation: true,
 };
 
-export function initJSProjectWithProfile(cwd: string, settings: Object, testingWithLatestCodebase = false) {
+export function initJSProjectWithProfile(cwd: string, settings: Object, testingWithLatestCodebase = false): Promise<void> {
   const s = { ...defaultSettings, ...settings };
   let env;
 

--- a/packages/amplify-migration-tests/tsconfig.tests.json
+++ b/packages/amplify-migration-tests/tsconfig.tests.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "sourceMap": true,
+    "outDir": "lib",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "sourceRoot": "src",
+    "lib": ["es2017", "esnext.asynciterable", "dom"],
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "lib"],
+  "include": ["src/"]
+}

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "e2e": "jest",
-    "build-tests": "tsc --build tsconfig.tests.json"
+    "build-tests": "yarn tsc --build tsconfig.tests.json"
   },
   "dependencies": {
     "amazon-cognito-identity-js": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7064,6 +7064,18 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+amplify-cli-core@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-1.14.1.tgz#7bdf82b00f82cdb4f83895349a0963abb797ada7"
+  integrity sha512-iHeFaePbG24sZX/oJi/d+k1b74sFor5NJREMa7am2YLbdq9TsiPAgcVXNjzYbfESJoaQLUdBYpQsJYr10XEOUw==
+  dependencies:
+    ajv "^6.12.3"
+    amplify-cli-logger "1.1.0"
+    dotenv "^8.2.0"
+    fs-extra "^8.1.0"
+    hjson "^3.2.1"
+    lodash "^4.17.19"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7064,18 +7064,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-cli-core@1.14.1:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-1.14.1.tgz#7bdf82b00f82cdb4f83895349a0963abb797ada7"
-  integrity sha512-iHeFaePbG24sZX/oJi/d+k1b74sFor5NJREMa7am2YLbdq9TsiPAgcVXNjzYbfESJoaQLUdBYpQsJYr10XEOUw==
-  dependencies:
-    ajv "^6.12.3"
-    amplify-cli-logger "1.1.0"
-    dotenv "^8.2.0"
-    fs-extra "^8.1.0"
-    hjson "^3.2.1"
-    lodash "^4.17.19"
-
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"


### PR DESCRIPTION
*Issue #, if available:*

updated the husky hooks to compile test file before pushing as these files are not compiled with regular build. With this update errors in the test files will be discovered upfront instead of it happening in CCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.