### PR TITLE
Revert "Revert "fix: insert hostedUIProviderCreds empty array on hostedUI""

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.js
@@ -145,9 +145,10 @@ async function updateConfigOnEnvInit(context, category, service) {
   if (hostedUIProviderMeta) {
     currentEnvSpecificValues = getOAuthProviderKeys(currentEnvSpecificValues, resourceParams);
   }
-
+  const isPullingOrNewEnv = context.input.command === 'pull' || context.input.command === 'env';
+  // don't ask for env_specific params when creating a new env or pulling
   srvcMetaData.inputs = srvcMetaData.inputs.filter(
-    input => ENV_SPECIFIC_PARAMS.includes(input.key) && !Object.keys(currentEnvSpecificValues).includes(input.key),
+    input => ENV_SPECIFIC_PARAMS.includes(input.key) && !Object.keys(currentEnvSpecificValues).includes(input.key) && !isPullingOrNewEnv,
   );
 
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;

--- a/packages/amplify-provider-awscloudformation/src/resourceParams.js
+++ b/packages/amplify-provider-awscloudformation/src/resourceParams.js
@@ -1,5 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra');
+const _ = require('lodash');
+const hostedUIProviderCredsField = 'hostedUIProviderCreds';
 
 function getResourceDirPath(context, category, resource) {
   const { projectPath } = context.migrationInfo || context.amplify.getEnvInfo();
@@ -39,7 +41,11 @@ function loadResourceParameters(context, category, resource) {
     parameters = context.amplify.readJsonFile(parametersFilePath);
   }
   const envSpecificParams = context.amplify.loadEnvResourceParameters(context, category, resource);
-  return { ...parameters, ...envSpecificParams };
+  let resourceParameters = { ...parameters, ...envSpecificParams };
+  if (category === 'auth' && parameters && parameters.hostedUI && !resourceParameters[hostedUIProviderCredsField]) {
+    resourceParameters = _.set(resourceParameters, hostedUIProviderCredsField, '[]');
+  }
+  return resourceParameters;
 }
 
 module.exports = {


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#6682. Reintroducing this PR to fix issue with HostedUIProviderCreds not found and skipping prompting the users for providing the Provider Secrets on `amplify pull` and `amplify env checkout`