### PR TITLE
test: fix context type on unit test

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/execute-provider-utils.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/execute-provider-utils.test.ts
@@ -1,7 +1,10 @@
+import { $TSContext } from 'amplify-cli-core';
 import { executeProviderUtils } from '../../../extensions/amplify-helpers/execute-provider-utils';
+
 jest.mock('../../../extensions/amplify-helpers/get-provider-plugins.ts', () => ({
   getProviderPlugins: jest.fn().mockReturnValue({ awscloudformation: '../../../__mocks__/faked-plugin' }),
 }));
+
 jest.mock('../../../../__mocks__/faked-plugin', () => ({
   providerUtils: {
     compileSchema: jest.fn().mockReturnValue(Promise.resolve({})),
@@ -10,8 +13,9 @@ jest.mock('../../../../__mocks__/faked-plugin', () => ({
     }),
   },
 }));
+
 describe('executeProviderUtils', () => {
-  const mockContext = {};
+  const mockContext = ({} as unknown) as $TSContext;
   let options = {};
   it('should execute compileSchema', async () => {
     const util = await executeProviderUtils(mockContext, 'awscloudformation', 'compileSchema', options);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add `$TSContext` type to context stub in unit test: `execute-provider-utils.test.ts`

#### Description of how you validated changes
yarn test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.