### PR TITLE
Use encodeURIComponent over encodeURI

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -87,3 +87,16 @@ describe('$utils.toJson', () => {
     expect(generalUtils.toJson(object)).toBe('false');
   });
 });
+
+describe('$util.urlEncode and $util.urlDecode following application/x-www-form-urlencoded specification', () => {
+  // Appsync does not encode the asterisk
+  const reservedChars = "!#$%&'()+,/:;=?@[]";
+  const encodedReservedChars = '%21%23%24%25%26%27%28%29%2B%2C%2F%3A%3B%3D%3F%40%5B%5D';
+  it('should encode reserved chars from application/x-www-form-urlencoded', () => {
+    expect(generalUtils.urlEncode(reservedChars)).toBe(encodedReservedChars);
+  });
+
+  it('should not decode reserved chars from application/x-www-form-urlencoded', () => {
+    expect(generalUtils.urlDecode(encodedReservedChars)).toBe(reservedChars);
+  });
+});

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -14,10 +14,10 @@ export const generalUtils = {
     return jsStringEscape(value);
   },
   urlEncode(value) {
-    return encodeURI(value);
+    return encodeURIComponent(value);
   },
   urlDecode(value) {
-    return decodeURI(value);
+    return decodeURIComponent(value);
   },
   base64Encode(value) {
     // eslint-disable-next-line

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -14,7 +14,10 @@ export const generalUtils = {
     return jsStringEscape(value);
   },
   urlEncode(value) {
-    return encodeURIComponent(value);
+    // Stringent in adhering to RFC 3986 ( except the asterisk that appsync ingores to encode )
+    return encodeURIComponent(value).replace(/[!'()]/g, function (c) {
+      return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+    });
   },
   urlDecode(value) {
     return decodeURIComponent(value);


### PR DESCRIPTION
AppSync utils uses `encodeURIComponent()` and `decodeURIComponent()` over `decodeURI` and `encodeURI`.

*Issue #, if available:* I haven't created the issue because I tested myself in the AppSync. 

*Description of changes:*

Using the context: 
```
{
    "identity": {
        "accountId": "id-accountId",
        "cognitoIdentityPoolId": "id-cognitoIdentityPoolId",
        "cognitoIdentityId": "id-cognitoIdentityId",
        "sourceIp": [
            "x.x.x.x"
        ],
        "username": "12314%40N32",
        "userArn": "my:user:arn"
    }
}
``` 

With the resolver: 
```
{
   ":userId": $util.dynamodb.toStringJson($util.urlDecode($context.identity.username))
}
```

You can see that AppSync decodes `12314%40N32` to `12314@N32`. 

It seems that
**decodeURI()**: It takes encodeURI(url) string so it cannot decoded characters (, / ? : @ & = + $ #)
**decodeURIComponent()**: It takes encodeURIComponent(url) string so it can decode these characters.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.