### PR TITLE
fix: add sms auth message to cfn template

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -176,6 +176,7 @@ Resources:
       <% } %>
       MfaConfiguration: !Ref mfaConfiguration
       SmsVerificationMessage: !Ref smsVerificationMessage
+      SmsAuthenticationMessage: !Ref smsAuthenticationMessage
       SmsConfiguration:
         SnsCallerArn: !GetAtt SNSRole.Arn
         ExternalId: <%=`${props.resourceNameTruncated}_role_external_id`%>


### PR DESCRIPTION
Fix issue where custom sms auth message was not set in CFN template

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.