### PR TITLE
ci: update CircleCI workflow to run cleanup script

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -5,7 +5,7 @@ machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 
-node12: &node12
+node10: &node10
   working_directory: ~/repo
   docker:
     - image: circleci/node:10
@@ -22,6 +22,14 @@ defaults: &defaults
         aws_access_key_id: $ECR_ACCESS_KEY
         aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
   resource_class: large
+
+clean_e2e_resources: &clean_e2e_resources
+  name: Cleanup resources
+  command: |
+    pwd
+    cd packages/amplify-e2e-tests
+    yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
+  working_directory: ~/repo
 
 run_e2e_tests: &run_e2e_tests
   name: Run Amplify end-to-end tests
@@ -50,7 +58,7 @@ install_cli_from_local_registery: &install_cli_from_local_registery
 
 jobs:
   build:
-    <<: *node12
+    <<: *node10
     steps:
       - checkout
       - run: yarn run production-build
@@ -67,7 +75,7 @@ jobs:
           paths: .
 
   test:
-    <<: *node12
+    <<: *node10
     steps:
       - attach_workspace:
           at: ./
@@ -87,7 +95,7 @@ jobs:
           command: yarn coverage
 
   mock_e2e_tests:
-    <<: *node12
+    <<: *node10
     steps:
       - attach_workspace:
           at: ./
@@ -515,6 +523,39 @@ jobs:
           command: |
             version=$(cat .amplify-pkg-version)
             yarn ts-node scripts/github-release.ts $version
+  cleanup_resources:
+    <<: *node10
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: 'Run cleanup script'
+          command: |
+            cd packages/amplify-e2e-tests
+            yarn clean-e2e-resources
+          no_output_timeout: 90m
+      - store_artifacts:
+          path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
+    working_directory: ~/repo
+
+  cleanup_resources_after_e2e_runs:
+    <<: *node10
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: 'Run cleanup script'
+          command: |
+            cd packages/amplify-e2e-tests
+            yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
+          no_output_timeout: 90m
+      - store_artifacts:
+          path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
+    working_directory: ~/repo
 
 workflows:
   version: 2
@@ -538,6 +579,20 @@ workflows:
           requires:
             - build
             - publish_to_local_registry
+  e2e_resource_cleanup:
+    triggers:
+      - schedule:
+          cron: '45 0,12 * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build
+      - cleanup_resources:
+          requires:
+            - build
+
   build_test_deploy:
     jobs:
       - build
@@ -594,6 +649,8 @@ workflows:
                 - master
       - amplify_e2e_tests:
           context: amplify-cli-ecr
+          post-steps:
+            - run: *clean_e2e_resources
           filters:
             branches:
               only:
@@ -608,6 +665,8 @@ workflows:
             - amplify_e2e_tests
       - amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
+          post-steps:
+            - run: *clean_e2e_resources
           filters:
             branches:
               only:
@@ -648,6 +707,8 @@ workflows:
             - build
       - amplify_console_integration_tests:
           context: amplify-cli-ecr
+          post-steps:
+            - run: *clean_e2e_resources
           filters:
             branches:
               only:
@@ -671,6 +732,14 @@ workflows:
             branches:
               only:
                 - release
