### PR TITLE
Add GitHub Action to update issues/PRs referenced in published releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/2.feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 >**Note**: If your feature-request is regarding the AWS Amplify Console service, please log it in the 
-[official AWS Amplify Console forum](https://forums.aws.amazon.com/forum.jspa?forumID=314&start=0)
+[AWS Amplify Console repository](https://github.com/aws-amplify/amplify-console/issues)
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/3.usage-question.md
+++ b/.github/ISSUE_TEMPLATE/3.usage-question.md
@@ -6,8 +6,9 @@ labels: question
 assignees: ''
 
 ---
+
 >**Note**: If your question is regarding the AWS Amplify Console service, please log it in the 
-[official AWS Amplify Console forum](https://forums.aws.amazon.com/forum.jspa?forumID=314&start=0)
+[AWS Amplify Console repository](https://github.com/aws-amplify/amplify-console/issues)
 
 **Which Category is your question related to?**
 

--- a/.github/workflows/release-follow-up.yaml
+++ b/.github/workflows/release-follow-up.yaml
@@ -1,0 +1,16 @@
+# https://github.com/marketplace/actions/release-follow-up
+# Follow up on issues and PRs after a release is published. 
+# The corresponding pending-release label will be removed if 
+# it's present and the referenced-in-release label added.
+name: release-follow-up
+on:
+  release:
+    types: [published]
+
+jobs:
+  follow-up:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: siegerts/release-follow-up-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ Generally, match the style of the surrounding code. Please ensure your changes d
 
 ## Finding Contributions
 
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any [`help-wanted`](https://github.com/aws-amplify/amplify-cli/labels/help-wanted) or [`good-first-issue`](https://github.com/aws-amplify/amplify-cli/labels/good-first-issue) is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any [`help-wanted`](https://github.com/aws-amplify/amplify-cli/labels/help-wanted) or [`good first issue`](https://github.com/aws-amplify/amplify-cli/labels/good%20first%20issue) is a great place to start.
 
 You could also contribute by reporting bugs, reproduction of bugs with sample code, documentation and test improvements.
 
@@ -259,7 +259,7 @@ For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of
 
 ## Security Issue Reporting
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
 
 ## Licensing
 


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Introduce an action to update issues/PRs referenced in published releases using https://github.com/marketplace/actions/release-follow-up


Any issue linked in the release body with the pattern `/<current-repo>/issues/<issue-number>` will be matched. If the issue exists in the current repo, a comment will be added referencing the release link. The corresponding `pending-release` label will be removed if it's present and the `referenced-in-release` label added.

Currently, issues and PRs are **not closed**, only commented on.


Also, 
- minor updates contrib guide
- replace the link to Amplify Console forum w/ GH 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- test the GH action in sandbox repos using similar labels
- test against the same changelog/release notes structure as the CLI repo

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.