### PR TITLE
fix(amplify-category-auth): add lambda with AdminQueries API permissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1077,14 +1077,6 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-northeast-1
-  schema-iterative-update-locking-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: ap-southeast-1
   migration-node-function-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1092,15 +1084,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: ap-southeast-2
-  function_5-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
   api_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1108,6 +1092,22 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
+      CLI_REGION: ap-southeast-2
+  schema-iterative-update-locking-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
+      CLI_REGION: us-east-2
+  function_5-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: us-west-2
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1719,16 +1719,6 @@ jobs:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-northeast-1
     steps: *ref_5
-  schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: ap-southeast-1
-    steps: *ref_5
   migration-node-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1737,17 +1727,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: ap-southeast-2
-    steps: *ref_5
-  function_5-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_5
   api_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1757,6 +1737,26 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_4.test.ts
+      CLI_REGION: ap-southeast-2
+    steps: *ref_5
+  schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
+      CLI_REGION: us-east-2
+    steps: *ref_5
+  function_5-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: us-west-2
     steps: *ref_5
 workflows:
@@ -1854,11 +1854,11 @@ workflows:
             - hostingPROD-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - init-amplify_e2e_tests
-            - function_5-amplify_e2e_tests
+            - schema-iterative-update-locking-amplify_e2e_tests
             - predictions-amplify_e2e_tests
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
+            - function_5-amplify_e2e_tests
             - function_3-amplify_e2e_tests
             - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
@@ -1874,22 +1874,22 @@ workflows:
             - schema-key-amplify_e2e_tests
             - analytics-amplify_e2e_tests
             - notifications-amplify_e2e_tests
-            - schema-iterative-update-locking-amplify_e2e_tests
+            - migration-node-function-amplify_e2e_tests
             - schema-auth-10-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - tags-amplify_e2e_tests
-            - migration-node-function-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           context: amplify-cli-ecr
           requires:
             - hostingPROD-amplify_e2e_tests_pkg_linux
             - amplify-app-amplify_e2e_tests_pkg_linux
             - init-amplify_e2e_tests_pkg_linux
-            - function_5-amplify_e2e_tests_pkg_linux
+            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
             - predictions-amplify_e2e_tests_pkg_linux
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
+            - function_5-amplify_e2e_tests_pkg_linux
             - function_3-amplify_e2e_tests_pkg_linux
             - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
@@ -1905,11 +1905,11 @@ workflows:
             - schema-key-amplify_e2e_tests_pkg_linux
             - analytics-amplify_e2e_tests_pkg_linux
             - notifications-amplify_e2e_tests_pkg_linux
-            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
+            - migration-node-function-amplify_e2e_tests_pkg_linux
             - schema-auth-10-amplify_e2e_tests_pkg_linux
             - hosting-amplify_e2e_tests_pkg_linux
             - tags-amplify_e2e_tests_pkg_linux
-            - migration-node-function-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           context: amplify-cli-ecr
           filters:
@@ -2059,7 +2059,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-auth-7-amplify_e2e_tests
-      - function_5-amplify_e2e_tests:
+      - schema-iterative-update-locking-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2119,7 +2119,7 @@ workflows:
           filters: *ref_8
           requires:
             - auth_4-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - function_5-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2335,7 +2335,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-searchable-amplify_e2e_tests
-      - schema-iterative-update-locking-amplify_e2e_tests:
+      - migration-node-function-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2389,7 +2389,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-auth-8-amplify_e2e_tests
-      - migration-node-function-amplify_e2e_tests:
+      - api_4-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2457,7 +2457,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
-      - function_5-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2521,7 +2521,7 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - function_5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2753,7 +2753,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-searchable-amplify_e2e_tests_pkg_linux
-      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+      - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2811,7 +2811,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-8-amplify_e2e_tests_pkg_linux
-      - migration-node-function-amplify_e2e_tests_pkg_linux:
+      - api_4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10

--- a/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
@@ -292,7 +292,7 @@
           "Value": "AdminQueries"
         },
         "ApiId": {
-          "Description": "AdminQueries API Id",
+          "Description": "AdminQueries's API ID",
           "Value": "AdminQueriesApiId"
         }
     }

--- a/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
@@ -292,7 +292,7 @@
           "Value": "AdminQueries"
         },
         "ApiId": {
-          "Description": "API Id",
+          "Description": "AdminQueries API Id",
           "Value": "AdminQueriesApiId"
         }
     }

--- a/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
@@ -293,7 +293,7 @@
         },
         "ApiId": {
           "Description": "AdminQueries's API ID",
-          "Value": "AdminQueriesApiId"
+          "Value": {"Ref": "AdminQueries"}
         }
     }
   }

--- a/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-queries-api-template.json.ejs
@@ -290,6 +290,10 @@
         "ApiName": {
           "Description": "API Friendly name",
           "Value": "AdminQueries"
+        },
+        "ApiId": {
+          "Description": "API Id",
+          "Value": "AdminQueriesApiId"
         }
     }
   }


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes bug in creating a function with permissions to the AdminQueries API. The operation fails because the AdminQueries API does not output it's Id.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Fixes #6576

#### Description of how you validated changes

Added integration test to verify if lambda is added with AdminQueries API permissions.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.