### PR TITLE
Only apply $authCondition if $authCondition.expression is specified.

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -761,7 +761,7 @@ export class ResourceFactory {
       RequestMappingTemplate: print(
         compoundExpression([
           ifElse(
-            ref(ResourceConstants.SNIPPETS.AuthCondition),
+            raw(`$${ResourceConstants.SNIPPETS.AuthCondition} && $${ResourceConstants.SNIPPETS.AuthCondition}.expression != ""`),
             compoundExpression([
               set(ref('condition'), ref(ResourceConstants.SNIPPETS.AuthCondition)),
               ifElse(


### PR DESCRIPTION
Avoids errors when having an empty $authCondition object initialized.

*Issue #, if available:*
None.

*Description of changes:*

Changing the resolver condition to allow for initializing $authCondition above without necessarily setting $authCondition.expression (e.g. if there are no rules generating such an expression).

**The same change was already done for `makeUpdateResolver`** more than two years ago in this change: https://github.com/aws-amplify/amplify-cli/commit/faff0c3ca39900bcf215efa0cce832b7ccf0a83e#diff-d634883a373d0ee30a418eaa44857d7cefc79c7f3e1cc2d42da40157c3032aa8
I feel like the delete resolver may just have been overlooked.

The two-years-ago change relates to:
- https://github.com/aws-amplify/amplify-cli/issues/183
- https://github.com/aws-amplify/amplify-cli/pull/285

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.