### PR TITLE
test(cli): add test for get cloud init status extensions

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-cloud-init-status.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-cloud-init-status.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs-extra';
+import {
+  getCloudInitStatus,
+  CLOUD_INITIALIZED,
+  CLOUD_NOT_INITIALIZED,
+  NON_AMPLIFY_PROJECT,
+} from '../../../extensions/amplify-helpers/get-cloud-init-status';
+
+jest.mock('fs-extra');
+jest.mock('amplify-cli-core', () => ({
+  pathManager: {
+    getAmplifyMetaFilePath: jest.fn().mockReturnValue('/home/user/project/amplify/backend/amplify-meta.json'),
+    getBackendConfigFilePath: jest.fn().mockReturnValue('/home/user/project/amplify/backend/backend-config.json'),
+  },
+}));
+
+const fsMock = fs as jest.Mocked<typeof fs>;
+
+describe('getCloudInitStatus', () => {
+  test('returns CLOUD_INITIALIZED when amplify meta file exists', () => {
+    fsMock.existsSync.mockReturnValue(true);
+    expect(getCloudInitStatus()).toBe(CLOUD_INITIALIZED);
+  });
+
+  test('returns CLOUD_NOT_INITIALIZED when no amplify meta file exists and backend config file exists', () => {
+    fsMock.existsSync.mockReturnValue(true).mockReturnValueOnce(false);
+    expect(getCloudInitStatus()).toBe(CLOUD_NOT_INITIALIZED);
+  });
+
+  test('returns NON_AMPLIFY_PROJECT when no amplify meta file and backend config file exists', () => {
+    fsMock.existsSync.mockReturnValue(false);
+    expect(getCloudInitStatus()).toBe(NON_AMPLIFY_PROJECT);
+  });
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Increase test coverage of amplify-cli/extensions.

#### Description of how you validated changes

> lerna --scope @aws-amplify/cli run test



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.