### PR TITLE
fix(cli): add defensive coding to isContainersEnabled()

### DIFF
--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -33,14 +33,8 @@ export async function executeCommand(context: Context) {
 }
 
 function isContainersEnabled(context) {
-  const { frontend } = context.amplify.getProjectConfig();
-  if (frontend) {
-    const { config: { ServerlessContainers = false } = {} } = context.amplify.getProjectConfig()[frontend];
-
-    return ServerlessContainers;
-  }
-
-  return false;
+  const projectConfig = context.amplify.getProjectConfig();
+  return projectConfig?.[projectConfig.frontend]?.config?.ServerlessContainers ?? false;
 }
 
 async function selectPluginForExecution(context: Context, pluginCandidates: PluginInfo[]): Promise<PluginInfo> {


### PR DESCRIPTION
*Issue #, if available:* #6757

*Description of changes:*
This commit adds optional chaining and nullish coalescing to the `isContainersEnabled()` function. It also stores the project config in a variable instead of parsing it multiple times.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.