### PR TITLE
fix(cli): freeze constants object to not be changed

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/constants.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/constants.test.ts
@@ -1,0 +1,12 @@
+import { amplifyCLIConstants } from '../../../extensions/amplify-helpers/constants';
+
+describe('constants', () => {
+  it('should freeze values', () => {
+    expect(amplifyCLIConstants.AmplifyCLIDirName).toBe('amplify');
+    expect(() => {
+      // @ts-ignore
+      amplifyCLIConstants.AmplifyCLIDirName = 'test';
+    }).toThrow(new TypeError("Cannot assign to read only property 'AmplifyCLIDirName' of object '#<Object>'"));
+    expect(amplifyCLIConstants.AmplifyCLIDirName).toBe('amplify');
+  });
+});

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/constants.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/constants.test.ts
@@ -4,8 +4,7 @@ describe('constants', () => {
   it('should freeze values', () => {
     expect(amplifyCLIConstants.AmplifyCLIDirName).toBe('amplify');
     expect(() => {
-      // @ts-ignore
-      amplifyCLIConstants.AmplifyCLIDirName = 'test';
+      (amplifyCLIConstants as any).AmplifyCLIDirName = 'test';
     }).toThrow(new TypeError("Cannot assign to read only property 'AmplifyCLIDirName' of object '#<Object>'"));
     expect(amplifyCLIConstants.AmplifyCLIDirName).toBe('amplify');
   });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/constants.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/constants.ts
@@ -1,4 +1,4 @@
-export const amplifyCLIConstants = {
+export const amplifyCLIConstants = Object.freeze({
   AmplifyCLIDirName: 'amplify',
   DotAmplifyDirName: '.amplify',
   DotConfigamplifyCLISubDirName: '.config',
@@ -24,4 +24,4 @@ export const amplifyCLIConstants = {
   CURRENT_PROJECT_CONFIG_VERSION: '3.1',
   BreadcrumbsFileName: 'amplify.state',
   LogDirectory: '.amplify-log',
-};
+} as const);


### PR DESCRIPTION
*Description of changes:*
Increase test coverage of amplify-cli.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.