### PR TITLE
fix(amplify-util-mock): mock AWS access key when server is running

### DIFF
--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -17,6 +17,9 @@ import { getInvoker } from 'amplify-category-function';
 import { lambdaArnToConfig } from './lambda-arn-to-config';
 import { timeConstrainedInvoker } from '../func';
 
+export const GRAPHQL_API_ENDPOINT_OUTPUT = 'GraphQLAPIEndpointOutput';
+export const GRAPHQL_API_KEY_OUTPUT = 'GraphQLAPIKeyOutput';
+export const MOCK_API_KEY = 'da2-fakeApiId123456';
 export const MOCK_API_PORT = 20002;
 
 export class APITest {

--- a/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
@@ -1,6 +1,6 @@
 import { $TSContext, stateManager } from 'amplify-cli-core';
 import _ from 'lodash';
-import { MOCK_API_PORT } from '../../api/api';
+import { GRAPHQL_API_ENDPOINT_OUTPUT, GRAPHQL_API_KEY_OUTPUT, MOCK_API_KEY, MOCK_API_PORT } from '../../api/api';
 
 /**
  * Loads all parameters that should be passed into the lambda CFN template when resolving values
@@ -61,9 +61,18 @@ const getAmplifyMetaParams = (
         );
         print.warning('This attribute will be undefined in the mock environment until you run `amplify push`');
       }
-      if (overrideApiToLocal && attribute === 'GraphQLAPIEndpointOutput') {
-        val = `http://localhost:${MOCK_API_PORT}/graphql`;
+
+      if (overrideApiToLocal) {
+        switch (attribute) {
+          case GRAPHQL_API_ENDPOINT_OUTPUT:
+            val = `http://localhost:${MOCK_API_PORT}/graphql`;
+            break;
+          case GRAPHQL_API_KEY_OUTPUT:
+            val = MOCK_API_KEY;
+            break;
+        }
       }
+
       acc[dependency.category + dependency.resourceName + attribute] = val;
     });
     return acc;


### PR DESCRIPTION
#### Description of changes
This commit updates function mocking to use the mock AWS access key value when the mock API server is running.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/6897

#### Description of how you validated changes
Local testing and unit tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.