### PR TITLE
fix: make ECR repository name validation more strict

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/containers-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/containers-walkthrough.ts
@@ -69,8 +69,8 @@ async function askResourceName(context, allDefaultValues) {
       validate: amplify.inputValidation({
         validation: {
           operator: 'regex',
-          value: '^[a-zA-Z0-9]+$',
-          onErrorMsg: 'Resource name should be alphanumeric',
+          value: '^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$',
+          onErrorMsg: 'Resource name should be alphanumeric with no uppercase letters',
         },
         required: true,
       }),


### PR DESCRIPTION
#### Description of changes
This commit makes the ECR repository name validation more strict.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/7322

#### Description of how you validated changes
Manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.