### PR TITLE
fix: add `sharedId` in `externalAuthEnable()`

### DIFF
--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -116,6 +116,7 @@ async function externalAuthEnable(context, externalCategory, resourceName, requi
     ? Object.assign(defaults.functionMap[requirements.authSelections](currentAuthName), currentAuthParams, immutables, requirements)
     : Object.assign(defaults.functionMap[requirements.authSelections](currentAuthName), requirements, {
         resourceName: `cognito${sharedId}`,
+        sharedId: defaults.sharedId,
       }); //eslint-disable-line
   /* eslint-enable */
   const { roles } = defaults;

--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -1,7 +1,6 @@
 const category = 'auth';
 
 const _ = require('lodash');
-const uuid = require('uuid');
 const path = require('path');
 const sequential = require('promise-sequential');
 
@@ -72,7 +71,6 @@ async function externalAuthEnable(context, externalCategory, resourceName, requi
     .projectName.toLowerCase()
     .replace(/[^A-Za-z0-9_]+/g, '_');
   let currentAuthParams;
-  const [sharedId] = uuid().split('-');
 
   const immutables = {};
 
@@ -115,7 +113,7 @@ async function externalAuthEnable(context, externalCategory, resourceName, requi
   const authPropsValues = authExists
     ? Object.assign(defaults.functionMap[requirements.authSelections](currentAuthName), currentAuthParams, immutables, requirements)
     : Object.assign(defaults.functionMap[requirements.authSelections](currentAuthName), requirements, {
-        resourceName: `cognito${sharedId}`,
+        resourceName: `cognito${defaults.sharedId}`,
         sharedId: defaults.sharedId,
       }); //eslint-disable-line
   /* eslint-enable */

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/cognito-defaults.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/assets/cognito-defaults.js
@@ -96,4 +96,5 @@ module.exports = {
   withSocialDefaults,
   entityKeys,
   roles,
+  sharedId,
 };


### PR DESCRIPTION
#### Description of changes
This commit updates `externalAuthEnable()` to include the auth `sharedId` when creating an auth resource. The `sharedId` is given the lowest priority in the `authProps` object so that it will not overwrite any previously existing `sharedId`. It also uses the `sharedId` from `cognito-defaults` for consistency. This change prevents the creation of `snsundefined` roles.

#### Issue #, if available
N/A

#### Description of how you validated changes
Manual testing - create a new project, add a REST API with restricted access

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.