### PR TITLE
fix: carry existing container secret config over

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.test.ts
@@ -1,27 +1,9 @@
-import { JSONUtilities } from 'amplify-cli-core';
-import * as fs from 'fs-extra';
 import { setExistingSecretArns } from '../../../../../provider-utils/awscloudformation/utils/containers/set-existing-secret-arns';
-
-jest.mock('fs-extra');
-const fs_mock = fs as jest.Mocked<typeof fs>;
-fs_mock.existsSync.mockReturnValue(true);
-
-jest.mock('amplify-cli-core', () => ({
-  pathManager: {
-    getBackendDirPath: jest.fn().mockReturnValue('/backend/dir/path'),
-  },
-  JSONUtilities: {
-    readJson: jest.fn(),
-  },
-}));
-
-const readJson_mock = JSONUtilities.readJson as jest.MockedFunction<typeof JSONUtilities.readJson>;
 
 describe('set existing secret arns', () => {
   it('does nothing if no template found', () => {
-    fs_mock.existsSync.mockReturnValueOnce(false);
     const secretMap = new Map<string, string>();
-    setExistingSecretArns(secretMap, 'resourceName');
+    setExistingSecretArns(secretMap, {});
     expect(secretMap.size).toBe(0);
   });
 
@@ -40,9 +22,8 @@ describe('set existing secret arns', () => {
         },
       },
     };
-    readJson_mock.mockReturnValueOnce(mockTemplate);
     const secretMap = new Map<string, string>();
-    setExistingSecretArns(secretMap, 'resourceName');
+    setExistingSecretArns(secretMap, mockTemplate);
     expect(secretMap.size).toBe(0);
   });
 
@@ -66,9 +47,8 @@ describe('set existing secret arns', () => {
         },
       },
     };
-    readJson_mock.mockReturnValueOnce(mockTemplate);
     const secretMap = new Map<string, string>();
