### PR TITLE
fix: Enable, instead of Configure, conflict detection

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -361,7 +361,7 @@ async function askAdditionalQuestions(context, authConfig, defaultAuthType, mode
 async function askResolverConflictQuestion(context, modelTypes?) {
   let resolverConfig: any = {};
 
-  if (await context.prompt.confirm('Configure conflict detection?')) {
+  if (await context.prompt.confirm('Enable conflict detection?')) {
     const askConflictResolutionStrategy = async msg => {
       let conflictResolutionStrategy;
 

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -117,7 +117,7 @@ export function addApiWithSchemaAndConflictDetection(cwd: string, schemaFile: st
       .sendLine(KEY_DOWN_ARROW) // Down
       .wait(/.*Configure additional auth types.*/)
       .sendLine('n')
-      .wait(/.*Configure conflict detection.*/)
+      .wait(/.*Enable conflict detection.*/)
       .sendLine('y')
       .wait(/.*Select the default resolution strategy.*/)
       .sendCarriageReturn()
@@ -184,7 +184,7 @@ export function updateApiWithMultiAuth(cwd: string, settings: any) {
       .sendLine('1000')
       .wait(/.*Enter the number of milliseconds a token is valid after being authenticated.*/)
       .sendLine('2000')
-      .wait('Configure conflict detection?')
+      .wait('Enable conflict detection?')
       .sendLine('n')
       .wait(/.*Successfully updated resource.*/)
       .sendEof()
@@ -235,7 +235,7 @@ export function updateAPIWithResolutionStrategy(cwd: string, settings: any) {
       .sendLine(KEY_DOWN_ARROW) // Down
       .wait(/.*Configure additional auth types.*/)
       .sendLine('n')
-      .wait(/.*Configure conflict detection.*/)
+      .wait(/.*Enable conflict detection.*/)
       .sendLine('y')
       .wait(/.*Select the default resolution strategy.*/)
       .sendLine(KEY_DOWN_ARROW) // Down
@@ -360,7 +360,7 @@ export function addApi(projectDir: string, settings?: any) {
           setupAuthType(authType, chain, settings);
         });
 
-        chain.wait('Configure conflict detection?').sendCarriageReturn(); //No
+        chain.wait('Enable conflict detection?').sendCarriageReturn(); //No
       } else {
         chain.wait('Do you want to configure advanced settings for the GraphQL API').sendCarriageReturn(); //No
       }


### PR DESCRIPTION
Customers often struggle quite a bit to figure out how to enable/disable conflict detection with the CLI.   They can do it via the top level "Enable DataStore for entire API" or "Disable DataStore for entire API" options, but if they choose to walk through all options, they are forced to explicit decide if conflict detection should be enabled or not.  I've been confused by this myself.  Initially I thought that the "Configure conflict detection?" step was just a question asking if I wanted to make a _change_ to the current value.  That's not the case.  If you answer "y", it _enables_ conflict detection.  If you answer "n", it _disables_ conflict detection.  This PR changes the wording so that customers know that this is causing an action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.