### PR TITLE
fix: mock bug fixes and e2e test updates

### DIFF
--- a/packages/amplify-category-function/src/commands/function/build.ts
+++ b/packages/amplify-category-function/src/commands/function/build.ts
@@ -15,10 +15,7 @@ export const run = async (context: $TSContext) => {
   const confirmContinue =
     !!resourceName ||
     context.input?.options?.yes ||
-    (await context.amplify.confirmPrompt(
-      'This will build all functions and layers in your project. Are you sure you want to continue?',
-      false,
-    ));
+    (await context.amplify.confirmPrompt('Are you sure you want to continue building the resources?', false));
   if (!confirmContinue) {
     return;
   }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -2,7 +2,7 @@ import { FunctionParameters, FunctionTriggerParameters, FunctionTemplate, Provid
 import { isMultiEnvLayer, LayerParameters, StoredLayerParameters } from './utils/layerParams';
 import { chooseParamsOnEnvInit } from './utils/layerHelpers';
 import { supportedServices } from '../supported-services';
-import { ServiceName, provider, parametersFileName, functionParametersFileName } from './utils/constants';
+import { ServiceName, provider, functionParametersFileName } from './utils/constants';
 import { category as categoryName } from '../../constants';
 import {
   createFunctionResources,
@@ -226,7 +226,7 @@ export async function updateFunctionResource(context, category, service, paramet
   }
 
   if (!parameters || (parameters && !parameters.skipEdit)) {
-    const breadcrumb = context.amplify.readBreadcrumbs(context, categoryName, parameters.resourceName);
+    const breadcrumb = context.amplify.readBreadcrumbs(categoryName, parameters.resourceName);
     const displayName = 'trigger' in parameters ? parameters.resourceName : undefined;
     await openEditor(context, category, parameters.resourceName, { defaultEditorFile: breadcrumb.defaultEditorFile }, displayName, false);
   }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/build.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/build.ts
@@ -3,8 +3,8 @@ import { buildFunction, BuildRequestMeta } from './buildFunction';
 import { ServiceName } from './constants';
 
 export const buildResource = (context: $TSContext, resource: BuildRequestMeta & { service: string }) => {
-  // no build step for lambda layers
-  if (resource.service === ServiceName.LambdaLayer) {
+  // only build lambda functions
+  if (resource.service !== ServiceName.LambdaFunction) {
     return;
   }
   return buildFunction(context, resource);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/package.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/package.ts
@@ -6,13 +6,6 @@ import { packageLayer } from './packageLayer';
 
 export const packageResource: Packager = async (context, resource) => getServicePackager(resource.service)(context, resource);
 
-const getServicePackager = (service: string) => (servicePackagerMap[service] ?? packageUnknown) as Packager;
-
-const servicePackagerMap: Record<ServiceName, Packager> = {
-  [ServiceName.LambdaFunction]: packageFunction,
-  [ServiceName.LambdaLayer]: packageLayer,
-};
-
-const packageUnknown: Packager = (_, resource) => {
-  throw new Error(`Unknown function service type ${resource.service}`);
-};
+// there are some other categories (api and maybe others) that depend on the packageFunction function to create a zip file of resource
+// which is why it is the default return value here
+const getServicePackager = (service: string) => (service === ServiceName.LambdaLayer ? packageLayer : packageFunction);

--- a/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
@@ -102,7 +102,12 @@ describe('python function tests', () => {
 });
 
 describe('dotnet function tests', () => {
-  const helloWorldSuccessOutput = '{"key1":"VALUE1","key2":"VALUE2","key3":"VALUE3"}';
+  const helloWorldSuccessObj = {
+    key1: 'VALUE1',
+    key2: 'VALUE2',
+    key3: 'VALUE3',
+  };
+  const helloWorldSuccessString = '  "key3": "VALUE3"';
   let projRoot: string;
   let funcName: string;
 
@@ -131,7 +136,7 @@ describe('dotnet function tests', () => {
   it('add dotnet hello world function and mock locally', async () => {
     await functionMockAssert(projRoot, {
       funcName,
-      successString: helloWorldSuccessOutput,
+      successString: helloWorldSuccessString,
       eventFile: 'src/event.json',
     }); // will throw if successString is not in output
   });
@@ -140,6 +145,6 @@ describe('dotnet function tests', () => {
     const payload = '{"key1":"value1","key2":"value2","key3":"value3"}';
     await amplifyPushAuth(projRoot);
     const response = await functionCloudInvoke(projRoot, { funcName, payload });
-    expect(JSON.parse(response.Payload.toString())).toEqual(JSON.parse(helloWorldSuccessOutput));
+    expect(JSON.parse(response.Payload.toString())).toEqual(helloWorldSuccessObj);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/function_4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_4.test.ts
@@ -14,7 +14,10 @@ import {
 } from 'amplify-e2e-core';
 
 describe('java function tests', () => {
-  const helloWorldSuccessOutput = '{"greetings":"Hello John Doe!"}';
+  const helloWorldSuccessObj = {
+    greetings: 'Hello John Doe!',
+  };
+  const helloWorldSuccessString = '  "greetings": "Hello John Doe!"';
   let projRoot: string;
   let funcName: string;
 
@@ -43,7 +46,7 @@ describe('java function tests', () => {
   it('add java hello world function and mock locally', async () => {
     await functionMockAssert(projRoot, {
       funcName,
-      successString: helloWorldSuccessOutput,
+      successString: helloWorldSuccessString,
       eventFile: 'src/event.json',
     }); // will throw if successString is not in output
   });
@@ -52,7 +55,7 @@ describe('java function tests', () => {
     const payload = '{"firstName":"John","lastName" : "Doe"}';
     await amplifyPushAuth(projRoot);
     const response = await functionCloudInvoke(projRoot, { funcName, payload });
-    expect(JSON.parse(response.Payload.toString())).toEqual(JSON.parse(helloWorldSuccessOutput));
+    expect(JSON.parse(response.Payload.toString())).toEqual(helloWorldSuccessObj);
   });
 });
 

--- a/packages/amplify-java-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-java-function-runtime-provider/src/utils/invoke.ts
@@ -20,10 +20,9 @@ export const invokeResource = async (request: InvocationRequest, context: any) =
       input: request.event,
       env: request.envVars,
       extendEnv: false,
-      stderr: 'inherit',
-      stdout: 'inherit',
     },
   );
+  childProcess.stderr.pipe(process.stderr);
   childProcess.stdout.pipe(process.stdout);
 
   const { stdout, exitCode } = await childProcess;

--- a/packages/amplify-java-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-java-function-runtime-provider/src/utils/invoke.ts
@@ -18,7 +18,7 @@ export const invokeResource = async (request: InvocationRequest, context: any) =
     ],
     {
       input: request.event,
-      env: request.envVars,
+      env: { PATH: process.env.PATH, ...request.envVars }, // Java relies on PATH so we have to add that into the env
       extendEnv: false,
     },
   );

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -471,7 +471,6 @@ async function prepareBuildableResources(context: $TSContext, resources: $TSAny[
 }
 
 async function prepareResource(context: $TSContext, resource: $TSAny) {
-  // currently the only category that has a "buildable" resource is the functions category, hence the hardcoding
   resource.lastBuildTimeStamp = await context.amplify.invokePluginMethod(context, 'function', undefined, 'buildResource', [
     context,
     resource,

--- a/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts
@@ -22,7 +22,13 @@ export const populateLambdaMockEnvVars = async (context: $TSContext, processedLa
 
 const getAwsCredentials = async (_, context: $TSContext): Promise<Record<string, string>> => {
   const env = stateManager.getLocalEnvInfo().envName;
-  const awsConfig = await loadConfigurationForEnv(context, env, resolveAppId(context));
+  let appId: string | undefined = undefined;
+  try {
+    appId = resolveAppId(context);
+  } catch {
+    // swallow no appId found as it's not necessary for mocking
+  }
+  const awsConfig = await loadConfigurationForEnv(context, env, appId);
   return {
     AWS_ACCESS_KEY_ID: awsConfig.accessKeyId,
     AWS_SECRET_ACCESS_KEY: awsConfig.secretAccessKey,


### PR DESCRIPTION
*Issue #, if available:*
Fixes the remaining e2e test issues with my previous PRs.
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/3781/workflows/87bc7f52-f22d-4713-873a-97d078a0c7c6
*Description of changes:*
Changed a confirm prompt back to original text to match tests, updated some test expect values to match new mock output (changes now pretty print json instead of printing on single line) and updated function build / package logic to handle cases where other categories depend on the zipping logic (we should remove this tight coupling in the future). Also fixed a couple bugs in the dotnet and java mock executors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.