### PR TITLE
fix: scope down usage of PassRole

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/user-pool-group-template.json.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/user-pool-group-template.json.ejs
@@ -185,7 +185,10 @@
                                     "Action": [
                                         "iam:PassRole"
                                     ],
-                                    "Resource": "*"
+                                    "Resource": [
+                                        { "Ref": "AuthRoleArn" },
+                                        { "Ref": "UnauthRoleArn" }
+                                    ]
                                 }
                             ]
                         }
@@ -235,7 +238,6 @@
                                 "    cognitoidentity.setIdentityPoolRoles(params).promise();",
                                 "    response.send(event, context, response.SUCCESS, {message: 'Successfully updated identity pool.'})",
                                 "    } catch(err) {",
-
                                 "        response.send(event, context, response.FAILED, {message: 'Error updating identity pool'});",
                                 "    }",
                                 "   };",


### PR DESCRIPTION
#### Description of changes
This commit reduces the scope of `iam:PassRole` to be limited to Amplify's `authRole` and `unauthRole`.

#### Issue #, if available
N/A

#### Description of how you validated changes
Manual testing - add Cognito user pool groups to a project and push. Any additional pointers on testing this feature are welcome.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.