### PR TITLE
fix: validates optional non nullable fields to be not null 

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/map.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/map.ts
@@ -32,9 +32,9 @@ export class JavaMap {
             key,
             value,
           },
-          this.mapper
-        )
-      )
+          this.mapper,
+        ),
+      ),
     );
 
     return new JavaArray(entries, this.mapper);
@@ -46,7 +46,7 @@ export class JavaMap {
 
   get(key) {
     if (this.map.has(key.toString())) {
-      return this.map.get(key);
+      return this.map.get(key.toString());
     }
     return null;
   }
@@ -95,7 +95,7 @@ export class JavaMap {
         ...sum,
         [key]: toJSON(value),
       }),
-      {}
+      {},
     );
   }
 }

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -184,6 +184,12 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 #end
 ## [End] Check authMode and execute owner/group checks **
 
+#set( $optionalNonNullableFields = [\\"title\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
@@ -829,6 +835,12 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 #end
 ## [End] Check authMode and execute owner/group checks **
 
+#set( $optionalNonNullableFields = [\\"title\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -186,7 +186,7 @@ exports[`Test "create", "update", "delete" auth operations 4`] = `
 
 #set( $optionalNonNullableFields = [\\"title\\"] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end
@@ -837,7 +837,7 @@ exports[`Test that operation overwrites queries in auth operations 4`] = `
 
 #set( $optionalNonNullableFields = [\\"title\\"] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -27,6 +27,7 @@ import {
   makeUpdateInputObject,
   makeModelXConditionInputObject,
   makeAttributeTypeEnum,
+  getFieldsOptionalNonNullableField,
 } from './definitions';
 import { ModelDirectiveArgs, getCreatedAtFieldName, getUpdatedAtFieldName } from './ModelDirectiveArgs';
 import { ResourceFactory } from './resources';
@@ -361,6 +362,10 @@ export class DynamoDBModelTransformer extends Transformer {
 
     if (shouldMakeUpdate) {
       const updateInput = makeUpdateInputObject(def, nonModelArray, ctx, isSyncEnabled);
+      const optionalNonNullableFields = getFieldsOptionalNonNullableField(
+        updateInput.fields.map(r => r),
+        def,
+      );
       if (!ctx.getType(updateInput.name.value)) {
         ctx.addInput(updateInput);
       }
@@ -369,6 +374,7 @@ export class DynamoDBModelTransformer extends Transformer {
         nameOverride: updateFieldNameOverride,
         syncConfig: this.opts.SyncConfig,
         timestamps: timestampFields,
+        optionalNonNullableFields,
       });
       const resourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName);
       ctx.setResource(resourceId, updateResolver);

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -352,7 +352,13 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"#set( $optionalNonNullableFields = [\\"createdAt\\", \\"updatedAt\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -632,7 +638,13 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"#set( $optionalNonNullableFields = [] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -932,7 +944,13 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"#set( $optionalNonNullableFields = [] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )
@@ -1336,7 +1354,13 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 `;
 
 exports[`Test timestamp parameters when generating resolvers and output schema 3`] = `
-"#if( $authCondition && $authCondition.expression != \\"\\" )
+"#set( $optionalNonNullableFields = [] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
     #foreach( $entry in $modelObjectKey.entrySet() )

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -354,7 +354,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
 "#set( $optionalNonNullableFields = [\\"createdAt\\", \\"updatedAt\\"] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end
@@ -640,7 +640,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
 "#set( $optionalNonNullableFields = [] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end
@@ -946,7 +946,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
 "#set( $optionalNonNullableFields = [] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end
@@ -1356,7 +1356,7 @@ $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
 exports[`Test timestamp parameters when generating resolvers and output schema 3`] = `
 "#set( $optionalNonNullableFields = [] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -15,6 +15,7 @@ import {
 import {
   wrapNonNull,
   unwrapNonNull,
+  isNonNullType,
   makeNamedType,
   toUpper,
   graphqlName,
@@ -201,6 +202,21 @@ export function makeCreateInputObject(
     ],
     directives: [],
   };
