### PR TITLE
ci: update cypress base image to node 12

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -358,7 +358,7 @@ jobs:
   integration_test:
     working_directory: ~/repo
     docker:
-      - image: cypress/base:10.18.0
+      - image: cypress/base:12
         environment:
           TERM: dumb
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Java
-          command: sudo apt-get install default-jdk
+          command: sudo apt-get update && sudo apt-get install default-jdk
       - run:
           name: Run Transformer end-to-end tests with mock server
           command: cd packages/amplify-util-mock/ && yarn e2e
@@ -367,7 +367,7 @@ jobs:
   integration_test:
     working_directory: ~/repo
     docker:
-      - image: cypress/base:10.18.0
+      - image: cypress/base:12
         environment:
           TERM: dumb
     resource_class: large


### PR DESCRIPTION
#### Description of changes

ci: update cypress base image to node 12

#### Description of how you validated changes

Cypress base image changed to node 12


#### Checklist

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.