### PR TITLE
fix: checking model directive  args when generating mutation input

### DIFF
--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -66,6 +66,7 @@ import {
 } from 'graphql';
 import { AppSync, Fn, Refs } from 'cloudform-types';
 import { Projection, GlobalSecondaryIndex, LocalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
+import _ from 'lodash';
 
 interface KeyArguments {
   name?: string;
@@ -463,10 +464,13 @@ export class KeyTransformer extends Transformer {
       if (ctx.featureFlags.getBoolean('skipOverrideMutationInputTypes', false)) {
         const modelDirective = definition.directives.find(dir => dir.name.value === 'model');
         const modelDirectiveArgs = getDirectiveArguments(modelDirective);
-        // Figure out which mutations to make and if they have name overrides
-        shouldMakeCreate = !!modelDirectiveArgs?.mutations?.create;
-        shouldMakeUpdate = !!modelDirectiveArgs?.mutations?.update;
-        shouldMakeDelete = !!modelDirectiveArgs?.mutations?.delete;
+
+        if (!_.isEmpty(modelDirectiveArgs) && Object.keys(modelDirectiveArgs).includes('mutations')) {
+          // Figure out which mutations to make and if they have name overrides
+          shouldMakeCreate = !!modelDirectiveArgs?.mutations?.create;
+          shouldMakeUpdate = !!modelDirectiveArgs?.mutations?.update;
+          shouldMakeDelete = !!modelDirectiveArgs?.mutations?.delete;
+        }
       }
       const hasIdField = definition.fields.find(f => f.name.value === 'id');
       if (!hasIdField) {

--- a/packages/graphql-key-transformer/src/__tests__/KeyTransformer.test.ts
+++ b/packages/graphql-key-transformer/src/__tests__/KeyTransformer.test.ts
@@ -394,6 +394,99 @@ describe('check schema input', () => {
     expect(senderIdField.type.kind).toBe('NonNullType');
   });
 
+  it('@model mutation with default', () => {
+    const validSchema = /* GraphQL */ `
+      type Call @model @key(fields: ["receiverId", "senderId"]) @key(name: "bySender", fields: ["senderId", "receiverId"]) {
+        senderId: ID!
+        receiverId: ID!
+      }
+
+      input CreateCallInput {
+        receiverId: ID!
+      }
+
+      input DeleteCallInput {
+        receiverId: ID!
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
+      featureFlags: ff,
+    });
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    const schema = parse(out.schema);
+
+    // checlk for delete input
+    const DeleteCallInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+      d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'DeleteCallInput',
+    ) as InputObjectTypeDefinitionNode | undefined;
+    expect(DeleteCallInput).toBeDefined();
+    const receiverIdField = DeleteCallInput.fields.find(f => f.name.value === 'receiverId');
+    expect(receiverIdField).toBeDefined();
+    expect(receiverIdField.type.kind).toBe('NonNullType');
+    const senderIdField = DeleteCallInput.fields.find(f => f.name.value === 'senderId');
+    expect(senderIdField).toBeDefined();
+    expect(senderIdField.type.kind).toBe('NonNullType');
+
+    // check for create input
+    const CreateCallInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+      d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreateCallInput',
+    ) as InputObjectTypeDefinitionNode | undefined;
+    expect(CreateCallInput).toBeDefined();
+    const receiverIdFieldCreate = CreateCallInput.fields.find(f => f.name.value === 'receiverId');
+    expect(receiverIdFieldCreate).toBeDefined();
+    expect(receiverIdFieldCreate.type.kind).toBe('NonNullType');
+    const senderIdFieldCreate = CreateCallInput.fields.find(f => f.name.value === 'senderId');
+    expect(senderIdFieldCreate).toBeUndefined();
+  });
+
+  it('@model mutation with queries', () => {
+    const validSchema = /* GraphQL */ `
+      type Call @model(queries: null) @key(fields: ["receiverId", "senderId"]) @key(name: "bySender", fields: ["senderId", "receiverId"]) {
+        senderId: ID!
+        receiverId: ID!
+      }
+      input CreateCallInput {
+        receiverId: ID!
+      }
+
+      input DeleteCallInput {
+        receiverId: ID!
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
+      featureFlags: ff,
+    });
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    const schema = parse(out.schema);
+
+    // checlk for delete input
+    const DeleteCallInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+      d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'DeleteCallInput',
+    ) as InputObjectTypeDefinitionNode | undefined;
+    expect(DeleteCallInput).toBeDefined();
+    const receiverIdField = DeleteCallInput.fields.find(f => f.name.value === 'receiverId');
+    expect(receiverIdField).toBeDefined();
+    expect(receiverIdField.type.kind).toBe('NonNullType');
+    const senderIdField = DeleteCallInput.fields.find(f => f.name.value === 'senderId');
+    expect(senderIdField).toBeDefined();
+    expect(senderIdField.type.kind).toBe('NonNullType');
+
+    // check for create input
+    const CreateCallInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+      d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreateCallInput',
+    ) as InputObjectTypeDefinitionNode | undefined;
+    expect(CreateCallInput).toBeDefined();
+    const receiverIdFieldCreate = CreateCallInput.fields.find(f => f.name.value === 'receiverId');
+    expect(receiverIdFieldCreate).toBeDefined();
+    expect(receiverIdFieldCreate.type.kind).toBe('NonNullType');
+    const senderIdFieldCreate = CreateCallInput.fields.find(f => f.name.value === 'senderId');
+    expect(senderIdFieldCreate).toBeUndefined();
+  });
+
   it('id field should be optional in updateInputObjects when it is not a primary key', () => {
     const validSchema = /* GraphQL */ `
       type Review
@@ -425,6 +518,6 @@ describe('check schema input', () => {
     expect(UpdateReviewInput).toBeDefined();
     const idField = UpdateReviewInput.fields.find(f => f.name.value === 'id');
     expect(idField).toBeDefined();
-    expect(idField.type.kind).toBe('NonNullType');
+    expect(idField.type.kind).toBe('NamedType');
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
* added check on model directive args if not defined for queries and mutations
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #7168 
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* added unit tests for the breaking changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.