### PR TITLE
fix: return rejected promise in getStackEvents()

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -198,7 +198,7 @@ class CloudFormation {
         if (e && e.code === 'Throttling') {
           return Promise.resolve([]);
         }
-        Promise.reject(e);
+        return Promise.reject(e);
       });
   }
 


### PR DESCRIPTION
#### Description of changes
This commit updates `getStackEvents()` to reject on error. Prior to this change, an unhandled rejection would be created, but not returned for proper handling.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/7004

#### Description of how you validated changes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.