### PR TITLE
fix: amplify configure project not updating access keys correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1119,6 +1119,14 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: eu-west-2
+  configure-project-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/configure-project.test.ts
+      CLI_REGION: eu-central-1
   api_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1126,7 +1134,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1787,6 +1795,16 @@ jobs:
       TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: eu-west-2
     steps: *ref_5
+  configure-project-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/configure-project.test.ts
+      CLI_REGION: eu-central-1
+    steps: *ref_5
   api_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1795,7 +1813,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_5
 workflows:
   version: 2
@@ -1904,11 +1922,11 @@ workflows:
             - predictions-amplify_e2e_tests
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
-            - function_3-amplify_e2e_tests
+            - configure-project-amplify_e2e_tests
             - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - datastore-modelgen-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
             - auth_5-amplify_e2e_tests
             - schema-iterative-update-2-amplify_e2e_tests
             - schema-data-access-patterns-amplify_e2e_tests
@@ -1935,11 +1953,11 @@ workflows:
             - predictions-amplify_e2e_tests_pkg_linux
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
-            - function_3-amplify_e2e_tests_pkg_linux
+            - configure-project-amplify_e2e_tests_pkg_linux
             - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
             - datastore-modelgen-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
             - auth_5-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
             - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
@@ -2277,7 +2295,7 @@ workflows:
           filters: *ref_8
           requires:
             - auth_4-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - configure-project-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
           filters: *ref_8
@@ -2337,6 +2355,12 @@ workflows:
           filters: *ref_8
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
+      - api_4-amplify_e2e_tests:
+          context: amplify-cli-ecr
+          post-steps: *ref_7
+          filters: *ref_8
+          requires:
+            - function_3-amplify_e2e_tests
       - schema-auth-2-amplify_e2e_tests:
           context: amplify-cli-ecr
           post-steps: *ref_7
@@ -2699,7 +2723,7 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - configure-project-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9
           filters: *ref_10
@@ -2763,6 +2787,12 @@ workflows:
           filters: *ref_10
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
+      - api_4-amplify_e2e_tests_pkg_linux:
+          context: amplify-cli-ecr
+          post-steps: *ref_9
+          filters: *ref_10
+          requires:
+            - function_3-amplify_e2e_tests_pkg_linux
       - schema-auth-2-amplify_e2e_tests_pkg_linux:
           context: amplify-cli-ecr
           post-steps: *ref_9

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -28,8 +28,9 @@ export const amplifyRegions = [
   'ca-central-1',
 ];
 
-const configurationOptions = ['project', 'profile', 'containers'];
-const profileOptions = ['cancel', 'update', 'remove'];
+const configurationOptions = ['Project information', 'AWS Profile setting', 'Advanced: Container-based deployments'];
+const profileOptions = ['No', 'Update AWS Profile', 'Remove AWS Profile'];
+const authenticationOptions = ['AWS profile', 'AWS access keys'];
 
 const MANDATORY_PARAMS = ['accessKeyId', 'secretAccessKey', 'region'];
 
@@ -73,18 +74,53 @@ export function amplifyConfigure(settings: AmplifyConfiguration): Promise<void> 
   });
 }
 
