### PR TITLE
fix(amplify-provider-awscloudformation): add slow down on index check

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -230,7 +230,7 @@ export class DeploymentManager {
     }
   };
 
-  private getTableStatus = async (tableName: string, region: string): Promise<boolean> => {
+  private getTableStatus = async (tableName: string): Promise<boolean> => {
     assert(tableName, 'table name should be passed');
 
     const response = await this.ddbClient.describeTable({ TableName: tableName }).promise();
@@ -239,13 +239,17 @@ export class DeploymentManager {
   };
 
   private waitForIndices = async (stackParams: DeploymentMachineOp) => {
-    if (stackParams.tableNames.length) console.log('\nWaiting for DynamoDB table indices to be ready');
+    if (stackParams.tableNames.length) {
+      console.log('\nWaiting for DynamoDB table indices to be ready');
+      // cfn is async to ddb gsi creation the api can return true before the gsi creation starts
+      await new Promise(res => setTimeout(res, 2000));
+    }
     const throttledGetTableStatus = throttle(this.getTableStatus, this.options.throttleDelay);
 
     const waiters = stackParams.tableNames.map(name => {
       return new Promise(resolve => {
         let interval = setInterval(async () => {
-          const areIndexesReady = await throttledGetTableStatus(name, this.region);
+          const areIndexesReady = await throttledGetTableStatus(name);
           if (areIndexesReady) {
             clearInterval(interval);
             resolve(undefined);


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
cfn is async to ddb gsi creation slowing the api call can wait for gsi operation to start before
checking a table with potentially wrong info

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.