### PR TITLE
fix: skip admin queries when consolidating REST APIs

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -178,6 +178,10 @@ export function consolidateApiGatewayPolicies(context: $TSContext, stackName: st
   const apis = amplifyMeta?.api ?? {};
 
   Object.keys(apis).forEach(resourceName => {
+    if (resourceName === 'AdminQueries') {
+      return;
+    }
+
     const resource = apis[resourceName];
     const apiParams = loadApiWithPrivacyParams(context, resourceName, resource);
 
@@ -231,7 +235,7 @@ export function loadApiWithPrivacyParams(context: $TSContext, name: string, reso
 }
 
 function updateExistingApiCfn(context: $TSContext, api: $TSObject): void {
-  const { resourceName } = api.params;
+  const resourceName = api.resourceName || api.params.resourceName;
   const resourceDir = getResourceDirPath(context, 'api', resourceName);
   const cfnTemplate = path.join(resourceDir, `${resourceName}-cloudformation-template.json`);
   const paramsFile = path.join(resourceDir, 'parameters.json');


### PR DESCRIPTION
#### Description of changes
This commit skips over the admin queries REST API when consolidating the user's REST APIs.

#### Issue #, if available
Refs: https://github.com/aws-amplify/amplify-cli/issues/2084

#### Description of how you validated changes
Ran several failing E2E tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.