### PR TITLE
fix(auth): update oauth prompt help text to mention that selecting "no" will remove existing configuration

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -733,7 +733,7 @@ export const supportedServices = {
         key: 'hostedUI',
         question: 'Do you want to use an OAuth flow?',
         learnMore:
-        'When you create a user pool in Amazon Cognito and configure a domain for it, Amazon Cognito automatically provisions a hosted web UI to let you add sign-up and sign-in pages to your app. Note: Selecting "No" will remove the existing oAuth configuration, if any.',
+        'When you create a user pool in Amazon Cognito and configure a domain for it, Amazon Cognito automatically provisions a hosted web UI to let you add sign-up and sign-in pages to your app. Note: Selecting "No" will remove any existing oAuth configuration.',
         required: true,
         type: 'list',
         map: 'booleanOptions',

--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -733,7 +733,7 @@ export const supportedServices = {
         key: 'hostedUI',
         question: 'Do you want to use an OAuth flow?',
         learnMore:
-        'When you create a user pool in Amazon Cognito and configure a domain for it, Amazon Cognito automatically provisions a hosted web UI to let you add sign-up and sign-in pages to your app. Note: Selecting "No" will remove any existing oAuth configuration.',
+        'When you create a user pool in Amazon Cognito and configure a domain for it, Amazon Cognito automatically provisions a hosted web UI to let you add sign-up and sign-in pages to your app. Selecting "No" will remove any existing OAuth configuration.',
         required: true,
         type: 'list',
         map: 'booleanOptions',

--- a/packages/amplify-category-auth/src/provider-utils/supported-services.ts
+++ b/packages/amplify-category-auth/src/provider-utils/supported-services.ts
@@ -733,7 +733,7 @@ export const supportedServices = {
         key: 'hostedUI',
         question: 'Do you want to use an OAuth flow?',
         learnMore:
-          'When you create a user pool in Amazon Cognito and configure a domain for it, Amazon Cognito automatically provisions a hosted web UI to let you add sign-up and sign-in pages to your app.',
+        'When you create a user pool in Amazon Cognito and configure a domain for it, Amazon Cognito automatically provisions a hosted web UI to let you add sign-up and sign-in pages to your app. Note: Selecting "No" will remove the existing oAuth configuration, if any.',
         required: true,
         type: 'list',
         map: 'booleanOptions',


### PR DESCRIPTION
*Issue #, if  #available:* #6599 

*Description of changes:*
updated oauth prompt help text that appears on doing `amplify update auth` and selecting `I want to learn more` under the question "Do you want to use an OAuth flow? " to mention that selecting "no" will remove existing configuration, if any.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.