### PR TITLE
fix(graphql-key-transformer): fix delta with selective sync query

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -1076,7 +1076,7 @@ function setSyncQueryFilterSnippet() {
     compoundExpression([
       set(ref('filterArgsMap'), ref('ctx.args.filter.get("and")')),
       ifElse(
-        raw(`!$util.isNullOrEmpty($filterArgsMap)`),
+        raw(`!$util.isNullOrEmpty($filterArgsMap)) && $util.isNull($ctx.args.lastSync)`),
         compoundExpression([
           set(ref('json'), raw(`$filterArgsMap`)),
           forEach(ref('item'), ref(`json`), [

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -1235,7 +1235,7 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
-#if( !$util.isNullOrEmpty($filterArgsMap) )
+#if( !$util.isNullOrEmpty($filterArgsMap)) && $util.isNull($ctx.args.lastSync) )
   #set( $json = $filterArgsMap )
   #foreach( $item in $json )
     #set( $ind = $foreach.index )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/7495

*Description of changes:*
Currently, when the sync query request resolver for a model receives a sync expression that maps to a DynamoDB Query operation, we're ignoring the `lastSync` value and performing a query against the Base Table. 
In other words,
If we have a model like:
```gql
type User
  @model
  @key(
    name: "byUsername"
    queryField: "userByUsername"
    fields: ["username", "sortOrder"]
  )
```
The following query variables
```json
{
  "limit":1000,
  "nextToken":null,
  "filter":{"and":[{"username":{"eq":"user1"}}]},

  "lastSync":1613615765839
}
```
Result in a query on the Base Table

We [should instead be](https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-delta-sync.html#sync-queries) retrieving records from the Delta Table.

This PR adds a check to the resolver to ignore the query expression logic when `$ctx.args.lastSync !== null` and query the Delta Table.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.