### PR TITLE
Reland: fix(amplify-category-notifications): clean up notifications IAM policy

### DIFF
--- a/packages/amplify-category-notifications/lib/multi-env-manager.js
+++ b/packages/amplify-category-notifications/lib/multi-env-manager.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const _ = require('lodash');
 const sequential = require('promise-sequential');
+const authHelper = require('./auth-helper');
 const pinpointHelper = require('./pinpoint-helper');
 const constants = require('./constants');
 const notificationManager = require('./notifications-manager');
@@ -144,6 +145,7 @@ async function deletePinpointAppForEnv(context, envName) {
     };
     const pinpointClient = await pinpointHelper.getPinpointClient(context, 'delete', envName);
 
+    await authHelper.deleteRolePolicy(context);
     return pinpointClient
       .deleteApp(params)
       .promise()

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -137,6 +137,7 @@ async function deletePinpointApp(context) {
     pinpointApp = scanCategoryMetaForPinpoint(amplifyMeta[constants.AnalyticsCategoryName]);
   }
   if (pinpointApp) {
+    await authHelper.deleteRolePolicy(context);
     pinpointApp = await deleteApp(context, pinpointApp.Id);
     removeCategoryMetaForPinpoint(amplifyMeta[constants.CategoryName], pinpointApp.Id);
     removeCategoryMetaForPinpoint(amplifyMeta[constants.AnalyticsCategoryName], pinpointApp.Id);

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -199,7 +199,9 @@ export const getCloudWatchLogs = async (region: string, logGroupName: string, lo
 
 export const describeCloudFormationStack = async (stackName: string, region: string, profileConfig?: any) => {
   const service = profileConfig ? new CloudFormation(profileConfig) : new CloudFormation({ region });
-  return (await service.describeStacks({ StackName: stackName }).promise()).Stacks.find(stack => stack.StackName === stackName);
+  return (await service.describeStacks({ StackName: stackName }).promise()).Stacks.find(
+    stack => stack.StackName === stackName || stack.StackId === stackName,
+  );
 };
 
 export const putKinesisRecords = async (data: string, partitionKey: string, streamName: string, region: string) => {

--- a/packages/amplify-e2e-tests/src/__tests__/notifications.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/notifications.test.ts
@@ -6,7 +6,9 @@ import {
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
+  describeCloudFormationStack,
   getAppId,
+  getProjectMeta,
   getTeamProviderInfo,
   initJSProjectWithProfile,
 } from 'amplify-e2e-core';
@@ -70,6 +72,13 @@ describe('notification category test', () => {
       await amplifyPull(projectRootPull, { override: false, emptyDir: true, appId });
 
       expectLocalAndPulledTeamNotificationMatching(projectRoot, projectRootPull);
+
+      // Delete the project now to assert that CFN is able to clean up successfully.
+      const { StackId: stackId, Region: region } = getProjectMeta(projectRoot).providers.awscloudformation;
+      await deleteProject(projectRoot);
+      ignoreProjectDeleteErrors = true;
+      const stack = await describeCloudFormationStack(stackId, region);
+      expect(stack.StackStatus).toEqual('DELETE_COMPLETE');
     } finally {
       deleteProjectDir(projectRootPull);
     }


### PR DESCRIPTION
#### Description of changes
This is a revert of the revert in #6944. The relevant docs PR is https://github.com/aws-amplify/docs/pull/3081.

#### Issue #, if available
#6944, #6872, #6866

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.