### PR TITLE
Add feature flags for new codegen features

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -577,6 +577,18 @@ export class FeatureFlags {
         type: 'boolean',
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
+      },
+      {
+        name: 'cleanGeneratedModelsDirectory',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
+      {
+        name: 'retainCaseStyle',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
       }
     ]);
 


### PR DESCRIPTION
*Description of changes:*
Added Feature Flags for some of the enhancements made to `amplify-codegen` in the migrated packages. 
This PR needs to be looked into in combination with:
- https://github.com/aws-amplify/amplify-codegen/pull/85
- https://github.com/aws-amplify/amplify-codegen/pull/89

And the relevant docs PR: 
https://github.com/aws-amplify/docs/pull/2983


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.