### PR TITLE
chore: fix nodejs migration e2e test and yaml parsing

### DIFF
--- a/packages/amplify-cli/src/project-config-version-check.ts
+++ b/packages/amplify-cli/src/project-config-version-check.ts
@@ -77,13 +77,13 @@ const CF_SCHEMA = new yaml.Schema([
   new yaml.Type('!GetAtt', {
     kind: 'scalar',
     construct: function (data) {
-      return { 'Fn::GetAtt': data };
+      return { 'Fn::GetAtt': Array.isArray(data) ? data : data.split('.') };
     },
   }),
   new yaml.Type('!GetAtt', {
     kind: 'sequence',
     construct: function (data) {
-      return { 'Fn::GetAtt': data };
+      return { 'Fn::GetAtt': Array.isArray(data) ? data : data.split('.') };
     },
   }),
   new yaml.Type('!GetAZs', {


### PR DESCRIPTION
*Description of changes:*

chore: fix nodejs migration e2e test
chore: fix configuration for yaml parser to handle Fn::GetAtt correctly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.