### PR TITLE
Enables M1 MacBooks support for packaged CLI support

### DIFF
--- a/install
+++ b/install
@@ -32,9 +32,11 @@ else
   exit 1
 fi
 
-# Detect architecture
+# Detect architecture and fallback to Rosetta when using M1 Macbook
 MACHINE_TYPE=`uname -m`
 if [[ $MACHINE_TYPE == "x86_64" ]]; then
+  ARCH='x64'
+elif [[ $OSTYPE =="darwin"* && $MACHINE_TYPE == "arm64" ]]; then
   ARCH='x64'
 else
   echo "$red Sorry, there's no Amplify CLI binary installer available for $MACHINE_TYPE architecture."

--- a/install
+++ b/install
@@ -36,7 +36,7 @@ fi
 MACHINE_TYPE=`uname -m`
 if [[ $MACHINE_TYPE == "x86_64" ]]; then
   ARCH='x64'
-elif [[ $OSTYPE =="darwin"* && $MACHINE_TYPE == "arm64" ]]; then
+elif [[ $OSTYPE == "darwin"* && $MACHINE_TYPE == "arm64" ]]; then
   ARCH='x64'
 else
   echo "$red Sorry, there's no Amplify CLI binary installer available for $MACHINE_TYPE architecture."


### PR DESCRIPTION
Rosetta will automatically kick in when x64 architecture is detected. We should still allow M1 MacBooks to install the packaged CLI.

*Issue #, if available:*
- https://github.com/aws-amplify/amplify-cli/issues/6312

*Description of changes:*
- Forces the x64 binary download of the packaged CLI
- Rosetta built-in to M1 MacBooks will automatically translate the x64 binary during runtime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.