### PR TITLE
fix: handle errors and provide better error message when adding data source

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -180,8 +180,8 @@ async function selectDatabase(context, inputs, clusterArn, secretArn, AWS) {
     // eslint-disable-next-line prefer-destructuring
     const records = dataApiResult.records;
 
-    for (let i = 0; i < records.length; i += 1) {
-      const recordValue = records[i][0].stringValue;
+    for (const record of records) {
+      const recordValue = record[0].stringValue;
       // ignore the three meta tables that the cluster creates
       if (!['information_schema', 'performance_schema', 'mysql'].includes(recordValue)) {
         databaseList.push(recordValue);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -167,26 +167,31 @@ async function selectDatabase(context, inputs, clusterArn, secretArn, AWS) {
   // Database Name Question
   const DataApi = new AWS.RDSDataService();
   const params = new DataApiParams();
+  const databaseList = [];
   params.secretArn = secretArn;
   params.resourceArn = clusterArn;
   params.sql = 'SHOW databases';
 
   spinner.start('Fetching Aurora Serverless cluster...');
-  const dataApiResult = await DataApi.executeStatement(params).promise();
 
-  // eslint-disable-next-line prefer-destructuring
-  const records = dataApiResult.records;
-  const databaseList = [];
+  try {
+    const dataApiResult = await DataApi.executeStatement(params).promise();
 
-  for (let i = 0; i < records.length; i += 1) {
-    const recordValue = records[i][0].stringValue;
-    // ignore the three meta tables that the cluster creates
-    if (!['information_schema', 'performance_schema', 'mysql'].includes(recordValue)) {
-      databaseList.push(recordValue);
+    // eslint-disable-next-line prefer-destructuring
+    const records = dataApiResult.records;
+
+    for (let i = 0; i < records.length; i += 1) {
+      const recordValue = records[i][0].stringValue;
+      // ignore the three meta tables that the cluster creates
+      if (!['information_schema', 'performance_schema', 'mysql'].includes(recordValue)) {
+        databaseList.push(recordValue);
+      }
     }
-  }
 
-  spinner.succeed('Fetched Aurora Serverless cluster.');
+    spinner.succeed('Fetched Aurora Serverless cluster.');
+  } catch (err) {
+    spinner.fail(err.message);
+  }
 
   if (databaseList.length > 0) {
     return await promptWalkthroughQuestion(inputs, 3, databaseList);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.js
@@ -191,6 +191,13 @@ async function selectDatabase(context, inputs, clusterArn, secretArn, AWS) {
     spinner.succeed('Fetched Aurora Serverless cluster.');
   } catch (err) {
     spinner.fail(err.message);
+
+    if (err.code === 'BadRequestException' && /Access denied for user/.test(err.message)) {
+      const msg =
+        `Ensure that '${secretArn}' contains your database credentials. ` +
+        'Please note that Aurora Serverless does not support IAM database authentication.';
+      context.print.error(msg);
+    }
   }
 
   if (databaseList.length > 0) {


### PR DESCRIPTION
#### Description of changes
This PR fixes two issues related to `amplify api add-graphql-datasource`:

1. Error handling is added so that the spinner does not keep the process alive in the case of an error. This is the first commit, and it wraps existing code in a `try...catch` block.
2. Additional error messaging is provided when the provided secret does not contain valid credentials for Aurora Serverless. This is the second commit.

#### Issue #, if available
#4384

#### Description of how you validated changes
Set up an Aurora Serverless cluster. Attempt to connect using a secret with both valid and invalid credentials.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.