### PR TITLE
chore: use latest prod versions of docker images

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14.15.1-debian-10-r8
+FROM public.ecr.aws/bitnami/node:14-prod-debian-10
 
 ENV PORT=8080
 EXPOSE 8080
@@ -10,4 +10,3 @@ RUN npm install
 COPY . .
 
 CMD [ "node", "index.js" ]
-    

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/python/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/python/Dockerfile
@@ -1,5 +1,5 @@
 # set base image (host OS)
-FROM public.ecr.aws/bitnami/python:3.8-debian-10
+FROM public.ecr.aws/bitnami/python:3.8-prod-debian-10
 
 # set the working directory in the container
 WORKDIR /code

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14.15.1-debian-10-r8
+FROM public.ecr.aws/bitnami/node:14-prod-debian-10
 
 ENV PORT=8080
 EXPOSE 8080

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14.15.1-debian-10-r8
+FROM public.ecr.aws/bitnami/node:14-prod-debian-10
 
 WORKDIR /usr/src/app
 COPY package*.json ./

--- a/packages/amplify-container-hosting/resources/express-template/Dockerfile
+++ b/packages/amplify-container-hosting/resources/express-template/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14.15.1-debian-10-r8
+FROM public.ecr.aws/bitnami/node:14-prod-debian-10
 
 WORKDIR /app
 

--- a/packages/amplify-container-hosting/resources/simple-template/Dockerfile
+++ b/packages/amplify-container-hosting/resources/simple-template/Dockerfile
@@ -1,12 +1,12 @@
 # Build the App using node
-FROM public.ecr.aws/bitnami/node:14.15.1-debian-10-r8 AS builder
+FROM public.ecr.aws/bitnami/node:14-prod-debian-10 AS builder
 WORKDIR /app
 COPY . .
 RUN yarn install && yarn build
 
 # Host the App using nginx
 EXPOSE 80
-FROM public.ecr.aws/nginx/nginx:1.19.5
+FROM public.ecr.aws/nginx/nginx:1
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY --from=builder /app/build .


### PR DESCRIPTION
*Description of changes:*

Remove pinned version from container deployed images to make sure the latest prod image is deployed always on fresh deployments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.