### PR TITLE
feat: generate datastore models for Admin CMS to consume post-deployment from CLI

### DIFF
--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -48,9 +48,7 @@ export async function createNewProjectDir(
   projectName: string,
   prefix = path.join(fs.realpathSync(os.tmpdir()), amplifyTestsDir),
 ): Promise<string> {
-  const currentHash = execSync('git rev-parse --short HEAD', { cwd: __dirname })
-    .toString()
-    .trim();
+  const currentHash = execSync('git rev-parse --short HEAD', { cwd: __dirname }).toString().trim();
   let projectDir;
   do {
     const randomId = await global.getRandomId();
@@ -58,6 +56,7 @@ export async function createNewProjectDir(
   } while (fs.existsSync(projectDir));
 
   fs.ensureDirSync(projectDir);
+  console.log(projectDir);
   return projectDir;
 }
 

--- a/packages/amplify-e2e-core/src/init/adminUI.ts
+++ b/packages/amplify-e2e-core/src/init/adminUI.ts
@@ -1,0 +1,41 @@
+import { setupAmplifyAdminUI, getAmplifyBackendJobStatus } from '../utils/sdk-calls';
+
+export async function enableAdminUI(appId: string, envName: string, region: string) {
+  const setupAdminUIJobDetails = await setupAmplifyAdminUI(appId, region);
+
+  const jobCompletionDetails = await pollUntilDone(setupAdminUIJobDetails.JobId, appId, envName, region, 2 * 1000, 2000 * 1000);
+
+  if (jobCompletionDetails.Status === 'FAILED') {
+    throw new Error('Setting up Admin UI failed');
+  }
+}
+
+// interval is how often to poll
+// timeout is how long to poll waiting for a result (0 means try forever)
+
+async function pollUntilDone(jobId: string, appId: string, envName: string, region: string, interval: number, timeout: number) {
+  const start = Date.now();
+  while (true) {
+    const jobDetails = await getAmplifyBackendJobStatus(jobId, appId, envName, region);
+
+    if (jobDetails.Status === 'FAILED' || jobDetails.Status === 'COMPLETED') {
+      // we know we're done here, return from here whatever you
+      // want the final resolved value of the promise to be
+      return jobDetails;
+    } else {
+      if (timeout !== 0 && Date.now() - start > timeout) {
+        throw new Error(`Job Timed out for ${jobId}`);
+      } else {
+        // run again with a short delay
+        await delay(interval);
+      }
+    }
+  }
+}
+
+// create a promise that resolves after a short delay
+function delay(t: number) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, t);
+  });
+}

--- a/packages/amplify-e2e-core/src/init/index.ts
+++ b/packages/amplify-e2e-core/src/init/index.ts
@@ -3,3 +3,4 @@ export * from './amplifyPush';
 export * from './deleteProject';
 export * from './initProjectHelper';
 export * from './pull-headless';
+export * from './adminUI';

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -44,6 +44,11 @@ function getBackendConfig(projectRoot: string) {
   return JSON.parse(fs.readFileSync(backendFConfigFilePath, 'utf8'));
 }
 
+function getLocalEnvInfo(projectRoot: string) {
+  const localEnvInfoFilePath: string = path.join(projectRoot, 'amplify', '.config', 'local-env-info.json');
+  return JSON.parse(fs.readFileSync(localEnvInfoFilePath, 'utf8'));
+}
+
 function getCloudBackendConfig(projectRoot: string) {
   const currentCloudPath: string = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'backend-config.json');
   return JSON.parse(fs.readFileSync(currentCloudPath, 'utf8'));
@@ -133,4 +138,5 @@ export {
   getParameters,
   getCloudBackendConfig,
   setParameters,
+  getLocalEnvInfo,
 };

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -11,6 +11,7 @@ import {
   CloudWatchEvents,
   Kinesis,
   CloudFormation,
+  AmplifyBackend,
 } from 'aws-sdk';
 import _ from 'lodash';
 
@@ -225,4 +226,22 @@ export const getCloudWatchEventRule = async (targetName: string, region: string)
     console.log(e);
   }
   return ruleName;