+}
+export function getFieldsOptionalNonNullableField(fields: InputValueDefinitionNode[], obj: ObjectTypeDefinitionNode): string[] {
+  const fieldMap = fields.reduce((map, field) => {
+    map.set(field.name.value, field);
+    return map;
+  }, new Map<string, InputValueDefinitionNode>());
+
+  return obj.fields
+    .filter(
+      r =>
+        fieldMap.has(r.name.value) && //field exists in the model
+        isNonNullType(r.type) && // field was non null type in model
+        fieldMap.get(r.name.value).type.kind !== Kind.NON_NULL_TYPE, // field is not nullable type in update mutation model
+    )
+    .map(r => r.name.value);
 }
 
 export function makeUpdateInputObject(

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -503,7 +503,7 @@ export class ResourceFactory {
           set(ref('optionalNonNullableFields'), list(optionalNonNullableExpression)),
           forEach(ref('field'), ref('optionalNonNullableFields'), [
             iff(
-              and([ref('util.isNull($context.args.input.get($field))'), ref('context.arguments.input.keySet().contains($field)')]),
+              and([ref('context.arguments.input.keySet().contains($field)'), ref('util.isNull($context.args.input.get($field))')]),
               ref('util.error("An argument you marked as Non-Null is set to Null in the query or the body of your request.")'),
             ),
           ]),

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -158,6 +158,12 @@ $util.toJson($ctx.result)
   $util.qr($dynamodbNameOverrideMap.put(\\"status#createdAt\\", \\"statusCreatedAt\\"))
 #end
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
+#set( $optionalNonNullableFields = [\\"orderId\\", \\"status\\", \\"createdAt\\", \\"name\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
@@ -766,6 +772,12 @@ $util.toJson($ctx.result)
   $util.qr($dynamodbNameOverrideMap.put(\\"status#createdAt\\", \\"statusCreatedAt\\"))
 #end
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
+#set( $optionalNonNullableFields = [\\"orderId\\", \\"status\\", \\"createdAt\\", \\"name\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )
@@ -1647,6 +1659,12 @@ exports[`GSI composite sort keys are wrapped in conditional to check presence in
   $util.qr($dynamodbNameOverrideMap.put(\\"firstName#lastName\\", \\"firstNameLastName\\"))
 #end
 $util.qr($ctx.args.input.put(\\"firstName#lastName\\",\\"\${ctx.args.input.firstName}#\${ctx.args.input.lastName}\\"))
+#set( $optionalNonNullableFields = [\\"firstName\\", \\"lastName\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
 #if( $authCondition && $authCondition.expression != \\"\\" )
   #set( $condition = $authCondition )
   #if( $modelObjectKey )

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -160,7 +160,7 @@ $util.toJson($ctx.result)
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 #set( $optionalNonNullableFields = [\\"orderId\\", \\"status\\", \\"createdAt\\", \\"name\\"] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end
@@ -774,7 +774,7 @@ $util.toJson($ctx.result)
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 #set( $optionalNonNullableFields = [\\"orderId\\", \\"status\\", \\"createdAt\\", \\"name\\"] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end
@@ -1661,7 +1661,7 @@ exports[`GSI composite sort keys are wrapped in conditional to check presence in
 $util.qr($ctx.args.input.put(\\"firstName#lastName\\",\\"\${ctx.args.input.firstName}#\${ctx.args.input.lastName}\\"))
 #set( $optionalNonNullableFields = [\\"firstName\\", \\"lastName\\"] )
 #foreach( $field in $optionalNonNullableFields )
-  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
 $util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
   #end
 #end

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -205,7 +205,7 @@ test('Test createPost mutation', async () => {
   expect(response.data.createPost.createdAt).toBeDefined();
   expect(response.data.createPost.updatedAt).toBeDefined();
 });
-test.only('Test updateComment mutation with null and empty', async () => {
+test('Test updateComment mutation with null and empty', async () => {
   const requiredFieldValue = 'thisisrequired';
   const notRequiredFieldValue = 'thisisnotrequired';
   const response = await GRAPHQL_CLIENT.query(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -68,6 +68,11 @@ beforeAll(async () => {
       EMPIRE
       JEDI
     }
+    type Require @model {
+      id: ID!
+      requiredField: String!
+      notRequiredField: String
+    }
     type Comment @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn" }) {
       id: ID!
       title: String!
@@ -200,7 +205,67 @@ test('Test createPost mutation', async () => {
   expect(response.data.createPost.createdAt).toBeDefined();
   expect(response.data.createPost.updatedAt).toBeDefined();
 });
-
+test.only('Test updateComment mutation with null and empty', async () => {
+  const requiredFieldValue = 'thisisrequired';
+  const notRequiredFieldValue = 'thisisnotrequired';
+  const response = await GRAPHQL_CLIENT.query(
+    /* GraphQL */ `
+      mutation($input: CreateRequireInput!) {
+        createRequire(input: $input) {
+          id
+          requiredField
+          notRequiredField
+        }
+      }
+    `,
+    {
+      input: {
+        requiredField: requiredFieldValue,
+        notRequiredField: notRequiredFieldValue,
+      },
+    },
+  );
+  expect(response.data.createRequire.id).toBeDefined();
+  const id = response.data.createRequire.id;
+  const updateResponse = await GRAPHQL_CLIENT.query(
+    /* GraphQL */ `
+      mutation($input: UpdateRequireInput!) {
+        updateRequire(input: $input) {
+          id
+          requiredField
+          notRequiredField
+        }
+      }
+    `,
+    {
+      input: {
+        id: id,
+      },
+    },
+  );
+  expect(updateResponse.data.updateRequire.requiredField).toEqual(requiredFieldValue);
+  expect(updateResponse.data.updateRequire.notRequiredField).toEqual(notRequiredFieldValue);
+  const update2Response = await GRAPHQL_CLIENT.query(
+    /* GraphQL */ `
+      mutation($input: UpdateRequireInput!) {
+        updateRequire(input: $input) {
+          id
+          requiredField
+          notRequiredField
+        }
+      }
+    `,
+    {
+      input: {
+        id: id,
+        requiredField: null,
+      },
+    },
+  );
+  expect(update2Response.errors[0].message).toEqual(
+    'An argument you marked as Non-Null is set to Null in the query or the body of your request.',
+  );
+});
 test('Test updatePost mutation', async () => {
   const createResponse = await GRAPHQL_CLIENT.query(
     `mutation {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
For a model with some non-nullable field types
```gql
type ListContainer @model {
  id: ID!
  name: String
  list: [String]
  requiredList: [String]!
  requiredListOfRequired: [String!]!
  listOfRequired: [String!]
}

```
It generates the updateResolver 

```
#set( $optionalNonNullableFields = ["requiredList", "requiredListOfRequired"] )
#foreach( $field in $optionalNonNullableFields )
  #if( $util.isNull($context.args.input.get($field)) && $context.arguments.input.keySet().contains($field) )
$util.error("An argument you marked as Non-Null is set to Null in the query or the body of your request.")
  #end
#end
```

The resolver basically checks if the field exist and is set to null

The schema remains unchanged
```gql
input UpdateListContainerInput {
  id: ID!
  name: String
  list: [String]
  requiredList: [String]
  requiredListOfRequired: [String!]
  listOfRequired: [String!]
}
```
#### Issue #, if available
closes #6961 



#### Description of how you validated changes
``` bash
cd packages/graphql-transformers-e2e-tests
yarn e2e
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.