-    setExistingSecretArns(secretMap, 'resourceName');
+    setExistingSecretArns(secretMap, mockTemplate);
     expect(secretMap.size).toBe(1);
     expect(secretMap.entries().next().value).toMatchInlineSnapshot(`
       Array [

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.test.ts
@@ -1,0 +1,80 @@
+import { JSONUtilities } from 'amplify-cli-core';
+import * as fs from 'fs-extra';
+import { setExistingSecretArns } from '../../../../../provider-utils/awscloudformation/utils/containers/set-existing-secret-arns';
+
+jest.mock('fs-extra');
+const fs_mock = fs as jest.Mocked<typeof fs>;
+fs_mock.existsSync.mockReturnValue(true);
+
+jest.mock('amplify-cli-core', () => ({
+  pathManager: {
+    getBackendDirPath: jest.fn().mockReturnValue('/backend/dir/path'),
+  },
+  JSONUtilities: {
+    readJson: jest.fn(),
+  },
+}));
+
+const readJson_mock = JSONUtilities.readJson as jest.MockedFunction<typeof JSONUtilities.readJson>;
+
+describe('set existing secret arns', () => {
+  it('does nothing if no template found', () => {
+    fs_mock.existsSync.mockReturnValueOnce(false);
+    const secretMap = new Map<string, string>();
+    setExistingSecretArns(secretMap, 'resourceName');
+    expect(secretMap.size).toBe(0);
+  });
+
+  it('does nothing if template does not have secrets', () => {
+    const mockTemplate = {
+      Resources: {
+        TaskDefinition: {
+          Type: 'AWS::ECS::TaskDefinition',
+          Properties: {
+            ContainerDefinitions: [
+              {
+                Secrets: [],
+              },
+            ],
+          },
+        },
+      },
+    };
+    readJson_mock.mockReturnValueOnce(mockTemplate);
+    const secretMap = new Map<string, string>();
+    setExistingSecretArns(secretMap, 'resourceName');
+    expect(secretMap.size).toBe(0);
+  });
+
+  it('adds all secrets to secret map', () => {
+    const mockTemplate = {
+      Resources: {
+        TaskDefinition: {
+          Type: 'AWS::ECS::TaskDefinition',
+          Properties: {
+            ContainerDefinitions: [
+              {
+                Secrets: [
+                  {
+                    Name: 'SOMETHING',
+                    ValueFrom: 'some:secretsmanager:arn',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+    readJson_mock.mockReturnValueOnce(mockTemplate);
+    const secretMap = new Map<string, string>();
+    setExistingSecretArns(secretMap, 'resourceName');
+    expect(secretMap.size).toBe(1);
+    expect(secretMap.entries().next().value).toMatchInlineSnapshot(`
+      Array [
+        "SOMETHING",
+        "some:secretsmanager:arn",
+      ]
+    `);
+  });
+});

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers-artifacts.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers-artifacts.ts
@@ -9,9 +9,10 @@ import Container from '../docker-compose/ecs-objects/container';
 import { EcsStack } from '../ecs-apigw-stack';
 import { API_TYPE, ResourceDependency } from '../../../provider-utils/awscloudformation/service-walkthroughs/containers-walkthrough';
 import { getGitHubOwnerRepoFromPath } from '../../../provider-utils/awscloudformation/utils/github';
-import { JSONUtilities } from 'amplify-cli-core';
+import { JSONUtilities, pathManager, readCFNTemplate } from 'amplify-cli-core';
 import { DEPLOYMENT_MECHANISM } from '../base-api-stack';
 import { setExistingSecretArns } from './containers/set-existing-secret-arns';
+import { category } from '../../../category-constants';
 
 export const cfnFileName = (resourceName: string) => `${resourceName}-cloudformation-template.json`;
 
@@ -289,7 +290,10 @@ export async function processDockerConfig(context: any, resource: ApiResource, s
       secretsArns.set(secretName, secretArn);
     }
   } else {
-    setExistingSecretArns(secretsArns, resourceName);
+    const { cfnTemplate } = await readCFNTemplate(
+      path.join(pathManager.getBackendDirPath(), category, resourceName, cfnFileName(resourceName)),
+    );
+    setExistingSecretArns(secretsArns, cfnTemplate);
   }
 
   const desiredCount = service?.replicas ?? 1; // TODO: 1 should be from meta (HA setting)

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers-artifacts.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers-artifacts.ts
@@ -11,6 +11,9 @@ import { API_TYPE, ResourceDependency } from '../../../provider-utils/awscloudfo
 import { getGitHubOwnerRepoFromPath } from '../../../provider-utils/awscloudformation/utils/github';
 import { JSONUtilities } from 'amplify-cli-core';
 import { DEPLOYMENT_MECHANISM } from '../base-api-stack';
+import { setExistingSecretArns } from './containers/set-existing-secret-arns';
+
+export const cfnFileName = (resourceName: string) => `${resourceName}-cloudformation-template.json`;
 
 export type ApiResource = {
   category: string;
@@ -106,8 +109,7 @@ export async function generateContainersArtifacts(
 
   const cfn = stack.toCloudFormation();
 
-  const cfnFileName = `${resourceName}-cloudformation-template.json`;
-  JSONUtilities.writeJson(path.normalize(path.join(resourceDir, cfnFileName)), cfn);
+  JSONUtilities.writeJson(path.normalize(path.join(resourceDir, cfnFileName(resourceName))), cfn);
 
   return {
     exposedContainer,
@@ -286,6 +288,8 @@ export async function processDockerConfig(context: any, resource: ApiResource, s
 
       secretsArns.set(secretName, secretArn);
     }
+  } else {
+    setExistingSecretArns(secretsArns, resourceName);
   }
 
   const desiredCount = service?.replicas ?? 1; // TODO: 1 should be from meta (HA setting)

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.ts
@@ -1,9 +1,5 @@
-import { $TSAny, JSONUtilities, pathManager } from 'amplify-cli-core';
+import { $TSAny } from 'amplify-cli-core';
 import _ from 'lodash';
-import * as path from 'path';
-import * as fs from 'fs-extra';
-import { category } from '../../../../category-constants';
-import { cfnFileName } from '../containers-artifacts';
 /**
  * Check if the template contains existing secret configuration and if so, add it to the secretsMap
  * The secrets configuration is stored in the template in the following format
@@ -26,15 +22,13 @@ import { cfnFileName } from '../containers-artifacts';
       }
     }
   */
-export const setExistingSecretArns = (secretsMap: Map<string, string>, resourceName: string) => {
-  const cfnPath = path.join(pathManager.getBackendDirPath(), category, resourceName, cfnFileName(resourceName));
-  if (!fs.existsSync(cfnPath)) {
+export const setExistingSecretArns = (secretsMap: Map<string, string>, cfnObj: $TSAny) => {
+  if (_.isEmpty(cfnObj)) {
     return;
   }
-  const cfn = JSONUtilities.readJson<$TSAny>(cfnPath);
-  const taskDef = Object.values(cfn?.Resources) // get all the resources
-    .find((value: $TSAny) => value?.Type === 'AWS::ECS::TaskDefinition') as any; // find the task definition
-  const containerDefs = taskDef?.Properties?.ContainerDefinitions as any[]; // pull out just the container definitions
+  const taskDef = Object.values(cfnObj?.Resources) // get all the resources
+    .find((value: $TSAny) => value?.Type === 'AWS::ECS::TaskDefinition') as $TSAny; // find the task definition
+  const containerDefs = taskDef?.Properties?.ContainerDefinitions as $TSAny[]; // pull out just the container definitions
   if (!Array.isArray(containerDefs)) {
     return;
   }

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers/set-existing-secret-arns.ts
@@ -1,0 +1,48 @@
+import { $TSAny, JSONUtilities, pathManager } from 'amplify-cli-core';
+import _ from 'lodash';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { category } from '../../../../category-constants';
+import { cfnFileName } from '../containers-artifacts';
+/**
+ * Check if the template contains existing secret configuration and if so, add it to the secretsMap
+ * The secrets configuration is stored in the template in the following format
+ * {
+ *   "Resources": {
+      "TaskDefinition": {
+        "Type": "AWS::ECS::TaskDefinition",
+        "Properties": {
+          "ContainerDefinitions": [
+            {
+              "Secrets": [
+                {
+                  "Name": "SECRETNAME",
+                  "ValueFrom": "<some secrets manager arn>"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  */
+export const setExistingSecretArns = (secretsMap: Map<string, string>, resourceName: string) => {
+  const cfnPath = path.join(pathManager.getBackendDirPath(), category, resourceName, cfnFileName(resourceName));
+  if (!fs.existsSync(cfnPath)) {
+    return;
+  }
+  const cfn = JSONUtilities.readJson<$TSAny>(cfnPath);
+  const taskDef = Object.values(cfn?.Resources) // get all the resources
+    .find((value: $TSAny) => value?.Type === 'AWS::ECS::TaskDefinition') as any; // find the task definition
+  const containerDefs = taskDef?.Properties?.ContainerDefinitions as any[]; // pull out just the container definitions
+  if (!Array.isArray(containerDefs)) {
+    return;
+  }
+  containerDefs
+    .map(def => def?.Secrets) // get the secrets array
+    .filter(secrets => !_.isEmpty(secrets)) // filter out defs that don't contain secrets
+    .flat(1) // merge nested secrets array into one array
+    .filter(secretDef => !!secretDef?.Name) // make sure the name is defined
+    .filter(secretDef => !!secretDef.ValueFrom) // make sure the arn is defined
+    .forEach(secretDef => secretsMap.set(secretDef.Name, secretDef.ValueFrom)); // add it to the secretsMap map
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When a customer selected "don't update secrets" when deploying changes to a containers resource, the existing secrets config was removed rather than retained. This change adds logic to parse the existing secret config and apply it to the updated template

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-cli/issues/6669


#### Description of how you validated changes
Manually tested and added unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.