### PR TITLE
chore: add ci detect disable to e2e test

### DIFF
--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -36,7 +36,7 @@ export const amplifyRegions = [
 
 export function initJSProjectWithProfile(cwd: string, settings: Object): Promise<void> {
   const s = { ...defaultSettings, ...settings };
-  let env = undefined;
+  let env;
 
   if (s.disableAmplifyAppCreation === true) {
     env = {

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -44,19 +44,10 @@ export function initJSProjectWithProfile(cwd: string, settings: Object): Promise
     };
   }
 
-  // Undo ci-info detection, required for some tests
-  if (s.disableCIDetection === true) {
-    delete process.env.CI;
-    delete process.env.CONTINUOUS_INTEGRATION;
-    delete process.env.BUILD_NUMBER;
-    delete process.env.TRAVIS;
-    delete process.env.GITHUB_ACTIONS;
-  }
-
   addCircleCITags(cwd);
 
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['init'], { cwd, stripColors: true, env })
+    spawn(getCLIPath(), ['init'], { cwd, stripColors: true, env, disableCIDetection: s.disableAmplifyAppCreation })
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Enter a name for the environment')

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -16,6 +16,7 @@ const defaultSettings = {
   region: process.env.CLI_REGION,
   local: false,
   disableAmplifyAppCreation: true,
+  disableCIDetection: false,
 };
 
 export const amplifyRegions = [
@@ -35,12 +36,21 @@ export const amplifyRegions = [
 
 export function initJSProjectWithProfile(cwd: string, settings: Object): Promise<void> {
   const s = { ...defaultSettings, ...settings };
-  let env;
+  let env = undefined;
 
   if (s.disableAmplifyAppCreation === true) {
     env = {
       CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
     };
+  }
+
+  // Undo ci-info detection, required for some tests
+  if (s.disableCIDetection === true) {
+    delete process.env.CI;
+    delete process.env.CONTINUOUS_INTEGRATION;
+    delete process.env.BUILD_NUMBER;
+    delete process.env.TRAVIS;
+    delete process.env.GITHUB_ACTIONS;
   }
 
   addCircleCITags(cwd);

--- a/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
@@ -26,7 +26,9 @@ describe('nodejs version migration tests', () => {
   });
 
   it('init a project and add simple function and migrate node version', async () => {
-    await initJSProjectWithProfile(projectRoot, {});
+    await initJSProjectWithProfile(projectRoot, {
+      disableCIDetection: true,
+    });
 
     const random = Math.floor(Math.random() * 10000);
     const functionName = `nodefunction${random}`;


### PR DESCRIPTION
*Description of changes:*

chore: add CI detection disable capability to e2e tests, update nodejs migration test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.