### PR TITLE
fix: e2e failed tests for auth Triggers PR

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/generate-auth-trigger-template.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/generate-auth-trigger-template.ts
@@ -87,7 +87,7 @@ async function createCustomResourceforAuthTrigger(context: any, authTriggerConne
 function createCustomResource(stack: cdk.Stack, authTriggerConnections: AuthTriggerConnection[], userpoolId: cdk.CfnParameter) {
   const triggerCode = fs.readFileSync(authTriggerAssetFilePath, 'utf-8');
   const authTriggerFn = new lambda.Function(stack, 'authTriggerFn', {
-    runtime: lambda.Runtime.NODEJS_10_X,
+    runtime: lambda.Runtime.NODEJS_12_X,
     code: lambda.Code.fromInline(triggerCode),
     handler: 'index.handler',
   });

--- a/packages/amplify-provider-awscloudformation/src/utils/upload-auth-trigger-template.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/upload-auth-trigger-template.ts
@@ -14,7 +14,11 @@ export async function uploadAuthTriggerTemplate(context: $TSContext) {
   const category = 'auth';
   let { amplifyMeta } = context.amplify.getProjectDetails();
   const authResource = amplifyMeta?.auth ?? {};
-  const resourceDir = path.join(pathManager.getBackendDirPath(), category, Object.keys(authResource)[0]);
+  const authResourceParams = Object.keys(authResource);
+  if (authResourceParams.length === 0) {
+    return {};
+  }
+  const resourceDir = path.join(pathManager.getBackendDirPath(), category, authResourceParams[0]);
   const authTriggerCfnFilePath = path.join(resourceDir, AUTH_TRIGGER_TEMPLATE);
   const { DeploymentBucketName } = context.amplify.getProjectMeta()?.providers?.[ProviderName] ?? {};
   try {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Added a check to check for authResource when breakcircularddependency is enabled for this PR #6968
Updated auth trigger lambda runtime to node12

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* tested using running e2e test locally

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.