### PR TITLE
fix(amplify-codegen-appsync-model-plugin): JS targetName for hasOne

### DIFF
--- a/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/amplify-codegen-appsync-model-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -48,6 +48,7 @@ export type AssociationHasMany = AssociationBaseType & {
 };
 type AssociationHasOne = AssociationHasMany & {
   connectionType: CodeGenConnectionType.HAS_ONE;
+  targetName: string;
 };
 
 type AssociationBelongsTo = AssociationBaseType & {
@@ -168,8 +169,11 @@ export class AppSyncJSONVisitor<
     if (field.connectionInfo) {
       const { connectionInfo } = field;
       const connectionAttribute: any = { connectionType: connectionInfo.kind };
-      if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY || connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
         connectionAttribute.associatedWith = this.getFieldName(connectionInfo.associatedWith);
+      } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        connectionAttribute.associatedWith = this.getFieldName(connectionInfo.associatedWith);
+        connectionAttribute.targetName = connectionInfo.targetName;
       } else {
         connectionAttribute.targetName = connectionInfo.targetName;
       }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/6560

Adding the same change to JS as was added to iOS in [this PR](https://github.com/aws-amplify/amplify-cli/pull/6031/files#diff-6afc42087dd9ca87a26c81fe25d4b97f27a677500dbdb95ca19c5db8d090c637R250)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.