### PR TITLE
fix(amplify-appsync-simulator): map info to Java objects

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -121,7 +121,7 @@ export class VelocityTemplate {
     const vtlContext = {
       arguments: args,
       args,
-      info: createInfo(info),
+      info: convertToJavaTypes(createInfo(info)),
       request: { headers: requestContext.headers },
       identity,
       stash: convertToJavaTypes(stash || {}),


### PR DESCRIPTION
#### Description of changes
Some of the java methods would not work on the `$ctx.info` object. This PR makes sure they get converted to java Objects

#### Description of how you validated changes

*It works on my machine* 🙂 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.