### PR TITLE
chore(amplify-frontend-ios): fix e2e tests

### DIFF
--- a/packages/amplify-app/src/index.js
+++ b/packages/amplify-app/src/index.js
@@ -52,12 +52,6 @@ const run = async opts => {
     if (!opts.skipInit) {
       await createAmplifySkeletonProject(platform.frontend);
     }
-    if (platform.frontend === 'ios' && !opts.internalOnlyIosCallback) {
-      // the ios frontend plugin handles the post init event to call back to ampfliy-app
-      // So we need to return here if this is the original invocation of amplify-app (aka not the callback)
-      // yes, this needs to be refactored
-      return;
-    }
     updateFrameworkInProjectConfig(platform.framework);
     await createAmplifyHelperFiles(platform.frontend);
     console.log(`${emoji.get('white_check_mark')} Amplify setup completed successfully.`);

--- a/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/amplify-app.test.ts
@@ -7,7 +7,7 @@ import {
   amplifyPush,
   addIntegAccountInConfig,
 } from '../amplify-app-helpers/amplify-app-setup';
-import { createNewProjectDir, deleteProject, deleteProjectDir } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProject, deleteProjectDir, isCI } from 'amplify-e2e-core';
 import {
   validateProject,
   validateProjectConfig,
@@ -41,6 +41,12 @@ describe('amplify-app platform tests', () => {
   });
 
   it('should setup an iOS project', async () => {
+    // disable this test locally to prevent execution of
+    // amplify-xcode in an empty folder.
+    // TODO: copy a valid Xcode project before executing this test
+    if (!isCI()) {
+      return;
+    }
     await amplifyAppIos(projRoot);
     validateProject(projRoot, 'ios');
     validateProjectConfig(projRoot, 'ios');

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-validation.ts
@@ -12,7 +12,6 @@ function validateProject(projRoot: string, platform: string) {
       expect(fs.existsSync(path.join(projRoot, 'app', 'src', 'main', 'res', 'raw', 'amplifyconfiguration.json'))).toBe(true);
       break;
     case 'ios':
-      expect(fs.existsSync(path.join(projRoot, 'amplifytools.xcconfig'))).toBe(true);
       expect(fs.existsSync(path.join(projRoot, 'amplifyconfiguration.json'))).toBe(true);
       expect(fs.existsSync(path.join(projRoot, 'awsconfiguration.json'))).toBe(true);
       break;


### PR DESCRIPTION
#### Description of changes
This PR fixes the e2e `amplify-app` tests for iOS projects.

#### Description of how you validated changes
Validated the following flows in an Amplify iOS project:
- `amplify init --quickstart platform ios`
- `amplify init`
- `amplify codegen models`

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.