### PR TITLE
fix(amplify-codegen-appsync-model-plugin): include isNullable in version hash

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -23,7 +23,7 @@ export 'SimpleModel.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = \\"c93024b4cb5966d577b5aa548edfb992\\";
+  String version = \\"dc3c6d4f5a93c447c05a7adb901ee79e\\";
   @override
   List<ModelSchema> modelSchemas = [SimpleModel.schema];
   static final ModelProvider _instance = ModelProvider();

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -338,7 +338,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "ace65a3762ae8764a52a487c71055733",
+            "version": "c67353403fbe0ce39751869febc23e9b",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -422,7 +422,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -499,7 +499,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -642,7 +642,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -750,7 +750,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -854,7 +854,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"bff2efaf6e138056991c723932df2763\\"
+            \\"version\\": \\"07b159e5243ee5817fb1e965dbc3ffdb\\"
         };"
       `);
     });
@@ -943,7 +943,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"bff2efaf6e138056991c723932df2763\\"
+            \\"version\\": \\"07b159e5243ee5817fb1e965dbc3ffdb\\"
         };"
       `);
     });

--- a/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -867,7 +867,7 @@ describe('AppSyncSwiftVisitor', () => {
       // Contains the set of classes that conforms to the \`Model\` protocol. 
 
       final public class AmplifyModels: AmplifyModelRegistration {
-        public let version: String = \\"ca73d7dc63498f675fff2b260548d216\\"
+        public let version: String = \\"cc0c3fc03caae9e6458da692ebe0b460\\"
         
         public func registerModels(registry: ModelRegistry.Type) {
           ModelRegistry.register(modelType: Attraction.self)

--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-visitor.ts
@@ -391,6 +391,7 @@ export class AppSyncModelVisitor<
             name: field.name,
             directives: fieldDirectives,
             type: field.type,
+            isNullable: field.isNullable,
           };
         })
         .sort((a, b) => sortFields(a, b));
@@ -401,11 +402,7 @@ export class AppSyncModelVisitor<
       });
     });
     typeArr.sort(sortFields);
-    return crypto
-      .createHash('MD5')
-      .update(JSON.stringify(typeArr))
-      .digest()
-      .toString('hex');
+    return crypto.createHash('MD5').update(JSON.stringify(typeArr)).digest().toString('hex');
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*
Given a basic schema in a JavaScript project:
```graphql
type Post @model {
  id: ID!
  title: String
}
```
after running `amplify models codegen` for the first time, the `schema.js` file is populated as expected with a unique `version` hash based on the type and the fields.

However, after changing `title` to be required with `String!`, and then running `amplify models codegen` again, the `version` doesn't change.

My expectation is that a field's "required" attribute should be considered in this hash.

*Description of changes:*
- include `isNullable` when calculating the `version` hash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.