### PR TITLE
fix(amplify-provider-awscloudformation): admin token refresh, configure project

### DIFF
--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -106,7 +106,6 @@
     "moment": "^2.24.0",
     "netmask": "^1.0.6",
     "node-fetch": "^2.6.1",
-    "open": "^7.0.0",
     "ora": "^4.0.3",
     "promise-sequential": "^1.1.1",
     "proxy-agent": "^3.1.1",

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -1,11 +1,11 @@
-import open from 'open';
 import ora from 'ora';
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext, open } from 'amplify-cli-core';
 
 import { adminVerifyUrl, adminBackendMap, isAmplifyAdminApp } from './utils/admin-helpers';
 import { AdminLoginServer } from './utils/admin-login-server';
 
-export async function adminLoginFlow(context: $TSContext, appId: string, envName: string, region?: string) {
+export async function adminLoginFlow(context: $TSContext, appId: string, envName?: string, region?: string) {
+  envName = envName || context.amplify.getEnvInfo().envName;
   if (!region) {
     const { isAdminApp, region: _region } = await isAmplifyAdminApp(appId);
     if (!isAdminApp) {

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -2,6 +2,7 @@ import { stateManager, $TSContext } from 'amplify-cli-core';
 import aws from 'aws-sdk';
 import _ from 'lodash';
 import fetch from 'node-fetch';
+import { adminLoginFlow } from '../admin-login';
 import { AdminAuthConfig, AwsSdkConfig, CognitoAccessToken, CognitoIdToken } from './auth-types';
 
 export const adminVerifyUrl = (appId: string, envName: string, region: string): string => {
@@ -27,8 +28,11 @@ export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: bo
   return { isAdminApp: !!appState.appId, region: appState.region };
 }
 
-export async function getTempCredsWithAdminTokens(appId: string, print: $TSContext['print']): Promise<AwsSdkConfig> {
-  const authConfig = await getRefreshedTokens(appId, print);
+export async function getTempCredsWithAdminTokens(context: $TSContext, appId: string): Promise<AwsSdkConfig> {
+  if (!doAdminTokensExist(appId)) {
+    await adminLoginFlow(context, appId);
+  }
+  const authConfig = await getRefreshedTokens(context, appId);
   const { idToken, IdentityId, region } = authConfig;
   // use tokens to get creds and assign to config
   const awsConfig = await getAdminCognitoCredentials(idToken, IdentityId, region);
@@ -82,17 +86,23 @@ async function getAdminStsCredentials(idToken: CognitoIdToken, region: string): 
   };
 }
 
-export async function getRefreshedTokens(appId: string, print: $TSContext['print']) {
+async function getRefreshedTokens(context: $TSContext, appId: string) {
   // load token, check expiry, refresh if needed
   const authConfig: AdminAuthConfig = stateManager.getAmplifyAdminConfigEntry(appId);
 
   if (isJwtExpired(authConfig.idToken)) {
-    const refreshedTokens = await refreshJWTs(authConfig, print);
-    // Refresh stored tokens
-    authConfig.accessToken.jwtToken = refreshedTokens.AccessToken;
-    authConfig.idToken.jwtToken = refreshedTokens.IdToken;
-    authConfig.refreshToken.token = refreshedTokens.RefreshToken;
-    stateManager.setAmplifyAdminConfigEntry(appId, authConfig);
+    let refreshedTokens: aws.CognitoIdentityServiceProvider.AuthenticationResultType;
+    try {
+      refreshedTokens = (await refreshJWTs(authConfig)).AuthenticationResult;
+      // Refresh stored tokens
+      authConfig.accessToken.jwtToken = refreshedTokens.AccessToken;
+      authConfig.idToken.jwtToken = refreshedTokens.IdToken;
+      authConfig.refreshToken.token = refreshedTokens.RefreshToken;
+      stateManager.setAmplifyAdminConfigEntry(appId, authConfig);
+    } catch {
+      // Refresh failed, fall back to login
+      await adminLoginFlow(context, appId, null, authConfig.region);
+    }
   }
   return authConfig;
 }
@@ -103,21 +113,15 @@ function isJwtExpired(token: CognitoAccessToken | CognitoIdToken) {
   return secSinceEpoch >= expiration - 60;
 }
 
-async function refreshJWTs(authConfig: AdminAuthConfig, print: $TSContext['print']) {
+async function refreshJWTs(authConfig: AdminAuthConfig) {
   const CognitoISP = new aws.CognitoIdentityServiceProvider({ region: authConfig.region });
-  try {
-    const result = await CognitoISP.initiateAuth({
-      AuthFlow: 'REFRESH_TOKEN',
-      AuthParameters: {
-        REFRESH_TOKEN: authConfig.refreshToken.token,
-      },
-      ClientId: authConfig.accessToken.payload.client_id, // App client id from identityPool
-    }).promise();
-    return result.AuthenticationResult;
-  } catch (e) {
-    print.error(`Failed to refresh tokens: ${e.message || 'Unknown error occurred'}`);
-    throw e;
-  }
+  return await CognitoISP.initiateAuth({
+    AuthFlow: 'REFRESH_TOKEN',
+    AuthParameters: {
+      REFRESH_TOKEN: authConfig.refreshToken.token,
+    },
+    ClientId: authConfig.accessToken.payload.client_id, // App client id from identityPool
+  }).promise();
 }
 
 export const adminBackendMap: {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/6593 #6635

*Description of changes:*
Fall back to admin login if token refresh fails. Also fixed a couple of bugs in `amplify configure project`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.