### PR TITLE
fix(amplify-appsync-simulator): expose other than GraphQLError

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/query-and-mutation.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/query-and-mutation.test.ts
@@ -154,4 +154,23 @@ describe('runQueryAndMutation', () => {
       errors: [error],
     });
   });
+
+  it('should have error object populated when error occurs in the resolver (e.g. Lambda DataSource)', async () => {
+    const name = 'John Doe';
+    const doc = parse(/* GraphQL */ `
+      query getName {
+        getName
+      }
+    `);
+
+    const error: Error = new Error('An error from the resolver');
+    executionContext.appsyncErrors = [error];
+    const variables = { var1: 'val1' };
+    getNameResolver.mockReturnValue(null);
+
+    await expect(runQueryOrMutation(schema, doc, variables, 'getName', executionContext)).resolves.toEqual({
+      data: { getName: null },
+      errors: [error],
+    });
+  });
 });

--- a/packages/amplify-appsync-simulator/src/utils/expose-graphql-errors.ts
+++ b/packages/amplify-appsync-simulator/src/utils/expose-graphql-errors.ts
@@ -9,17 +9,14 @@
  *
  */
 
-import { GraphQLError } from 'graphql';
 export function exposeGraphQLErrors(errors = []) {
-  return errors
-    .filter(e => e.extensions || e instanceof GraphQLError)
-    .map(e => {
-      if (e.extensions) {
-        const additionalProps = Object.entries(e.extensions).reduce((sum, [k, v]) => {
-          return { ...sum, [k]: { value: v, enumerable: true } };
-        }, {});
-        return Object.defineProperties({}, additionalProps);
-      }
-      return e;
-    });
+  return errors.map(e => {
+    if (e.extensions) {
+      const additionalProps = Object.entries(e.extensions).reduce((sum, [k, v]) => {
+        return { ...sum, [k]: { value: v, enumerable: true } };
+      }, {});
+      return Object.defineProperties({}, additionalProps);
+    }
+    return e;
+  });
 }


### PR DESCRIPTION
*Issue #, if available:*

Since [version 1.25.1 of amplify-appsync-simulator](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-appsync-simulator/CHANGELOG.md#1251-2021-02-10), the behavior when an error occurs in a resolver has changed.
When I am using Lambda as DataSource and an error occurs in Lambda, the error type is Error instead of GraphQLError.
So, the error is filtered out from errors and I can not refer the error in `response.vtl`.
In a real environment, the error does not seem to be filtered out.

*Description of changes:*

I have removed the filter with GraphQLError and added a test to reproduce the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.