### PR TITLE
test(amplify-provider-awscloudformation): fix a test for system-config-manager that caused an error

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -23,12 +23,15 @@ describe('profile tests', () => {
     return true;
   });
 
-  it('should use credential_process defined in config file', () => {
+  it('should use credential_process defined in config file', async () => {
     fs_mock.readFileSync.mockImplementationOnce(() => {
       return '[profile fake]\noutput = json\nregion = us-fake-1\ncredential_process = fake credential process';
     });
+    fs_mock.readFileSync.mockImplementation(() => {
+      return '{}';
+    });
     const getProfileCredentials_mock = jest.fn(getProfileCredentials);
-    const profile_config = getProfiledAwsConfig(context_stub, 'fake');
+    const profile_config = await getProfiledAwsConfig(context_stub, 'fake');
     expect(profile_config).toBeDefined();
     expect(getProfileCredentials_mock).toHaveBeenCalledTimes(0);
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixed a test that caused an error in system-config-manager.test.ts

When I run `yarn test`, I get the following error:

```
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "Error: 'jsonString' argument missing or empty".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
FAIL src/__tests__/system-config-manager.test.ts
  ● Test suite failed to run

    Call retries were exceeded

      at ChildProcessWorker.initialize (../../node_modules/jest-worker/build/workers/ChildProcessWorker.js:193:21)
```

My environment:
- Node.js v16.0.0
- macOS Big Sur


The cause is as follows.
* The mock function is not returning the expected json string.
* Not waiting for the completion of the validation of the return value of the `getProfiledAwsConfig` function that returns a Promise.

I changed to wait for the completion of the promise. And set return value to mock function.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

```
yarn test
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.