+      - cleanup_resources_after_e2e_runs:
+          requires:
+            - done_with_pkg_linux_e2e_tests
+            - amplify_migration_tests_latest
+            - amplify_migration_tests_v4
+            - amplify_migration_tests_v4_30_0
+            - done_with_node_e2e_tests
+
       - deploy:
           context: amplify-cli-ecr
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 machine:
   environment:
     PATH: ${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin
-node12:
+node10:
   working_directory: ~/repo
   docker: &ref_0
     - image: circleci/node:10
@@ -21,6 +21,13 @@ defaults:
         aws_access_key_id: $ECR_ACCESS_KEY
         aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
   resource_class: large
+clean_e2e_resources: &ref_6
+  name: Cleanup resources
+  command: |
+    pwd
+    cd packages/amplify-e2e-tests
+    yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
+  working_directory: ~/repo
 run_e2e_tests: &ref_3
   name: Run Amplify end-to-end tests
   command: |
@@ -548,6 +555,40 @@ jobs:
           command: |
             version=$(cat .amplify-pkg-version)
             yarn ts-node scripts/github-release.ts $version
+  cleanup_resources:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Run cleanup script
+          command: |
+            cd packages/amplify-e2e-tests
+            yarn clean-e2e-resources
+          no_output_timeout: 90m
+      - store_artifacts:
+          path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
+  cleanup_resources_after_e2e_runs:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Run cleanup script
+          command: |
+            cd packages/amplify-e2e-tests
+            yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
+          no_output_timeout: 90m
+      - store_artifacts:
+          path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
   schema-iterative-update-4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1740,6 +1781,19 @@ workflows:
           requires:
             - build
             - publish_to_local_registry
+  e2e_resource_cleanup:
+    triggers:
+      - schedule:
+          cron: 45 0,12 * * *
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build
+      - cleanup_resources:
+          requires:
+            - build
   build_test_deploy:
     jobs:
       - build
@@ -1885,6 +1939,8 @@ workflows:
             - build
       - amplify_console_integration_tests:
           context: amplify-cli-ecr
+          post-steps:
+            - run: *ref_6
           filters:
             branches:
               only:
@@ -1908,6 +1964,13 @@ workflows:
             branches:
               only:
                 - release
+      - cleanup_resources_after_e2e_runs:
+          requires:
+            - done_with_pkg_linux_e2e_tests
+            - amplify_migration_tests_latest
+            - amplify_migration_tests_v4
+            - amplify_migration_tests_v4_30_0
+            - done_with_node_e2e_tests
       - deploy:
           context: amplify-cli-ecr
           requires:
@@ -1938,7 +2001,9 @@ workflows:
                 - release
       - schema-iterative-update-4-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: &ref_6
+          post-steps: &ref_7
+            - run: *ref_6
+          filters: &ref_8
             branches:
               only:
                 - master
@@ -1948,327 +2013,393 @@ workflows:
             - publish_to_local_registry
       - schema-auth-6-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - function_1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - import_s3_1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-auth-7-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-iterative-update-4-amplify_e2e_tests
       - schema-auth-3-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-6-amplify_e2e_tests
       - hostingPROD-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - function_1-amplify_e2e_tests
       - amplify-app-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - import_s3_1-amplify_e2e_tests
       - init-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-7-amplify_e2e_tests
       - function_5-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-3-amplify_e2e_tests
       - api_2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-connection-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - migration-api-key-migration2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - import_auth_2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - auth_4-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - api_2-amplify_e2e_tests
       - schema-iterative-update-1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-connection-amplify_e2e_tests
       - predictions-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - migration-api-key-migration2-amplify_e2e_tests
       - schema-predictions-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - import_auth_2-amplify_e2e_tests
       - amplify-configure-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - auth_4-amplify_e2e_tests
       - api_4-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-iterative-update-1-amplify_e2e_tests
       - storage-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - migration-api-connection-migration-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-auth-11-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - import_auth_1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - migration-api-key-migration1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - storage-amplify_e2e_tests
       - function_3-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - migration-api-connection-migration-amplify_e2e_tests
       - containers-api-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-11-amplify_e2e_tests
       - interactions-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - import_auth_1-amplify_e2e_tests
       - datastore-modelgen-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
       - schema-auth-5-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-model-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-auth-9-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - api_3-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - layer-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-5-amplify_e2e_tests
       - auth_5-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-model-amplify_e2e_tests
       - schema-iterative-update-2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-9-amplify_e2e_tests
       - schema-data-access-patterns-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - api_3-amplify_e2e_tests
       - init-special-case-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - layer-amplify_e2e_tests
       - api_1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-function-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - auth_2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-auth-4-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - auth_3-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - api_1-amplify_e2e_tests
       - auth_1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-function-amplify_e2e_tests
       - feature-flags-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - auth_2-amplify_e2e_tests
       - schema-versioned-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-4-amplify_e2e_tests
       - plugin-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - auth_3-amplify_e2e_tests
       - schema-auth-2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - function_4-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - env-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-searchable-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - function_2-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-2-amplify_e2e_tests
       - schema-key-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - function_4-amplify_e2e_tests
       - analytics-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - env-amplify_e2e_tests
       - notifications-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-searchable-amplify_e2e_tests
       - schema-iterative-update-locking-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - function_2-amplify_e2e_tests
       - schema-iterative-update-3-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-auth-1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - import_dynamodb_1-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - schema-auth-8-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - publish_to_local_registry
       - delete-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-iterative-update-3-amplify_e2e_tests
       - schema-auth-10-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-1-amplify_e2e_tests
       - hosting-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - import_dynamodb_1-amplify_e2e_tests
       - tags-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - schema-auth-8-amplify_e2e_tests
       - migration-node-function-amplify_e2e_tests:
           context: amplify-cli-ecr
-          filters: *ref_6
+          post-steps: *ref_7
+          filters: *ref_8
           requires:
             - delete-amplify_e2e_tests
       - schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: &ref_7
+          post-steps: &ref_9
+            - run: *ref_6
+          filters: &ref_10
             branches:
               only:
                 - master
@@ -2277,348 +2408,412 @@ workflows:
             - build_pkg_binaries
       - schema-auth-6-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - function_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_s3_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-7-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-update-4-amplify_e2e_tests_pkg_linux
       - schema-auth-3-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-6-amplify_e2e_tests_pkg_linux
       - hostingPROD-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_1-amplify_e2e_tests_pkg_linux
       - amplify-app-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_s3_1-amplify_e2e_tests_pkg_linux
       - init-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
       - function_5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-3-amplify_e2e_tests_pkg_linux
       - api_2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-connection-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_auth_2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - auth_4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - api_2-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-connection-amplify_e2e_tests_pkg_linux
       - predictions-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - migration-api-key-migration2-amplify_e2e_tests_pkg_linux
       - schema-predictions-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_auth_2-amplify_e2e_tests_pkg_linux
       - amplify-configure-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
       - api_4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-update-1-amplify_e2e_tests_pkg_linux
       - storage-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-11-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_auth_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - storage-amplify_e2e_tests_pkg_linux
       - function_3-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - migration-api-connection-migration-amplify_e2e_tests_pkg_linux
       - containers-api-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-11-amplify_e2e_tests_pkg_linux
       - interactions-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_auth_1-amplify_e2e_tests_pkg_linux
       - datastore-modelgen-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
       - schema-auth-5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-model-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-9-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - api_3-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - layer-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-5-amplify_e2e_tests_pkg_linux
       - auth_5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-model-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-9-amplify_e2e_tests_pkg_linux
       - schema-data-access-patterns-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - api_3-amplify_e2e_tests_pkg_linux
       - init-special-case-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - layer-amplify_e2e_tests_pkg_linux
       - api_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-function-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - auth_2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - auth_3-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - api_1-amplify_e2e_tests_pkg_linux
       - auth_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-function-amplify_e2e_tests_pkg_linux
       - feature-flags-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_2-amplify_e2e_tests_pkg_linux
       - schema-versioned-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-4-amplify_e2e_tests_pkg_linux
       - plugin-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_3-amplify_e2e_tests_pkg_linux
       - schema-auth-2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - function_4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - env-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-searchable-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - function_2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-2-amplify_e2e_tests_pkg_linux
       - schema-key-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_4-amplify_e2e_tests_pkg_linux
       - analytics-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - env-amplify_e2e_tests_pkg_linux
       - notifications-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-searchable-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_2-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-3-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_dynamodb_1-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-8-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - delete-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-update-3-amplify_e2e_tests_pkg_linux
       - schema-auth-10-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-1-amplify_e2e_tests_pkg_linux
       - hosting-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_dynamodb_1-amplify_e2e_tests_pkg_linux
       - tags-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-8-amplify_e2e_tests_pkg_linux
       - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
-          filters: *ref_7
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - delete-amplify_e2e_tests_pkg_linux

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -54,7 +54,12 @@ export const deleteS3Bucket = async (bucket: string) => {
         ...continuationToken,
       })
       .promise();
