### PR TITLE
fix: set sys.modules when loading python handler

### DIFF
--- a/packages/amplify-python-function-runtime-provider/shim/shim.py
+++ b/packages/amplify-python-function-runtime-provider/shim/shim.py
@@ -18,6 +18,7 @@ def main(argv):
   # load handler
   spec = importlib.util.spec_from_file_location("module.name", handlerFile)
   handlerModule = importlib.util.module_from_spec(spec)
+  sys.modules[spec.name] = handlerModule
   spec.loader.exec_module(handlerModule)
   handler = getattr(handlerModule, handlerName)
   


### PR DESCRIPTION
Fixes issue with mocking python handlers that import other relative dependencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.