### PR TITLE
chore: enhance project version detection

### DIFF
--- a/packages/amplify-cli/src/project-config-version-check.ts
+++ b/packages/amplify-cli/src/project-config-version-check.ts
@@ -143,11 +143,26 @@ export async function checkProjectConfigVersion(context: Context): Promise<void>
   if (projectPath) {
     const projectConfig = stateManager.getProjectConfig(projectPath, {
       throwIfNotExist: false,
-      default: {},
+      default: undefined,
     });
+
+    // If we do not have a projectConig, just bail out, probably it is an
+    // uninitialized project
+    if (!projectConfig?.version) {
+      return;
+    }
 
     const currentProjectVersion = coerce(projectConfig.version);
     const minProjectVersion = coerce(constants.MIN_NODE12_PROJECT_CONFIG_VERSION);
+
+    // If coerceProjectVersion fails for some reason bail out
+    if (currentProjectVersion === null) {
+      const error = new Error(`Invalid project version was found in project-config.json: '${projectConfig.version}'`);
+
+      error.stack = undefined;
+
+      throw error;
+    }
 
     if (lt(currentProjectVersion!, minProjectVersion!)) {
       await checkLambdaCustomResourceNodeVersion(context, projectPath);


### PR DESCRIPTION
*Description of changes:*

This PR enhances a case for NodeJS version detection when the project is not yet initialized or or is a broken state (after ctrl+c during a pull) to not to fail but handle it accordingly or give back meaningful error message when a non-version value was found in `project-config.json`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.