### PR TITLE
fix: parse nested yaml GetAtt refs correctly

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs-extra';
-import * as path from 'path';
 import { CFNTemplateFormat, JSONUtilities, readCFNTemplate, writeCFNTemplate } from '../../lib';
 
 jest.mock('fs-extra');
@@ -47,6 +46,23 @@ describe('readCFNTemplate', () => {
     const result = await readCFNTemplate(testPath);
     expect(result.templateFormat).toEqual(CFNTemplateFormat.YAML);
     expect(result.cfnTemplate).toEqual(testTemplate);
+  });
+
+  it('reads yaml template with nested GetAtt refs', async () => {
+    const yamlContent = `
+      !GetAtt myResource.output.someProp
+    `;
+    ((fs_mock.readFile as unknown) as jest.MockedFunction<TwoArgReadFile>).mockResolvedValueOnce(yamlContent);
+
+    const result = await readCFNTemplate(testPath);
+    expect(result.cfnTemplate).toMatchInlineSnapshot(`
+      Object {
+        "Fn::GetAtt": Array [
+          "myResource",
+          "output.someProp",
+        ],
+      }
+    `);
   });
 });
 

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -112,13 +112,31 @@ const CF_SCHEMA = new yaml.Schema([
   new yaml.Type('!GetAtt', {
     kind: 'scalar',
     construct: function (data) {
-      return { 'Fn::GetAtt': Array.isArray(data) ? data : data.split('.') };
+      if (Array.isArray(data)) {
+        return {
+          'Fn::GetAtt': data,
+        };
+      }
+      // data is a string
+      const firstPeriodIdx = data.indexOf('.');
+      return {
+        'Fn::GetAtt': [data.slice(0, firstPeriodIdx), data.slice(firstPeriodIdx + 1)],
+      };
     },
   }),
   new yaml.Type('!GetAtt', {
     kind: 'sequence',
     construct: function (data) {
-      return { 'Fn::GetAtt': Array.isArray(data) ? data : data.split('.') };
+      if (Array.isArray(data)) {
+        return {
+          'Fn::GetAtt': data,
+        };
+      }
+      // data is a string
+      const firstPeriodIdx = data.indexOf('.');
+      return {
+        'Fn::GetAtt': [data.slice(0, firstPeriodIdx), data.slice(firstPeriodIdx + 1)],
+      };
     },
   }),
   new yaml.Type('!GetAZs', {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Per the CFN spec: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html, the logic for reading YAML templates had a bug where
```yaml
!GetAtt myResource.output.propName
```
would be translated into
```json
{
  "Fn::GetAtt": ["myResource", "output", "propName"]
}
```
instead of
```json
{
  "Fn::GetAtt": ["myResource", "output.propName"]
}
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit tested


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.