+
     results.Versions?.forEach(({ Key, VersionId }) => {
+      objectKeyAndVersion.push({ Key, VersionId });
+    });
+
+    results.DeleteMarkers?.forEach(({ Key, VersionId }) => {
       objectKeyAndVersion.push({ Key, VersionId });
     });
 

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -18,7 +18,8 @@
   "private": true,
   "scripts": {
     "e2e": "npm run setup-profile && jest --verbose",
-    "setup-profile": "ts-node ./src/configure_tests.ts"
+    "setup-profile": "ts-node ./src/configure_tests.ts",
+    "clean-e2e-resources": "ts-node ./src/cleanup-e2e-resources.ts"
   },
   "dependencies": {
     "amplify-cli-core": "1.18.0",
@@ -26,6 +27,7 @@
     "aws-amplify": "^3.0.8",
     "aws-appsync": "^4.0.3",
     "aws-sdk": "^2.845.0",
+    "circleci-api": "^4.1.3",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",
     "fs-extra": "^8.1.0",
@@ -35,7 +37,8 @@
     "lodash": "^4.17.19",
     "promise-sequential": "^1.1.1",
     "rimraf": "^3.0.0",
-    "uuid": "^3.4.0"
+    "uuid": "^3.4.0",
+    "yargs": "^15.1.0"
   },
   "devDependencies": {
     "ts-node": "^8.9.0"

--- a/packages/amplify-e2e-tests/sample.env
+++ b/packages/amplify-e2e-tests/sample.env
@@ -20,3 +20,8 @@ AMAZON_APP_SECRET=<your-amazon-app-secret>
 AWS_ACCESS_KEY_ID=<your-access-key>
 AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
 CLI_REGION=<region>
+
+# Used for cleanup script
+CIRCLECI_TOKEN = '<your token>' # Token used for querying CircleCI to get the build details
+CIRCLE_PROJECT_USERNAME='<your github username>'
+CIRCLE_PROJECT_REPONAME='amplify-cli'

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -1,0 +1,456 @@
+import { CircleCI, GitType, CircleCIOptions } from 'circleci-api';
+import { config } from 'dotenv';
+import yargs from 'yargs';
+import * as aws from 'aws-sdk';
+import _ from 'lodash';
+import fs from 'fs-extra';
+import path from 'path';
+import { deleteS3Bucket } from 'amplify-e2e-core';
+
+import { AWS_REGIONS_TO_RUN_TESTS } from '../../../scripts/e2e-test-regions';
+
+const reportPath = path.normalize(path.join(__dirname, '..', 'amplify-e2e-reports', 'stale-resources.json'));
+
+const MULTI_JOB_APP = '<Amplify App resued by muliple apps>';
+const ORPHAN = '<orphan>';
+const UNKNOWN = '<unknown>';
+
+export type CircleCIJobDetails = {
+  build_url: string;
+  branch: string;
+  build_num: number;
+  outcome: string;
+  canceled: string;
+  infrastructure_fail: boolean;
+  status: string;
+  committer_name: null;
+  workflows: { workflow_id: string };
+};
+
+export type StackInfo = {
+  stackName: string;
+  stackStatus: string;
+  resourcesFailedToDelete?: string[];
+  tags: Record<string, string>;
+  region: string;
+  cciInfo: CircleCIJobDetails;
+};
+
+export type AmplifyAppInfo = {
+  appId: string;
+  name: string;
+  region: string;
+  backends: Record<string, StackInfo>;
+};
+
+export type S3BucketInfo = {
+  name: string;
+  cciInfo?: CircleCIJobDetails;
+};
+
+export type ReportEntry = {
+  jobId?: string;
+  workflowId?: string;
+  lifecycle?: string;
+  cciJobDetails?: CircleCIJobDetails;
+  amplifyApps: Record<string, AmplifyAppInfo>;
+  stacks: Record<string, StackInfo>;
+  buckets: Record<string, S3BucketInfo>;
+};
+
+/**
+ * Configure the AWS SDK with credentials and retry
+ */
+const configureAws = (): void => {
+  if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    throw new Error('AWS credentials are not configured. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables');
+  }
+  aws.config.update({
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      ...(process.env.AWS_SESSION_TOKEN ? { sessionToken: process.env.AWS_SESSION_TOKEN } : {}),
+    },
+    maxRetries: 10,
+  });
+};
+
+/**
+ * Returns a list of Amplify Apps in the region. The apps includes information about the CircleCI build that created the app
+ * This is determined by looking at tags of the backend environments that are associated with the Apps
+ * @param region aws region to query for amplify Apps
+ * @returns Promise<AmplifyAppInfo[]> a list of Amplify Apps in the region with build info
+ */
+const getAmplifyApps = async (region: string): Promise<AmplifyAppInfo[]> => {
+  const amplifyClient = new aws.Amplify({ region });
+  const amplifyApps = await amplifyClient.listApps({ maxResults: 50 }).promise(); // keeping it to 100 as max supported is 50
+  const result: AmplifyAppInfo[] = [];
+  for (const app of amplifyApps.apps) {
+    const backends: Record<string, StackInfo> = {};
+    try {
+      const backendEnvironments = await amplifyClient.listBackendEnvironments({ appId: app.appId, maxResults: 50 }).promise();
+      for (const backendEnv of backendEnvironments.backendEnvironments) {
+        const buildInfo = await getStackDetails(backendEnv.stackName, region);
+        if (buildInfo) {
+          backends[backendEnv.environmentName] = buildInfo;
+        }
+      }
+    } catch (e) {
+      console.log(e);
+    }
+    result.push({
+      appId: app.appId,
+      name: app.name,
+      region,
+      backends: backends,
+    });
+  }
+  return result;
+};
+
+/**
+ * Return the CircleCI job id looking at `circleci:build_id` in the tags
+ * @param tags Tags associated with the resource
+ * @returns build number or undefined
+ */
+export const getJobId = (tags: aws.CloudFormation.Tags = []): number | undefined => {
+  const jobId = tags.find(tag => tag.Key === 'circleci:build_id')?.Value;
+  return jobId ? Number.parseInt(jobId, 10) : undefined;
+};
+
+/**
+ * Gets detail about a stack including the details about CircleCI job that created the stack. If a stack
+ * has status of `DELETE_FAILED` then it also includes the list of physical id of resources that caused 
+ * deletion failures
+ * 
+ * @param stackName name of the stack
+ * @param region region
+ * @returns stack details
+ */
+const getStackDetails = async (stackName: string, region: string): Promise<StackInfo | void> => {
+  const cfnClient = new aws.CloudFormation({ region });
+  const stack = await cfnClient.describeStacks({ StackName: stackName }).promise();
+  const tags = stack.Stacks.length && stack.Stacks[0].Tags;
+  const stackStatus = stack.Stacks[0].StackStatus;
+  let resourcesFailedToDelete: string[] = [];
+  if (stackStatus === 'DELETE_FAILED') {
+    // We need to investigate if  we should go ahead and remove the resources to prevent account getting cluttered
+    const resources = await cfnClient.listStackResources({ StackName: stackName }).promise();
+    resourcesFailedToDelete = resources.StackResourceSummaries.filter(r => r.ResourceStatus === 'DELETE_FAILED').map(
+      r => r.LogicalResourceId,
+    );
+  }
+  const jobId = getJobId(tags);
+  return {
+    stackName,
+    stackStatus,
+    resourcesFailedToDelete,
+    region,
+    tags: tags.reduce((acc, tag) => ({ ...acc, [tag.Key]: tag.Value }), {}),
+    cciInfo: jobId ? await getJobCircleCIDetails(jobId) : undefined,
+  };
+};
+
+const getStacks = async (region: string): Promise<StackInfo[]> => {
+  const cfnClient = new aws.CloudFormation({ region });
+  const stacks = await cfnClient
+    .listStacks({
+      StackStatusFilter: [
+        'CREATE_COMPLETE',
+        'ROLLBACK_FAILED',
+        'DELETE_FAILED',
+        'UPDATE_COMPLETE',
+        'UPDATE_ROLLBACK_FAILED',
+        'UPDATE_ROLLBACK_COMPLETE',
+        'IMPORT_COMPLETE',
+        'IMPORT_ROLLBACK_FAILED',
+        'IMPORT_ROLLBACK_COMPLETE',
+      ],
+    })
+    .promise();
+
+  // We are interested in only the root stacks that are deployed by amplify-cli
+  const rootStacks = stacks.StackSummaries.filter(stack => !stack.RootId);
+  const results: StackInfo[] = [];
+  for (const stack of rootStacks) {
+    const details = await getStackDetails(stack.StackName, region);
+    details && results.push(details);
+  }
+  return results;
+};
+
+const getCircleCIClient = (): CircleCI => {
+  const options: CircleCIOptions = {
+    token: process.env.CIRCLECI_TOKEN,
+    vcs: {
+      repo: process.env.CIRCLE_PROJECT_REPONAME,
+      owner: process.env.CIRCLE_PROJECT_USERNAME,
+      type: GitType.GITHUB,
+    },
+  };
+  return new CircleCI(options);
+};
+
+export const getJobCircleCIDetails = async (jobId: number): Promise<CircleCIJobDetails> => {
+  const client = getCircleCIClient();
+  const result = await client.build(jobId);
+
+  const r = (_.pick(result, [
+    'build_url',
+    'branch',
+    'build_num',
+    'outcome',
+    'canceled',
+    'infrastructure_fail',
+    'status',
+    'committer_name',
+    'workflows.workflow_id',
+    'lifecycle',
+  ]) as any) as CircleCIJobDetails;
+  return r;
+};
+
+export const getS3Buckets = async (): Promise<S3BucketInfo[]> => {
+  const s3Client = new aws.S3();
+  const buckets = await s3Client.listBuckets().promise();
+  const result: S3BucketInfo[] = [];
+  for (const bucket of buckets.Buckets) {
+    try {
+      const bucketDetails = await s3Client.getBucketTagging({ Bucket: bucket.Name }).promise();
+      const jobId = getJobId(bucketDetails.TagSet);
+      if (jobId) {
+        result.push({
+          name: bucket.Name,
+          cciInfo: await getJobCircleCIDetails(jobId),
+        });
+      }
+    } catch (e) {
+      if (e.code !== 'NoSuchTagSet' && e.code !== 'NoSuchBucket') {
+        throw e;
+      }
+      result.push({
+        name: bucket.Name,
+      });
+    }
+  }
+  return result;
+};
+
+/**
+ * extract and moves CircleCI job details
+ * @param record 
+ * @returns 
+ */
+export const extractCCIJobInfo = (record: S3BucketInfo | StackInfo | AmplifyAppInfo) => {
+  return {
+    workflowId: _.get(record, ['0', 'cciInfo', 'workflows', 'workflow_id']),
+    workflowName: _.get(record, ['0', 'cciInfo', 'workflows', 'workflow_name']),
+    lifecycle: _.get(record, ['0', 'cciInfo', 'lifecycle']),
+    cciJobDetails: _.get(record, ['0', 'cciInfo']),
+    status: _.get(record, ['0', 'cciInfo', 'status']),
+  };
+};
+
+/**
+ * Merges stale resources and returns a list grouped by the CircleCI jobId. Amplify Apps that don't have
+ * any backend environment are grouped as Orphan apps and apps that have Backend created by different CircleCI jobs are
+ * grouped as MULTI_JOB_APP. Any resource that do not have a CircleCI job is grouped under UNKNOWN
+ * @param amplifyApp list of AmplifyApps
+ * @param cfnStacks list of Cloudformation stacks
+ * @param s3Buckets list of S3 Buckets
+ * @returns 
+ */
+export const mergeResourcesByCCIJob = (
+  amplifyApp: AmplifyAppInfo[],
+  cfnStacks: StackInfo[],
+  s3Buckets: S3BucketInfo[],
+): Record<string, ReportEntry> => {
+  const result: Record<string, ReportEntry> = {};
+
+  const stacksByJobId = _.groupBy(cfnStacks, (stack: StackInfo) => {
+    return _.get(stack, ['cciInfo', 'build_num'], UNKNOWN);
+  });
+
+  const bucketByJobId = _.groupBy(s3Buckets, (bucketInfo: S3BucketInfo) => {
+    return _.get(bucketInfo, ['cciInfo', 'build_num'], UNKNOWN);
+  });
+
+  const amplifyAppByJobId = _.groupBy(amplifyApp, (appInfo: AmplifyAppInfo) => {
+    if (Object.keys(appInfo.backends).length === 0) {
+      return ORPHAN;
+    }
+    const buildIds = _.groupBy(appInfo.backends, backendInfo => _.get(backendInfo, ['cciInfo', 'build_num'], UNKNOWN));
+    if (Object.keys(buildIds).length === 1) {
+      return Object.keys(buildIds)[0];
+    }
+    return MULTI_JOB_APP;
+  });
+
+  _.mergeWith(
+    result,
+    _.pickBy(amplifyAppByJobId, (_, key) => key !== MULTI_JOB_APP),
+    (val, src, key) => {
+      return {
+        ...val,
+        ...extractCCIJobInfo(src),
+        jobId: key,
+        amplifyApps: src,
+      };
+    },
+  );
+
+  _.mergeWith(
+    result,
+    stacksByJobId, (_, key) => key !== ORPHAN,
+    (val, src, key) => {
+      return {
+        ...val,
+        ...extractCCIJobInfo(src),
+        jobId: key,
+        stacks: src,
+      };
+    },
+  );
+
+  _.mergeWith(
+    result,
+    bucketByJobId,
+    (val, src, key) => {
+      return {
+        ...val,
+        ...extractCCIJobInfo(src),
+        jobId: key,
+        buckets: src,
+      };
+    },
+  );
+  return result;
+};
+
+export const deleteAmplifyApps = async (apps: AmplifyAppInfo[]): Promise<void> => {
+  for (const appInfo of apps) {
+    console.log(`Deleting App ${appInfo.name}(${appInfo.appId})`);
+    await deleteAmplifyApp(appInfo.appId, appInfo.region);
+  }
+};
+
+export const deleteAmplifyApp = async (appId: string, region: string): Promise<void> => {
+  const amplifyClient = new aws.Amplify({ region });
+  try {
+    await amplifyClient.deleteApp({ appId: appId }).promise();
+  } catch (e) {
+    console.log(`Deleting Amplify App ${appId} failed with the following error`, e);
+  }
+};
+
+export const deleteBuckets = async (buckets: S3BucketInfo[]): Promise<void> => {
+  for (const bucketInfo of buckets) {
+    try {
+      console.log(`Deleting S3 Bucket ${bucketInfo.name}`);
+      await deleteS3Bucket(bucketInfo.name);
+    } catch (e) {
+      console.log(`Deleting bucket ${bucketInfo.name} failed with error ${e.message}`);
+    }
+  }
+};
+
+export const deleteCfnStacks = async (stacks: StackInfo[]): Promise<void> => {
+  for (const stackInfo of stacks) {
+    try {
+      console.log(`Deleting CloudFormation stack ${stackInfo.stackName}`);
+      await deleteCfnStack(
+        stackInfo.stackName,
+        stackInfo.region,
+        stackInfo.resourcesFailedToDelete.length ? stackInfo.resourcesFailedToDelete : undefined,
+      );
+    } catch (e) {
+      console.log(`Deleting CloudFormation stack ${stackInfo.stackName} failed with error ${e.message}`);
+    }
+  }
+};
+
+export const deleteCfnStack = async (stackName: string, region: string, resourceToRetain?: string[]): Promise<void> => {
+  const cfnClient = new aws.CloudFormation({ region });
+  await cfnClient.deleteStack({ StackName: stackName, RetainResources: resourceToRetain }).promise();
+  await cfnClient.waitFor('stackDeleteComplete', { StackName: stackName }).promise();
+};
+
+const generateReport = jobs => {
+  fs.ensureFileSync(reportPath);
+  fs.writeFileSync(reportPath, JSON.stringify(jobs, null, 4));
+};
+
+export const filterByJobId = (jobId: string) => (job: ReportEntry) => job.jobId === jobId;
+
+export const filterByWorkflowId = (workflowId: string) => (job: ReportEntry) => job.workflowId === workflowId;
+
+export const filterAllStaleResources = () => (job: ReportEntry) => job.lifecycle === 'finished' || job.jobId === ORPHAN;
+
+export const deleteResources = async (staleResources: Record<string, ReportEntry>): Promise<void> => {
+  for (const jobId of Object.keys(staleResources)) {
+    const resources = staleResources[jobId];
+    if (resources.amplifyApps) {
+      await deleteAmplifyApps(Object.values(resources.amplifyApps));
+    }
+
+    if (resources.stacks) {
+      await deleteCfnStacks(Object.values(resources.stacks));
+    }
+
+    if (resources.buckets) {
+      await deleteBuckets(Object.values(resources.buckets));
+    }
+  }
+};
+
+export const cleanup = async () => {
+  const args = yargs
+    .command('*', 'clean up all the stale resources')
+    .command('workflow <workflow-id>', 'clean all the resources created by workflow', yargs => {
+      yargs.positional('workflowId', {
+        describe: 'Workflow Id of the workflow',
+        type: 'string',
+        demandOption: '',
+      });
+    })
+    .command('job <jobId>', 'clean all the resource created by a job', yargs => {
+      yargs.positional('jobId', {
+        describe: 'job id of the job',
+        type: 'number',
+      });
+    })
+    .help().argv;
+  config();
+  configureAws();
+
+  let filterPredicate;
+  if (args._.length === 0) {
+    filterPredicate = filterAllStaleResources();
+  } else {
+    if (args._[0] === 'workflow') {
+      filterPredicate = filterByWorkflowId(args.workflowId as string);
+    } else if (args._[0] === 'job') {
+      if (Number.isNaN(args.jobId)) {
+        throw new Error('job-id should be integer');
+      }
+      filterPredicate = filterByJobId((args.jobId as number).toString());
+    }
+  }
+  const amplifyApps: AmplifyAppInfo[] = [];
+  const stacks: StackInfo[] = [];
+
+  for (const region of AWS_REGIONS_TO_RUN_TESTS) {
+    amplifyApps.push(...(await getAmplifyApps(region)));
+    stacks.push(...(await getStacks(region)));
+  }
+
+  const buckets = await getS3Buckets();
+  const allResources = mergeResourcesByCCIJob(amplifyApps, stacks, buckets);
+  const staleResources = _.pickBy(allResources, filterPredicate);
+  generateReport(staleResources);
+  await deleteResources(staleResources);
+
+  console.log('Cleanup done!');
+};
+
+cleanup();

