### PR TITLE
chore: change minimum CLI version to Node 12 as it is the minimum LTS

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -5,10 +5,10 @@ machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 
-node10: &node10
+node12: &node12
   working_directory: ~/repo
   docker:
-    - image: circleci/node:10
+    - image: circleci/node:12
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_ACCESS_TOKEN
@@ -58,7 +58,7 @@ install_cli_from_local_registery: &install_cli_from_local_registery
 
 jobs:
   build:
-    <<: *node10
+    <<: *node12
     steps:
       - checkout
       - run: yarn run production-build
@@ -75,7 +75,7 @@ jobs:
           paths: .
 
   test:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -95,7 +95,7 @@ jobs:
           command: yarn coverage
 
   mock_e2e_tests:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -114,7 +114,7 @@ jobs:
           path: packages/amplify-util-mock/
 
   publish_to_local_registry:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -154,7 +154,7 @@ jobs:
             - ~/repo/.amplify-pkg-version
 
   build_pkg_binaries:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -227,12 +227,12 @@ jobs:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
 
   done_with_node_e2e_tests:
-    <<: *node10
+    <<: *node12
     steps:
       - run: echo 'Done with Node CLI E2E Tests'
 
   done_with_pkg_linux_e2e_tests:
-    <<: *node10
+    <<: *node12
     steps:
       - run: echo 'Done with pkg CLI E2E Tests'
 
@@ -473,7 +473,7 @@ jobs:
               echo "Skipping deploy."
             fi
   github_prerelease:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -497,7 +497,7 @@ jobs:
             yarn ts-node scripts/github-prerelease.ts $version
 
   github_prerelease_install_sanity_check:
-    <<: *node10
+    <<: *node12
     steps:
       - restore_cache:
           key: amplfiy-pkg-tag-{{ .Branch }}-{{ .Revision }}
@@ -512,7 +512,7 @@ jobs:
           command: |
             amplify version
   github_release:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -526,7 +526,7 @@ jobs:
             version=$(cat .amplify-pkg-version)
             yarn ts-node scripts/github-release.ts $version
   cleanup_resources:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -543,7 +543,7 @@ jobs:
     working_directory: ~/repo
 
   cleanup_resources_after_e2e_runs:
-    <<: *node10
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ orbs:
 machine:
   environment:
     PATH: ${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin
-node10:
+node12:
   working_directory: ~/repo
   docker: &ref_0
-    - image: circleci/node:10
+    - image: circleci/node:12
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_ACCESS_TOKEN

--- a/packages/amplify-app/package.json
+++ b/packages/amplify-app/package.json
@@ -24,8 +24,8 @@
     "clean": "rimraf ./lib"
   },
   "engines": {
-    "node": ">=10.0.0",
-    "@aws-amplify/cli": ">=4.37.0"
+    "node": ">=12.0.0",
+    "@aws-amplify/cli": ">=4.50.0"
   },
   "dependencies": {
     "amplify-frontend-android": "2.15.1",

--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -61,7 +61,7 @@
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.2",
     "@types/moment-timezone": "0.5.12",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/pino": "5.15.3",
     "@types/ws": "^7.2.3",
     "amplify-graphiql-explorer": "1.4.3"

--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -40,7 +40,7 @@
     "@types/hjson": "^2.4.2",
     "@types/json-schema": "^7.0.5",
     "@types/lodash": "^4.14.149",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/rimraf": "^3.0.0",
     "@types/uuid": "^8.0.0",
     "amplify-function-plugin-interface": "1.7.2",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -30,7 +30,7 @@
     "clean": "rimraf ./lib"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "amplify-app": "2.23.3",
@@ -106,7 +106,7 @@
     "@types/glob": "^7.1.1",
     "@types/global-prefix": "^3.0.0",
     "@types/gunzip-maybe": "^1.4.0",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/node-fetch": "^2.5.7",
     "@types/parse-json": "^4.0.0",
     "@types/progress": "^2.0.3",

--- a/packages/amplify-dotnet-function-runtime-provider/package.json
+++ b/packages/amplify-dotnet-function-runtime-provider/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/which": "^1.3.2"
   }
 }

--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/invoke.ts
@@ -21,8 +21,8 @@ export const invoke = async (request: InvocationRequest): Promise<string> => {
         env: request.envVars,
       },
     );
-    execPromise.stderr.pipe(process.stderr);
-    execPromise.stdout.pipe(process.stdout);
+    execPromise.stderr?.pipe(process.stderr);
+    execPromise.stdout?.pipe(process.stdout);
     result = await execPromise;
   } finally {
     // Clean up

--- a/packages/amplify-dotnet-function-template-provider/package.json
+++ b/packages/amplify-dotnet-function-template-provider/package.json
@@ -28,6 +28,6 @@
   },
   "devDependencies": {
     "@types/inquirer": "^6.5.0",
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   }
 }

--- a/packages/amplify-go-function-runtime-provider/package.json
+++ b/packages/amplify-go-function-runtime-provider/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/semver": "^7.1.0",
     "@types/which": "^1.3.2"
   }

--- a/packages/amplify-go-function-template-provider/package.json
+++ b/packages/amplify-go-function-template-provider/package.json
@@ -24,6 +24,6 @@
     "amplify-function-plugin-interface": "1.7.2"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   }
 }

--- a/packages/amplify-graphiql-explorer/package.json
+++ b/packages/amplify-graphiql-explorer/package.json
@@ -7,7 +7,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.15",
-    "@types/node": "^12.0.0",
+    "@types/node": "^12.12.6",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "cross-env": "^6.0.3",

