### PR TITLE
fix(amplify-dynamodb-simulator): detect errors logged to stderr

### DIFF
--- a/packages/amplify-dynamodb-simulator/__test__/index.test.js
+++ b/packages/amplify-dynamodb-simulator/__test__/index.test.js
@@ -90,4 +90,9 @@ describe('emulator operations', () => {
     emulators.push(emu);
     expect(emu.port).toBe(port);
   });
+
+  it('reports on invalid dbPath values', async () => {
+    expect.assertions(1);
+    await expect(ddbSimulator.launch({ dbPath: 'dynamodb-data' })).rejects.toThrow('invalid directory for database creation');
+  });
 });


### PR DESCRIPTION
*Issue #, if available:* #5078

*Description of changes:*
This commit updates the dynamodb simulator to detect errors logged to stderr by the Java process. Currently, only a single error type is detected, but others could be added as well.

Note - there are other ways to handle the error reported in #5078. For example, `dbPath` could be validated as an absolute path before trying to launch the simulator. I went with the current approach because I thought it could be extended to other errors that the simulator process might report. I can change the approach here if that is desirable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.