### PR TITLE
test(amplify-provider-awscloudformation): minify context stub

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
@@ -1,20 +1,7 @@
 import { AdminLoginServer } from '../../utils/admin-login-server';
 import { $TSContext } from 'amplify-cli-core';
-import { FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
 
-const runtimePlugin_stub = ({
-  checkDependencies: jest.fn().mockResolvedValue({ hasRequiredDependencies: true }),
-  build: jest.fn().mockResolvedValue({ rebuilt: true }),
-} as unknown) as jest.Mocked<FunctionRuntimeLifecycleManager>;
-
-const context_stub = ({
-  amplify: {
-    readBreadcrumbs: jest.fn().mockReturnValue({ pluginId: 'testPluginId' }),
-    loadRuntimePlugin: jest.fn().mockResolvedValue(runtimePlugin_stub),
-    updateamplifyMetaAfterBuild: jest.fn(),
-  },
-} as unknown) as jest.Mocked<$TSContext>;
-
+const context_stub = ({} as unknown) as jest.Mocked<$TSContext>;
 const useMock = jest.fn();
 const postMock = jest.fn(async () => {});
 const listenMock = jest.fn();


### PR DESCRIPTION
*Description of changes:*
This PR is to address @jhockett's comment on https://github.com/aws-amplify/amplify-cli/pull/6780#discussion_r586647736 and remove unused stub methods from the test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.