### PR TITLE
fix: cross-drive linking support for amplify-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@typescript-eslint/parser": "^4.14.2",
     "babel-loader": "^8.1.0",
     "babel-eslint": "^10.1.0",
+    "@zkochan/cmd-shim": "^5.1.0",
     "cmd-shim": "^3.0.3",
     "codecov": "^3.7.0",
     "commitizen": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,12 @@
     "lerna": "^3.16.4"
   },
   "workspaces": {
-    "packages": ["packages/*"],
-    "nohoist": ["@aws-amplify/cli/amplify-codegen"]
+    "packages": [
+      "packages/*"
+    ],
+    "nohoist": [
+      "@aws-amplify/cli/amplify-codegen"
+    ]
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -84,10 +88,9 @@
     "@types/js-yaml": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
-    "babel-loader": "^8.1.0",
-    "babel-eslint": "^10.1.0",
     "@zkochan/cmd-shim": "^5.1.0",
-    "cmd-shim": "^3.0.3",
+    "babel-eslint": "^10.1.0",
+    "babel-loader": "^8.1.0",
     "codecov": "^3.7.0",
     "commitizen": "^3.1.2",
     "copyfiles": "^2.2.0",
@@ -95,17 +98,17 @@
     "eslint": "^7.19.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^7.2.0",
+    "eslint-config-react-app": "^6.0.0",
     "eslint-import-resolver-typescript": "^2.0.0",
+    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-json": "^2.0.1",
-    "eslint-plugin-prettier": "^3.1.2",
-    "eslint-plugin-spellcheck": "^0.0.17",
-    "eslint-config-react-app": "^6.0.0",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-spellcheck": "^0.0.17",
     "eslint-plugin-testing-library": "^3.10.1",
     "execa": "^4.1.0",
     "glob": "^7.1.6",

--- a/scripts/link-bin.js
+++ b/scripts/link-bin.js
@@ -1,5 +1,5 @@
 const lnk = require('lnk');
-const cmdShim = require('cmd-shim');
+const cmdShim = require('@zkochan/cmd-shim');
 const path = require('path');
 const fs = require('fs-extra');
 const childProcess = require('child_process');
@@ -13,10 +13,7 @@ const src = path.join(process.cwd(), process.argv[2]);
 
 let dest;
 if (process.argv.length === 4) {
-  const yarnGlobalBin = childProcess
-    .execSync('yarn global bin')
-    .toString()
-    .trim();
+  const yarnGlobalBin = childProcess.execSync('yarn global bin').toString().trim();
   dest = path.join(yarnGlobalBin, process.argv[3]);
 } else {
   dest = path.isAbsolute(process.argv[4])

--- a/yarn.lock
+++ b/yarn.lock
@@ -10205,14 +10205,6 @@ clsx@^1.1.1:
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
-cmd-shim@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-3.0.3.tgz#2c35238d3df37d98ecdd7d5f6b8dc6b21cadc7cb"
-  integrity sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==
-  dependencies:
-    graceful-fs "^4.1.2"
-    mkdirp "~0.5.0"
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -17806,7 +17798,7 @@ mkdirp@0.3.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
   integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7618,6 +7618,13 @@
     mkdirp-promise "^5.0.1"
     mz "^2.5.0"
 
+"@zkochan/cmd-shim@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-5.1.0.tgz#f72bb870731130795113b3f8dc4cb3c3f5e91533"
+  integrity sha512-i8bPf1u6Kv1qMBG2JqHvqpdo/+sMaOB5Ohonpm04fvBWZ7y4M0rfI7tbHYVCokWX4BUMR5Cpu4KRSFy+YuxSqQ==
+  dependencies:
+    is-windows "^1.0.2"
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Using the [pnpm/cmd-shim](https://github.com/pnpm/cmd-shim) library instead of [npm/cmd-shim](https://github.com/npm/cmd-shim) would fix the cross-drive linking issue for amplify-dev on Windows. [A PR](https://github.com/pnpm/cmd-shim/pull/18) on `pnpm/cmd-shim` fixed the issue whereas it's still [not fixed](https://github.com/npm/cmd-shim/issues/21) on `npm/cmd-shim`.

This PR adds the `pnpm/cmd-shim` library and updates the imports in `scripts/link-bin.js`


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

fixes #6950 

#### Description of how you validated changes
I checked the file at `C:\Users\Pawan\AppData\Local\Yarn\bin\amplify-dev.ps1` for proper linking and verified that the `amplify-dev` command is properly running in sample projects.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.