### PR TITLE
chore: restrict nodejs version migration execution, remove adminui modelgen error message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1068,6 +1068,22 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
+  node_modules-aws-appsync-link-offline-link-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: node_modules/aws-appsync/__tests__/link/offline-link.test.ts
+      CLI_REGION: eu-west-2
+  node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: node_modules/aws-appsync/__tests__/link/complex-object-link.test.ts
+      CLI_REGION: eu-central-1
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1718,6 +1734,26 @@ jobs:
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
     steps: *ref_5
+  node_modules-aws-appsync-link-offline-link-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: node_modules/aws-appsync/__tests__/link/offline-link.test.ts
+      CLI_REGION: eu-west-2
+    steps: *ref_5
+  node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: node_modules/aws-appsync/__tests__/link/complex-object-link.test.ts
+      CLI_REGION: eu-central-1
+    steps: *ref_5
 workflows:
   version: 2
   nightly_console_integration_tests:
@@ -1805,14 +1841,15 @@ workflows:
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
             - api_4-amplify_e2e_tests
-            - function_3-amplify_e2e_tests
             - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - datastore-modelgen-amplify_e2e_tests
-            - auth_5-amplify_e2e_tests
+            - node_modules-aws-appsync-link-offline-link-amplify_e2e_tests
             - schema-iterative-update-2-amplify_e2e_tests
             - schema-data-access-patterns-amplify_e2e_tests
             - init-special-case-amplify_e2e_tests
+            - >-
+              node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests
             - auth_1-amplify_e2e_tests
             - feature-flags-amplify_e2e_tests
             - schema-versioned-amplify_e2e_tests
@@ -1836,14 +1873,16 @@ workflows:
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
             - api_4-amplify_e2e_tests_pkg_linux
-            - function_3-amplify_e2e_tests_pkg_linux
             - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
             - datastore-modelgen-amplify_e2e_tests_pkg_linux
-            - auth_5-amplify_e2e_tests_pkg_linux
+            - >-
+              node_modules-aws-appsync-link-offline-link-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
             - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
             - init-special-case-amplify_e2e_tests_pkg_linux
+            - >-
+              node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests_pkg_linux
             - auth_1-amplify_e2e_tests_pkg_linux
             - feature-flags-amplify_e2e_tests_pkg_linux
             - schema-versioned-amplify_e2e_tests_pkg_linux
@@ -2086,6 +2125,11 @@ workflows:
           filters: *ref_6
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
+      - node_modules-aws-appsync-link-offline-link-amplify_e2e_tests:
+          context: amplify-cli-ecr
+          filters: *ref_6
+          requires:
+            - function_3-amplify_e2e_tests
       - schema-auth-5-amplify_e2e_tests:
           context: amplify-cli-ecr
           filters: *ref_6
@@ -2131,6 +2175,11 @@ workflows:
           filters: *ref_6
           requires:
             - layer-amplify_e2e_tests
+      - node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests:
+          context: amplify-cli-ecr
+          filters: *ref_6
+          requires:
+            - auth_5-amplify_e2e_tests
       - api_1-amplify_e2e_tests:
           context: amplify-cli-ecr
           filters: *ref_6
@@ -2426,6 +2475,11 @@ workflows:
           filters: *ref_7
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
+      - node_modules-aws-appsync-link-offline-link-amplify_e2e_tests_pkg_linux:
+          context: amplify-cli-ecr
+          filters: *ref_7
+          requires:
+            - function_3-amplify_e2e_tests_pkg_linux
       - schema-auth-5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           filters: *ref_7
@@ -2475,6 +2529,11 @@ workflows:
           filters: *ref_7
           requires:
             - layer-amplify_e2e_tests_pkg_linux
+      - node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests_pkg_linux:
+          context: amplify-cli-ecr
+          filters: *ref_7
+          requires:
+            - auth_5-amplify_e2e_tests_pkg_linux
       - api_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           filters: *ref_7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1068,22 +1068,6 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
-  node_modules-aws-appsync-link-offline-link-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: node_modules/aws-appsync/__tests__/link/offline-link.test.ts
-      CLI_REGION: eu-west-2
-  node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: node_modules/aws-appsync/__tests__/link/complex-object-link.test.ts
-      CLI_REGION: eu-central-1
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1734,26 +1718,6 @@ jobs:
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
     steps: *ref_5
-  node_modules-aws-appsync-link-offline-link-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: node_modules/aws-appsync/__tests__/link/offline-link.test.ts
-      CLI_REGION: eu-west-2
-    steps: *ref_5
-  node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: node_modules/aws-appsync/__tests__/link/complex-object-link.test.ts
-      CLI_REGION: eu-central-1
-    steps: *ref_5
 workflows:
   version: 2
   nightly_console_integration_tests:
