### PR TITLE
fix: ensure policy resource name when pushing REST APIs

### DIFF
--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1275,3 +1275,30 @@ export function addAuthUserPoolOnlyNoOAuth(cwd: string, settings: AddAuthUserPoo
       });
   });
 }
+
+export function updateAuthAddAdminQueries(projectDir: string, groupName: string = 'adminQueriesGroup'): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['update', 'auth'], { cwd: projectDir, stripColors: true })
+      .wait('What do you want to do?')
+      .send(KEY_DOWN_ARROW)
+      .send(KEY_DOWN_ARROW)
+      .send(KEY_DOWN_ARROW)
+      .send(KEY_DOWN_ARROW)
+      .sendCarriageReturn() // Create or update Admin queries API
+      .wait('Do you want to restrict access to the admin queries API to a specific Group')
+      .sendConfirmYes()
+      .wait('Select the group to restrict access with')
+      .sendCarriageReturn() // Enter a custom group
+      .wait('Provide a group name')
+      .send(groupName)
+      .sendCarriageReturn()
+      .sendEof()
+      .run((err: Error) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+  });
+}

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -5,6 +5,7 @@ import {
   initJSProjectWithProfile,
   listAttachedRolePolicies,
   listRolePolicies,
+  updateAuthAddAdminQueries,
 } from 'amplify-e2e-core';
 import * as path from 'path';
 import { existsSync } from 'fs';
@@ -402,6 +403,7 @@ describe('amplify add api (REST)', () => {
       allowGuestUsers: false,
     });
     await addRestApi(projRoot, { existingLambda: true });
+    await updateAuthAddAdminQueries(projRoot);
     await amplifyPushUpdate(projRoot);
 
     const amplifyMeta = getProjectMeta(projRoot);

--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -249,6 +249,12 @@ function updateExistingApiCfn(context: $TSContext, api: $TSObject): void {
   for (const parameterName in parameters) {
     if (parameterName === AUTH_ROLE_NAME || parameterName === UNAUTH_ROLE_NAME) {
       delete parameters[parameterName];
+      modified = true;
+    }
+  }
+
+  for (const parameterName in parameterJson as any) {
+    if (parameterName === AUTH_ROLE_NAME || parameterName === UNAUTH_ROLE_NAME) {
       delete parameterJson[parameterName];
       modified = true;
     }

--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -178,10 +178,6 @@ export function consolidateApiGatewayPolicies(context: $TSContext, stackName: st
   const apis = amplifyMeta?.api ?? {};
 
   Object.keys(apis).forEach(resourceName => {
-    if (resourceName === 'AdminQueries') {
-      return;
-    }
-
     const resource = apis[resourceName];
     const apiParams = loadApiWithPrivacyParams(context, resourceName, resource);
 
@@ -220,7 +216,7 @@ function createApiGatewayAuthResources(context: $TSContext, stackName: string, a
 }
 
 export function loadApiWithPrivacyParams(context: $TSContext, name: string, resource: any): object | undefined {
-  if (resource.providerPlugin !== ProviderName || resource.service !== 'API Gateway') {
+  if (resource.providerPlugin !== ProviderName || resource.service !== 'API Gateway' || name === 'AdminQueries') {
     return;
   }
 

--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -277,13 +277,7 @@ function updateExistingApiCfn(context: $TSContext, api: $TSObject): void {
   if (Array.isArray(api.params.paths)) {
     api.params.paths.forEach(path => {
       if (!path.policyResourceName) {
-        if (typeof path.name !== 'string') {
-          const err = new Error(`Malformed parameters file for REST API ${resourceName}`);
-          err.stack = undefined;
-          throw err;
-        }
-
-        path.policyResourceName = path.name.replace(/{[a-zA-Z0-9\-]+}/g, '*');
+        path.policyResourceName = String(path.name).replace(/{[a-zA-Z0-9\-]+}/g, '*');
         modified = true;
       }
     });


### PR DESCRIPTION
#### Description of changes
It is possible that older REST APIs have never been updated to include the `policyResourceName` field on paths. This commit ensures that the field is present.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/7190
https://github.com/aws-amplify/amplify-cli/issues/7201

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.