--- a/scripts/e2e-test-regions.ts
+++ b/scripts/e2e-test-regions.ts
@@ -1,0 +1,9 @@
+export const AWS_REGIONS_TO_RUN_TESTS = [
+  'us-east-2',
+  'us-west-2',
+  'eu-west-2',
+  'eu-central-1',
+  'ap-northeast-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+];

--- a/scripts/e2e-test-regions.ts
+++ b/scripts/e2e-test-regions.ts
@@ -1,9 +1,0 @@
-export const AWS_REGIONS_TO_RUN_TESTS = [
-  'us-east-2',
-  'us-west-2',
-  'eu-west-2',
-  'eu-central-1',
-  'ap-northeast-1',
-  'ap-southeast-1',
-  'ap-southeast-2',
-];

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -2,8 +2,17 @@ import * as yaml from 'js-yaml';
 import * as glob from 'glob';
 import { join } from 'path';
 import * as fs from 'fs-extra';
-import { AWS_REGIONS_TO_RUN_TESTS } from './e2e-test-regions';
 const CONCURRENCY = 4;
+// Ensure to update packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts is also updated this gets updated
+const AWS_REGIONS_TO_RUN_TESTS = [
+  'us-east-2',
+  'us-west-2',
+  'eu-west-2',
+  'eu-central-1',
+  'ap-northeast-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+];
 
 // This array needs to be update periodically when new tests suites get added
 // or when a test suite changes drastically

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -2,17 +2,8 @@ import * as yaml from 'js-yaml';
 import * as glob from 'glob';
 import { join } from 'path';
 import * as fs from 'fs-extra';
-
+import { AWS_REGIONS_TO_RUN_TESTS } from './e2e-test-regions';
 const CONCURRENCY = 4;
-const AWS_REGIONS_TO_RUN_TESTS = [
-  'us-east-2',
-  'us-west-2',
-  'eu-west-2',
-  'eu-central-1',
-  'ap-northeast-1',
-  'ap-southeast-1',
-  'ap-southeast-2',
-];
 
 // This array needs to be update periodically when new tests suites get added
 // or when a test suite changes drastically

--- a/yarn.lock
+++ b/yarn.lock
@@ -8791,6 +8791,13 @@ axios@^0.19.0:
   dependencies:
     follow-redirects "1.5.10"
 
+axios@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
+  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -10053,6 +10060,13 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+circleci-api@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/circleci-api/-/circleci-api-4.1.3.tgz#cafd80bc1905c6064724636741b4b5b231ed34d0"
+  integrity sha512-Km6H8LB3nNbFUjErhI+sNQrcHcU7dCBnQEi4ckBtQMkCXh+2gDvaYchfkeuIaA1hkakQT5sLmdPbYzhKbvsOMg==
+  dependencies:
+    axios "^0.20.0"
 
 cjs-module-lexer@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
updated the repository to include a cleanup script which deletes stale
resources left over by the e2e test. These scripts get run at the end
of each e2e test and at the end of the workflow.

The script will also run twice a day to clean up any resources that
were left out due to the cancellation of test workflow

Sample run: https://app.circleci.com/pipelines/github/yuth/amplify-cli/888/workflows/c1bf1141-4615-4180-8fa2-1c5c1005cf40