### PR TITLE
test: remove extraneous 'y' response from function e2e

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -41,7 +41,7 @@ const appSyncOptions = ['Query', 'Mutation', 'Subscription'];
 
 const additionalPermissions = (cwd: string, chain: ExecutionContext, settings: any) => {
   multiSelect(
-    chain.sendLine('y').wait('Select the categories you want this function to have access to'),
+    chain.wait('Select the categories you want this function to have access to'),
     settings.additionalPermissions.permissions,
     settings.additionalPermissions.choices,
   );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixed e2e test: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/27/workflows/2c0fd343-d520-4ccf-9bc9-9132f546e23b/jobs/410/steps

#### Description of how you validated changes

Ran failing e2e test locally:
    amplify add function with additional permissions
      ✓ environment vars comment should update on permission update (92481 ms)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.