### PR TITLE
fix: incorrect import and update yarn lock

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -5,7 +5,7 @@ import {
   BuildRequest,
   BuildResult,
   BuildType,
-} from 'amplify-function-plugin-interface/src';
+} from 'amplify-function-plugin-interface';
 import * as which from 'which';
 import execa from 'execa';
 import archiver from 'archiver';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7069,18 +7069,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-cli-core@1.14.1:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-1.14.1.tgz#7bdf82b00f82cdb4f83895349a0963abb797ada7"
-  integrity sha512-iHeFaePbG24sZX/oJi/d+k1b74sFor5NJREMa7am2YLbdq9TsiPAgcVXNjzYbfESJoaQLUdBYpQsJYr10XEOUw==
-  dependencies:
-    ajv "^6.12.3"
-    amplify-cli-logger "1.1.0"
-    dotenv "^8.2.0"
-    fs-extra "^8.1.0"
-    hjson "^3.2.1"
-    lodash "^4.17.19"
-
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"


### PR DESCRIPTION
*Issue #, if available:*
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/3763/workflows/ffd47f18-bd59-4ffb-b904-c16ad2709633
*Description of changes:*
Fix incorrect import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.