+};
+
+export const setupAmplifyAdminUI = async (appId: string, region: string) => {
+  const amplifyBackend = new AmplifyBackend({ region });
+
+  return await amplifyBackend.createBackendConfig({ AppId: appId }).promise();
+};
+
+export const getAmplifyBackendJobStatus = async (jobId: string, appId: string, envName: string, region: string) => {
+  const amplifyBackend = new AmplifyBackend({ region });
+
+  return await amplifyBackend
+    .getBackendJob({
+      JobId: jobId,
+      AppId: appId,
+      BackendEnvironmentName: envName,
+    })
+    .promise();
 };

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { existsSync } from 'fs';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import gql from 'graphql-tag';
+const providerName = 'awscloudformation';
 
 import {
   addApiWithSchema,
@@ -17,7 +18,9 @@ import {
   deleteProjectDir,
   getAppSyncApi,
   getProjectMeta,
+  getLocalEnvInfo,
   getTransformConfig,
+  enableAdminUI,
 } from 'amplify-e2e-core';
 import { TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
 import _ from 'lodash';
@@ -48,7 +51,7 @@ describe('amplify add api (GraphQL)', () => {
     await amplifyPush(projRoot);
 
     const meta = getProjectMeta(projRoot);
-    const region = meta['providers']['awscloudformation']['Region'] as string;
+    const region = meta['providers'][providerName]['Region'] as string;
     const { output } = meta.api[name];
     const url = output.GraphQLAPIEndpointOutput as string;
     const apiKey = output.GraphQLAPIKeyOutput as string;
@@ -127,6 +130,7 @@ describe('amplify add api (GraphQL)', () => {
     const name = `conflictdetection`;
     await initJSProjectWithProfile(projRoot, { name });
     await addApiWithSchemaAndConflictDetection(projRoot, 'simple_model.graphql');
+
     await amplifyPush(projRoot);
 
     const meta = getProjectMeta(projRoot);
@@ -156,6 +160,35 @@ describe('amplify add api (GraphQL)', () => {
     const disableDSConfig = getTransformConfig(projRoot, name);
     expect(disableDSConfig).toBeDefined();
     expect(_.isEmpty(disableDSConfig.ResolverConfig)).toBe(true);
+  });
+
+  it('init a project with conflict detection enabled and admin UI enabled to generate datastore models in the cloud', async () => {
+    const name = `dsadminui`;
+    await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, name });
+
+    const meta = getProjectMeta(projRoot);
+    const appId = meta.providers?.[providerName]?.AmplifyAppId;
+    const region = meta.providers?.[providerName]?.Region;
+
+    const localEnvInfo = getLocalEnvInfo(projRoot);
+    const envName = localEnvInfo.envName;
+
+    // setupAdminUI
+    await enableAdminUI(appId, envName, region);
+
+    await addApiWithSchemaAndConflictDetection(projRoot, 'simple_model.graphql');
+    await amplifyPush(projRoot);
+
+    const { output } = meta.api[name];
+    const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, meta.providers.awscloudformation.Region);
+
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
   });
 
   it('init a sync enabled project and update conflict resolution strategy', async () => {

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -21,7 +21,8 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
 
   const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
   if (!appId) {
-    throw new Error('Could not find AmplifyAppId in amplify-meta.json.');
+    context.print.error('Could not find AmplifyAppId in amplify-meta.json.');
+    return;
   }
   const envName = localEnvInfo.envName;
   const { isAdminApp } = await isAmplifyAdminApp(appId);

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -13,8 +13,8 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
   if (appSyncResources.length === 0) {
     return;
   }
-
-  const { appSyncResourceName } = appSyncResources[0];
+  const appSyncResource = appSyncResources[0];
+  const { resourceName } = appSyncResource;
 
   const amplifyMeta = stateManager.getMeta();
   const localEnvInfo = stateManager.getLocalEnvInfo();
@@ -25,7 +25,7 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
   }
   const envName = localEnvInfo.envName;
   const { isAdminApp } = await isAmplifyAdminApp(appId);
-  const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', appSyncResourceName));
+  const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName));
 
   if (!isAdminApp || !isDSEnabled) {
     return;
@@ -38,7 +38,7 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
       .generateBackendAPIModels({
         AppId: appId,
         BackendEnvironmentName: envName,
-        ResourceName: appSyncResourceName,
+        ResourceName: resourceName,
       })
       .promise();
 

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,0 +1,103 @@
+import ora from 'ora';
+import { $TSContext, stateManager, pathManager, $TSAny } from 'amplify-cli-core';
+import { isDataStoreEnabled } from 'graphql-transformer-core';
+import * as path from 'path';
+import { ProviderName as providerName } from './constants';
+import { isAmplifyAdminApp } from './utils/admin-helpers';
+import { AmplifyBackend } from './aws-utils/aws-amplify-backend';
+
+export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
+  resources = resources.filter(resource => resource.service === 'AppSync');
+
+  if (resources.length > 0) {
+    const resource = resources[0];
+    const { resourceName } = resource;
+
+    const amplifyMeta = stateManager.getMeta();
+    const localEnvInfo = stateManager.getLocalEnvInfo();
+
+    const appId = amplifyMeta.providers[providerName].AmplifyAppId;
+    const envName = localEnvInfo.envName;
+
+    const { isAdminApp } = await isAmplifyAdminApp(appId);
+    const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName));
+
+    if (isAdminApp && isDSEnabled) {
+      // Generate DataStore Models for Admin UI CMS to consume
+      const spinner = ora('Generating models in the cloud…\n').start();
+      const amplifyBackendInstance = await new AmplifyBackend(context);
+      try {
+        const jobStartDetails = await amplifyBackendInstance.amplifyBackend
+          .generateBackendAPIModels({
+            AppId: appId,
+            BackendEnvironmentName: envName,
+            ResourceName: resourceName,
+          })
+          .promise();
+
+        const jobCompletionDetails = await pollUntilDone(
+          jobStartDetails.JobId,
+          appId,
+          envName,
+          2 * 1000,
+          2000 * 1000,
+          amplifyBackendInstance.amplifyBackend,
+        );
+        if (jobCompletionDetails.Status === 'COMPLETED') {
+          spinner.succeed('Successfully generated models in the cloud.');
+        } else {
+          throw new Error('Modelgen job creation failed');
+        }
+      } catch (e) {
+        spinner.stop();
+        console.log(e.stack);
+        context.print.error(`Failed to create models in the cloud`);
+      }
+    }
+  }
+}
+
+// create a promise that resolves after a short delay
+function delay(t: number) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, t);
+  });
+}
+
+// interval is how often to poll
+// timeout is how long to poll waiting for a result (0 means try forever)
+
+async function pollUntilDone(
+  jobId: string,
+  appId: string,
+  backendEnvironmentName: string,
+  interval: number,
+  timeout: number,
+  amplifyBackendClient: any,
+) {
+  const start = Date.now();
+  function run() {
+    return amplifyBackendClient
+      .getBackendJob({
+        JobId: jobId,
+        AppId: appId,
+        BackendEnvironmentName: backendEnvironmentName,
+      })
+      .promise()
+      .then(function (dataResult) {
+        if (dataResult.Status === 'FAILED' || dataResult.Status === 'COMPLETED') {
+          // we know we're done here, return from here whatever you
+          // want the final resolved value of the promise to be
+          return dataResult;
+        } else {
+          if (timeout !== 0 && Date.now() - start > timeout) {
+            throw new Error(`Job Timed out for ${jobId}`);
+          } else {
+            // run again with a short delay
+            return delay(interval).then(run);
+          }
+        }
+      });
+  }
+  return run();
+}

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,4 +1,5 @@
 import ora from 'ora';
