### PR TITLE
test(graphql-transformers-e2e-tests): set fallback region for cognito

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
@@ -27,7 +27,7 @@ interface E2Econfiguration {
   USER_POOL_ID?: string;
 }
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: process.env.CLI_REGION });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: process.env.CLI_REGION || 'us-west-2' });
 
 export function configureAmplify(userPoolId: string, userPoolClientId: string, identityPoolId?: string) {
   Amplify.configure({


### PR DESCRIPTION
*Description of changes:*

Fix the missing region in the new docker image to fall back to us-west-2 in case no `CLI_REGION` env var is defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.