### PR TITLE
fix: install script putting duplicate paths in bash config files

### DIFF
--- a/install
+++ b/install
@@ -86,31 +86,25 @@ if [[ $SHELLTYPE = "fish" ]]; then
   printf "\n$yellow Added ~/.amplify/bin to fish_user_paths universal variable$reset."
 elif [[ $SHELLTYPE = "zsh" ]]; then
   SHELL_CONFIG=$HOME/.zshrc
-  if [ ! -r $SHELL_CONFIG ] || (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
+  if [ -r $SHELL_CONFIG ] && (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
     add_to_path $SHELL_CONFIG
   fi
 else
   SHELL_CONFIG=$HOME/.bashrc
-  if [ ! -r $SHELL_CONFIG ] || (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
+  if [ -r $SHELL_CONFIG ] && (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
     add_to_path $SHELL_CONFIG
   fi
   SHELL_CONFIG=$HOME/.bash_profile
-  if [[ -r $SHELL_CONFIG ]]; then
-    if [[ ! $(grep -q '.amplify/bin' $SHELL_CONFIG) ]]; then
-      add_to_path $SHELL_CONFIG
-    fi
-  else
-    SHELL_CONFIG=$HOME/.bash_login
-    if [[ -r $SHELL_CONFIG ]]; then
-      if [[ ! $(grep -q '.amplify/bin' $SHELL_CONFIG) ]]; then
-        add_to_path $SHELL_CONFIG
-      fi
-    else
-      SHELL_CONFIG=$HOME/.profile
-      if [ ! -r $SHELL_CONFIG ] || (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
-        add_to_path $SHELL_CONFIG
-      fi
-    fi
+  if [ -r $SHELL_CONFIG ] && (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
+    add_to_path $SHELL_CONFIG
+  fi
+  SHELL_CONFIG=$HOME/.bash_login
+  if [ -r $SHELL_CONFIG ] && (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
+    add_to_path $SHELL_CONFIG
+  fi
+  SHELL_CONFIG=$HOME/.profile
+  if [ -r $SHELL_CONFIG ] && (! `grep -q '.amplify/bin' $SHELL_CONFIG`); then
+    add_to_path $SHELL_CONFIG
   fi
 fi
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixed checks for existing file paths in bash config files to prevent subsequent runs of the install script from inserting duplicates

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-cli/issues/6300


#### Description of how you validated changes
Tested manually


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.