### PR TITLE
fix(amplify-codegen): update dependency on amplify-codegen to latest

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -46,7 +46,7 @@
     "amplify-category-xr": "2.7.3",
     "amplify-cli-core": "1.17.2",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "^2.22.3",
+    "amplify-codegen": "^2.22.4",
     "amplify-console-hosting": "1.7.3",
     "amplify-container-hosting": "1.2.3",
     "amplify-dotnet-function-runtime-provider": "1.5.2",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -67,7 +67,7 @@
     "@octokit/rest": "^18.0.9",
     "amplify-cli-core": "1.17.2",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "^2.22.3",
+    "amplify-codegen": "^2.22.4",
     "amplify-util-import": "1.3.13",
     "archiver": "^3.1.1",
     "aws-sdk": "^2.845.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -28,7 +28,7 @@
     "amplify-appsync-simulator": "1.25.3",
     "amplify-category-function": "2.30.2",
     "amplify-cli-core": "1.17.2",
-    "amplify-codegen": "^2.22.3",
+    "amplify-codegen": "^2.22.4",
     "amplify-dynamodb-simulator": "1.17.11",
     "amplify-provider-awscloudformation": "4.39.2",
     "amplify-storage-simulator": "1.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,16 +7828,15 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-codegen@^2.22.3:
-  version "2.22.3"
-  resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-2.22.3.tgz#5530a5c917e0be53c9872ee47ddfbea76380edd1"
-  integrity sha512-XOLV55utftI0DbVyWDrNGTm7aLtzj/cQarFxm/NrCzoYzSyTK3seRYcx0Xm8ibGBqx9RPOtxvKStyd1Me2mg4A==
+amplify-codegen@^2.22.4:
+  version "2.22.4"
+  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-2.22.4.tgz#b329e118aa8bb4409c26a268acd000e4532e8749"
+  integrity sha512-cwvACYWQ2rmf+POhiwcewWgG/QEoRecSOsNCL/S7s+nw0rwiccxTOIFYy1ZN95SmtfBvviiGB9bJxFrl/88lMA==
   dependencies:
     "@aws-amplify/appsync-modelgen-plugin" "1.22.10"
     "@aws-amplify/graphql-docs-generator" "2.3.2"
     "@aws-amplify/graphql-types-generator" "2.7.3"
     "@graphql-codegen/core" "1.8.3"
-    amplify-cli-core "^1.17.0"
     amplify-codegen-appsync-model-plugin "^1.22.3"
     amplify-graphql-docs-generator "^2.2.1"
     amplify-graphql-types-generator "^2.7.0"
@@ -7847,7 +7846,6 @@ amplify-codegen@^2.22.3:
     glob-parent "^5.1.1"
     graphql "^14.5.8"
     graphql-config "^2.2.1"
-    graphql-transformer-core "^6.26.2"
     inquirer "^7.3.3"
     ora "^4.0.3"
     slash "^3.0.0"


### PR DESCRIPTION
*Description of changes:*
These changes will fix the failing beta CLI builds due to codegen specifying the upstream CLI dependencies incorrectly. Please refer to this PR: https://github.com/aws-amplify/amplify-codegen/pull/101/files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.