### PR TITLE
fix(amplify-provider-awscloudformation): Fix amplify configure opening wrong IAM User Creation URL in Windows & WSL

### DIFF
--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -110,7 +110,8 @@
     "promise-sequential": "^1.1.1",
     "proxy-agent": "^3.1.1",
     "rimraf": "^3.0.0",
-    "xstate": "^4.14.0"
+    "xstate": "^4.14.0",
+    "is-wsl": "^2.2.0"
   },
   "devDependencies": {
     "@types/columnify": "^1.5.0",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -100,6 +100,7 @@
     "import-global": "^0.1.0",
     "ini": "^1.3.5",
     "inquirer": "^7.3.3",
+    "is-wsl": "^2.2.0",
     "jose": "^2.0.2",
     "lodash": "^4.17.19",
     "lodash.throttle": "^4.1.1",
@@ -110,8 +111,7 @@
     "promise-sequential": "^1.1.1",
     "proxy-agent": "^3.1.1",
     "rimraf": "^3.0.0",
-    "xstate": "^4.14.0",
-    "is-wsl": "^2.2.0"
+    "xstate": "^4.14.0"
   },
   "devDependencies": {
     "@types/columnify": "^1.5.0",

--- a/packages/amplify-provider-awscloudformation/src/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/src/setup-new-user.js
@@ -6,6 +6,7 @@ const constants = require('./constants.js');
 const systemConfigManager = require('./system-config-manager');
 const obfuscationUtil = require('./utility-obfuscate');
 const { open } = require('amplify-cli-core');
+const isOnWsl = require('is-wsl');
 
 async function run(context) {
   const awsConfig = {
@@ -43,9 +44,13 @@ async function run(context) {
     },
   ]);
 
-  const deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', userName).replace('{region}', awsConfig.region);
+  let deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', userName).replace('{region}', awsConfig.region);
+  const isOnWindows = /^win/.test(process.platform);
+  if (isOnWindows || isOnWsl) {
+    deepLinkURL = deepLinkURL.replace('$new', '`$new');
+  }
   context.print.info('Complete the user creation using the AWS console');
-  context.print.info(chalk.green(deepLinkURL));
+  context.print.info(chalk.green(deepLinkURL.replace('`', '')));
   open(deepLinkURL, { wait: false }).catch(() => {});
   await context.amplify.pressEnterToContinue.run({ message: 'Press Enter to continue' });
 

--- a/packages/amplify-provider-awscloudformation/src/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/src/setup-new-user.js
@@ -45,7 +45,7 @@ async function run(context) {
   ]);
 
   let deepLinkURL = constants.AWSCreateIAMUsersUrl.replace('{userName}', userName).replace('{region}', awsConfig.region);
-  const isOnWindows = /^win/.test(process.platform);
+  const isOnWindows = process.platform === 'win32';
   if (isOnWindows || isOnWsl) {
     deepLinkURL = deepLinkURL.replace('$new', '`$new');
   }


### PR DESCRIPTION
*Issue #, if available:* Closes #6836 and #5664 

*Description of changes:*
Escapes $ in IAM user creation URL string for Windows & WSL environments, since powershell treats it as environment var and therefore ignores it.

_More details_:
- Checks whether the platform is windows or WSL.
    - using `process.platform` to check for windows.
    - using an existing dependency `is-wsl` ( `open` depends on `is-wsl` ) to check for wsl.
- if it is either windows or wsl, $new is replaced by \`$new in deepLinkURL. on line 53, deepLinkURL is printed without ` to ensure that correct url is shown in the terminal.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.