### PR TITLE
fix(amplify-provider-awscloudformation): support ap-northeast

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/aws-pinpoint.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/aws-pinpoint.test.ts
@@ -1,0 +1,26 @@
+const { getPinpointRegionMapping, getConfiguredPinpointClient } = require('../../aws-utils/aws-pinpoint');
+
+let region = 'non-existent-region';
+
+jest.mock('../../configuration-manager', () => ({
+  loadConfiguration: jest.fn(() => ({
+    region: region,
+  })),
+}));
+
+jest.mock('../../aws-utils/user-agent', () => ({
+  formUserAgentParam: jest.fn(),
+}));
+
+describe('getConfiguredPinpointClient', () => {
+  const regionMap = getPinpointRegionMapping();
+  test('return mapped region based on config', async () => {
+    const { config } = await getConfiguredPinpointClient();
+    expect(config.region).toBe('us-east-1');
+    for (const regionKey in regionMap) {
+      region = regionMap[regionKey];
+      const { config } = await getConfiguredPinpointClient();
+      expect(config.region).toBe(regionMap[regionKey]);
+    }
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-pinpoint.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-pinpoint.js
@@ -15,10 +15,10 @@ const serviceRegionMap = {
   'cn-northwest-1': 'us-west-2',
   'ap-south-1': 'us-west-2',
   'ap-northeast-3': 'us-west-2',
-  'ap-northeast-2': 'us-west-2',
+  'ap-northeast-2': 'ap-northeast-2',
   'ap-southeast-1': 'us-west-2',
   'ap-southeast-2': 'us-west-2',
-  'ap-northeast-1': 'us-west-2',
+  'ap-northeast-1': 'ap-northeast-1',
   'eu-central-1': 'eu-central-1',
   'eu-west-1': 'eu-west-1',
   'eu-west-2': 'eu-west-1',
@@ -38,6 +38,7 @@ async function getConfiguredPinpointClient(context, category, action, envName) {
   } catch (e) {
     // ignore missing config
   }
+
   category = category || 'missing';
   action = action || ['missing'];
   const userAgentAction = `${category}:${action[0]}`;


### PR DESCRIPTION
Update region mapping of Pinpoint on ap-northeast.
Fixes: https://github.com/aws-amplify/amplify-cli/issues/5287

*Description of changes:*
As it's reported, `ap-northeast-1` and `ap-northeast-2` seem to be supported already and `amplify add analytics` should make Pinpoint resource in their region . Refs: [docs](https://docs.aws.amazon.com/general/latest/gr/pinpoint.html). I also heard the same issue from a developer that they needed to manually update the config file and I came up with this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.