### PR TITLE
fix(amplify-provider-awscloudformation): Amplify Admin authentication token refresh

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -771,8 +771,11 @@ async function determineAuthFlow(context: $TSContext, projectConfig?: ProjectCon
     appId = resolveAppId(context);
     if (appId) {
       adminAppConfig = await isAmplifyAdminApp(appId);
-      if (adminAppConfig.isAdminApp && doAdminTokensExist(appId) && projectConfig?.configLevel === 'amplifyAdmin') {
-        return { type: 'admin', appId, region: adminAppConfig.region };
+      if (adminAppConfig.isAdminApp && adminAppConfig.region) {
+        region = adminAppConfig.region;
+        if (doAdminTokensExist(appId) && projectConfig?.configLevel === 'amplifyAdmin') {
+          return { type: 'admin', appId, region };
+        }
       }
     }
   } catch (e) {
@@ -803,6 +806,9 @@ async function determineAuthFlow(context: $TSContext, projectConfig?: ProjectCon
   }
 
   const authType = await askAuthType(adminAppConfig?.isAdminApp);
+  if (authType === 'admin') {
+    return { type: authType, appId, region };
+  }
   return { type: authType };
 }
 

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -97,7 +97,6 @@ async function getRefreshedTokens(context: $TSContext, appId: string) {
       // Refresh stored tokens
       authConfig.accessToken.jwtToken = refreshedTokens.AccessToken;
       authConfig.idToken.jwtToken = refreshedTokens.IdToken;
-      authConfig.refreshToken.token = refreshedTokens.RefreshToken;
       stateManager.setAmplifyAdminConfigEntry(appId, authConfig);
     } catch {
       // Refresh failed, fall back to login


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/6720
https://github.com/aws-amplify/amplify-cli/issues/6593

*Description of changes:*
In some cases appId was not passed back into `getConfigurationForEnv()`, now fixed.
Fixes https://github.com/aws-amplify/amplify-cli/pull/6433, which caused the refreshToken to be overwritten with an empty object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.