### PR TITLE
fix: assign group env from source

### DIFF
--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -122,6 +122,8 @@ export async function initEnv(context) {
       amplify.saveEnvResourceParameters(context, category, resourceName, config);
     };
   });
+  const sourceEnv = context.exeInfo?.sourceEnvName;
+  const isNewEnv = context.exeInfo?.isNewEnv;
 
   // Need to fetch metadata from #current-cloud-backend, since amplifyMeta
   // gets regenerated in intialize-env.ts in the amplify-cli package
@@ -152,6 +154,17 @@ export async function initEnv(context) {
         _.set(amplifyMeta, lvmPath, currentVersionMap);
       }
     });
+  resourcesToBeCreated.forEach(resource => {
+    const { resourceName, service } = resource;
+    if (service === ServiceName.LambdaFunction) {
+      if (sourceEnv && isNewEnv) {
+        const groupName = _.get(teamProviderInfo, [sourceEnv, 'categories', category, resourceName, 'GROUP']);
+        if (groupName) {
+          _.set(teamProviderInfo, [envName, 'categories', category, resourceName, 'GROUP'], groupName);
+        }
+      }
+    }
+  });
 
   stateManager.setMeta(undefined, amplifyMeta);
   stateManager.setTeamProviderInfo(undefined, teamProviderInfo);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The PR clones the group name for postconfirmation trigger on group in the team-provider info

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fixes: #2841


#### Description of how you validated changes
```bash
cd packages/amplify-e2e-tests
yarn e2e src/__tests__/function_*
yarn e2e src/__tests__/auth_*
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.