### PR TITLE
fix: delete prompt text should be red, not yellow

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
@@ -68,10 +68,8 @@ export async function getConfirmation(context, env?) {
   const environmentText = env ? `'${env}' environment` : 'all the environments';
   return {
     proceed: await context.amplify.confirmPrompt(
-      chalk.yellow(
-        `Are you sure you want to continue? This ${chalk.red(
-          'CANNOT',
-        )} be undone. (This will delete ${environmentText} of the project from the cloud${
+      chalk.red(
+        `Are you sure you want to continue? This CANNOT be undone. (This will delete ${environmentText} of the project from the cloud${
           env ? '' : ' and wipe out all the local files created by Amplify CLI'
         })`,
       ),


### PR DESCRIPTION
I know I may be in the minority with my rejection of dark mode, but there are others like me too!    The `amplify delete` confirmation prompt is almost unreadable in my terminal:

<img width="956" alt="Screen Shot 2021-03-15 at 2 08 51 PM" src="https://user-images.githubusercontent.com/850345/111208878-522b6c00-8599-11eb-90a1-1595c9cab07b.png">

This PR updates the message so that the text is all red.  I'm open to other suggestions for colors, but yellow just doesn't work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.