-export function amplifyConfigureProject(settings: { cwd: string; enableContainers: boolean }): Promise<void> {
-  const { enableContainers = false, cwd } = settings;
+// TODO amplify admin enabled case
+export function amplifyConfigureProject(settings: {
+  cwd: string;
+  enableContainers?: boolean;
+  configLevel?: string;
+  profileOption?: string;
+  authenticationOption?: string;
+  region?: string;
+}): Promise<void> {
+  const {
+    cwd,
+    enableContainers = false,
+    profileOption = profileOptions[0],
+    authenticationOption,
+    configLevel = 'project',
+    region = defaultSettings.region,
+  } = settings;
 
   return new Promise((resolve, reject) => {
     const chain = spawn(getCLIPath(), ['configure', 'project'], { cwd, stripColors: true }).wait('Which setting do you want to configure?');
+
     if (enableContainers) {
       singleSelect(chain, 'containers', configurationOptions);
-      chain.wait('Do you want to enable container-based deployments?').sendLine('y');
+      chain.wait('Do you want to enable container-based deployments?').sendConfirmYes();
     } else {
-      singleSelect(chain, 'profile', configurationOptions);
-      chain.wait('Do you want to update or remove the project level AWS profile?');
-      singleSelect(chain, profileOptions[0], profileOptions);
+      singleSelect(chain, configurationOptions[1], configurationOptions);
+
+      if (configLevel === 'project') {
+        chain.wait('Do you want to update or remove the project level AWS profile?');
+        singleSelect(chain, profileOption, profileOptions);
+      } else {
+        chain.wait('Do you want to set the project level configuration').sendConfirmYes();
+      }
+
+      if (profileOption === profileOptions[1] || configLevel === 'general') {
+        chain.wait('Select the authentication method you want to use:');
+        singleSelect(chain, authenticationOption, authenticationOptions);
+
+        if (authenticationOption === authenticationOptions[0]) {
+          chain.wait('Please choose the profile you want to use').sendCarriageReturn(); // Default profile
+        } else if (authenticationOption === authenticationOptions[1]) {
+          chain.wait('accessKeyId:').sendLine('fake-access-key-id');
+          chain.wait('secretAccessKey:').sendLine('fake-secret-access-key');
+          chain.wait('region:');
+          singleSelect(chain, region, amplifyRegions);
+        }
+      }
     }
 
     chain.wait('Successfully made configuration changes to your project.').run((err: Error) => {

--- a/packages/amplify-e2e-tests/src/__tests__/configure-project.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/configure-project.test.ts
@@ -1,0 +1,75 @@
+import {
+  amplifyConfigureProject,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+  readJsonFile,
+} from 'amplify-e2e-core';
+import * as path from 'path';
+
+describe('amplify configure project tests', () => {
+  let projRoot: string;
+  const envName = 'integtest';
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('configProjTest');
+    await initJSProjectWithProfile(projRoot, { envName });
+  });
+
+  afterAll(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('should update the project to use access keys', async () => {
+    await amplifyConfigureProject({ cwd: projRoot, profileOption: 'Update AWS Profile', authenticationOption: 'AWS access keys' });
+    const projectConfigForEnv = getLocalAwsInfoForEnv(projRoot, envName);
+    expect(projectConfigForEnv).toBeDefined();
+    expect(projectConfigForEnv.configLevel).toBe('project');
+    expect(projectConfigForEnv.useProfile).toBe(false);
+    expect(projectConfigForEnv.awsConfigFilePath).toBeDefined();
+  });
+
+  it('should update the project to use a profile', async () => {
+    await amplifyConfigureProject({ cwd: projRoot, profileOption: 'Update AWS Profile', authenticationOption: 'AWS profile' });
+    const projectConfigForEnv = getLocalAwsInfoForEnv(projRoot, envName);
+    expect(projectConfigForEnv).toBeDefined();
+    expect(projectConfigForEnv.configLevel).toBe('project');
+    expect(projectConfigForEnv.useProfile).toBe(true);
+    expect(projectConfigForEnv.profileName).toBeDefined();
+  });
+
+  it('should update the project to remove a profile', async () => {
+    await amplifyConfigureProject({ cwd: projRoot, profileOption: 'Remove AWS Profile' });
+    const projectConfigForEnv = getLocalAwsInfoForEnv(projRoot, envName);
+    expect(projectConfigForEnv).toBeDefined();
+    expect(projectConfigForEnv.configLevel).toBe('general');
+  });
+
+  it('should update the project to add access keys when configLevel is general', async () => {
+    await amplifyConfigureProject({ cwd: projRoot, configLevel: 'general', authenticationOption: 'AWS access keys' });
+    const projectConfigForEnv = getLocalAwsInfoForEnv(projRoot, envName);
+    expect(projectConfigForEnv).toBeDefined();
+    expect(projectConfigForEnv.configLevel).toBe('project');
+    expect(projectConfigForEnv.useProfile).toBe(false);
+    expect(projectConfigForEnv.awsConfigFilePath).toBeDefined();
+  });
+
+  // Set to profile last or deletProject() in afterAll() will fail
+  it('should update the project to use a profile', async () => {
+    await amplifyConfigureProject({ cwd: projRoot, profileOption: 'Update AWS Profile', authenticationOption: 'AWS profile' });
+    const projectConfigForEnv = getLocalAwsInfoForEnv(projRoot, envName);
+    expect(projectConfigForEnv).toBeDefined();
+    expect(projectConfigForEnv.configLevel).toBe('project');
+    expect(projectConfigForEnv.useProfile).toBe(true);
+    expect(projectConfigForEnv.profileName).toBeDefined();
+  });
+});
+
+function getLocalAwsInfoForEnv(projRoot: string, envName: string) {
+  return getLocalAwsInfo(projRoot)[envName];
+}
+
+function getLocalAwsInfo(projRoot: string) {
+  return readJsonFile(path.join(projRoot, 'amplify', '.config', 'local-aws-info.json'));
+}

--- a/packages/amplify-e2e-tests/src/__tests__/configure-project.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/configure-project.test.ts
@@ -1,12 +1,5 @@
-import {
-  amplifyConfigureProject,
-  createNewProjectDir,
-  deleteProject,
-  deleteProjectDir,
-  initJSProjectWithProfile,
-  readJsonFile,
-} from 'amplify-e2e-core';
-import * as path from 'path';
+import { amplifyConfigureProject, createNewProjectDir, deleteProject, deleteProjectDir, initJSProjectWithProfile } from 'amplify-e2e-core';
+import { stateManager } from 'amplify-cli-core';
 
 describe('amplify configure project tests', () => {
   let projRoot: string;
@@ -67,9 +60,5 @@ describe('amplify configure project tests', () => {
 });
 
 function getLocalAwsInfoForEnv(projRoot: string, envName: string) {
-  return getLocalAwsInfo(projRoot)[envName];
-}
-
-function getLocalAwsInfo(projRoot: string) {
-  return readJsonFile(path.join(projRoot, 'amplify', '.config', 'local-aws-info.json'));
+  return stateManager.getLocalAWSInfo(projRoot)[envName];
 }

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -303,7 +303,6 @@ async function setProjectConfigAction(context: $TSContext) {
     } else if (inputParams.configLevel === 'project') {
       context.exeInfo.awsConfigInfo.action = 'create';
       context.exeInfo.awsConfigInfo.configLevel = 'project';
-      context.exeInfo.awsConfigInfo.config = defaultAWSConfig;
     } else {
       context.exeInfo.awsConfigInfo.action = 'none';
       context.exeInfo.awsConfigInfo.configLevel = 'general';
@@ -319,7 +318,6 @@ async function setProjectConfigAction(context: $TSContext) {
       if (answer.setProjectLevelConfig) {
         context.exeInfo.awsConfigInfo.action = 'create';
         context.exeInfo.awsConfigInfo.configLevel = 'project';
-        context.exeInfo.awsConfigInfo.config = defaultAWSConfig;
       } else {
         context.exeInfo.awsConfigInfo.action = 'none';
         context.exeInfo.awsConfigInfo.configLevel = 'general';
@@ -351,6 +349,7 @@ async function promptForAuthConfig(context: $TSContext, authConfig?: AuthFlowCon
   if (availableProfiles && availableProfiles.length > 0) {
     let authType: AuthFlow;
     let isAdminApp = false;
+
     if (authConfig?.type) {
       authType = authConfig.type;
     } else {
@@ -362,6 +361,7 @@ async function promptForAuthConfig(context: $TSContext, authConfig?: AuthFlowCon
       }
       authType = await askAuthType(isAdminApp);
     }
+
     if (authType === 'profile') {
       printProfileInfo(context);
       awsConfigInfo.config.useProfile = true;

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -372,6 +372,9 @@ async function promptForAuthConfig(context: $TSContext, authConfig?: AuthFlowCon
       awsConfigInfo.configLevel = 'amplifyAdmin';
       awsConfigInfo.config.useProfile = false;
       return;
+    } else {
+      awsConfigInfo.config.useProfile = false;
+      delete awsConfigInfo.config.profileName;
     }
   } else {
     awsConfigInfo.config.useProfile = false;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
amplify configure project would not update `local-aws-info.json` when selecting "AWS access keys" in some cases.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.