### PR TITLE
add-graphql-datasource - aurora serverless - request template missing quotes for DELETE and UPDATE

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/RelationalDBResolverGenerator.ts
+++ b/packages/graphql-relational-schema-transformer/src/RelationalDBResolverGenerator.ts
@@ -197,9 +197,16 @@ export class RelationalDBResolverGenerator {
    */
   private makeUpdateRelationalResolver(type: string, mutationTypeName: string = 'Mutation') {
     const fieldName = graphqlName('update' + toUpper(type));
-    const updateSql = `UPDATE ${type} SET $update WHERE ${this.typePrimaryKeyMap.get(type)}=$ctx.args.update${toUpper(
-      type,
-    )}Input.${this.typePrimaryKeyMap.get(type)}`;
+    let updateSql;
+    if (this.typePrimaryKeyTypeMap.get(type).includes('String')) {
+      updateSql = `UPDATE ${type} SET $update WHERE ${this.typePrimaryKeyMap.get(type)}=\'$ctx.args.update${toUpper(
+        type,
+      )}Input.${this.typePrimaryKeyMap.get(type)}\'`;
+    } else {
+      updateSql = `UPDATE ${type} SET $update WHERE ${this.typePrimaryKeyMap.get(type)}=$ctx.args.update${toUpper(
+        type,
+      )}Input.${this.typePrimaryKeyMap.get(type)}`;
+    }
     let selectSql;
     if (this.typePrimaryKeyTypeMap.get(type).includes('String')) {
       selectSql = `SELECT * FROM ${type} WHERE ${this.typePrimaryKeyMap.get(type)}=\'$ctx.args.update${toUpper(
@@ -276,7 +283,12 @@ export class RelationalDBResolverGenerator {
     } else {
       selectSql = `SELECT * FROM ${type} WHERE ${this.typePrimaryKeyMap.get(type)}=$ctx.args.${this.typePrimaryKeyMap.get(type)}`;
     }
-    const deleteSql = `DELETE FROM ${type} WHERE ${this.typePrimaryKeyMap.get(type)}=$ctx.args.${this.typePrimaryKeyMap.get(type)}`;
+    let deleteSql;
+    if (this.typePrimaryKeyTypeMap.get(type).includes('String')) {
+      deleteSql = `DELETE FROM ${type} WHERE ${this.typePrimaryKeyMap.get(type)}=\'$ctx.args.${this.typePrimaryKeyMap.get(type)}\'`;
+    } else {
+      deleteSql = `DELETE FROM ${type} WHERE ${this.typePrimaryKeyMap.get(type)}=$ctx.args.${this.typePrimaryKeyMap.get(type)}`;
+    }
     const reqFileName = `${mutationTypeName}.${fieldName}.req.vtl`;
     const resFileName = `${mutationTypeName}.${fieldName}.res.vtl`;
     const reqTemplate = print(

--- a/packages/graphql-relational-schema-transformer/src/__tests__/__snapshots__/RelationalDBResolverGenerator.test.ts.snap
+++ b/packages/graphql-relational-schema-transformer/src/__tests__/__snapshots__/RelationalDBResolverGenerator.test.ts.snap
@@ -54,7 +54,7 @@ exports[`verify generated templates 10`] = `
 #set( $update = $updateList.toString().replace(\\"{\\",\\"\\").replace(\\"}\\",\\"\\") )
 {
   \\"version\\": \\"2018-05-29\\",
-  \\"statements\\":   [\\"UPDATE Tomatoes SET $update WHERE Id=$ctx.args.updateTomatoesInput.Id\\", \\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.updateTomatoesInput.Id'\\"]
+  \\"statements\\":   [\\"UPDATE Tomatoes SET $update WHERE Id='$ctx.args.updateTomatoesInput.Id'\\", \\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.updateTomatoesInput.Id'\\"]
 }"
 `;
 
@@ -77,7 +77,7 @@ exports[`verify generated templates 13`] = `"testFilePath/Mutation.deleteTomatoe
 exports[`verify generated templates 14`] = `
 "{
   \\"version\\": \\"2018-05-29\\",
-  \\"statements\\":   [\\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.Id'\\", \\"DELETE FROM Tomatoes WHERE Id=$ctx.args.Id\\"]
+  \\"statements\\":   [\\"SELECT * FROM Tomatoes WHERE Id='$ctx.args.Id'\\", \\"DELETE FROM Tomatoes WHERE Id='$ctx.args.Id'\\"]
 }"
 `;
 


### PR DESCRIPTION
*Issue #, if available:* #6798 

*Description of changes:* Added single quotes around the query input if it's a string for DELETE and UPDATE query templates (similar to #2133, which was for SELECT query templates). Also updated the relevant snapshots to match the changes made.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.