### PR TITLE
fix(graphql-relational-schema-transformer): escape String primary key

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/__tests__/__snapshots__/RelationalDBResolverGenerator.test.ts.snap
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/__snapshots__/RelationalDBResolverGenerator.test.ts.snap
@@ -54,7 +54,7 @@ exports[`verify generated templates 10`] = `
 #set( $update = $updateList.toString().replace(\\"{\\",\\"\\").replace(\\"}\\",\\"\\") )
 {
   \\"version\\": \\"2018-05-29\\",
-  \\"statements\\":   [\\"UPDATE Tomatoes SET $update WHERE Id=$ctx.args.updateTomatoesInput.Id\\", \\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.updateTomatoesInput.Id'\\"]
+  \\"statements\\":   [\\"UPDATE Tomatoes SET $update WHERE Id='$ctx.args.updateTomatoesInput.Id'\\", \\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.updateTomatoesInput.Id'\\"]
 }"
 `;
 
@@ -77,7 +77,7 @@ exports[`verify generated templates 13`] = `"testFilePath/Mutation.deleteTomatoe
 exports[`verify generated templates 14`] = `
 "{
   \\"version\\": \\"2018-05-29\\",
-  \\"statements\\":   [\\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.Id'\\", \\"DELETE FROM Tomatoes WHERE Id=$ctx.args.Id\\"]
+  \\"statements\\":   [\\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.Id'\\", \\"DELETE FROM Tomatoes WHERE Id='$ctx.args.Id'\\"]
 }"
 `;
 
@@ -107,3 +107,111 @@ exports[`verify generated templates 18`] = `
 exports[`verify generated templates 19`] = `"testFilePath/Query.listTomatoess.res.vtl"`;
 
 exports[`verify generated templates 20`] = `"$utils.toJson($utils.rds.toJsonObject($ctx.result)[0])"`;
+
+exports[`verify generated templates using a Int primary key 1`] = `"testFilePath/Mutation.createApples.req.vtl"`;
+
+exports[`verify generated templates using a Int primary key 2`] = `
+"#set( $cols = [] )
+#set( $vals = [] )
+#foreach( $entry in $ctx.args.createApplesInput.keySet() )
+  #set( $discard = $cols.add($entry) )
+  #set( $discard = $vals.add(\\"'$ctx.args.createApplesInput[$entry]'\\") )
+#end
+#set( $valStr = $vals.toString().replace(\\"[\\",\\"(\\").replace(\\"]\\",\\")\\") )
+#set( $colStr = $cols.toString().replace(\\"[\\",\\"(\\").replace(\\"]\\",\\")\\") )
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"statements\\":   [\\"INSERT INTO Apples $colStr VALUES $valStr\\", \\"SELECT * FROM Apples WHERE Id=$ctx.args.createApplesInput.Id\\"]
+}"
+`;
+
+exports[`verify generated templates using a Int primary key 3`] = `"testFilePath/Mutation.createApples.res.vtl"`;
+
+exports[`verify generated templates using a Int primary key 4`] = `"$utils.toJson($utils.parseJson($utils.rds.toJsonString($ctx.result))[1][0])"`;
+
+exports[`verify generated templates using a Int primary key 5`] = `"testFilePath/Query.getApples.req.vtl"`;
+
+exports[`verify generated templates using a Int primary key 6`] = `
+"{
+  \\"version\\": \\"2018-05-29\\",
+  \\"statements\\":   [\\"SELECT * FROM Apples WHERE Id=$ctx.args.Id\\"]
+}"
+`;
+
+exports[`verify generated templates using a Int primary key 7`] = `"testFilePath/Query.getApples.res.vtl"`;
+
+exports[`verify generated templates using a Int primary key 8`] = `
+"#set( $output = $utils.rds.toJsonObject($ctx.result) )
+#if( $output.isEmpty() )
+  $util.error(\\"Invalid response from RDS DataSource. See info for the full response.\\", \\"InvalidResponse\\", {}, $output)
+#end
+#set( $output = $output[0] )
+#if( $output.isEmpty() )
+  #return
+#end
+$utils.toJson($output[0])"
+`;
+
+exports[`verify generated templates using a Int primary key 9`] = `"testFilePath/Mutation.updateApples.req.vtl"`;
+
+exports[`verify generated templates using a Int primary key 10`] = `
+"#set( $updateList = {} )
+#foreach( $entry in $ctx.args.updateApplesInput.keySet() )
+  #set( $discard = $updateList.put($entry, \\"'$ctx.args.updateApplesInput[$entry]'\\") )
+#end
+#set( $update = $updateList.toString().replace(\\"{\\",\\"\\").replace(\\"}\\",\\"\\") )
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"statements\\":   [\\"UPDATE Apples SET $update WHERE Id=$ctx.args.updateApplesInput.Id}\\", \\"SELECT * FROM Apples WHERE Id=$ctx.args.updateApplesInput.Id\\"]
+}"
+`;
+
+exports[`verify generated templates using a Int primary key 11`] = `"testFilePath/Mutation.updateApples.res.vtl"`;
+
+exports[`verify generated templates using a Int primary key 12`] = `
+"#set( $output = $utils.rds.toJsonObject($ctx.result) )
+#if( $output.length() < 2 )
+  $util.error(\\"Invalid response from RDS DataSource. See info for the full response.\\", \\"InvalidResponse\\", {}, $output)
+#end
+#set( $output = $output[1] )
+#if( $output.isEmpty() )
+  #return
+#end
+$utils.toJson($output[0])"
+`;
+
+exports[`verify generated templates using a Int primary key 13`] = `"testFilePath/Mutation.deleteApples.req.vtl"`;
+
+exports[`verify generated templates using a Int primary key 14`] = `
+"{
+  \\"version\\": \\"2018-05-29\\",
+  \\"statements\\":   [\\"SELECT * FROM Apples WHERE Id=$ctx.args.Id\\", \\"DELETE FROM Apples WHERE Id=$ctx.args.Id\\"]
+}"
+`;
+
+exports[`verify generated templates using a Int primary key 15`] = `"testFilePath/Mutation.deleteApples.res.vtl"`;
+
+exports[`verify generated templates using a Int primary key 16`] = `
+"#set( $output = $utils.rds.toJsonObject($ctx.result) )
+#if( $output.isEmpty() )
+  $util.error(\\"Invalid response from RDS DataSource. See info for the full response.\\", \\"InvalidResponse\\", {}, $output)
+#end
+#set( $output = $output[0] )
+#if( $output.isEmpty() )
+  #return
+#end
+$utils.toJson($output[0])"
+`;
+
+exports[`verify generated templates using a Int primary key 17`] = `"testFilePath/Query.listAppless.req.vtl"`;
+
+exports[`verify generated templates using a Int primary key 18`] = `
+"{
+  \\"version\\": \\"2018-05-29\\",
+  \\"statements\\":   [\\"SELECT * FROM Apples\\"]
+}"
+`;
+
+exports[`verify generated templates using a Int primary key 19`] = `"testFilePath/Query.listAppless.res.vtl"`;
+
+exports[`verify generated templates using a Int primary key 20`] = `"$utils.toJson($utils.rds.toJsonObject($ctx.result)[0])"`;


### PR DESCRIPTION
Check the primary key type in order to generate a valid SQL statement to string and none string data types

*Issue #, if available:*
[#5392 Update Mutations is not working in Serverless RDS GraphQ](https://github.com/aws-amplify/amplify-cli/issues/5392) 


*Description of changes:*

The **Update** statement wasn't checking if the primary key was a String data type, so the sql statement generated didn't work 
The same behavior applies to the **Delete** sql statement

The change address this issues

### Update before
```
{
  "version": "2018-05-29",
  "statements":   [
      "UPDATE Tomatoes SET $update WHERE id=$ctx.args.updateTomatoesInput.Id",
      "SELECT * FROM Tomatoes WHERE id='$ctx.args.updateTomatoesInput.Id'"
  ]
}
```

### Update after

```
{
  "version": "2018-05-29",
  "statements":   [
      "UPDATE Tomatoes SET $update WHERE Id='$ctx.args.updateTomatoesInput.Id'",
      "SELECT * FROM Tomatoes WHERE Id='$ctx.args.updateTomatoesInput.Id'"
  ]
}"
```

### Delete before
```
{
  "version": "2018-05-29",
  "statements":   [
      "SELECT * FROM Tomatoes WHERE id='$ctx.args.Id'",
      "DELETE FROM Tomatoes WHERE id=$ctx.args.Id"
  ]
}
```

### Delete after

```
"{
  "version": "2018-05-29",
  "statements":   [
      "SELECT * FROM Tomatoes WHERE Id='$ctx.args.Id'",
      "DELETE FROM Tomatoes WHERE Id='$ctx.args.Id'"
  ]
}"
```

In order to fix the issue, a refactor was applied to increase the code readability, promoting duplicated code into private functions to reuse on the class.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.