+import AWS from 'aws-sdk';
 import { $TSContext, stateManager, pathManager, $TSAny } from 'amplify-cli-core';
 import { isDataStoreEnabled } from 'graphql-transformer-core';
 import * as path from 'path';
@@ -9,59 +10,55 @@ import { AmplifyBackend } from './aws-utils/aws-amplify-backend';
 export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
   resources = resources.filter(resource => resource.service === 'AppSync');
 
-  if (resources.length > 0) {
-    const resource = resources[0];
-    const { resourceName } = resource;
-
-    const amplifyMeta = stateManager.getMeta();
-    const localEnvInfo = stateManager.getLocalEnvInfo();
-
-    const appId = amplifyMeta.providers[providerName].AmplifyAppId;
-    const envName = localEnvInfo.envName;
-
-    const { isAdminApp } = await isAmplifyAdminApp(appId);
-    const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName));
-
-    if (isAdminApp && isDSEnabled) {
-      // Generate DataStore Models for Admin UI CMS to consume
-      const spinner = ora('Generating models in the cloud…\n').start();
-      const amplifyBackendInstance = await new AmplifyBackend(context);
-      try {
-        const jobStartDetails = await amplifyBackendInstance.amplifyBackend
-          .generateBackendAPIModels({
-            AppId: appId,
-            BackendEnvironmentName: envName,
-            ResourceName: resourceName,
-          })
-          .promise();
-
-        const jobCompletionDetails = await pollUntilDone(
-          jobStartDetails.JobId,
-          appId,
-          envName,
-          2 * 1000,
-          2000 * 1000,
-          amplifyBackendInstance.amplifyBackend,
-        );
-        if (jobCompletionDetails.Status === 'COMPLETED') {
-          spinner.succeed('Successfully generated models in the cloud.');
-        } else {
-          throw new Error('Modelgen job creation failed');
-        }
-      } catch (e) {
-        spinner.stop();
-        console.log(e.stack);
-        context.print.error(`Failed to create models in the cloud`);
-      }
-    }
+  if (resources.length === 0) {
+    return;
   }
