### PR TITLE
fix(amplify-frontend-javascript) update aws-exports.js on new env creation

### DIFF
--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -82,7 +82,10 @@ async function createAWSExports(context, amplifyResources, cloudAmplifyResources
 
   const customConfigs = getCustomConfigs(cloudAWSExports, currentAWSExports);
 
-  Object.assign(newAWSExports, customConfigs);
+  if (context.input.command !== 'push' && context.input.command !== 'init') {
+    Object.assign(newAWSExports, customConfigs);
+  }
+
   generateAWSExportsFile(context, newAWSExports);
   return context;
 }
@@ -339,7 +342,8 @@ function getAPIGWConfig(apigwResources, projectRegion, configOutput) {
   };
 
   for (let i = 0; i < apigwResources.length; i += 1) {
-    if (apigwResources[i].output.ApiName && apigwResources[i].output.RootUrl) { // only REST endpoints contains this information
+    if (apigwResources[i].output.ApiName && apigwResources[i].output.RootUrl) {
+      // only REST endpoints contains this information
       apigwConfig.aws_cloud_logic_custom.push({
         name: apigwResources[i].output.ApiName,
         endpoint: apigwResources[i].output.RootUrl,


### PR DESCRIPTION
*Issue #, if available:* #6432 

*Description of changes:*

The issue was that running `amplify init` and `amplify push` to create a new environment would not update the `aws-exports.js` to match the newly created environment. (Note that it would set the current active env to the newly created one, but the `aws-exports.js` file would still have old endpoints and keys.)

The generation of `aws-exports.js` file is done [here](https://github.com/aws-amplify/amplify-cli/blob/0e5d85be780c800aad2322ebb2b5598187c97ae8/packages/amplify-frontend-javascript/lib/frontend-config-creator.js#L210), On the CLI side, `initialize-env.ts` calls `context.amplify.onCategoryOutputsChange` which in turn calls the `generateAWSExportsFile` function. The `generateAWSExportsFile` function takes in a config object and outputs it to the file.

So, the function was getting called properly, but [this line](https://github.com/aws-amplify/amplify-cli/blob/0e5d85be780c800aad2322ebb2b5598187c97ae8/packages/amplify-frontend-javascript/lib/frontend-config-creator.js#L85), i.e. `Object.assign(newAWSExports, customConfigs);` was causing the `newAWSExports` object values (which actually contain the config for the newly created env) were getting overridden by `customConfigs`, and `customConfigs` were the values that belonged to the older env. Thus, `aws-exports.js` ended up with the values that actually belonged to older env. 

To fix this, I have added a condition which does not execute the Object.assign line when the CLI command is "push" or "init", since those are the scenarios where the issue is occurring. But then even though it solves this particular issue, since it effectively ignores `customConfigs` on `push` and `init`, i am not sure what other repercussions it has, so i am including as much detail as possible so that someone experienced can help me out here.

Debug outputs (before Object.assign) on running `init` for `newAWSExports`, `cloudAWSExports`, `currentAWSExports` and `customConfigs`

![image](https://user-images.githubusercontent.com/32734049/107887347-81fc3b00-6f2b-11eb-9a9d-b071eba32be8.png)

As you can see, the `newAWSExports` object contains the correct object that should be written to file, but Object.assign overwrites that and includes the old one (in `customConfigs`) instead. Same thing happens with `push` as well. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
