### PR TITLE
Revert "fix(amplify-category-notifications): clean up notifications IAM policy"

### DIFF
--- a/packages/amplify-category-notifications/lib/auth-helper.js
+++ b/packages/amplify-category-notifications/lib/auth-helper.js
@@ -3,7 +3,6 @@ const os = require('os');
 const constants = require('./constants');
 
 const providerName = 'awscloudformation';
-const policyNamePrefix = 'pinpoint_amplify-';
 const spinner = ora('');
 
 async function ensureAuth(context, resourceName) {
@@ -59,46 +58,6 @@ async function attachPolicyToRole(context, policy, roleName) {
       }
     });
   });
-}
-
-async function deletePolicy(context, policyArn) {
-  const params = {
-    PolicyArn: policyArn,
-  };
-  const iamClient = await getIamClient(context);
-  return iamClient.deletePolicy(params).promise();
-}
-
-async function detachPolicyFromRole(context, policyArn, roleName) {
-  const params = {
-    PolicyArn: policyArn,
-    RoleName: roleName,
-  };
-  const iamClient = await getIamClient(context);
-  return iamClient.detachRolePolicy(params).promise();
-}
-
-async function listAttachedRolePolicies(context, roleName) {
-  const params = { RoleName: roleName };
-  const iamClient = await getIamClient(context);
-  return iamClient.listAttachedRolePolicies(params).promise();
-}
-
-async function deleteRolePolicy(context) {
-  const amplifyMeta = context.amplify.getProjectMeta();
-  const authRoleName = amplifyMeta.providers[providerName].AuthRoleName;
-  const unAuthRoleName = amplifyMeta.providers[providerName].UnauthRoleName;
-  const rolePolicies = await listAttachedRolePolicies(context, authRoleName);
-
-  if (rolePolicies && Array.isArray(rolePolicies.AttachedPolicies)) {
-    const policy = rolePolicies.AttachedPolicies.find(policy => policy.PolicyName.startsWith(policyNamePrefix));
-
-    if (policy) {
-      await detachPolicyFromRole(context, policy.PolicyArn, authRoleName);
-      await detachPolicyFromRole(context, policy.PolicyArn, unAuthRoleName);
-      await deletePolicy(context, policy.PolicyArn);
-    }
-  }
 }
 
 async function checkAuth(context, resourceName) {
@@ -166,10 +125,9 @@ function getPolicyDoc(context) {
 }
 
 function getPolicyName(context) {
-  return `${policyNamePrefix}${context.amplify.makeId(8)}`;
+  return `pinpoint_amplify-${context.amplify.makeId(8)}`;
 }
 
 module.exports = {
-  deleteRolePolicy,
   ensureAuth,
 };

--- a/packages/amplify-category-notifications/lib/multi-env-manager.js
+++ b/packages/amplify-category-notifications/lib/multi-env-manager.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra');
 const _ = require('lodash');
 const sequential = require('promise-sequential');
-const authHelper = require('./auth-helper');
 const pinpointHelper = require('./pinpoint-helper');
 const constants = require('./constants');
 const notificationManager = require('./notifications-manager');
@@ -145,7 +144,6 @@ async function deletePinpointAppForEnv(context, envName) {
     };
     const pinpointClient = await pinpointHelper.getPinpointClient(context, 'delete', envName);
 
-    await authHelper.deleteRolePolicy(context);
     return pinpointClient
       .deleteApp(params)
       .promise()

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -137,7 +137,6 @@ async function deletePinpointApp(context) {
     pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.AnalyticsCategoryName]);
   }
   if (pinpointApp) {
-    await authHelper.deleteRolePolicy(context);
     pinpointApp = await deleteApp(context, pinpointApp.Id);
     removeCategoryMetaForPinpoint(amplifyMeta[constants.CategoryName], pinpointApp.Id);
     removeCategoryMetaForPinpoint(amplifyMeta[constants.AnalyticsCategoryName], pinpointApp.Id);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
@@ -9,14 +9,6 @@ export async function removeEnvFromCloud(context, envName, deleteS3) {
   context.print.info('');
   context.print.info(`Deleting env:${envName}`);
 
-  // Pinpoint attaches an IAM policy to several roles, which blocks CFN from
-  // deleting the roles. Work around that by deleting Pinpoint first.
-  const categoryPluginInfoList = getAllCategoryPluginInfo(context);
-  if (categoryPluginInfoList.notifications) {
-    const notificationsModule = require(categoryPluginInfoList.notifications[0].packageLocation);
-    await notificationsModule.deletePinpointAppForEnv(context, envName);
-  }
-
   providers.forEach(providerName => {
     const pluginModule = require(providerPlugins[providerName]);
     providerPromises.push(pluginModule.deleteEnv(context, envName, deleteS3));
@@ -29,5 +21,11 @@ export async function removeEnvFromCloud(context, envName, deleteS3) {
     context.print.error(`Error in deleting env:${envName}`);
     context.print.info(e.message);
     throw e;
+  }
+
+  const categoryPluginInfoList = getAllCategoryPluginInfo(context);
+  if (categoryPluginInfoList.notifications) {
+    const notificationsModule = require(categoryPluginInfoList.notifications[0].packageLocation);
+    await notificationsModule.deletePinpointAppForEnv(context, envName);
   }
 }

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -199,9 +199,7 @@ export const getCloudWatchLogs = async (region: string, logGroupName: string, lo
 
 export const describeCloudFormationStack = async (stackName: string, region: string, profileConfig?: any) => {
   const service = profileConfig ? new CloudFormation(profileConfig) : new CloudFormation({ region });
-  return (await service.describeStacks({ StackName: stackName }).promise()).Stacks.find(
-    stack => stack.StackName === stackName || stack.StackId === stackName,
-  );
+  return (await service.describeStacks({ StackName: stackName }).promise()).Stacks.find(stack => stack.StackName === stackName);
 };
 
 export const putKinesisRecords = async (data: string, partitionKey: string, streamName: string, region: string) => {

--- a/packages/amplify-e2e-tests/src/__tests__/notifications.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/notifications.test.ts
@@ -6,9 +6,7 @@ import {
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
-  describeCloudFormationStack,
   getAppId,
-  getProjectMeta,
   getTeamProviderInfo,
   initJSProjectWithProfile,
 } from 'amplify-e2e-core';
@@ -72,13 +70,6 @@ describe('notification category test', () => {
       await amplifyPull(projectRootPull, { override: false, emptyDir: true, appId });
 
       expectLocalAndPulledTeamNotificationMatching(projectRoot, projectRootPull);
-
-      // Delete the project now to assert that CFN is able to clean up successfully.
-      const { StackId: stackId, Region: region } = getProjectMeta(projectRoot).providers.awscloudformation;
-      await deleteProject(projectRoot);
-      ignoreProjectDeleteErrors = true;
-      const stack = await describeCloudFormationStack(stackId, region);
-      expect(stack.StackStatus).toEqual('DELETE_COMPLETE');
     } finally {
       deleteProjectDir(projectRootPull);
     }


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#6872

Reverting for now as this needs the following policy to work 
- `iam:ListAttachedRolePolicies`