### PR TITLE
fix: normalize app names on pull

### DIFF
--- a/packages/amplify-cli/src/__tests__/attach-backend-steps.test.ts
+++ b/packages/amplify-cli/src/__tests__/attach-backend-steps.test.ts
@@ -1,0 +1,27 @@
+import { analyzeProject } from '../attach-backend-steps/a20-analyzeProject';
+import { $TSContext, stateManager } from 'amplify-cli-core';
+
+jest.mock('amplify-cli-core');
+const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
+
+const contextStub = {
+  exeInfo: {
+    projectConfig: {
+      projectName: 'this-is-a-possible-name-from-the-console!',
+      version: '3.0',
+    },
+    localEnvInfo: {},
+  },
+} as $TSContext;
+
+describe('a20-analyzeProject', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('long console name', async () => {
+    stateManager_mock.getLocalEnvInfo.mockReturnValueOnce({ defaultEditor: 'gedit' });
+    await analyzeProject(contextStub);
+    expect(contextStub.exeInfo.projectConfig.projectName.length).toBe(20);
+  });
+});

--- a/packages/amplify-cli/src/attach-backend-steps/a20-analyzeProject.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a20-analyzeProject.ts
@@ -1,13 +1,16 @@
 import { normalizeEditor, editorSelection } from '../extensions/amplify-helpers/editor-selection';
 import { amplifyCLIConstants } from '../extensions/amplify-helpers/constants';
-import { stateManager } from 'amplify-cli-core';
+import { $TSContext, stateManager } from 'amplify-cli-core';
+import { normalizeProjectName } from '../extensions/amplify-helpers/project-name-validation';
 
-export async function analyzeProject(context) {
+export async function analyzeProject(context: $TSContext) {
   let defaultEditor = getDefaultEditor();
 
   if (!defaultEditor) {
     defaultEditor = await getEditor(context);
   }
+
+  context.exeInfo.projectConfig.projectName = normalizeProjectName(context.exeInfo.projectConfig.projectName);
 
   context.exeInfo.forcePush = !!context?.parameters?.options?.forcePush;
 
@@ -17,10 +20,7 @@ export async function analyzeProject(context) {
   return context;
 }
 
-/* End getProjectName */
-
-/* Begin getEditor */
-async function getEditor(context) {
+async function getEditor(context: $TSContext) {
   let editor;
   if (context.exeInfo.inputParams.amplify && context.exeInfo.inputParams.amplify.defaultEditor) {
     editor = normalizeEditor(context.exeInfo.inputParams.amplify.defaultEditor);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/project-name-validation.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/project-name-validation.ts
@@ -3,11 +3,11 @@ import { makeId } from './make-id';
 export const validAlphanumericRegex = /^[a-zA-Z0-9]+$/;
 export const invalidAlphanumericRegex = /[^a-zA-Z0-9]/g;
 
-export function isProjectNameValid(projectName) {
-  return projectName && projectName.length >= 3 && projectName.length <= 20 && validAlphanumericRegex.test(projectName);
+export function isProjectNameValid(projectName: string) {
+  return !!projectName && projectName.length >= 3 && projectName.length <= 20 && validAlphanumericRegex.test(projectName);
 }
 
-export function normalizeProjectName(projectName) {
+export function normalizeProjectName(projectName: string) {
   if (!projectName) {
     projectName = `amplify${makeId(5)}`;
   }


### PR DESCRIPTION
*Description of changes:* 
Normalize app names on pull because app names in Amplify console have different validation rules. This change will not rename the app in the cloud.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.