### PR TITLE
feat(graphql-http-transformer): support ${region} template in @http url

### DIFF
--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -191,6 +191,7 @@ export class HttpTransformer extends TransformerPluginBase {
 
     const stack: cdk.Stack = context.stackManager.createStack(HTTP_DIRECTIVE_STACK);
     const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const region = stack.region;
 
     stack.templateOptions.templateFormatVersion = '2010-09-09';
     stack.templateOptions.description = 'An auto-generated nested stack for the @http directive.';
@@ -200,7 +201,7 @@ export class HttpTransformer extends TransformerPluginBase {
       const dataSourceId = HttpResourceIDs.HttpDataSourceID(directive.origin);
 
       if (context.api.getDataSource(dataSourceId) === undefined) {
-        context.api.addHttpDataSource(dataSourceId, replaceEnv(env, directive.origin), {}, stack);
+        context.api.addHttpDataSource(dataSourceId, replaceEnvAndRegion(env, region, directive.origin), {}, stack);
       }
 
       // Create the GraphQL resolver.
@@ -211,6 +212,8 @@ export class HttpTransformer extends TransformerPluginBase {
 
 function createResolver(stack: cdk.Stack, dataSourceId: string, context: TransformerContextProvider, config: HttpDirectiveConfiguration) {
   const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+  const region = stack.region;
+
   const { method, supportsBody } = config;
   const reqCompoundExpr: any[] = [];
   const requestParams: any = { headers: ref('util.toJson($headers)') };
@@ -264,7 +267,7 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
     }),
   );
 
-  const requestTemplateString = replaceEnv(env, printBlock('Create request')(compoundExpression(reqCompoundExpr)));
+  const requestTemplateString = replaceEnvAndRegion(env, region, printBlock('Create request')(compoundExpression(reqCompoundExpr)));
   const requestMappingTemplate = cdk.Token.isUnresolved(requestTemplateString)
     ? MappingTemplate.inlineTemplateFromString(requestTemplateString)
     : MappingTemplate.s3MappingTemplateFromString(requestTemplateString, `${config.resolverTypeName}.${config.resolverFieldName}.req.vtl`);
@@ -293,14 +296,24 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
   );
 }
 
-function replaceEnv(env: cdk.CfnParameter, value: string): string {
-  if (!value.includes('${env}')) {
+function replaceEnvAndRegion(env: cdk.CfnParameter, region: string, value: string): string {
+  const vars: {
+    [key: string]: string;
+  } = {};
+
+  if (value.includes('${env}')) {
+    vars.env = (env as unknown) as string;
+  }
+
+  if (value.includes('${aws_region}')) {
+    vars.aws_region = region;
+  }
+
+  if (Object.keys(vars).length === 0) {
     return value;
   }
 
-  return cdk.Fn.sub(value, {
-    env: (env as unknown) as string,
-  });
+  return cdk.Fn.sub(value, vars);
 }
 
 function makeUrlParamInputObject(directive: HttpDirectiveConfiguration, urlParams: string[]): InputObjectTypeDefinitionNode {

--- a/packages/graphql-http-transformer/src/__tests__/HttpTransformer.test.ts
+++ b/packages/graphql-http-transformer/src/__tests__/HttpTransformer.test.ts
@@ -149,56 +149,56 @@ test('Test HttpTransformer with four basic requests with env on the URI', () => 
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][0]
+    ][0],
   ).toContain('${env}');
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][1].env.Ref
+    ][1].env.Ref,
   ).toBe('env');
 
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content2')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][0]
+    ][0],
   ).toContain('${env}');
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content2')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][1].env.Ref
+    ][1].env.Ref,
   ).toBe('env');
 
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'more')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][0]
+    ][0],
   ).toContain('${env}');
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'more')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][1].env.Ref
+    ][1].env.Ref,
   ).toBe('env');
 
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'evenMore')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][0]
+    ][0],
   ).toContain('${env}');
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'evenMore')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][1].env.Ref
+    ][1].env.Ref,
   ).toBe('env');
 
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'stillMore')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][0]
+    ][0],
   ).toContain('${env}');
   expect(
     out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'stillMore')].Properties.RequestMappingTemplate[
       'Fn::Sub'
-    ][1].env.Ref
+    ][1].env.Ref,
   ).toBe('env');
 });
 
