### PR TITLE
fix(amplify-appsync-simulator): parse AWSTimestamp literals as Ints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1077,22 +1077,6 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-northeast-1
-  migration-node-function-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: ap-southeast-1
-  api_4-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: ap-southeast-2
   schema-iterative-update-locking-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1100,7 +1084,15 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
+  migration-node-function-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/migration/node.function.test.ts
+      CLI_REGION: ap-southeast-2
   function_5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1108,6 +1100,14 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
+      CLI_REGION: us-east-2
+  api_4-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1719,26 +1719,6 @@ jobs:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-northeast-1
     steps: *ref_5
-  migration-node-function-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: ap-southeast-1
-    steps: *ref_5
-  api_4-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: ap-southeast-2
-    steps: *ref_5
   schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1747,7 +1727,17 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
+    steps: *ref_5
+  migration-node-function-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/migration/node.function.test.ts
+      CLI_REGION: ap-southeast-2
     steps: *ref_5
   function_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1757,6 +1747,16 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_5.test.ts
+      CLI_REGION: us-east-2
+    steps: *ref_5
+  api_4-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
     steps: *ref_5
 workflows:
@@ -1854,11 +1854,11 @@ workflows:
             - hostingPROD-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - init-amplify_e2e_tests
-            - schema-iterative-update-locking-amplify_e2e_tests
+            - function_5-amplify_e2e_tests
             - predictions-amplify_e2e_tests
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
-            - function_5-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
             - function_3-amplify_e2e_tests
             - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
@@ -1874,22 +1874,22 @@ workflows:
             - schema-key-amplify_e2e_tests
             - analytics-amplify_e2e_tests
             - notifications-amplify_e2e_tests
-            - migration-node-function-amplify_e2e_tests
+            - schema-iterative-update-locking-amplify_e2e_tests
             - schema-auth-10-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - tags-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
+            - migration-node-function-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           context: amplify-cli-ecr
           requires:
             - hostingPROD-amplify_e2e_tests_pkg_linux
             - amplify-app-amplify_e2e_tests_pkg_linux
             - init-amplify_e2e_tests_pkg_linux
-            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
+            - function_5-amplify_e2e_tests_pkg_linux
             - predictions-amplify_e2e_tests_pkg_linux
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
-            - function_5-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
             - function_3-amplify_e2e_tests_pkg_linux
             - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
@@ -1905,11 +1905,11 @@ workflows:
             - schema-key-amplify_e2e_tests_pkg_linux
             - analytics-amplify_e2e_tests_pkg_linux
             - notifications-amplify_e2e_tests_pkg_linux
-            - migration-node-function-amplify_e2e_tests_pkg_linux
+            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
             - schema-auth-10-amplify_e2e_tests_pkg_linux
             - hosting-amplify_e2e_tests_pkg_linux
             - tags-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
+            - migration-node-function-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           context: amplify-cli-ecr
           filters:
@@ -2059,7 +2059,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-auth-7-amplify_e2e_tests
-      - schema-iterative-update-locking-amplify_e2e_tests:
+      - function_5-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2119,7 +2119,7 @@ workflows:
           filters: *ref_8
           requires:
             - auth_4-amplify_e2e_tests
-      - function_5-amplify_e2e_tests:
+      - api_4-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2335,7 +2335,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-searchable-amplify_e2e_tests
-      - migration-node-function-amplify_e2e_tests:
+      - schema-iterative-update-locking-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2389,7 +2389,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-auth-8-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - migration-node-function-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2457,7 +2457,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
-      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+      - function_5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2521,7 +2521,7 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - function_5-amplify_e2e_tests_pkg_linux:
+      - api_4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2753,7 +2753,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-searchable-amplify_e2e_tests_pkg_linux
-      - migration-node-function-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2811,7 +2811,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-8-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSTimestamp.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSTimestamp.test.ts
@@ -1,0 +1,17 @@
+import { ValueNode } from 'graphql';
+import { scalars } from '../../schema/appsync-scalars';
+
+describe('AWSTimestamp parseLiteral', () => {
+  it('Returns literals as integers', () => {
+    const astNode = { kind: 'IntValue', value: '1234', loc: { start: 68, end: 74 } } as ValueNode;
+    expect(scalars.AWSTimestamp.parseLiteral(astNode, null)).toEqual(1234);
+  });
+
+  it('Rejects non-integer literals', () => {
+    const astNode = { kind: 'StringValue', value: '1234', loc: { start: 68, end: 74 } } as ValueNode;
+
+    expect(() => {
+      scalars.AWSTimestamp.parseLiteral(astNode, null);
+    }).toThrow('Can only validate integers but received: StringValue');
+  });
+});

--- a/packages/amplify-appsync-simulator/src/schema/appsync-scalars/index.ts
+++ b/packages/amplify-appsync-simulator/src/schema/appsync-scalars/index.ts
@@ -1,5 +1,5 @@
 import { URL } from 'url';
-import { GraphQLInt, GraphQLScalarType, GraphQLError, Kind, StringValueNode } from 'graphql';
+import { GraphQLInt, GraphQLScalarType, GraphQLError, Kind, StringValueNode, ValueNode } from 'graphql';
 import { isValidNumber } from 'libphonenumber-js';
 
 import { GraphQLDate, GraphQLTime, GraphQLDateTime } from 'graphql-iso-date';
@@ -104,8 +104,12 @@ are also accepted and these represent the number of seconds till 1970-01-01T00:0
   parseValue(value) {
     return GraphQLInt.parseValue(value) ? value : undefined;
   },
-  parseLiteral(value) {
-    return GraphQLInt.parseLiteral(value, null) ? (value as StringValueNode).value : undefined;
+  parseLiteral(value: ValueNode) {
+    if (value.kind !== Kind.INT) {
+      throw new GraphQLError(`Can only validate integers but received: ${value.kind}`);
+    }
+
+    return Number.parseInt(value.value, 10);
   },
 });
 


### PR DESCRIPTION
#### Description of changes
This commit updates the `AWSTimestamp` custom scalar to return literals as integers instead of strings. The AST representation of a literal is always a string, so it needs to be converted to an int before returning it for further processing.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/6436

#### Description of how you validated changes
Manual testing and unit tests added in this PR.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.