### PR TITLE
fix: conditionally rebuild container apis on push

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -4,12 +4,16 @@ import path from 'path';
 import { run } from './commands/api/console';
 import { getCfnApiArtifactHandler } from './provider-utils/awscloudformation/cfn-api-artifact-handler';
 
-export { NETWORK_STACK_LOGICAL_ID } from './category-constants'
+export { NETWORK_STACK_LOGICAL_ID } from './category-constants';
 export { DEPLOYMENT_MECHANISM } from './provider-utils/awscloudformation/base-api-stack';
 export { EcsStack } from './provider-utils/awscloudformation/ecs-apigw-stack';
 export { EcsAlbStack } from './provider-utils/awscloudformation/ecs-alb-stack';
 export { getGitHubOwnerRepoFromPath } from './provider-utils/awscloudformation/utils/github';
-export { generateContainersArtifacts, ApiResource, processDockerConfig } from './provider-utils/awscloudformation/utils/containers-artifacts';
+export {
+  generateContainersArtifacts,
+  ApiResource,
+  processDockerConfig,
+} from './provider-utils/awscloudformation/utils/containers-artifacts';
 export { getContainers } from './provider-utils/awscloudformation/docker-compose';
 
 const category = 'api';

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -113,6 +113,11 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject) {
         context.print.info(
           `It may take a few moments for this to appear. If you have trouble with first time deployments, please try refreshing this page after a few moments and watch the CodeBuild Details for debugging information.`,
         );
+
+        if (resourcesToBeUpdated.find(res => res.resourceName === resource.resourceName)) {
+          resource.lastPackageTimeStamp = undefined;
+          await context.amplify.updateamplifyMetaAfterResourceUpdate('api', resource.resourceName, 'lastPackageTimeStamp', undefined);
+        }
       }
 
       if (resource.service === ApiServiceNameElasticContainer && resource.category === 'hosting') {


### PR DESCRIPTION
#### Description of changes
This commit adds logic to rebuild container based APIs during
push if necessary.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/6684

#### Description of how you validated changes
Follow the steps to reproduce in https://github.com/aws-amplify/amplify-cli/issues/6684.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.