### PR TITLE
fix: generate correct auth mode for admin queries in amplifyconfiguration.json

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
@@ -405,6 +405,7 @@ const createAdminAuthAPI = async (context: any, authResourceName: string, functi
     const backendConfigs = {
       service: 'API Gateway',
       providerPlugin: 'awscloudformation',
+      authorizationType: 'AMAZON_COGNITO_USER_POOLS',
       dependsOn,
     };
 

--- a/packages/amplify-frontend-android/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-android/lib/amplify-config-helper.js
@@ -77,7 +77,7 @@ function constructApi(metadata, amplifyConfig) {
             endpointType: 'REST',
             endpoint: resourceMeta.output.RootUrl,
             region,
-            authorizationType: 'AWS_IAM',
+            authorizationType: resourceMeta.authorizationType || 'AWS_IAM',
           };
         } else if (resourceMeta.service === 'ElasticContainer' && resourceMeta.apiType === 'REST') {
           amplifyConfig[categoryName].plugins[pluginName][r] = {

--- a/packages/amplify-frontend-flutter/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-flutter/lib/amplify-config-helper.js
@@ -76,14 +76,14 @@ function constructApi(metadata, amplifyConfig) {
             endpointType: 'REST',
             endpoint: resourceMeta.output.RootUrl,
             region,
-            authorizationType: 'AWS_IAM',
+            authorizationType: resourceMeta.authorizationType || 'AWS_IAM',
           };
         } else if (resourceMeta.service === 'ElasticContainer' && resourceMeta.apiType === 'REST') {
           amplifyConfig[categoryName].plugins[pluginName][r] = {
             endpointType: 'REST',
             endpoint: resourceMeta.output.RootUrl,
             region,
-            authorizationType: resourceMeta.restrictAccess ? "AMAZON_COGNITO_USER_POOLS" : "AWS_IAM",
+            authorizationType: resourceMeta.restrictAccess ? 'AMAZON_COGNITO_USER_POOLS' : 'AWS_IAM',
           };
         }
       }

--- a/packages/amplify-frontend-ios/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-ios/lib/amplify-config-helper.js
@@ -77,14 +77,14 @@ function constructApi(metadata, amplifyConfig) {
             endpointType: 'REST',
             endpoint: resourceMeta.output.RootUrl,
             region,
-            authorizationType: 'AWS_IAM',
+            authorizationType: resourceMeta.authorizationType || 'AWS_IAM',
           };
         } else if (resourceMeta.service === 'ElasticContainer' && resourceMeta.apiType === 'REST') {
           amplifyConfig[categoryName].plugins[pluginName][r] = {
             endpointType: 'REST',
             endpoint: resourceMeta.output.RootUrl,
             region,
-            authorizationType: resourceMeta.restrictAccess ? "AMAZON_COGNITO_USER_POOLS" : "AWS_IAM",
+            authorizationType: resourceMeta.restrictAccess ? 'AMAZON_COGNITO_USER_POOLS' : 'AWS_IAM',
           };
         }
       }


### PR DESCRIPTION
Updated the fronted config files creator to have the correct authorization type for Admin Queries. The earlier implementation had AWS_IAM hardcoded. The updated config looks similar to this

```json
{
  "api": {
        "plugins": {
                "AdminQueries": {
                    "endpointType": "REST",
                    "endpoint": "https://zzzz.execute-api.us-west-2.amazonaws.com/dev",
                    "region": "us-west-2",
                    "authorizationType": "AMAZON_COGNITO_USER_POOLS"
                }
            }
        }
    }
}
```

fix #6983

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.