### PR TITLE
fix(amplify-go-function-runtime-provider): update deadline logic

### DIFF
--- a/packages/amplify-go-function-runtime-provider/resources/localinvoke/main.go
+++ b/packages/amplify-go-function-runtime-provider/resources/localinvoke/main.go
@@ -111,9 +111,10 @@ func createInvokeRequest(input LambdaInput) (*messages.InvokeRequest, error) {
 
 	if Deadline == nil {
 		now := time.Now()
+		deadline := now.Add(input.Timeout)
 		Deadline = &messages.InvokeRequest_Timestamp{
-			Seconds: int64(now.Unix()),
-			Nanos:   int64(now.Nanosecond()),
+			Seconds: int64(deadline.Unix()),
+			Nanos:   int64(deadline.Nanosecond()),
 		}
 	}
 
@@ -156,7 +157,7 @@ func main() {
 
 		// Invoke lambda
 		response, err := invokeLambda(LambdaInput{
-			Timeout: time.Duration(envelope.TimeoutMilliseconds),
+			Timeout: time.Duration(envelope.TimeoutMilliseconds * 1000000),
 			Port:    envelope.Port,
 			Payload: payload,
 		})


### PR DESCRIPTION
#### Description of changes
This commit addresses two issues with deadline logic:

1. The timeout in milliseconds is converted to nanoseconds for
   use with Go's Durations.
2. The deadline is updated to be time.Now() plus the provided
   timeout. This prevents the function from being invoked with
   an expired deadline.

#### Issue #, if available
#6407

#### Description of how you validated changes
Manual testing using the function provided in #6407

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.