### PR TITLE
fix(amplify-cli): add a warning on entering invalid subcommand for amplify env

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/env.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/env.test.ts
@@ -27,4 +27,25 @@ describe('amplify env: ', () => {
     });
     expect(mockEnvListRun).toHaveBeenCalledTimes(2);
   });
+
+  it('invalid env subcommand should give a warning', async () => {
+    const mockContextInvalidEnvSubcommand = {
+      amplify: {
+        showHelp: jest.fn()
+      },
+      parameters: {},
+      input: {
+        subCommands: ['test12345'],
+      },
+      print:{
+        warning: jest.fn(),
+        info: jest.fn(),
+      }
+    };
+    await runEnvCmd(mockContextInvalidEnvSubcommand);
+    expect(mockContextInvalidEnvSubcommand.amplify.showHelp).toBeCalled();
+    expect(mockContextInvalidEnvSubcommand.print.warning.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"Cannot find command: 'amplify env test12345'"`,
+    );
+  })
 });

--- a/packages/amplify-cli/src/commands/env.ts
+++ b/packages/amplify-cli/src/commands/env.ts
@@ -20,6 +20,9 @@ export const run = async context => {
     try {
       commandModule = require(path.normalize(path.join(__dirname, 'env', subcommand)));
     } catch (e) {
+      if(subCommands){
+        context.print.warning(`Cannot find command: 'amplify env ${subCommands.join(' ')}'`);
+      }
       displayHelp(context);
     }
 

--- a/packages/amplify-cli/src/commands/env.ts
+++ b/packages/amplify-cli/src/commands/env.ts
@@ -20,7 +20,7 @@ export const run = async context => {
     try {
       commandModule = require(path.normalize(path.join(__dirname, 'env', subcommand)));
     } catch (e) {
-      if(subCommands){
+      if (subCommands) {
         context.print.warning(`Cannot find command: 'amplify env ${subCommands.join(' ')}'`);
       }
       displayHelp(context);


### PR DESCRIPTION
#### Description of changes:
Added a warning log when a invalid subcommand for env is entered. 

#### Issue: 
Fixes #4969

#### Description of how you validated changes:
Ran an invalid subcommand to check if the warning log was getting printed.

#### Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.