### PR TITLE
fix(cli): adds dart config to git ignore

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
@@ -57,6 +57,7 @@ function getGitIgnoreAppendString() {
     'aws-exports.js',
     'awsconfiguration.json',
     'amplifyconfiguration.json',
+    'amplifyconfiguration.dart',
     'amplify-build-config.json',
     'amplify-gradle-config.json',
     'amplifytools.xcconfig',


### PR DESCRIPTION
#### Description of changes
Adds amplifyconfiguration.dart to gitignore list

#### Description of how you validated changes

1. Ran amplify-dev init locally.
2. Confirmed that .gitignore file was updated:
```
#amplify
amplify/\#current-cloud-backend
amplify/.config/local-*
amplify/logs
amplify/mock-data
amplify/backend/amplify-meta.json
amplify/backend/awscloudformation
amplify/backend/.temp
build/
dist/
node_modules/
aws-exports.js
awsconfiguration.json
amplifyconfiguration.json
amplifyconfiguration.dart
amplify-build-config.json
amplify-gradle-config.json
amplifytools.xcconfig
.secret-*
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.