### PR TITLE
feat(amplify-category-hosting): Send metadata to S3

### DIFF
--- a/packages/amplify-category-hosting/__mocks__/amplifyPublishMeta.json
+++ b/packages/amplify-category-hosting/__mocks__/amplifyPublishMeta.json
@@ -1,0 +1,7 @@
+[
+  {
+    "pattern": "mockMetaPattern",
+    "key": "mockMetaKey1",
+    "value": "mockMetaKey2"
+  }
+]

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Meta.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Meta.test.js
@@ -1,0 +1,101 @@
+jest.mock('inquirer');
+const fs = require('fs-extra');
+const path = require('path');
+const inquirer = require('inquirer');
+
+const configureMeta = require('../../../../lib/S3AndCloudFront/helpers/configure-Meta');
+
+describe('configure-Meta', () => {
+  const DONE = 'exit';
+  const configActions = {
+    list: 'list',
+    add: 'add',
+    remove: 'remove',
+    removeAll: 'remove all',
+    done: DONE,
+  };
+  const mockContext = {
+    amplify: {
+      pathManager: {
+        searchProjectRootPath: jest.fn(() => {
+          return path.join(__dirname, '../../../../__mocks__/');
+        }),
+      },
+      readJsonFile: jsonFilePath => {
+        let content = fs.readFileSync(jsonFilePath, 'utf8');
+        if (content.charCodeAt(0) === 0xfeff) {
+          content = content.slice(1);
+        }
+        return JSON.parse(content);
+      },
+    },
+    print: {
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+      success: jest.fn(),
+    },
+  };
+
+  beforeAll(() => {
+    fs.existsSync = jest.fn(() => {
+      return true;
+    });
+    fs.writeFileSync = jest.fn();
+  });
+
+  beforeEach(() => {
+    inquirer.prompt.mockClear();
+    fs.existsSync.mockClear();
+    fs.writeFileSync.mockClear();
+  });
+
+  test('configure, flow1', async () => {
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.list });
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
+    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern1', keyToAdd: 'mockKey1', valueToAdd: 'mockValue1' });
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
+    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern2', keyToAdd: 'mockKey2', valueToAdd: 'mockValue2' });
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.remove });
+    inquirer.prompt.mockResolvedValueOnce({ patternToRemove: 'mockPattern1' });
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.done });
+    const result = await configureMeta.configure(mockContext);
+    expect(mockContext.print.info).toBeCalled();
+    expect(fs.writeFileSync).toBeCalled();
+    expect(Array.isArray(result)).toBeTruthy();
+    console.log(result);
+    expect(result).not.toContain('mockPattern1');
+  });
+
+  test('configure, flow2', async () => {
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
+    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern1' });
+    inquirer.prompt.mockResolvedValueOnce({ keyToAdd: 'mockKey1' });
+    inquirer.prompt.mockResolvedValueOnce({ valueToAdd: 'mockValue1' });
+
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
+    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern2' });
+    inquirer.prompt.mockResolvedValueOnce({ keyToAdd: 'mockKey2' });
+    inquirer.prompt.mockResolvedValueOnce({ valueToAdd: 'mockValue2' });
+
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.removeAll });
+    inquirer.prompt.mockResolvedValueOnce({ action: configActions.done });
+    const result = await configureMeta.configure(mockContext);
+    expect(mockContext.print.info).toBeCalled();
+    expect(fs.writeFileSync).toBeCalled();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result).toHaveLength(0);
+  });
+
+  test('getMeta', async () => {
+    const actual = mockContext.amplify.readJsonFile(path.join(__dirname, '../../../../__mocks__/amplifyPublishMeta.json'));
+    const result = await configureMeta.getMeta(mockContext);
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result).toEqual(actual);
+  });
+
+  test('getMetaKeyValue', async () => {
+    const result = configureMeta.getMetaKeyValue('dist/metaFile', [{ pattern: 'metaFile', key: 'testKey1', value: 'testValue1' }], 'dist');
+    expect(result).toEqual([{ testKey1: 'testValue1' }]);
+  });
+});

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-scanner.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-scanner.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
-const publishConfig = require('../../../../lib/S3AndCloudFront/helpers/configure-Publish');
+const publishIgnoreConfig = require('../../../../lib/S3AndCloudFront/helpers/configure-Publish');
+const publishMetaConfig = require('../../../../lib/S3AndCloudFront/helpers/configure-Meta');
 
 const fileScanner = require('../../../../lib/S3AndCloudFront/helpers/file-scanner');
 
