### PR TITLE
fix: #4657 preserve previous authSelections in update flow

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -40,7 +40,7 @@ export const getUpdateAuthDefaultsApplier = (context: any, defaultValuesFilename
 ): Promise<ServiceQuestionsResult> => {
   const { functionMap, getAllDefaults } = await import(`../assets/${defaultValuesFilename}`);
   if (!result.authSelections) {
-    result.authSelections = 'identityPoolAndUserPool';
+    result.authSelections = previousResult.authSelections ?? 'identityPoolAndUserPool';
   }
 
   const defaults = functionMap[result.authSelections](previousResult.resourceName);


### PR DESCRIPTION
#### Description of changes

Fix an `update auth` issue when update flow could end up enabling identity pool that leads to unintended resources during push.

#### Issue #, if available

fix: #4657 preserve previous authSelections in update flow

#### Description of how you validated changes

Manual testing

#### Checklist

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.