### PR TITLE
fix: #6719 remove validator on function categories access prompt

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -274,7 +274,6 @@ const selectCategories = (choices: DistinctChoice<any>[], currentPermissionMap: 
   name: 'categories',
   message: 'Select the categories you want this function to have access to.',
   choices,
-  validate: answers => (_.isEmpty(answers) ? 'You must select at least one category' : true),
   default: fetchPermissionCategories(currentPermissionMap),
 });
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #6719 

*Description of changes:*

Package: amplify-category-function

Removes the validator for the prompt question: 'Select the categories you want this function to have access to.'
Fixes bug where user had to have atleast one category selected. This PR allows user to deselect all category options during that prompt.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.