### PR TITLE
fix: nexpect pathname parsing (#7324)

### DIFF
--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -19,6 +19,7 @@ import { AssertionError } from 'assert';
 import strip = require('strip-ansi');
 import { EOL } from 'os';
 import retimer = require('retimer');
+import { join, parse } from 'path';
 
 const DEFAULT_NO_OUTPUT_TIMEOUT = 5 * 60 * 1000; // 5 Minutes
 const EXIT_CODE_TIMEOUT = 2;
@@ -592,9 +593,9 @@ export function nspawn(command: string | string[], params: string[] = [], option
     params = command;
     command = params.shift();
   } else if (typeof command === 'string') {
-    command = command.split(' ');
-    params = params || command.slice(1);
-    command = command[0];
+    const parsedPath = parse(command);
+    command = join(parsedPath.dir, parsedPath.base.split(' ')[0]);
+    params = params || parsedPath.base.split(' ').splice(1);
   }
 
   let childEnv = undefined;

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -594,8 +594,9 @@ export function nspawn(command: string | string[], params: string[] = [], option
     command = params.shift();
   } else if (typeof command === 'string') {
     const parsedPath = parse(command);
-    command = join(parsedPath.dir, parsedPath.base.split(' ')[0]);
-    params = params || parsedPath.base.split(' ').splice(1);
+    const parsedArgs = parsedPath.base.split(' ');
+    command = join(parsedPath.dir, parsedArgs[0]);
+    params = params || parsedArgs.slice(1);
   }
 
   let childEnv = undefined;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR fixes the nexpect pathname parsing bug, where nexpect trims pathnames with spaces in it.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes #7324 


#### Description of how you validated changes
The environment tests located in `amplify-e2e-tests` is passing.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.