### PR TITLE
fix: respect headless frontend input

### DIFF
--- a/packages/amplify-cli/src/__tests__/init-steps/s1-initFrontend.test.ts
+++ b/packages/amplify-cli/src/__tests__/init-steps/s1-initFrontend.test.ts
@@ -1,0 +1,18 @@
+import { getSuitableFrontend } from '../../init-steps/s1-initFrontend';
+
+describe('getSuitableFrontend', () => {
+  it('supports headless inputs', () => {
+    const context = {
+      exeInfo: {
+        inputParams: {
+          amplify: {
+            frontend: 'ios',
+          },
+        },
+      },
+    } as any;
+    const frontendPlugins = { ios: '' } as any;
+    const result = getSuitableFrontend(context, frontendPlugins, '');
+    expect(result).toStrictEqual('ios');
+  });
+});

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -72,7 +72,7 @@ async function displayAndSetDefaults(context: $TSContext, projectPath: string, p
   await displayConfigurationDefaults(context, defaultProjectName, defaultEnv, defaultEditorName);
 
   const frontendPlugins = getFrontendPlugins(context);
-  const defaultFrontend = getSuitableFrontend(frontendPlugins, projectPath);
+  const defaultFrontend = getSuitableFrontend(context, frontendPlugins, projectPath);
   const frontendModule = require(frontendPlugins[defaultFrontend]);
 
   await frontendModule.displayFrontendDefaults(context, projectPath);

--- a/packages/amplify-cli/src/init-steps/s1-initFrontend.ts
+++ b/packages/amplify-cli/src/init-steps/s1-initFrontend.ts
@@ -12,7 +12,7 @@ export async function initFrontend(context: $TSContext) {
   }
 
   const frontendPlugins = getFrontendPlugins(context);
-  const suitableFrontend = getSuitableFrontend(frontendPlugins, context.exeInfo.localEnvInfo.projectPath);
+  const suitableFrontend = getSuitableFrontend(context, frontendPlugins, context.exeInfo.localEnvInfo.projectPath);
   const frontend = await getFrontendHandler(context, frontendPlugins, suitableFrontend);
 
   context.exeInfo.projectConfig.frontend = frontend;
@@ -22,7 +22,13 @@ export async function initFrontend(context: $TSContext) {
   return context;
 }
 
-export function getSuitableFrontend(frontendPlugins: $TSAny, projectPath: string) {
+export function getSuitableFrontend(context: $TSContext, frontendPlugins: $TSAny, projectPath: string) {
+  let headlessFrontend = context?.exeInfo?.inputParams?.amplify?.frontend;
+
+  if (headlessFrontend && headlessFrontend in frontendPlugins) {
+    return headlessFrontend;
+  }
+
   let suitableFrontend;
   let fitToHandleScore = -1;
 


### PR DESCRIPTION
#### Description of changes
This commit updates `getSuitableFrontend()` to respect headless inputs. Prior to this change, all headless projects were defaulting to JavaScript.

#### Description of how you validated changes
Manual and unit testing.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.