### PR TITLE
fix: skip credential validation when config has credential_process

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -1,4 +1,4 @@
-import { $TSAny, pathManager, SecretFileMode } from 'amplify-cli-core';
+import { $TSAny, $TSContext, JSONUtilities, pathManager, SecretFileMode } from 'amplify-cli-core';
 
 const aws = require('aws-sdk');
 const fs = require('fs-extra');
@@ -13,7 +13,7 @@ const logger = fileLogger('system-config-manager');
 const credentialsFilePath = pathManager.getAWSCredentialsFilePath();
 const configFilePath = pathManager.getAWSConfigFilePath();
 
-export function setProfile(awsConfig, profileName) {
+export function setProfile(awsConfig: $TSAny, profileName: string) {
   fs.ensureDirSync(pathManager.getDotAWSDirPath());
 
   let credentials = {};
@@ -65,13 +65,13 @@ export function setProfile(awsConfig, profileName) {
   fs.writeFileSync(configFilePath, ini.stringify(config), { mode: SecretFileMode });
 }
 
-export async function getProfiledAwsConfig(context, profileName, isRoleSourceProfile?) {
+export async function getProfiledAwsConfig(context: $TSContext, profileName: string, isRoleSourceProfile?: boolean) {
   let awsConfig;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
   const profileConfig = getProfileConfig(profileName);
   if (profileConfig) {
     logger('getProfiledAwsConfig.profileConfig', [profileConfig])();
-    if (!isRoleSourceProfile && profileConfig.role_arn) {
+    if (!isRoleSourceProfile && (profileConfig.role_arn || profileConfig.credential_process)) {
       const roleCredentials = await getRoleCredentials(context, profileName, profileConfig);
       delete profileConfig.role_arn;
       delete profileConfig.source_profile;
@@ -103,14 +103,14 @@ export async function getProfiledAwsConfig(context, profileName, isRoleSourcePro
   return awsConfig;
 }
 
-function makeFileOwnerReadWrite(filePath) {
+function makeFileOwnerReadWrite(filePath: string) {
   logger('makeFileOwnerReadWrite', [filePath])();
   fs.chmodSync(filePath, '600');
 }
 
-async function getRoleCredentials(context, profileName, profileConfig) {
+async function getRoleCredentials(context: $TSContext, profileName: string, profileConfig: $TSAny) {
   const roleSessionName = profileConfig.role_session_name || 'amplify';
-  let roleCredentials = getCachedRoleCredentials(context, profileConfig.role_arn, roleSessionName);
+  let roleCredentials = getCachedRoleCredentials(profileConfig.role_arn, roleSessionName);
 
   if (!roleCredentials) {
     const sourceProfileAwsConfig = profileConfig.source_profile
@@ -148,7 +148,7 @@ async function getRoleCredentials(context, profileName, profileConfig) {
       log(ex);
     }
 
-    cacheRoleCredentials(context, profileConfig.role_arn, roleSessionName, roleCredentials);
+    cacheRoleCredentials(profileConfig.role_arn, roleSessionName, roleCredentials);
   }
 
   return roleCredentials;
@@ -175,23 +175,22 @@ async function getMfaTokenCode() {
   return answer.tokenCode;
 }
 
-function cacheRoleCredentials(context, roleArn, sessionName, credentials) {
+function cacheRoleCredentials(roleArn: string, sessionName: string, credentials: $TSAny) {
   let cacheContents = {};
-  const cacheFilePath = getCacheFilePath(context);
+  const cacheFilePath = getCacheFilePath();
   if (fs.existsSync(cacheFilePath)) {
-    cacheContents = context.amplify.readJsonFile(cacheFilePath, 'utf-8');
+    cacheContents = JSONUtilities.readJson(cacheFilePath);
   }
   cacheContents[roleArn] = cacheContents[roleArn] || {};
   cacheContents[roleArn][sessionName] = credentials;
-  const jsonString = JSON.stringify(cacheContents, null, 4);
-  fs.writeFileSync(cacheFilePath, jsonString, 'utf8');
+  JSONUtilities.writeJson(cacheFilePath, cacheContents);
 }
 
-function getCachedRoleCredentials(context, roleArn, sessionName) {
+function getCachedRoleCredentials(roleArn: string, sessionName: string) {
   let roleCredentials;
-  const cacheFilePath = getCacheFilePath(context);
+  const cacheFilePath = getCacheFilePath();
   if (fs.existsSync(cacheFilePath)) {
-    const cacheContents = context.amplify.readJsonFile(cacheFilePath, 'utf-8');
+    const cacheContents = JSONUtilities.readJson(cacheFilePath);
     if (cacheContents[roleArn]) {
       roleCredentials = cacheContents[roleArn][sessionName];
       roleCredentials = validateCachedCredentials(roleCredentials) ? roleCredentials : undefined;
@@ -200,7 +199,7 @@ function getCachedRoleCredentials(context, roleArn, sessionName) {
   return roleCredentials;
 }
 
-function validateCachedCredentials(roleCredentials) {
+function validateCachedCredentials(roleCredentials: $TSAny) {
   let isValid = false;
 
   if (roleCredentials) {
@@ -214,7 +213,7 @@ function validateCachedCredentials(roleCredentials) {
   return isValid;
 }
 
-function isCredentialsExpired(roleCredentials) {
+function isCredentialsExpired(roleCredentials: $TSAny) {
   let isExpired = true;
 
   if (roleCredentials && roleCredentials.expiration) {
@@ -226,12 +225,12 @@ function isCredentialsExpired(roleCredentials) {
   return isExpired;
 }
 
-export async function resetCache(context, profileName) {
+export async function resetCache(context: $TSContext, profileName: string) {
   let awsConfig;
   const profileConfig = getProfileConfig(profileName);
-  const cacheFilePath = getCacheFilePath(context);
+  const cacheFilePath = getCacheFilePath();
   if (profileConfig && profileConfig.role_arn && fs.existsSync(cacheFilePath)) {
-    const cacheContents = context.amplify.readJsonFile(cacheFilePath, 'utf-8');
+    const cacheContents = JSONUtilities.readJson(cacheFilePath);
     if (cacheContents[profileConfig.role_arn]) {
       delete cacheContents[profileConfig.role_arn];
       const jsonString = JSON.stringify(cacheContents, null, 4);
@@ -249,14 +248,14 @@ export async function resetCache(context, profileName) {
   return awsConfig;
 }
 
-function getCacheFilePath(context) {
-  const sharedConfigDirPath = path.join(context.amplify.pathManager.getHomeDotAmplifyDirPath(), constants.Label);
+function getCacheFilePath() {
+  const sharedConfigDirPath = path.join(pathManager.getHomeDotAmplifyDirPath(), constants.Label);
   logger('getCacheFilePath', [sharedConfigDirPath])();
   fs.ensureDirSync(sharedConfigDirPath);
   return path.join(sharedConfigDirPath, constants.CacheFileName);
 }
 
-function getProfileConfig(profileName) {
+function getProfileConfig(profileName: string) {
   let profileConfig;
   logger('getProfileConfig', [profileName])();
   if (fs.existsSync(configFilePath)) {
@@ -271,7 +270,7 @@ function getProfileConfig(profileName) {
   return normalizeKeys(profileConfig);
 }
 
-export function getProfileCredentials(profileName) {
+export function getProfileCredentials(profileName: string) {
   let profileCredentials;
   logger('getProfileCredentials', [profileName])();
   if (fs.existsSync(credentialsFilePath)) {
@@ -308,7 +307,7 @@ function validateCredentials(credentials: $TSAny, profileName: string) {
   }
 }
 
-function normalizeKeys(config) {
+function normalizeKeys(config: $TSAny) {
   if (config) {
     config.accessKeyId = config.accessKeyId || config.aws_access_key_id;
     config.secretAccessKey = config.secretAccessKey || config.aws_secret_access_key;
@@ -320,7 +319,7 @@ function normalizeKeys(config) {
   return config;
 }
 
-export function getProfileRegion(profileName) {
+export function getProfileRegion(profileName: string) {
   let profileRegion;
   logger('getProfileRegion', [profileName])();
   const profileConfig = getProfileConfig(profileName);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Update profile logic to skip credential validation when the AWS `config` file has credential_process defined
- Add missing function parameter types for `system-config-manager.ts`
- Fixes support for using credentials sourced by an external process: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html

#### Description of how you validated changes
`yarn test` and manually tested multiple aws profile configurations


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.