### PR TITLE
fix(amplify-provider-awscloudformation): specify 127.0.0.1 as hostname

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
@@ -30,7 +30,7 @@ jest.mock('express', () => {
 });
 
 describe('AdminLoginServer', () => {
-  test('run server with 127.0.0.1', async () => {
+  test('run server with 0.0.0.0', async () => {
     const adminLoginServer = new AdminLoginServer('appId', 'http://example.com', context_stub.print);
 
     await new Promise<void>(resolve => {
@@ -39,6 +39,6 @@ describe('AdminLoginServer', () => {
     });
     expect(useMock).toBeCalled();
     expect(postMock).toBeCalled();
-    expect(listenMock).toBeCalledWith(4242, '127.0.0.1');
+    expect(listenMock).toBeCalledWith(4242, '0.0.0.0');
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
@@ -1,0 +1,44 @@
+import { AdminLoginServer } from '../../utils/admin-login-server';
+import { $TSContext } from 'amplify-cli-core';
+import { FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
+
+const runtimePlugin_stub = ({
+  checkDependencies: jest.fn().mockResolvedValue({ hasRequiredDependencies: true }),
+  build: jest.fn().mockResolvedValue({ rebuilt: true }),
+} as unknown) as jest.Mocked<FunctionRuntimeLifecycleManager>;
+
+const context_stub = ({
+  amplify: {
+    readBreadcrumbs: jest.fn().mockReturnValue({ pluginId: 'testPluginId' }),
+    loadRuntimePlugin: jest.fn().mockResolvedValue(runtimePlugin_stub),
+    updateamplifyMetaAfterBuild: jest.fn(),
+  },
+} as unknown) as jest.Mocked<$TSContext>;
+
+const useMock = jest.fn();
+const postMock = jest.fn(async () => {});
+const listenMock = jest.fn();
+
+jest.mock('express', () => {
+  return () => {
+    return {
+      use: useMock,
+      post: postMock,
+      listen: listenMock,
+    };
+  };
+});
+
+describe('AdminLoginServer', () => {
+  test('run server with 127.0.0.1', async () => {
+    const adminLoginServer = new AdminLoginServer('appId', 'http://example.com', context_stub.print);
+
+    await new Promise<void>(resolve => {
+      adminLoginServer.startServer(() => {});
+      resolve();
+    });
+    expect(useMock).toBeCalled();
+    expect(postMock).toBeCalled();
+    expect(listenMock).toBeCalledWith(4242, '127.0.0.1');
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
@@ -15,9 +15,8 @@ export class AdminLoginServer {
   private appId: string;
   private port = 4242; // placeholder
   private server: http.Server;
-  private serverLocalhost: http.Server;
   private print: $TSContext['print'];
-  private host = '127.0.0.1';
+  private host = '0.0.0.0'; // using this ip address for the host forces express to listen on IPV4 even if IPV6 is available
 
   private corsOptions: {
     origin: string[];
@@ -42,7 +41,6 @@ export class AdminLoginServer {
     await this.setupRoute(callback);
     // Need to specify hostname for WSL
     this.server = this.app.listen(this.getPort(), this.getHost());
-    this.serverLocalhost = this.app.listen(this.getPort());
   }
 
   private getHost() {
@@ -131,6 +129,5 @@ export class AdminLoginServer {
 
   shutdown() {
     this.server.close();
-    this.serverLocalhost.close();
   }
 }

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
@@ -15,7 +15,9 @@ export class AdminLoginServer {
   private appId: string;
   private port = 4242; // placeholder
   private server: http.Server;
+  private serverLocalhost: http.Server;
   private print: $TSContext['print'];
+  private host = '127.0.0.1';
 
   private corsOptions: {
     origin: string[];
@@ -38,7 +40,13 @@ export class AdminLoginServer {
 
   public async startServer(callback: () => void) {
     await this.setupRoute(callback);
-    this.server = this.app.listen(this.getPort());
+    // Need to specify hostname for WSL
+    this.server = this.app.listen(this.getPort(), this.getHost());
+    this.serverLocalhost = this.app.listen(this.getPort());
+  }
+
+  private getHost() {
+    return this.host;
   }
 
   // TODO: scan for available ports across a range like mock
@@ -123,5 +131,6 @@ export class AdminLoginServer {
 
   shutdown() {
     this.server.close();
+    this.serverLocalhost.close();
   }
 }


### PR DESCRIPTION
CLI uses express server in `amplify-provider-awscloudformation` to listen to POST request from Admin UI login page when `amplify configure`. The default of the hostname is localhost, 0.0.0.0 and 127.0.0.1 on macOS, but Ubuntu on WSL on Windows uses the only localhost by default. Since 127.0.0.1 seems to be coded in Admin UI, we should specify 127.0.0.1 as the hostname in CLI so that CLI can finish `amplify configure`.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/6779
Fixes: https://github.com/aws-amplify/amplify-adminui/issues/134

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.