### PR TITLE
test: add the 'y' response back only for create flow in function e2e

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -148,6 +148,7 @@ const coreFunction = (
         chain.sendLine('y').wait('Do you want to access other resources in this project from your Lambda function?');
         if (settings.additionalPermissions) {
           // other permissions flow
+          chain.sendLine('y');
           additionalPermissions(cwd, chain, settings);
         } else {
           chain.sendLine('n');


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fix failing e2e tests caused by previous PR https://github.com/aws-amplify/amplify-cli/pull/7031. The 'y' response is needed for `amplify add function`, but not used in `amplify update function`.


#### Description of how you validated changes
Full e2e run of function_2.test.ts

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   1 passed, 1 total
Time:        3406.696 s


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.