### PR TITLE
fix(amplify-e2e-core): update source of truth for supported regions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1077,22 +1077,6 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-northeast-1
-  migration-node-function-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: ap-southeast-1
-  api_4-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_4
-    environment:
-      TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: ap-southeast-2
   schema-iterative-update-locking-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1100,7 +1084,15 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
+  migration-node-function-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/migration/node.function.test.ts
+      CLI_REGION: ap-southeast-2
   function_5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1108,6 +1100,14 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
+      CLI_REGION: us-east-2
+  api_4-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1719,26 +1719,6 @@ jobs:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-northeast-1
     steps: *ref_5
-  migration-node-function-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: ap-southeast-1
-    steps: *ref_5
-  api_4-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: ap-southeast-2
-    steps: *ref_5
   schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1747,7 +1727,17 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-1
+    steps: *ref_5
+  migration-node-function-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/migration/node.function.test.ts
+      CLI_REGION: ap-southeast-2
     steps: *ref_5
   function_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1757,6 +1747,16 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_5.test.ts
+      CLI_REGION: us-east-2
+    steps: *ref_5
+  api_4-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-west-2
     steps: *ref_5
 workflows:
@@ -1854,11 +1854,11 @@ workflows:
             - hostingPROD-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - init-amplify_e2e_tests
-            - schema-iterative-update-locking-amplify_e2e_tests
+            - function_5-amplify_e2e_tests
             - predictions-amplify_e2e_tests
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
-            - function_5-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
             - function_3-amplify_e2e_tests
             - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
@@ -1874,22 +1874,22 @@ workflows:
             - schema-key-amplify_e2e_tests
             - analytics-amplify_e2e_tests
             - notifications-amplify_e2e_tests
-            - migration-node-function-amplify_e2e_tests
+            - schema-iterative-update-locking-amplify_e2e_tests
             - schema-auth-10-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - tags-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
+            - migration-node-function-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           context: amplify-cli-ecr
           requires:
             - hostingPROD-amplify_e2e_tests_pkg_linux
             - amplify-app-amplify_e2e_tests_pkg_linux
             - init-amplify_e2e_tests_pkg_linux
-            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
+            - function_5-amplify_e2e_tests_pkg_linux
             - predictions-amplify_e2e_tests_pkg_linux
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
-            - function_5-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
             - function_3-amplify_e2e_tests_pkg_linux
             - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
@@ -1905,11 +1905,11 @@ workflows:
             - schema-key-amplify_e2e_tests_pkg_linux
             - analytics-amplify_e2e_tests_pkg_linux
             - notifications-amplify_e2e_tests_pkg_linux
-            - migration-node-function-amplify_e2e_tests_pkg_linux
+            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
             - schema-auth-10-amplify_e2e_tests_pkg_linux
             - hosting-amplify_e2e_tests_pkg_linux
             - tags-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
+            - migration-node-function-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           context: amplify-cli-ecr
           filters:
@@ -2059,7 +2059,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-auth-7-amplify_e2e_tests
-      - schema-iterative-update-locking-amplify_e2e_tests:
+      - function_5-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2119,7 +2119,7 @@ workflows:
           filters: *ref_8
           requires:
             - auth_4-amplify_e2e_tests
-      - function_5-amplify_e2e_tests:
+      - api_4-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2335,7 +2335,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-searchable-amplify_e2e_tests
-      - migration-node-function-amplify_e2e_tests:
+      - schema-iterative-update-locking-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2389,7 +2389,7 @@ workflows:
           filters: *ref_8
           requires:
             - schema-auth-8-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - migration-node-function-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2457,7 +2457,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
-      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+      - function_5-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2521,7 +2521,7 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - function_5-amplify_e2e_tests_pkg_linux:
+      - api_4-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2753,7 +2753,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-searchable-amplify_e2e_tests_pkg_linux
-      - migration-node-function-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2811,7 +2811,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-8-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -14,7 +14,7 @@ const defaultSettings = {
   userName: '\r',
 };
 
-const regionOptions = [
+export const amplifyRegions = [
   'us-east-1',
   'us-east-2',
   'us-west-2',
@@ -26,6 +26,7 @@ const regionOptions = [
   'ap-southeast-1',
   'ap-southeast-2',
   'ap-south-1',
+  'ca-central-1',
 ];
 
 const profileOptions = ['cancel', 'update', 'remove'];
@@ -46,7 +47,7 @@ export function amplifyConfigure(settings: AmplifyConfiguration): Promise<void> 
       .sendCarriageReturn()
       .wait('Specify the AWS Region');
 
-    singleSelect(chain, s.region, regionOptions);
+    singleSelect(chain, s.region, amplifyRegions);
 
     chain
       .wait('user name:')

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -1,5 +1,6 @@
 import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';
 import { KEY_DOWN_ARROW } from '../utils';
+import { amplifyRegions } from '../configure';
 
 const defaultSettings = {
   name: '\r',
@@ -18,21 +19,6 @@ const defaultSettings = {
   disableAmplifyAppCreation: true,
   disableCIDetection: false,
 };
-
-export const amplifyRegions = [
-  'us-east-1',
-  'us-east-2',
-  'us-west-2',
-  'eu-west-1',
-  'eu-west-2',
-  'eu-central-1',
-  'ap-northeast-1',
-  'ap-northeast-2',
-  'ap-southeast-1',
-  'ap-southeast-2',
-  'ap-south-1',
-  'ca-central-1',
-];
 
 export function initJSProjectWithProfile(cwd: string, settings: Object): Promise<void> {
   const s = { ...defaultSettings, ...settings };

--- a/packages/amplify-provider-awscloudformation/src/aws-regions.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-regions.js
@@ -1,5 +1,5 @@
 // *** NOTE! ***
-// If updating this list, also update the corresponding list in amplify-e2e-tests/src/configure/index.ts
+// If updating this list, also update the corresponding list in amplify-e2e-core/src/configure/index.ts
 // *** NOTE! ***
 const regionMappings = {
   'us-east-1': 'US East (N. Virginia)',

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js
@@ -1,21 +1,7 @@
 const aws = require('aws-sdk');
 const proxyAgent = require('proxy-agent');
 const configurationManager = require('../configuration-manager');
-
-const amplifyServiceRegions = [
-  'us-east-1',
-  'us-east-2',
-  'us-west-2',
-  'eu-west-1',
-  'eu-west-2',
-  'eu-central-1',
-  'ap-northeast-1',
-  'ap-northeast-2',
-  'ap-south-1',
-  'ap-southeast-1',
-  'ap-southeast-2',
-  'ca-central-1',
-];
+const { regions: amplifyServiceRegions } = require('../aws-regions');
 
 async function getConfiguredAmplifyClient(context, options = {}) {
   let cred = {};


### PR DESCRIPTION
#### Description of changes
https://github.com/aws-amplify/amplify-cli/pull/3992 added a list of supported regions in amplify-e2e-core. When https://github.com/aws-amplify/amplify-cli/pull/4092 was merged, it added a second list of supported regions, which has drifted from the other list. This commit consolidates the two lists.

#### Issue #, if available

#### Description of how you validated changes
Ran an e2e test locally.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.