--- a/packages/amplify-graphql-docs-generator/package.json
+++ b/packages/amplify-graphql-docs-generator/package.json
@@ -16,7 +16,7 @@
     "aws"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "bin": {
     "amplify-graphql-docs-generator": "./bin/cli"
@@ -39,7 +39,7 @@
     "yargs": "^15.1.0"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/prettier": "^1.19.0"
   },
   "jest": {

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -57,7 +57,7 @@
     },
     "devDependencies": {
         "@types/fs-extra": "^8.0.1",
-        "@types/node": "^10.17.13"
+        "@types/node": "^12.12.6"
     },
     "jest": {
         "transform": {

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -61,7 +61,7 @@
     },
     "devDependencies": {
         "@types/fs-extra": "^8.0.1",
-        "@types/node": "^10.17.13"
+        "@types/node": "^12.12.6"
     },
     "jest": {
         "transform": {

--- a/packages/amplify-graphql-types-generator/package.json
+++ b/packages/amplify-graphql-types-generator/package.json
@@ -22,7 +22,7 @@
     "aws"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "bin": "./lib/cli.js",
   "scripts": {
@@ -56,7 +56,7 @@
     "@types/common-tags": "^1.8.0",
     "@types/glob": "^7.1.1",
     "@types/inflected": "^1.1.29",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/yargs": "^15.0.1"
   },
   "jest": {

--- a/packages/amplify-java-function-runtime-provider/package.json
+++ b/packages/amplify-java-function-runtime-provider/package.json
@@ -30,7 +30,7 @@
     "which": "^2.0.2"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/semver": "^7.1.0",
     "@types/which": "^1.3.2"
   }

--- a/packages/amplify-java-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-java-function-runtime-provider/src/utils/invoke.ts
@@ -22,8 +22,8 @@ export const invokeResource = async (request: InvocationRequest, context: any) =
       extendEnv: false,
     },
   );
-  childProcess.stderr.pipe(process.stderr);
-  childProcess.stdout.pipe(process.stdout);
+  childProcess.stderr?.pipe(process.stderr);
+  childProcess.stdout?.pipe(process.stdout);
 
   const { stdout, exitCode } = await childProcess;
   if (exitCode !== 0) {

--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/archiver": "^3.1.0",
     "@types/exit": "^0.1.31",
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-nodejs-function-template-provider/package.json
+++ b/packages/amplify-nodejs-function-template-provider/package.json
@@ -28,6 +28,6 @@
   },
   "devDependencies": {
     "@types/inquirer": "^6.5.0",
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   }
 }

--- a/packages/amplify-python-function-runtime-provider/package.json
+++ b/packages/amplify-python-function-runtime-provider/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/semver": "^7.1.0"
   }
 }

--- a/packages/amplify-python-function-runtime-provider/src/util/invokeUtil.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/invokeUtil.ts
@@ -27,8 +27,8 @@ export async function pythonInvoke(context: any, request: InvocationRequest): Pr
     input: JSON.stringify({ event: request.event, context: {} }) + '\n',
   });
 
-  childProcess.stderr.pipe(process.stderr);
-  childProcess.stdout.pipe(process.stdout);
+  childProcess.stderr?.pipe(process.stderr);
+  childProcess.stdout?.pipe(process.stdout);
 
   const { stdout } = await childProcess;
   const lines = stdout.split('\n');

--- a/packages/amplify-python-function-template-provider/package.json
+++ b/packages/amplify-python-function-template-provider/package.json
@@ -24,6 +24,6 @@
     "amplify-function-plugin-interface": "1.7.2"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   }
 }

--- a/packages/amplify-util-import/package.json
+++ b/packages/amplify-util-import/package.json
@@ -20,6 +20,6 @@
     "aws-sdk": "^2.845.0"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   }
 }

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/detect-port": "^1.3.0",
     "@types/lodash": "^4.14.149",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "@types/semver": "^7.1.0",
     "@types/which": "^1.3.2",
     "amplify-function-plugin-interface": "1.7.2",

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -30,7 +30,7 @@
     "graphql-transformer-core": "6.28.4"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "cloudform-types": "^4.2.0",
     "graphql-dynamodb-transformer": "6.22.4",
     "graphql-elasticsearch-transformer": "4.11.4",

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -31,7 +31,7 @@
     "graphql-transformer-core": "6.28.4"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/md5": "^2.1.33",
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -30,7 +30,7 @@
     "graphql-transformer-core": "6.28.4"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "bestzip": "^2.1.5",
     "graphql-dynamodb-transformer": "6.22.4"
   },

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -29,7 +29,7 @@
     "graphql-transformer-core": "6.28.4"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/md5": "^2.1.33",
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
-    "@types/node": "^10.17.13"
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@aws-amplify/core": "^2.1.0",
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "aws-amplify": "^2.2.2",
     "aws-appsync": "^4.0.3",
     "aws-cdk": "~1.72.0",

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -28,7 +28,7 @@
     "graphql-transformer-core": "6.28.4"
   },
   "devDependencies": {
-    "@types/node": "^10.17.13",
+    "@types/node": "^12.12.6",
     "graphql-dynamodb-transformer": "6.22.4"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7035,16 +7035,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
   integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
 
-"@types/node@^10.17.13":
-  version "10.17.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.35.tgz#58058f29b870e6ae57b20e4f6e928f02b7129f56"
-  integrity sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==
-
-"@types/node@^12.0.0":
-  version "12.19.15"
-  resolved "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz#0de7e978fb43db62da369db18ea088a63673c182"
-  integrity sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==
-
 "@types/node@^12.12.6":
   version "12.19.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.1.tgz#303f74c8a2b35644594139e948b2be470ae1186f"


### PR DESCRIPTION
#### Description of changes

chore: change minimum CLI version to Node 12 as it is the minimum LTS

#### Checklist

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.