### PR TITLE
fix(amplify-provider-awscloudformation): overriding credentials for env

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
@@ -8,6 +8,7 @@ const { ProviderName, AmplifyAppIdLabel } = require('./constants');
 const { checkAmplifyServiceIAMPermission } = require('./amplify-service-permission-check');
 const { stateManager } = require('amplify-cli-core');
 const { fileLogger } = require('./utils/aws-logger');
+const { loadConfigurationForEnv } = require('./configuration-manager');
 const logger = fileLogger('amplify-service-manager');
 
 async function init(amplifyServiceParams) {
@@ -211,7 +212,8 @@ async function deleteEnv(context, envName, awsConfig) {
       teamProviderInfo[envName][ProviderName] &&
       teamProviderInfo[envName][ProviderName][AmplifyAppIdLabel]
     ) {
-      const amplifyClient = await getConfiguredAmplifyClient(context, awsConfig);
+      const envConfig = await loadConfigurationForEnv(context, envName);
+      const amplifyClient = await getConfiguredAmplifyClient(context, { ...awsConfig, ...envConfig });
       if (!amplifyClient) {
         // This happens when the Amplify service is not available in the region
         return;

--- a/packages/amplify-provider-awscloudformation/src/delete-env.js
+++ b/packages/amplify-provider-awscloudformation/src/delete-env.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
-
+const { loadConfigurationForEnv } = require('./configuration-manager');
 const Cloudformation = require('./aws-utils/aws-cfn');
 const { S3 } = require('./aws-utils/aws-s3');
 const { deleteEnv } = require('./amplify-service-manager');
@@ -8,8 +8,9 @@ const { S3BackendZipFileName, ProviderName } = require('./constants');
 const { downloadZip, extractZip } = require('./zip-util');
 
 async function run(context, envName, deleteS3) {
-  const cfn = await new Cloudformation(context, null);
-  const s3 = await S3.getInstance(context, {});
+  const credentials = await loadConfigurationForEnv(context, envName);
+  const cfn = await new Cloudformation(context, null, credentials);
+  const s3 = await S3.getInstance(context, credentials);
   let removeBucket = false;
   let deploymentBucketName;
   let storageCategoryBucketName;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#4952 


#### Description of how you validated changes
I deleted environment by creating two env in two different accounts also validate my changes by using admin ui credentials https://docs.amplify.aws/console/adminui/extend-cli#to-install-the-amplify-cli


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.