### PR TITLE
fix: mock storage trigger invocation

### DIFF
--- a/packages/amplify-category-storage/resources/triggers/s3/index.js
+++ b/packages/amplify-category-storage/resources/triggers/s3/index.js
@@ -1,9 +1,8 @@
 // eslint-disable-next-line
-exports.handler = function(event, context) {
+exports.handler = async function (event) {
   console.log('Received S3 event:', JSON.stringify(event, null, 2));
   // Get the object from the event and show its content type
   const bucket = event.Records[0].s3.bucket.name; //eslint-disable-line
   const key = event.Records[0].s3.object.key; //eslint-disable-line
   console.log(`Bucket: ${bucket}`, `Key: ${key}`);
-  context.done(null, 'Successfully processed S3 event'); // SUCCESS with message
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes the loadLambdaConfig call when executing a mock storage trigger. Also added a try catch around the lambda invocation so if it fails the whole mock server doesn't crash. Also changed the default storage trigger template from using the deprecated `context.done()` to using `async`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#7052


#### Description of how you validated changes
Validated running the mock server locally. This change is in old code that does not have tests and is not easily testable. However, I added TS types that will catch this error at compile time now.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.