-}
+  const resource = resources[0];
+  const { resourceName } = resource;
 
-// create a promise that resolves after a short delay
-function delay(t: number) {
-  return new Promise(function (resolve) {
-    setTimeout(resolve, t);
-  });
+  const amplifyMeta = stateManager.getMeta();
+  const localEnvInfo = stateManager.getLocalEnvInfo();
+
+  const appId = amplifyMeta.providers[providerName].AmplifyAppId;
+  if (!appId) {
+    throw new Error('Could not find AmplifyAppId in amplify-meta.json.');
+  }
+  const envName = localEnvInfo.envName;
+  const { isAdminApp } = await isAmplifyAdminApp(appId);
+  const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName));
+
+  if (!isAdminApp || !isDSEnabled) {
+    return;
+  }
+  // Generate DataStore Models for Admin UI CMS to consume
+  const spinner = ora('Generating models in the cloud…\n').start();
+  const amplifyBackendInstance = await AmplifyBackend.getInstance(context);
+  try {
+    const jobStartDetails = await amplifyBackendInstance.amplifyBackend
+      .generateBackendAPIModels({
+        AppId: appId,
+        BackendEnvironmentName: envName,
+        ResourceName: resourceName,
+      })
+      .promise();
+
+    const jobCompletionDetails = await pollUntilDone(
+      jobStartDetails.JobId,
+      appId,
+      envName,
+      2 * 1000,
+      2000 * 1000,
+      amplifyBackendInstance.amplifyBackend,
+    );
+    if (jobCompletionDetails.Status === 'COMPLETED') {
+      spinner.succeed('Successfully generated models in the cloud.');
+    } else {
+      throw new Error('Modelgen job creation failed');
+    }
+  } catch (e) {
+    spinner.stop();
+    context.print.error(`Failed to create models in the cloud: ${e.message}`);
+  }
 }
 
 // interval is how often to poll
@@ -73,31 +70,36 @@ async function pollUntilDone(
   backendEnvironmentName: string,
   interval: number,
   timeout: number,
-  amplifyBackendClient: any,
+  amplifyBackendClient: AWS.AmplifyBackend,
 ) {
   const start = Date.now();
-  function run() {
-    return amplifyBackendClient
+  while (true) {
+    const jobDetails = await amplifyBackendClient
       .getBackendJob({
         JobId: jobId,
         AppId: appId,
         BackendEnvironmentName: backendEnvironmentName,
       })
-      .promise()
-      .then(function (dataResult) {
-        if (dataResult.Status === 'FAILED' || dataResult.Status === 'COMPLETED') {
-          // we know we're done here, return from here whatever you
-          // want the final resolved value of the promise to be
-          return dataResult;
-        } else {
-          if (timeout !== 0 && Date.now() - start > timeout) {
-            throw new Error(`Job Timed out for ${jobId}`);
-          } else {
-            // run again with a short delay
-            return delay(interval).then(run);
-          }
-        }
-      });
+      .promise();
+
+    if (jobDetails.Status === 'FAILED' || jobDetails.Status === 'COMPLETED') {
+      // we know we're done here, return from here whatever you
+      // want the final resolved value of the promise to be
+      return jobDetails;
+    } else {
+      if (timeout !== 0 && Date.now() - start > timeout) {
+        throw new Error(`Job Timed out for ${jobId}`);
+      } else {
+        // run again with a short delay
+        await delay(interval);
+      }
+    }
   }
-  return run();
+}
+
+// create a promise that resolves after a short delay
+function delay(t: number) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, t);
+  });
 }

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -8,24 +8,24 @@ import { isAmplifyAdminApp } from './utils/admin-helpers';
 import { AmplifyBackend } from './aws-utils/aws-amplify-backend';
 
 export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
-  resources = resources.filter(resource => resource.service === 'AppSync');
+  const appSyncResources = resources.filter(resource => resource.service === 'AppSync');
 
