### PR TITLE
improvement: go listening for running process

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -443,7 +443,7 @@ async function createAmplifyHelperFiles(frontend) {
   }
 
   if (frontend === 'flutter') {
-    initializeAmplifyConfiguration(path.resolve('src'));
+    initializeAmplifyConfiguration(path.resolve('lib'));
   }
 
   return frontend;

--- a/packages/amplify-go-function-runtime-provider/package.json
+++ b/packages/amplify-go-function-runtime-provider/package.json
@@ -25,6 +25,7 @@
     "amplify-function-plugin-interface": "1.6.0",
     "archiver": "^3.1.1",
     "execa": "^4.1.0",
+    "find-process": "^1.4.4",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "portfinder": "^1.0.25",

--- a/packages/amplify-go-function-runtime-provider/src/constants.ts
+++ b/packages/amplify-go-function-runtime-provider/src/constants.ts
@@ -8,6 +8,7 @@ export const DIST = 'dist';
 export const MAIN_SOURCE = 'main.go';
 export const MAIN_BINARY = 'main';
 export const MAIN_BINARY_WIN = 'main.exe';
+export const MAIN_DEBUG_BIN = '__debug_bin';
 
 export const BASE_PORT = 8900;
 export const MAX_PORT = 9999;


### PR DESCRIPTION
*Issue #, if available:*
#5229 
*Description of changes:*
amplify-go-function-runtime-provider/localinvoke.ts will now listen for a running debug process.
If it finds one it will get the port number for that process and use it instead of invoking a new process.
This allows a developer to have a local debug process running while testing locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.