### PR TITLE
fix(auth): add-to-group PostConfirmation Lambda should not throw

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
@@ -1,6 +1,6 @@
 /* eslint-disable-line */ const aws = require('aws-sdk');
 
-exports.handler = async (event, context) => {
+exports.handler = async (event, context, callback) => {
   const cognitoidentityserviceprovider = new aws.CognitoIdentityServiceProvider({ apiVersion: '2016-04-18' });
   const groupParams = {
     GroupName: process.env.GROUP,
@@ -19,16 +19,21 @@ exports.handler = async (event, context) => {
     await cognitoidentityserviceprovider.createGroup(groupParams).promise();
   }
 
+  /**
+   * For some reason, naively returning a value / Promise or throwing an error
+   * will not work as it is specified in the Lambda docs:
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html
+   *
+   * This causes an "Invalid JSON" error which can, so far, only be worked
+   * around by resolving with deprecated non-async `callback`:
+   * @see https://github.com/aws-amplify/amplify-cli/issues/2735
+   * @see https://github.com/aws-amplify/amplify-cli/issues/4341
+   * @see https://github.com/aws-amplify/amplify-cli/issues/7179
+   */
   try {
     await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
-    return {
-      statusCode: 200,
-      body: JSON.stringify(event)
-    }
+    callback(null, event);
   } catch (error) {
-    return {
-      statusCode: 500,
-      body: JSON.stringify(error)
-    }
+    callback(new Error(error));
   }
 };

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/add-to-group.js
@@ -1,39 +1,28 @@
 /* eslint-disable-line */ const aws = require('aws-sdk');
 
-exports.handler = async (event, context, callback) => {
-  const cognitoidentityserviceprovider = new aws.CognitoIdentityServiceProvider({ apiVersion: '2016-04-18' });
+exports.handler = async event => {
+  const cognitoidentityserviceprovider = new aws.CognitoIdentityServiceProvider({
+    apiVersion: '2016-04-18',
+  });
   const groupParams = {
     GroupName: process.env.GROUP,
     UserPoolId: event.userPoolId,
   };
-
   const addUserParams = {
     GroupName: process.env.GROUP,
     UserPoolId: event.userPoolId,
     Username: event.userName,
   };
-
+  /**
+   * Check if the group exists; if it doesn't, create it.
+   */
   try {
     await cognitoidentityserviceprovider.getGroup(groupParams).promise();
   } catch (e) {
     await cognitoidentityserviceprovider.createGroup(groupParams).promise();
   }
-
   /**
-   * For some reason, naively returning a value / Promise or throwing an error
-   * will not work as it is specified in the Lambda docs:
-   * @see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html
-   *
-   * This causes an "Invalid JSON" error which can, so far, only be worked
-   * around by resolving with deprecated non-async `callback`:
-   * @see https://github.com/aws-amplify/amplify-cli/issues/2735
-   * @see https://github.com/aws-amplify/amplify-cli/issues/4341
-   * @see https://github.com/aws-amplify/amplify-cli/issues/7179
+   * Then, add the user to the group.
    */
-  try {
-    await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
-    callback(null, event);
-  } catch (error) {
-    callback(new Error(error));
-  }
+  await cognitoidentityserviceprovider.adminAddUserToGroup(addUserParams).promise();
 };

--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/function-template-dir/trigger-index.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/PostConfirmation/function-template-dir/trigger-index.js
@@ -1,14 +1,51 @@
-/*
-  this file will loop through all js modules which are uploaded to the lambda resource,
-  provided that the file names (without extension) are included in the "MODULES" env variable.
-  "MODULES" is a comma-delimmited string.
-*/
+/**
+ * @fileoverview
+ *
+ * This CloudFormation Trigger creates a Lambda function which waits for all
+ * other specified Lambdas (modules) to resolve, which should be located in the
+ * same directory as this file (./).
+ */
+
+/**
+ * The names of modules to load are stored as a comma-delimited string in the
+ * `MODULES` env variable.
+ */
 const moduleNames = process.env.MODULES.split(',');
+/**
+ * The array of imported modules.
+ */
 const modules = moduleNames.map(name => require(`./${name}`));
 
-exports.handler = (event, context, callback) => {
-  for (let i = 0; i < modules.length; i += 1) {
-    const { handler } = modules[i];
-    handler(event, context, callback);
-  }
+/**
+ * This handler is itself a Lambda function which iterates over all of the given
+ * modules and awaits them.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html
+ *
+ * @param {object} event
+ *
+ * The event that triggered this Lambda.
+ *
+ * @param {object} context 
+ *
+ * The context for this Lambda. See:
+ * https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html
+
+ * @param {function} callback 
+ *
+ * A deprecated way to send a response synchronously. See:
+ * https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html#nodejs-handler-sync
+ *
+ * @returns
+ *
+ * The CloudFormation Trigger event.
+ */
+exports.handler = async (event, context, callback) => {
+  /**
+   * Instead of naively iterating over all handlers, run them concurrently with
+   * `await Promise.all(...)`. This would otherwise just be determined by the
+   * order of names in the `MODULES` var.
+   */
+  await Promise.all(modules.map(module => module.handler(event, context, callback)));
+  return event;
 };


### PR DESCRIPTION
#### Description of changes
The "Add Users to Groups" feature offered by `amplify auth` relies on an async Lambda function which, for some reason, will not actually resolve asynchronously, and instead, the PostConfirmation Lambda always throws 400 and breaks the sign-up flow. This PR adds an ugly workaround where the event is resolved with non-async `callback()`.

This is being submitted as a PR and not a draft because the current configuration actively breaks workflows, and merging this (or a modified version of it) ASAP is likely the best move. I'm struggling to get `yarn test` to run because of some issues with Cypress but I plan to circle back around, would appreciate reviews/edits to this PR.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#2735, #4341. Closes #7179.


#### Description of how you validated changes
I spent several hours trying to get the handler to asynchronously resolve to either a Promise or a value itself, but it did was unsuccessful. Only non-asynchronous `context.succeed()`, `context.done()`, and `callback()` allowed the Lambda to successfully complete, and `callback(null, event)` seemed most appropriate.  


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.