### PR TITLE
fix(amplify-category-api): mantain ff in iam api policy

### DIFF
--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as rimraf from 'rimraf';
 import { config } from 'dotenv';
+import execa from 'execa';
 
 export * from './add-circleci-tags';
 export * from './api';
@@ -35,6 +36,17 @@ export function deleteAmplifyDir(root: string) {
 export function overrideFunctionSrc(root: string, name: string, code: string) {
   let indexPath = path.join(getPathToFunction(root, name), 'src', 'index.js');
   fs.writeFileSync(indexPath, code);
+}
+
+export function overrideFunctionCode(root: string, name: string, fileName: string) {
+  let indexPath = path.join(getPathToFunction(root, name), 'src', 'index.js');
+  let functionPath = path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'functions', fileName);
+  fs.copySync(functionPath, indexPath);
+}
+
+export function addNodeJSDependencies(root: string, name: string, dependencies: string[]) {
+  let indexPath = path.join(getPathToFunction(root, name), 'src');
+  execa.commandSync(`yarn add ${dependencies.join(' ')}`, { cwd: indexPath });
 }
 
 export function getFunctionSrc(root: string, name: string): Buffer {

--- a/packages/amplify-e2e-tests/functions/get-api-appsync.js
+++ b/packages/amplify-e2e-tests/functions/get-api-appsync.js
@@ -1,0 +1,11 @@
+// /* eslint-disable no-console */
+const AWS = require('aws-sdk');
+
+const getGqlApi = async (idKey) => {
+  const appsync = new AWS.AppSync({ region: process.env.REGION });
+  return await appsync.getGraphqlApi({ apiId: process.env[idKey] }).promise();
+}
+
+exports.handler = async (event) => {
+  return await getGqlApi(event.idKey);
+};

--- a/packages/amplify-e2e-tests/functions/mutation-appsync.js
+++ b/packages/amplify-e2e-tests/functions/mutation-appsync.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+require("isomorphic-fetch");
+const AWS = require('aws-sdk');
+const AWSAppSyncClient = require("aws-appsync").default;
+const { AUTH_TYPE } = require("aws-appsync");
+const gql = require('graphql-tag');
+
+const runGQLMutation = async (gql_url, mutation, variables) => {
+  const client = new AWSAppSyncClient({
+    url: process.env[gql_url],
+    region: process.env.REGION,
+    auth: {
+        type: AUTH_TYPE.AWS_IAM,
+        credentials: AWS.config.credentials
+    },
+    disableOffline: true
+  });
+  return await client.mutate({ mutation: gql(mutation), variables });
+};
+
+exports.handler = async (event) => {
+  return await runGQLMutation(event.urlKey, event.mutation, event.variables);
+};

--- a/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
@@ -1,5 +1,6 @@
 import {
   addApiWithSchema,
+  addApi,
   addAuthWithDefault,
   addDDBWithTrigger,
   addFunction,
@@ -18,8 +19,12 @@ import {
   initJSProjectWithProfile,
   invokeFunction,
   overrideFunctionSrc,
+  addNodeJSDependencies,
   readJsonFile,
   updateFunction,
+  overrideFunctionCode,
+  getBackendConfig,
+  addFeatureFlag
 } from 'amplify-e2e-core';
 import fs from 'fs-extra';
 import path from 'path';
@@ -394,12 +399,26 @@ describe('nodejs', () => {
       expect(functionMeta).toStrictEqual(updatedFunctionMeta);
     });
 
-    it('should add api key from api to env vars', async () => {
-      await initJSProjectWithProfile(projRoot, {});
+    it('should be able to query AppSync with minimal permissions with featureFlag', async () => {
       const random = Math.floor(Math.random() * 10000);
-      const apiName = `apiwithapikey${random}`;
-      await addApiWithSchema(projRoot, 'simple_model.graphql', { apiName });
-      const fnName = `apikeyenvvar${random}`;
+      const fnName = `apienvvar${random}`;
+      const createTodo = `
+      mutation CreateTodo($input: CreateTodoInput!) {
+        createTodo(input: $input) {
+          id
+          name
+          description
+          createdAt
+          updatedAt
+        }
+      }
+    `;
+      await initJSProjectWithProfile(projRoot, {});
+      await addApi(projRoot, {
+        IAM: {},
+      });
+      const beforeMeta = getBackendConfig(projRoot);
+      const apiName = Object.keys(beforeMeta.api)[0];
       await addFunction(
         projRoot,
         {
@@ -409,25 +428,42 @@ describe('nodejs', () => {
             permissions: ['api'],
             choices: ['api'],
             resources: [apiName],
-            operations: ['Query'],
+            operations: ['Mutation'],
           },
         },
         'nodejs',
       );
-
+      addNodeJSDependencies(projRoot, fnName, ['aws-appsync', 'isomorphic-fetch', 'graphql-tag']);
+      overrideFunctionCode(projRoot, fnName, 'mutation-appsync.js');
+      await amplifyPush(projRoot);
+      const meta = getProjectMeta(projRoot);
+      const { Region: region, Name: functionName } = Object.keys(meta.function).map(key => meta.function[key])[0].output;
       const lambdaCFN = readJsonFile(
         path.join(projRoot, 'amplify', 'backend', 'function', fnName, `${fnName}-cloudformation-template.json`),
       );
-      const envVarsObj = lambdaCFN.Resources.LambdaFunction.Properties.Environment.Variables;
-      expect(_.keys(envVarsObj)).toContain(`API_${apiName.toUpperCase()}_GRAPHQLAPIKEYOUTPUT`);
+      const urlKey = Object.keys(lambdaCFN.Resources.LambdaFunction.Properties.Environment.Variables).filter( value => value.endsWith('GRAPHQLAPIENDPOINTOUTPUT'))[0];
+      const payloadObj = { urlKey, mutation: createTodo, variables: { input: { name: 'todo', description: 'sampleDesc' }} };
+      const fnResponse = await invokeFunction(functionName, JSON.stringify(payloadObj), region);
+
+      expect(fnResponse.StatusCode).toBe(200);
+      expect(fnResponse.Payload).toBeDefined();
+      const gqlResponse = JSON.parse(fnResponse.Payload as string);
+
+      expect(gqlResponse.data).toBeDefined();
+      expect(gqlResponse.data.createTodo.name).toEqual('todo');
+      expect(gqlResponse.data.createTodo.description).toEqual('sampleDesc');
     });
 
-    it('should be able to query AppSync with minimal permissions with featureFlag', async () => {
-      await initJSProjectWithProfile(projRoot, {});
+    it('should be able to make console calls with feature flag turned off', async () => {
       const random = Math.floor(Math.random() * 10000);
-      const apiName = `apiwithapikey${random}`;
-      await addApiWithSchema(projRoot, 'simple_model.graphql', { apiName });
-      const fnName = `apikeyenvvar${random}`;
+      const fnName = `apienvvar${random}`;
+      await initJSProjectWithProfile(projRoot, {});
+      await addApi(projRoot, {
+        IAM: {},
+      });
+      const beforeMeta = getBackendConfig(projRoot);
+      const apiName = Object.keys(beforeMeta.api)[0];
+      addFeatureFlag(projRoot, 'appsync', 'generategraphqlpermissions', false);
       await addFunction(
         projRoot,
         {
@@ -437,20 +473,26 @@ describe('nodejs', () => {
             permissions: ['api'],
             choices: ['api'],
             resources: [apiName],
-            operations: ['Query'],
+            operations: ['read'],
           },
         },
         'nodejs',
       );
-
+      overrideFunctionCode(projRoot, fnName, 'get-api-appsync.js');
+      await amplifyPush(projRoot);
+      const meta = getProjectMeta(projRoot);
+      const { Region: region, Name: functionName } = Object.keys(meta.function).map(key => meta.function[key])[0].output;
       const lambdaCFN = readJsonFile(
         path.join(projRoot, 'amplify', 'backend', 'function', fnName, `${fnName}-cloudformation-template.json`),
       );
-      const envVarsObj = lambdaCFN.Resources.AmplifyResourcesPolicy.Properties.PolicyDocument.Statement;
-      envVarsObj.forEach(statement => {
-        expect(statement.Action).toContain('appsync:GraphQL');
-        expect(statement.Resource[0]['Fn::Join'][1]).toContain('/types/Query/*');
-      });
+      const idKey = Object.keys(lambdaCFN.Resources.LambdaFunction.Properties.Environment.Variables).filter( value => value.endsWith('GRAPHQLAPIIDOUTPUT'))[0];
+      const fnResponse = await invokeFunction(functionName, JSON.stringify({ idKey }), region);
+
+      expect(fnResponse.StatusCode).toBe(200);
+      expect(fnResponse.Payload).toBeDefined();
+      const apiResponse = JSON.parse(fnResponse.Payload as string);
+      expect(apiResponse.graphqlApi).toBeDefined();
+      expect(apiResponse.graphqlApi.name).toContain(apiName);
     });
   });
 });


### PR DESCRIPTION
when using the ff for generating the appsync iam policy use the old format if the ff is empty

ref #6675

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.