### PR TITLE
feat: support adding REST API paths in 'add api'

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/index.ts
@@ -136,9 +136,10 @@ async function isRestContainer(context) {
 }
 
 export async function updateResource(context, category, service, options) {
+  const allowContainers = options?.allowContainers ?? true;
   let useContainerResource = false;
   let apiType = API_TYPE.GRAPHQL;
-  if (isContainersEnabled(context)) {
+  if (allowContainers && isContainersEnabled(context)) {
     const {
       hasAPIGatewayContainerResource,
       hasAPIGatewayLambdaResource,

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -66,6 +66,7 @@ export async function updateWalkthrough(context, defaultValuesFilename) {
       name: 'operation',
       message: 'What would you like to do',
       type: 'list',
+      when: context.input.command !== 'add',
       choices: [
         { name: 'Add another path', value: 'add' },
         { name: 'Update path', value: 'update' },
@@ -75,6 +76,12 @@ export async function updateWalkthrough(context, defaultValuesFilename) {
   ];
 
   const updateApi = await inquirer.prompt(question);
+
+  // Inquirer does not currently support combining 'when' and 'default', so
+  // manually set the operation if the user ended up here via amplify api add.
+  if (context.input.command === 'add') {
+    updateApi.operation = 'add';
+  }
 
   if (updateApi.resourceName === 'AdminQueries') {
     const errMessage = `The Admin Queries API is maintained through the Auth category and should be updated using 'amplify update auth' command`;

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -393,16 +393,18 @@ describe('amplify add api (REST)', () => {
       allowGuestUsers: true,
     });
     await addRestApi(projRoot, {
+      isFirstRestApi: false,
       existingLambda: true,
       restrictAccess: true,
       allowGuestUsers: true,
     });
     await addRestApi(projRoot, {
+      isFirstRestApi: false,
       existingLambda: true,
       restrictAccess: true,
       allowGuestUsers: false,
     });
-    await addRestApi(projRoot, { existingLambda: true });
+    await addRestApi(projRoot, { isFirstRestApi: false, existingLambda: true });
     await updateAuthAddAdminQueries(projRoot);
     await amplifyPushUpdate(projRoot);
 
@@ -426,5 +428,13 @@ describe('amplify add api (REST)', () => {
     for (let i = 0; i < unauthPolicies.length; i++) {
       expect(unauthPolicies[i].PolicyName).toMatch(/PolicyAPIGWUnauth\d/);
     }
+  });
+
+  it('adds a rest api and then adds a path to the existing api', async () => {
+    await initJSProjectWithProfile(projRoot, {});
+    await addFunction(projRoot, { functionTemplate: 'Hello World' }, 'nodejs');
+    await addRestApi(projRoot, { existingLambda: true });
+    await addRestApi(projRoot, { isFirstRestApi: false, existingLambda: true, path: '/newpath' });
+    await amplifyPushUpdate(projRoot);
   });
 });


### PR DESCRIPTION
#### Description of changes
This commit allows `amplify add api` to add new paths to API Gateway based REST APIs.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/5379

#### Description of how you validated changes
Manual and E2E testing.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.