### PR TITLE
fix: #6681, handling case when no frontend plugins found

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-frontend-plugins.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-frontend-plugins.ts
@@ -1,9 +1,20 @@
 export function getFrontendPlugins(context) {
   const frontendPlugins = {};
-  context.runtime.plugins.forEach(plugin => {
-    if (plugin.pluginType === 'frontend') {
-      frontendPlugins[plugin.pluginName] = plugin.directory;
-    }
-  });
+
+  context.runtime.plugins
+    .filter((plugin: { pluginType: string }) => plugin.pluginType === 'frontend')
+    .map((plugin: { pluginName: string; directory: string }) => (frontendPlugins[plugin.pluginName] = plugin.directory));
+
+  // If the CLI does not find any frontend plugins it means that the installation is
+  // probably corrupt.
+  if (Object.keys(frontendPlugins).length === 0) {
+    const errorMessage = `Can't find any frontend plugins configured for the CLI.`;
+    context.print.error(errorMessage);
+    context.print.info("Run 'amplify plugin scan' to scan your system for plugins.");
+    const error = new Error(errorMessage);
+    error.stack = undefined;
+    throw error;
+  }
+
   return frontendPlugins;
 }

--- a/packages/amplify-cli/src/init-steps/s9-onFailure.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onFailure.ts
@@ -4,7 +4,6 @@ import { print } from '../extensions/amplify-helpers/print';
 export function onFailure(e) {
   // If no stack present it means we already printed a friendly error message and cleared the stack.
   if (e.stack) {
-    print.error('init failed');
     print.info(util.inspect(e));
   }
 


### PR DESCRIPTION
*Issue #, if available:*

- fix: #6681 - provide proper DX when frontend plugins cannot be found in the system during init.
- add an `uncaughtException` and `unhandledRejection` handler to the CLI process to get better error handling when errors are raised from some async or `EventEmitter` handler based code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.