### PR TITLE
fix(amplify-cli): remove redundant prompt #6535

### DIFF
--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -254,8 +254,9 @@ async function getEnvName(context: $TSContext) {
     await newEnvQuestion();
   } else {
     const allEnvs = context.amplify.getAllEnvs();
+    const envAddExec = checkEnvAddExec(context);
 
-    if (allEnvs.length > 0 && addNewEnv(context).exec === false) {
+    if (allEnvs.length > 0 && envAddExec === false) {
       if (await context.amplify.confirmPrompt('Do you want to use an existing environment?')) {
         const envQuestion: inquirer.ListQuestion = {
           type: 'list',
@@ -268,8 +269,8 @@ async function getEnvName(context: $TSContext) {
       } else {
         await newEnvQuestion();
       }
-    } else if (addNewEnv(context).exec === true && addNewEnv(context).envName) {
-      envName = addNewEnv(context).envName;
+    } else if (envAddExec === true && context.parameters.first) {
+      envName = context.parameters.first;
     } else {
       await newEnvQuestion();
     }
@@ -314,27 +315,14 @@ function getDefaultEditor() {
 }
 
 /**
- *Checks if `amplify env add` has been executed, and extract environment name if exists
+ *Checks if `amplify env add` has been executed
  * @param {$TSContext} context The Amplify context object
- * @returns `{exec: boolean, envName?: string | null}`
- *
- * `exec` denotes if `amplify env add` has been executed
- *
- * `envName` extracts environment name if provided
+ * @returns `boolean`
  */
-function addNewEnv(context): { exec: boolean; envName?: string | null } {
+function checkEnvAddExec(context): boolean {
   if (context.parameters.command === 'env' && context.parameters.array[0] === 'add') {
-    let envName = null;
-    if (context.parameters.first) {
-      envName = context.parameters.first;
-    }
-    return {
-      exec: true,
-      envName,
-    };
+    return true;
   } else {
-    return {
-      exec: false,
-    };
+    return false;
   }
 }

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -315,14 +315,10 @@ function getDefaultEditor() {
 }
 
 /**
- *Checks if `amplify env add` has been executed
+ * Checks if `amplify env add` has been executed
  * @param {$TSContext} context The Amplify context object
  * @returns `boolean`
  */
 function checkEnvAddExec(context): boolean {
-  if (context.parameters.command === 'env' && context.parameters.array[0] === 'add') {
-    return true;
-  } else {
-    return false;
-  }
+  return context.parameters.command === 'env' && context.parameters.array[0] === 'add';
 }

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -255,7 +255,7 @@ async function getEnvName(context: $TSContext) {
   } else {
     const allEnvs = context.amplify.getAllEnvs();
 
-    if (allEnvs.length > 0) {
+    if (allEnvs.length > 0 && addNewEnv(context).exec === false) {
       if (await context.amplify.confirmPrompt('Do you want to use an existing environment?')) {
         const envQuestion: inquirer.ListQuestion = {
           type: 'list',
@@ -268,6 +268,8 @@ async function getEnvName(context: $TSContext) {
       } else {
         await newEnvQuestion();
       }
+    } else if (addNewEnv(context).exec === true && addNewEnv(context).envName) {
+      envName = addNewEnv(context).envName;
     } else {
       await newEnvQuestion();
     }
@@ -309,4 +311,30 @@ function getDefaultEditor() {
   });
 
   return localEnvInfo.defaultEditor;
+}
+
+/**
+ *Checks if `amplify env add` has been executed, and extract environment name if exists
+ * @param {$TSContext} context The Amplify context object
+ * @returns `{exec: boolean, envName?: string | null}`
+ *
+ * `exec` denotes if `amplify env add` has been executed
+ *
+ * `envName` extracts environment name if provided
+ */
+function addNewEnv(context): { exec: boolean; envName?: string | null } {
+  if (context.parameters.command === 'env' && context.parameters.array[0] === 'add') {
+    let envName = null;
+    if (context.parameters.first) {
+      envName = context.parameters.first;
+    }
+    return {
+      exec: true,
+      envName,
+    };
+  } else {
+    return {
+      exec: false,
+    };
+  }
 }

--- a/packages/amplify-e2e-tests/src/environment/env.ts
+++ b/packages/amplify-e2e-tests/src/environment/env.ts
@@ -3,8 +3,6 @@ import { nspawn as spawn, getCLIPath, getSocialProviders } from 'amplify-e2e-cor
 export function addEnvironment(cwd: string, settings: { envName: string; numLayers?: number }): Promise<void> {
   return new Promise((resolve, reject) => {
     const chain = spawn(getCLIPath(), ['env', 'add'], { cwd, stripColors: true })
-      .wait('Do you want to use an existing environment?')
-      .sendLine('n')
       .wait('Enter a name for the environment')
       .sendLine(settings.envName)
       .wait('Select the authentication method you want to use:')
@@ -29,8 +27,6 @@ export function addEnvironment(cwd: string, settings: { envName: string; numLaye
 export function addEnvironmentWithImportedAuth(cwd: string, settings: { envName: string; currentEnvName: string }): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['env', 'add'], { cwd, stripColors: true })
-      .wait('Do you want to use an existing environment?')
-      .sendConfirmNo()
       .wait('Enter a name for the environment')
       .sendLine(settings.envName)
       .wait('Select the authentication method you want to use:')
@@ -150,8 +146,6 @@ export function addEnvironmentHostedUI(cwd: string, settings: { envName: string 
   } = getSocialProviders();
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['env', 'add'], { cwd, stripColors: true })
-      .wait('Do you want to use an existing environment?')
-      .sendLine('n')
       .wait('Enter a name for the environment')
       .sendLine(settings.envName)
       .wait('Select the authentication method you want to use:')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Improves the `amplify env add` workflow.
Changes made:

1. Skip the `Do you want to use an existing environment?` question when `amplify env add` is executed.

![Screenshot from 2021-04-15 12-45-59](https://user-images.githubusercontent.com/54375111/114831497-13ccdb00-9deb-11eb-8871-5ae7c0ae510a.png)

2. On passing environment name in `amplify env add <envName>`, the new environment is directly added.

![Screenshot from 2021-04-15 12-47-02](https://user-images.githubusercontent.com/54375111/114831558-26dfab00-9deb-11eb-8311-d6071c2dbb9c.png)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes #6535 


#### Description of how you validated changes
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.