-  if (resources.length === 0) {
+  if (appSyncResources.length === 0) {
     return;
   }
-  const resource = resources[0];
-  const { resourceName } = resource;
+
+  const { appSyncResourceName } = appSyncResources[0];
 
   const amplifyMeta = stateManager.getMeta();
   const localEnvInfo = stateManager.getLocalEnvInfo();
 
-  const appId = amplifyMeta.providers[providerName].AmplifyAppId;
+  const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
   if (!appId) {
     throw new Error('Could not find AmplifyAppId in amplify-meta.json.');
   }
   const envName = localEnvInfo.envName;
   const { isAdminApp } = await isAmplifyAdminApp(appId);
-  const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName));
+  const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', appSyncResourceName));
 
   if (!isAdminApp || !isDSEnabled) {
     return;
@@ -38,7 +38,7 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
       .generateBackendAPIModels({
         AppId: appId,
         BackendEnvironmentName: envName,
-        ResourceName: resourceName,
+        ResourceName: appSyncResourceName,
       })
       .promise();
 

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify-backend.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify-backend.ts
@@ -1,0 +1,25 @@
+import AWS from 'aws-sdk';
+import aws from './aws';
+import { loadConfiguration } from '../configuration-manager';
+import { $TSContext } from 'amplify-cli-core';
+
+export class AmplifyBackend {
+  public amplifyBackend: AWS.AmplifyBackend;
+
+  constructor(private readonly context: $TSContext, options = {}) {
+    const instancePromise = (async () => {
+      let cred = {};
+      try {
+        cred = await loadConfiguration(context);
+      } catch (e) {
+        // ignore missing config
+      }
+
+      this.amplifyBackend = new (aws as typeof AWS).AmplifyBackend({ ...cred, ...options });
+
+      return this;
+    })();
+
+    return <AmplifyBackend>(<unknown>instancePromise);
+  }
+}

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify-backend.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify-backend.ts
@@ -21,7 +21,7 @@ export class AmplifyBackend {
     return AmplifyBackend.instance;
   }
 
-  constructor(context: $TSContext, creds, options = {}) {
+  private constructor(context: $TSContext, creds, options = {}) {
     this.context = context;
     this.amplifyBackend = new aws.AmplifyBackend({ ...creds, ...options });
   }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify-backend.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify-backend.ts
@@ -4,22 +4,25 @@ import { loadConfiguration } from '../configuration-manager';
 import { $TSContext } from 'amplify-cli-core';
 
 export class AmplifyBackend {
+  private static instance: AmplifyBackend;
+  private readonly context: $TSContext;
   public amplifyBackend: AWS.AmplifyBackend;
 
-  constructor(private readonly context: $TSContext, options = {}) {
-    const instancePromise = (async () => {
+  static async getInstance(context: $TSContext, options = {}): Promise<AmplifyBackend> {
+    if (!AmplifyBackend.instance) {
       let cred = {};
       try {
         cred = await loadConfiguration(context);
       } catch (e) {
         // ignore missing config
       }
+      AmplifyBackend.instance = new AmplifyBackend(context, cred, options);
+    }
+    return AmplifyBackend.instance;
+  }
 
-      this.amplifyBackend = new (aws as typeof AWS).AmplifyBackend({ ...cred, ...options });
-
-      return this;
-    })();
-
-    return <AmplifyBackend>(<unknown>instancePromise);
+  constructor(context: $TSContext, creds, options = {}) {
+    this.context = context;
+    this.amplifyBackend = new aws.AmplifyBackend({ ...creds, ...options });
   }
 }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -24,6 +24,7 @@ import { formUserAgentParam } from './aws-utils/user-agent';
 import constants, { ProviderName as providerName } from './constants';
 import { uploadAppSyncFiles } from './upload-appsync-files';
 import { prePushGraphQLCodegen, postPushGraphQLCodegen } from './graphql-codegen';
+import { adminModelgen } from './admin-modelgen';
 import { prePushAuthTransform } from './auth-transform';
 import { transformGraphQLSchema } from './transform-graphql-schema';
 import { displayHelpfulURLs } from './display-helpful-urls';
@@ -311,6 +312,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject) {
       .filter(resource => resource.category === 'auth' && resource.service === 'Cognito' && resource.providerPlugin === 'awscloudformation')
       .map(({ category, resourceName }) => context.amplify.removeDeploymentSecrets(context, category, resourceName));
 
+    await adminModelgen(context, resources);
     spinner.succeed('All resources are updated in the cloud');
 
     await displayHelpfulURLs(context, resources);


### PR DESCRIPTION
*Description of changes:*
This PR calls the Amplify Admin Service API post-deployment/post-push in the CLI to generate DataStore models in the cloud for the Admin UI CMS. This action is triggered only when Admin UI is enabled for the app + DataStore is enabled for the API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.