### PR TITLE
fix(amplify-appsync-simulator): remove graphql-scalars dependency

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -35,7 +35,6 @@
     "express": "^4.17.1",
     "graphql": "^14.5.8",
     "graphql-iso-date": "^3.6.1",
-    "graphql-scalars": "^1.0.6",
     "graphql-subscriptions": "^1.1.0",
     "graphql-tools": "^4.0.6",
     "graphql-type-json": "^0.3.1",

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSEmail.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSEmail.test.ts
@@ -1,0 +1,17 @@
+import { scalars } from '../../schema/appsync-scalars';
+
+describe('AWSEmail parse', () => {
+  it('Should reject a non-string', () => {
+    function parse() {
+      scalars.AWSEmail.parseValue(1);
+    }
+    expect(parse).toThrowErrorMatchingSnapshot();
+  });
+
+  it('Should reject an invalid email address', () => {
+    function parse() {
+      scalars.AWSEmail.parseValue('@@');
+    }
+    expect(parse).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSURL.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSURL.test.ts
@@ -1,0 +1,37 @@
+import { URL } from 'url';
+import { scalars } from '../../schema/appsync-scalars';
+
+describe('AWSURL parse', () => {
+  it('Returns falsy values unchanged', () => {
+    expect(scalars.AWSURL.parseValue(0)).toEqual(0);
+  });
+
+  it('Returns valid URL objects', () => {
+    const parsed = new URL('http://www.amazon.com');
+    expect(scalars.AWSURL.parseValue('http://www.amazon.com')).toEqual(parsed);
+  });
+
+  it('Should reject an invalid URL', () => {
+    function serialize() {
+      scalars.AWSURL.parseValue('invalid-url');
+    }
+    expect(serialize).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('AWSURL serialize', () => {
+  it('Returns falsy values unchanged', () => {
+    expect(scalars.AWSURL.serialize(0)).toEqual(0);
+  });
+
+  it('Returns valid URLs', () => {
+    expect(scalars.AWSURL.serialize('http://www.amazon.com')).toEqual('http://www.amazon.com/');
+  });
+
+  it('Should reject an invalid URL', () => {
+    function serialize() {
+      scalars.AWSURL.serialize('invalid-url');
+    }
+    expect(serialize).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSEmail.test.ts.snap
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSEmail.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AWSEmail parse Should reject a non-string 1`] = `"Value is not string: 1"`;
+
+exports[`AWSEmail parse Should reject an invalid email address 1`] = `"Value is not a valid email address: @@"`;

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSURL.test.ts.snap
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSURL.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AWSURL parse Should reject an invalid URL 1`] = `"Invalid URL: invalid-url"`;
+
+exports[`AWSURL serialize Should reject an invalid URL 1`] = `"Invalid URL: invalid-url"`;


### PR DESCRIPTION
*Issue #, if available:* #6656

*Description of changes:*
This commit removes the dependency on `graphql-scalars` and adds the implementations for the `AWSEmail` and `AWSURL` scalars.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.