### PR TITLE
fix: cross resource permission handling

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -31,7 +31,7 @@ export const askExecRolePermissionsQuestions = async (
 
   const amplifyMeta = stateManager.getMeta();
 
-  const categories = Object.keys(amplifyMeta).filter(category => category !== 'providers');
+  const categories = Object.keys(amplifyMeta).filter(category => category !== 'providers' && category !== 'predictions');
 
   // retrieve api's AppSync resource name for conditional logic
   // in blending appsync @model-backed dynamoDB tables into storage category flow
@@ -186,8 +186,16 @@ export const askExecRolePermissionsQuestions = async (
         }
       }
     } catch (e) {
-      context.print.warning(`Policies cannot be added for ${selectedCategory}`);
-      context.print.info(e.stack);
+      if (e.name === 'MethodNotFound') {
+        context.print.warning(`${selectedCategory} category does not support resource policies yet.`);
+      } else {
+        context.print.warning(`Policies cannot be added for ${selectedCategory}`);
+      }
+
+      if (e.stack) {
+        context.print.info(e.stack);
+      }
+
       context.usageData.emitError(e);
       process.exitCode = 1;
     }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/invoke-plugin-method.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/invoke-plugin-method.ts
@@ -18,7 +18,12 @@ export const invokePluginMethod = async <T>(
   const pluginMethod: any = plugin[method];
 
   if (!pluginMethod || typeof pluginMethod !== 'function') {
-    throw new Error(`Method ${method} does not exist or not a function in category plugin: ${category}.`);
+    const error = new Error(`Method ${method} does not exist or not a function in category plugin: ${category}.`);
+
+    error.name = 'MethodNotFound';
+    error.stack = undefined;
+
+    throw error;
   }
 
   return pluginMethod(...args);


### PR DESCRIPTION
#### Description of changes

This PR enhances the handling of cross resource permission handling for `predictions` category to filter out those resources as it does not support it yet.

![image](https://user-images.githubusercontent.com/230432/117489461-83357680-af22-11eb-84d9-23e04067c54f.png)

Also plugin invocation is enhanced to set `MethodNotFound` of the caller wants to handle it differently.

![image](https://user-images.githubusercontent.com/230432/117489421-7749b480-af22-11eb-8ae8-bb6073b9ccd8.png)

#### Issue #, if available

fixes the messaging part of #7269 enhancement

#### Description of how you validated changes

Manual testing

#### Checklist

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.