### PR TITLE
fix(amplify-provider-awscloudformation): throw helpful error if profile is missing keys

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -1,0 +1,58 @@
+import { getProfileCredentials } from '../system-config-manager';
+import fs from 'fs-extra';
+
+jest.mock('../utils/aws-logger', () => ({
+  fileLogger: () => jest.fn(() => jest.fn()),
+}));
+jest.mock('fs-extra');
+const fs_mock = fs as jest.Mocked<typeof fs>;
+
+describe('profile tests', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  fs_mock.existsSync.mockImplementation(() => {
+    return true;
+  });
+
+  it('should return profile credentials with aws prefix snake_case', () => {
+    fs_mock.readFileSync.mockImplementationOnce(() => {
+      return '[fake]\naws_access_key_id=fakeAccessKey\naws_secret_access_key=fakeSecretKey\n';
+    });
+    const creds = getProfileCredentials('fake');
+    expect(creds).toBeDefined();
+    expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
+    expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return profile credentials without aws prefix and camelCase', () => {
+    fs_mock.readFileSync.mockImplementationOnce(() => {
+      return '[fake]\naccessKeyId=fakeAccessKey\nsecretAccessKey=fakeSecretKey\n';
+    });
+    const creds = getProfileCredentials('fake');
+    expect(creds).toBeDefined();
+    expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
+    expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail to return profile credentials', () => {
+    fs_mock.readFileSync.mockImplementationOnce(() => {
+      return '[fake]\nmalformed_access_key_id=fakeAccessKey\naws_secret_access_key=fakeSecretKey\n';
+    });
+    expect(() => getProfileCredentials('fake')).toThrow("Profile configuration for 'fake' is invalid: missing aws_access_key_id");
+    expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
+    expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail to return profile credentials', () => {
+    fs_mock.readFileSync.mockImplementationOnce(() => {
+      return '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n';
+    });
+    expect(() => getProfileCredentials('fake')).toThrowError(
+      "Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key",
+    );
+    expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
+    expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -580,11 +580,7 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
     }
   } else if (authType.type === 'profile') {
     try {
-      if (authType?.profileName) {
-        awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
-      } else {
-        throw Error('Project configuration invalid. Missing profile name.');
-      }
+      awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
     } catch (e) {
       context.print.error(`Failed to get profile: ${e.message || e}`);
       await context.usageData.emitError(e);
@@ -710,11 +706,7 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsConfig> {
   if (awsConfigInfo.configLevel === 'project') {
     if (awsConfigInfo.config.useProfile) {
       try {
-        if (awsConfigInfo.config.profileName) {
-          awsConfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
-        } else {
-          throw Error('Project configuration invalid. Missing profile name.');
-        }
+        awsConfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
       } catch (e) {
         context.print.error(`Failed to get profile: ${e.message || e}`);
         await context.usageData.emitError(e);

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -579,10 +579,16 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
       exitOnNextTick(1);
     }
   } else if (authType.type === 'profile') {
-    if (authType?.profileName) {
-      awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
-    } else {
-      throw Error('Project configuration invalid. Missing profile name.');
+    try {
+      if (authType?.profileName) {
+        awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
+      } else {
+        throw Error('Project configuration invalid. Missing profile name.');
+      }
+    } catch (e) {
+      context.print.error(`Failed to get profile: ${e.message || e}`);
+      await context.usageData.emitError(e);
+      exitOnNextTick(1);
     }
   } else if (authType.type === 'accessKeys') {
     awsConfig = loadConfigFromPath(projectConfigInfo.config.awsConfigFilePath);
@@ -703,6 +709,17 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsConfig> {
   let awsConfig: AwsSdkConfig;
   if (awsConfigInfo.configLevel === 'project') {
     if (awsConfigInfo.config.useProfile) {
+      try {
+        if (awsConfigInfo.config.profileName) {
+          awsConfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
+        } else {
+          throw Error('Project configuration invalid. Missing profile name.');
+        }
+      } catch (e) {
+        context.print.error(`Failed to get profile: ${e.message || e}`);
+        await context.usageData.emitError(e);
+        exitOnNextTick(1);
+      }
       awsConfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
     } else {
       awsConfig = {

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -720,7 +720,6 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsConfig> {
         await context.usageData.emitError(e);
         exitOnNextTick(1);
       }
-      awsConfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
     } else {
       awsConfig = {
         accessKeyId: awsConfigInfo.config.accessKeyId,

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.js
@@ -298,7 +298,7 @@ function validateCredentials(credentials, profileName) {
     missingKeys.push('aws_secret_access_key');
   }
   if (missingKeys.length > 0) {
-    const err = new Error(`${profileName} profile configuration is invalid: missing ${missingKeys.join(', ')}`);
+    const err = new Error(`Profile configuration for '${profileName}' is invalid: missing ${missingKeys.join(', ')}`);
     logger('validateCredentials', [profileName])(err);
     err.stack = undefined;
     throw err;

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.js
@@ -284,7 +284,25 @@ function getProfileCredentials(profileName) {
       }
     });
   }
-  return normalizeKeys(profileCredentials);
+  profileCredentials = normalizeKeys(profileCredentials);
+  validateCredentials(profileCredentials, profileName);
+  return profileCredentials;
+}
+
+function validateCredentials(credentials, profileName) {
+  const missingKeys = [];
+  if (!credentials?.accessKeyId) {
+    missingKeys.push('aws_access_key_id');
+  }
+  if (!credentials?.secretAccessKey) {
+    missingKeys.push('aws_secret_access_key');
+  }
+  if (missingKeys.length > 0) {
+    const err = new Error(`${profileName} profile configuration is invalid: missing ${missingKeys.join(', ')}`);
+    logger('validateCredentials', [profileName])(err);
+    err.stack = undefined;
+    throw err;
+  }
 }
 
 function normalizeKeys(config) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
throw helpful error if profile is missing keys, adapted from @nikhname's PR: https://github.com/aws-amplify/amplify-cli/pull/6567

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#5777


#### Description of how you validated changes
Added unit tests and validated manually


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.