@@ -1841,15 +1805,14 @@ workflows:
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
             - api_4-amplify_e2e_tests
+            - function_3-amplify_e2e_tests
             - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - datastore-modelgen-amplify_e2e_tests
-            - node_modules-aws-appsync-link-offline-link-amplify_e2e_tests
+            - auth_5-amplify_e2e_tests
             - schema-iterative-update-2-amplify_e2e_tests
             - schema-data-access-patterns-amplify_e2e_tests
             - init-special-case-amplify_e2e_tests
-            - >-
-              node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests
             - auth_1-amplify_e2e_tests
             - feature-flags-amplify_e2e_tests
             - schema-versioned-amplify_e2e_tests
@@ -1873,16 +1836,14 @@ workflows:
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
             - api_4-amplify_e2e_tests_pkg_linux
+            - function_3-amplify_e2e_tests_pkg_linux
             - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
             - datastore-modelgen-amplify_e2e_tests_pkg_linux
-            - >-
-              node_modules-aws-appsync-link-offline-link-amplify_e2e_tests_pkg_linux
+            - auth_5-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
             - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
             - init-special-case-amplify_e2e_tests_pkg_linux
-            - >-
-              node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests_pkg_linux
             - auth_1-amplify_e2e_tests_pkg_linux
             - feature-flags-amplify_e2e_tests_pkg_linux
             - schema-versioned-amplify_e2e_tests_pkg_linux
@@ -2125,11 +2086,6 @@ workflows:
           filters: *ref_6
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
-      - node_modules-aws-appsync-link-offline-link-amplify_e2e_tests:
-          context: amplify-cli-ecr
-          filters: *ref_6
-          requires:
-            - function_3-amplify_e2e_tests
       - schema-auth-5-amplify_e2e_tests:
           context: amplify-cli-ecr
           filters: *ref_6
@@ -2175,11 +2131,6 @@ workflows:
           filters: *ref_6
           requires:
             - layer-amplify_e2e_tests
-      - node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests:
-          context: amplify-cli-ecr
-          filters: *ref_6
-          requires:
-            - auth_5-amplify_e2e_tests
       - api_1-amplify_e2e_tests:
           context: amplify-cli-ecr
           filters: *ref_6
@@ -2475,11 +2426,6 @@ workflows:
           filters: *ref_7
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
-      - node_modules-aws-appsync-link-offline-link-amplify_e2e_tests_pkg_linux:
-          context: amplify-cli-ecr
-          filters: *ref_7
-          requires:
-            - function_3-amplify_e2e_tests_pkg_linux
       - schema-auth-5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           filters: *ref_7
@@ -2529,11 +2475,6 @@ workflows:
           filters: *ref_7
           requires:
             - layer-amplify_e2e_tests_pkg_linux
-      - node_modules-aws-appsync-link-complex-object-link-amplify_e2e_tests_pkg_linux:
-          context: amplify-cli-ecr
-          filters: *ref_7
-          requires:
-            - auth_5-amplify_e2e_tests_pkg_linux
       - api_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           filters: *ref_7

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -13,6 +13,7 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
   if (appSyncResources.length === 0) {
     return;
   }
+
   const appSyncResource = appSyncResources[0];
   const { resourceName } = appSyncResource;
 
@@ -20,10 +21,11 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
   const localEnvInfo = stateManager.getLocalEnvInfo();
 
   const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
+
   if (!appId) {
-    context.print.error('Could not find AmplifyAppId in amplify-meta.json.');
     return;
   }
+
   const envName = localEnvInfo.envName;
   const { isAdminApp } = await isAmplifyAdminApp(appId);
   const isDSEnabled = await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName));
@@ -31,9 +33,11 @@ export async function adminModelgen(context: $TSContext, resources: $TSAny[]) {
   if (!isAdminApp || !isDSEnabled) {
     return;
   }
+
   // Generate DataStore Models for Admin UI CMS to consume
-  const spinner = ora('Generating models in the cloud…\n').start();
+  const spinner = ora('Generating models in the cloud...\n').start();
   const amplifyBackendInstance = await AmplifyBackend.getInstance(context);
+
   try {
     const jobStartDetails = await amplifyBackendInstance.amplifyBackend
       .generateBackendAPIModels({

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -313,6 +313,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject) {
       .map(({ category, resourceName }) => context.amplify.removeDeploymentSecrets(context, category, resourceName));
 
     await adminModelgen(context, resources);
+
     spinner.succeed('All resources are updated in the cloud');
 
     await displayHelpfulURLs(context, resources);


### PR DESCRIPTION
*Description of changes:*

- Restrict NodeJS migration to happen only during `push` command and don't run under CI/CD
- Remove AdminUI modelgen error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.