### PR TITLE
chore(amplify-migration-tests): use yarn tsc instead of global tsc

### DIFF
--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -17,7 +17,7 @@
   ],
   "private": true,
   "scripts": {
-    "build-tests": "tsc --build tsconfig.tests.json",
+    "build-tests": "yarn tsc --build tsconfig.tests.json",
     "migration_v4.0.0": "npm run setup-profile 4.0.0 && jest --testPathIgnorePatterns=.*auth.deployment.secrets.test.ts --verbose",
     "migration_v4.30.0_auth": "npm run setup-profile 4.30.0 && jest src/__tests__/migration_tests/auth-deployment-migration/auth.deployment.secrets.test.ts --verbose",
     "migration": "npm run setup-profile latest && jest --testPathIgnorePatterns=.*auth.deployment.secrets.test.ts --verbose",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.