@@ -251,4 +251,135 @@ test('Test HttpTransformer with four basic requests with env on the hostname', (
     ][0];
   expect(out.stacks.HttpStack.Resources[stillMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${env}');
   expect(out.stacks.HttpStack.Resources[stillMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].env.Ref).toBe('env');
+});
+
+test('Test HttpTransformer with four basic requests with aws_region on the URI', () => {
+  const validSchema = `
+    type Comment {
+        id: ID!
+        content: String @http(method: POST, url: "http://www.api.com/ping\${aws_region}")
+        content2: String @http(method: PUT, url: "http://www.api.com/ping\${aws_region}")
+        more: String @http(url: "http://api.com/ping/me/2\${aws_region}")
+        evenMore: String @http(method: DELETE, url: "http://www.google.com/query/id\${aws_region}")
+        stillMore: String @http(method: PATCH, url: "https://www.api.com/ping/id\${aws_region}")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new HttpTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const schemaDoc = parse(out.schema);
+
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][0],
+  ).toContain('${aws_region}');
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][1].aws_region.Ref,
+  ).toBe('AWS::Region');
+
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content2')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][0],
+  ).toContain('${aws_region}');
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content2')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][1].aws_region.Ref,
+  ).toBe('AWS::Region');
+
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'more')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][0],
+  ).toContain('${aws_region}');
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'more')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][1].aws_region.Ref,
+  ).toBe('AWS::Region');
+
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'evenMore')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][0],
+  ).toContain('${aws_region}');
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'evenMore')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][1].aws_region.Ref,
+  ).toBe('AWS::Region');
+
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'stillMore')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][0],
+  ).toContain('${aws_region}');
+  expect(
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'stillMore')].Properties.RequestMappingTemplate[
+      'Fn::Sub'
+    ][1].aws_region.Ref,
+  ).toBe('AWS::Region');
+});
+
+test('Test HttpTransformer with four basic requests with aws_region on the hostname', () => {
+  const validSchema = `
+    type Comment {
+        id: ID!
+        content: String @http(method: POST, url: "http://\${aws_region}www.api.com/ping")
+        content2: String @http(method: PUT, url: "http://\${aws_region}www.api.com/ping")
+        more: String @http(url: "http://\${aws_region}api.com/ping/me/2")
+        evenMore: String @http(method: DELETE, url: "http://\${aws_region}www.google.com/query/id")
+        stillMore: String @http(method: PATCH, url: "https://\${aws_region}www.api.com/ping/id")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new HttpTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const schemaDoc = parse(out.schema);
+
+  const contentDatasource =
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content')].Properties.DataSourceName['Fn::GetAtt'][0];
+  expect(out.stacks.HttpStack.Resources[contentDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${aws_region}');
+  expect(out.stacks.HttpStack.Resources[contentDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].aws_region.Ref).toBe('AWS::Region');
+
+  const content2Datasource =
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'content2')].Properties.DataSourceName[
+      'Fn::GetAtt'
+    ][0];
+  expect(out.stacks.HttpStack.Resources[content2Datasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${aws_region}');
+  expect(out.stacks.HttpStack.Resources[content2Datasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].aws_region.Ref).toBe(
+    'AWS::Region',
+  );
+
+  const moreDatasource =
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'more')].Properties.DataSourceName['Fn::GetAtt'][0];
+  expect(out.stacks.HttpStack.Resources[moreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${aws_region}');
+  expect(out.stacks.HttpStack.Resources[moreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].aws_region.Ref).toBe('AWS::Region');
+
+  const evenMoreDatasource =
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'evenMore')].Properties.DataSourceName[
+      'Fn::GetAtt'
+    ][0];
+  expect(out.stacks.HttpStack.Resources[evenMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${aws_region}');
+  expect(out.stacks.HttpStack.Resources[evenMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].aws_region.Ref).toBe(
+    'AWS::Region',
+  );
+
+  const stillMoreDatasource =
+    out.stacks.HttpStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'stillMore')].Properties.DataSourceName[
+      'Fn::GetAtt'
+    ][0];
+  expect(out.stacks.HttpStack.Resources[stillMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][0]).toContain('${aws_region}');
+  expect(out.stacks.HttpStack.Resources[stillMoreDatasource].Properties.HttpConfig.Endpoint['Fn::Sub'][1].aws_region.Ref).toBe(
+    'AWS::Region',
+  );
 });


### PR DESCRIPTION
#### Description of changes

This commit adds support for a `${region}` template, that is replaced with the AWS region of the
environment. It works similarly to the exiting `${env}` template which returns the name of the current
amplify environment.

#### Issue #, if available

fix #6520

re https://github.com/aws-amplify/docs/pull/3203

#### Description of how you validated changes

I added unit tests. I also created an app using the feature it generated the expected data source  in AppSync.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.