### PR TITLE
feat(cli): add 'amplify env ls' alias

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/env.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/env.test.ts
@@ -1,0 +1,30 @@
+describe('amplify env: ', () => {
+  const mockExit = jest.fn();
+  jest.mock('amplify-cli-core', () => ({
+    exitOnNextTick: mockExit,
+  }));
+  const { run: runEnvCmd } = require('../../commands/env');
+  const envList = require('../../commands/env/list');
+  jest.mock('../../commands/env/list');
+
+  it('env run method should exist', () => {
+    expect(runEnvCmd).toBeDefined();
+  });
+
+  it('env ls is an alias for env list', async () => {
+    const mockEnvListRun = jest.spyOn(envList, 'run');
+    await runEnvCmd({
+      input: {
+        subCommands: ['list'],
+      },
+      parameters: {},
+    });
+    await runEnvCmd({
+      input: {
+        subCommands: ['ls'],
+      },
+      parameters: {},
+    });
+    expect(mockEnvListRun).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/amplify-cli/src/commands/env.ts
+++ b/packages/amplify-cli/src/commands/env.ts
@@ -11,6 +11,7 @@ export const run = async context => {
     /* eslint-enable */
   }
   shiftParams(context);
+  subcommand = mapSubcommandAlias(subcommand);
   if (subcommand === 'help') {
     displayHelp(context);
   } else {
@@ -86,4 +87,11 @@ function displayHelp(context) {
 
   context.amplify.showHelp(header, commands);
   context.print.info('');
+}
+
+function mapSubcommandAlias(subcommand: string): string {
+  if (subcommand === 'ls') {
+    return 'list';
+  }
+  return subcommand;
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-cli/issues/6188

*Description of changes:* This commit aliases `amplify env ls` to `amplify env list`