@@ -20,10 +21,17 @@ describe('file-scanner', () => {
   };
 
   beforeAll(() => {
-    publishConfig.isIgnored = jest.fn(() => {
+    publishMetaConfig.getMetaKeyValue = jest.fn(() => {
+      return {};
+    });
+    publishMetaConfig.getMeta = jest.fn(() => {
+      return [];
+    });
+
+    publishIgnoreConfig.isIgnored = jest.fn(() => {
       return false;
     });
-    publishConfig.getIgnore = jest.fn(() => {
+    publishIgnoreConfig.getIgnore = jest.fn(() => {
       return [];
     });
     fs.existsSync = jest.fn();

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
@@ -2,7 +2,10 @@ jest.mock('mime-types');
 jest.mock('../../../../lib/S3AndCloudFront/helpers/file-scanner', () => {
   return {
     scan: jest.fn(() => {
-      return ['filePath1', 'filePath2'];
+      return [
+        { filePath: 'filePath1', meta: [{ metaKey1: 'metaValue1' }] },
+        { filePath: 'filePath2', meta: [{ metaKey2: 'metaValue2' }] },
+      ];
     }),
   };
 });

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Meta.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Meta.js
@@ -1,0 +1,180 @@
+const path = require('path');
+const inquirer = require('inquirer');
+const minimatch = require('minimatch');
+const fs = require('fs-extra');
+
+const PublishMetaFileName = 'amplifyPublishMeta.json';
+
+async function configure(context) {
+  const publishMetaFilePath = getPublishMetaFilePath(context);
+  let publishMeta = [];
+
+  if (fs.existsSync(publishMetaFilePath)) {
+    try {
+      publishMeta = require(publishMetaFilePath);
+    } catch (e) {
+      publishMeta = [];
+    }
+  }
+
+  publishMeta = publishMeta
+    .filter(meta => meta.pattern.length > 0)
+    .filter(meta => meta.key.length > 0)
+    .filter(meta => !/^#/.test(meta.pattern));
+
+  context.print.info('You can configure the publish command to include metadata on certain directories or files.');
+  context.print.info('Use glob patterns as in the .gitignore file.');
+
+  publishMeta = await configurePublishMeta(context, publishMeta);
+
+  const jsonString = JSON.stringify(publishMeta, null, 4);
+  fs.writeFileSync(publishMetaFilePath, jsonString, 'utf8');
+
+  return publishMeta;
+}
+
+function getPublishMetaFilePath(context) {
+  const projectPath = context.amplify.pathManager.searchProjectRootPath();
+  if (projectPath || fs.existsSync(projectPath)) {
+    return path.join(projectPath, PublishMetaFileName);
+  }
+  const error = new Error(
+    "You are not working inside a valid Amplify project.\nUse 'amplify init' in the root of your app directory to initialize your project, or 'amplify pull' to pull down an existing project.",
+  );
+
+  error.name = 'NotInitialized';
+  error.stack = undefined;
+
+  throw error;
+}
+
+async function configurePublishMeta(context, publishMeta) {
+  const DONE = 'exit';
+  const configActions = ['list', 'add', 'remove', 'remove all', DONE];
+  const answer = await inquirer.prompt({
+    name: 'action',
+    type: 'list',
+    message: 'Please select the configuration action on the publish metadata.',
+    choices: configActions,
+    default: configActions[0],
+  });
+
+  switch (answer.action) {
+    case 'list':
+      listPublishMeta(context, publishMeta);
+      break;
+    case 'add':
+      publishMeta = await addMeta(context, publishMeta);
+      break;
+    case 'remove':
+      publishMeta = await removeMeta(context, publishMeta);
+      break;
+    case 'remove all':
+      publishMeta = [];
+      break;
+    default:
+      break;
+  }
+
+  if (answer.action !== DONE) {
+    publishMeta = await configurePublishMeta(context, publishMeta);
+  }
+
+  return publishMeta;
+}
+
+function listPublishMeta(context, publishMeta) {
+  context.print.info('');
+  publishMeta.forEach(element => {
+    context.print.info(element);
+  });
+  context.print.info('');
+}
+
+async function addMeta(context, publishMeta) {
+  const answer = await inquirer.prompt(
+    {
+      name: 'patternToAdd',
+      type: 'input',
+      message: 'Meta pattern to add: ',
+    },
+    {
+      name: 'keyToAdd',
+      type: 'input',
+      message: 'Meta key to add: ',
+    },
+    {
+      name: 'valueToAdd',
+      type: 'input',
+      message: 'Meta value to add: ',
+    },
+  );
+
+  if (answer.patternToAdd && answer.keyToAdd && answer.valueToAdd) {
+    const pattern = answer.patternToAdd.trim();
+    const key = answer.keyToAdd.trim();
+    const value = answer.valueToAdd.trim();
+
+    if (pattern.length > 0 && key.length > 0 && value.length >= 0) {
+      publishMeta.push({ pattern: pattern, key: key, value: value });
+    }
+  }
+  return publishMeta;
+}
+
+async function removeMeta(context, publishMeta) {
+  const CANCEL = '# cancel remove #';
+  if (!publishMeta || publishMeta.length === 0) {
+    context.print.error('Publish metadata list is empty, nothing to remove.');
+    publishMeta = [];
+  } else {
+    const answer = await inquirer.prompt({
+      name: 'patternToRemove',
+      type: 'list',
+      choices: [...publishMeta, CANCEL],
+    });
+    if (answer.patternToRemove && answer.patternToRemove !== CANCEL) {
+      publishMeta = publishMeta.filter(meta => answer.patternToRemove !== meta.pattern);
+    }
+  }
+  return publishMeta;
+}
+
+function getMeta(context) {
+  let publishMeta;
+  const publishMetaFilePath = getPublishMetaFilePath(context);
+  if (fs.existsSync(publishMetaFilePath)) {
+    try {
+      publishMeta = context.amplify.readJsonFile(publishMetaFilePath);
+    } catch (e) {
+      publishMeta = [];
+    }
+  } else {
+    publishMeta = [];
+  }
+  return publishMeta;
+}
+
+function getMetaKeyValue(filePath, publishMeta, metaRoot) {
+  let result = [];
+  if (publishMeta && publishMeta.length > 0) {
+    for (let i = 0; i < publishMeta.length; i++) {
+      let pattern = publishMeta[i].pattern;
+      const key = publishMeta[i].key;
+      const value = publishMeta[i].value;
+      if (/^\/.*/.test(pattern)) {
+        pattern = path.normalize(path.join(metaRoot, pattern));
+      }
+      if (minimatch(filePath, pattern, { matchBase: true })) {
+        result.push({ [key]: value });
+      }
+    }
+  }
+  return result;
+}
+
+module.exports = {
+  configure,
+  getMeta,
+  getMetaKeyValue,
+};

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-scanner.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-scanner.js
@@ -1,12 +1,14 @@
 const fs = require('fs-extra');
 const path = require('path');
-const publishConfig = require('./configure-Publish');
+const publishIgnoreConfig = require('./configure-Publish');
+const publishMetaConfig = require('./configure-Meta');
 
 function scan(context, distributionDirPath, WebsiteConfiguration) {
   let fileList = [];
   if (fs.existsSync(distributionDirPath)) {
-    const ignored = publishConfig.getIgnore(context);
-    fileList = recursiveScan(distributionDirPath, [], ignored, distributionDirPath);
+    const ignored = publishIgnoreConfig.getIgnore(context);
+    const meta = publishMetaConfig.getMeta(context);
+    fileList = recursiveScan(distributionDirPath, [], ignored, meta, distributionDirPath);
     if (fileList.length === 0) {
       const message = 'The distribution folder is empty';
       context.print.info('');
@@ -40,17 +42,18 @@ function scan(context, distributionDirPath, WebsiteConfiguration) {
   return fileList;
 }
 
-function recursiveScan(dir, filelist, amplifyIgnore, ignoreRoot) {
+function recursiveScan(dir, filelist, amplifyIgnore, amplifyMeta, amplifyRoot) {
   const files = fs.readdirSync(dir);
   filelist = filelist || [];
   files.forEach(file => {
     const filePath = path.join(dir, file);
     if (fs.statSync(filePath).isDirectory()) {
-      if (!publishConfig.isIgnored(filePath, amplifyIgnore, ignoreRoot)) {
-        filelist = recursiveScan(filePath, filelist, amplifyIgnore, ignoreRoot);
+      if (!publishIgnoreConfig.isIgnored(filePath, amplifyIgnore, amplifyRoot)) {
+        filelist = recursiveScan(filePath, filelist, amplifyIgnore, amplifyRoot);
       }
-    } else if (!publishConfig.isIgnored(filePath, amplifyIgnore, ignoreRoot)) {
-      filelist.push(filePath);
+    } else if (!publishIgnoreConfig.isIgnored(filePath, amplifyIgnore, amplifyRoot)) {
+      const metaData = publishMetaConfig.getMetaKeyValue(filePath, amplifyMeta, amplifyRoot);
+      filelist.push({ filePath: filePath, meta: metaData });
     }
   });
   return filelist;


### PR DESCRIPTION
#6393

*Description of changes:*

Adds amplifyPublishMeta.json with format:

[{
pattern:"**/*.html",
key:"metadataKey",
value:"metaDataValue"
},
...
]

This allows for including s3 metadata when uploading the hosted files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.