### PR TITLE
fix(graphql-key-transformer): check if lastSync == 0 in selective sync resolver

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -1104,7 +1104,7 @@ function setSyncQueryFilterSnippet() {
     compoundExpression([
       set(ref('filterArgsMap'), ref('ctx.args.filter.get("and")')),
       ifElse(
-        raw(`!$util.isNullOrEmpty($filterArgsMap) && $util.isNull($ctx.args.lastSync)`),
+        raw(`!$util.isNullOrEmpty($filterArgsMap) && ($util.isNull($ctx.args.lastSync) || $ctx.args.lastSync == 0)`),
         compoundExpression([
           set(ref('json'), raw(`$filterArgsMap`)),
           forEach(ref('item'), ref(`json`), [

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -1235,7 +1235,7 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
-#if( !$util.isNullOrEmpty($filterArgsMap) && $util.isNull($ctx.args.lastSync) )
+#if( !$util.isNullOrEmpty($filterArgsMap) && ($util.isNull($ctx.args.lastSync) || $ctx.args.lastSync == 0) )
   #set( $json = $filterArgsMap )
   #foreach( $item in $json )
     #set( $ind = $foreach.index )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/7923

*Description of changes:*
Minor change that adds a check if `lastSync == 0` in the sync query resolver when attempting to construct a query expression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.