### PR TITLE
fix: removing individual non-legacy layer regenerates cfn template

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
@@ -59,7 +59,7 @@ const layerCloudReturnStub: LayerVersionMetadata[] = [
     permissions: [],
     LogicalName: 'myLayer',
     Version: 10,
-    LegacyLayer: true,
+    legacyLayer: true,
   },
   {
     LogicalName: 'anotherLayer',
@@ -70,7 +70,7 @@ const layerCloudReturnStub: LayerVersionMetadata[] = [
     CompatibleRuntimes: ['nodejs14.x'],
     LicenseInfo: '',
     permissions: [],
-    LegacyLayer: true,
+    legacyLayer: true,
   },
 ];
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
@@ -4,9 +4,11 @@ describe('remove walkthough test', () => {
   const layerName = 'layerName';
   const module = __dirname + '/dummy_module';
   const deleteLayerVersionsMockFn = jest.fn();
-  const saveLayerVersionsToBeRemovedByCfn = jest.fn();
   const loadLayerDataFromCloudMock = jest.fn();
+  const loadStoredLayerParameters = jest.fn();
+  const saveLayerVersionsToBeRemovedByCfn = jest.fn();
   const selectPromptMock = jest.fn();
+  const updateLayerArtifacts = jest.fn();
 
   beforeEach(() => {
     mockContext = {
@@ -38,8 +40,9 @@ describe('remove walkthough test', () => {
     }));
 
     jest.mock('../../../../provider-utils/awscloudformation/utils/layerHelpers', () => ({
-      loadLayerDataFromCloud: loadLayerDataFromCloudMock,
       getLayerName: jest.fn().mockReturnValue(layerName),
+      loadLayerDataFromCloud: loadLayerDataFromCloudMock,
+      loadStoredLayerParameters: loadStoredLayerParameters,
     }));
 
     jest.mock('../../../../provider-utils/awscloudformation/utils/layerCloudState', () => ({
@@ -48,6 +51,10 @@ describe('remove walkthough test', () => {
           getLayerVersionsFromCloud: loadLayerDataFromCloudMock,
         }),
       },
+    }));
+
+    jest.mock('../../../../provider-utils/awscloudformation/utils/storeResources', () => ({
+      updateLayerArtifacts: updateLayerArtifacts,
     }));
 
     jest.mock('inquirer', () => ({

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
@@ -1,7 +1,7 @@
 import { $TSContext } from 'amplify-cli-core';
 import { FunctionDependency, LambdaLayer } from 'amplify-function-plugin-interface';
 import enquirer from 'enquirer';
-import inquirer, { CheckboxQuestion, InputQuestion, ListQuestion } from 'inquirer';
+import inquirer, { CheckboxQuestion, InputQuestion } from 'inquirer';
 import { categoryName } from '../../../../constants';
 import {
   askCustomArnQuestion,
@@ -12,7 +12,6 @@ import {
 import { ServiceName } from '../../../../provider-utils/awscloudformation/utils/constants';
 import { getLayerRuntimes } from '../../../../provider-utils/awscloudformation/utils/layerConfiguration';
 import { LayerCloudState } from '../../../../provider-utils/awscloudformation/utils/layerCloudState';
-import { layerVersionQuestion } from '../../../../provider-utils/awscloudformation/utils/layerHelpers';
 import { LayerVersionMetadata } from '../../../../provider-utils/awscloudformation/utils/layerParams';
 
 jest.mock('inquirer');
@@ -80,7 +79,7 @@ const layerCloudReturnStub: LayerVersionMetadata[] = [
     permissions: [],
     LogicalName: 'myLayer',
     Version: 1,
-    LegacyLayer: false,
+    legacyLayer: false,
   },
   {
     LogicalName: 'aLayer',
@@ -91,7 +90,7 @@ const layerCloudReturnStub: LayerVersionMetadata[] = [
     CompatibleRuntimes: ['nodejs14.x'],
     LicenseInfo: '',
     permissions: [],
-    LegacyLayer: false,
+    legacyLayer: false,
   },
 ];
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/buildLayer.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/buildLayer.test.ts
@@ -1,5 +1,5 @@
 import { $TSContext, pathManager } from 'amplify-cli-core';
-import { BuildType, FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
+import { FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
 import { buildLayer } from '../../../../provider-utils/awscloudformation/utils/buildLayer';
 import { loadLayerConfigurationFile } from '../../../../provider-utils/awscloudformation/utils/layerConfiguration';
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
@@ -1,3 +1,4 @@
+import { pathManager, stateManager } from 'amplify-cli-core';
 import { ServiceName } from '../../../../provider-utils/awscloudformation/utils/constants';
 import {
   LayerParameters,
@@ -5,14 +6,17 @@ import {
   LayerVersionCfnMetadata,
   PermissionEnum,
 } from '../../../../provider-utils/awscloudformation/utils/layerParams';
-import { getLayerDirPath, isMultiEnvLayer } from '../../../../provider-utils/awscloudformation/utils/layerHelpers';
+import { isMultiEnvLayer } from '../../../../provider-utils/awscloudformation/utils/layerHelpers';
+
+jest.mock('amplify-cli-core');
+const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
+const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
+pathManager_mock.getResourceDirectoryPath.mockReturnValue('fakeProject/amplify/backend/myLayer/');
+stateManager_mock.getLocalEnvInfo.mockReturnValue({ envName: 'mock' });
 
 jest.mock('../../../../provider-utils/awscloudformation/utils/layerHelpers');
 const isMultiEnvLayer_mock = isMultiEnvLayer as jest.MockedFunction<typeof isMultiEnvLayer>;
-const getLayerDirPath_mock = getLayerDirPath as jest.MockedFunction<typeof getLayerDirPath>;
-
 isMultiEnvLayer_mock.mockImplementation(jest.fn(() => true));
-getLayerDirPath_mock.mockImplementation(jest.fn(() => 'fakeProject/amplify/backend/myLayer/'));
 
 const parameters_stub: LayerParameters = {
   build: true,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
@@ -4,8 +4,9 @@ import inquirer, { QuestionCollection } from 'inquirer';
 import ora from 'ora';
 import { LayerCloudState } from '../utils/layerCloudState';
 import { saveLayerVersionsToBeRemovedByCfn } from '../utils/layerConfiguration';
-import { getLayerName } from '../utils/layerHelpers';
+import { loadStoredLayerParameters, getLayerName } from '../utils/layerHelpers';
 import { LayerVersionMetadata } from '../utils/layerParams';
+import { updateLayerArtifacts } from '../utils/storeResources';
 
 const removeLayerQuestion = 'Choose the Layer versions you want to remove.';
 
@@ -60,6 +61,15 @@ export async function removeWalkthrough(context: $TSContext, layerName: string):
         envName,
       );
     }
+
+    // Load configuration for layer and regenerate cfn template
+    const layerParameters = loadStoredLayerParameters(context, layerName);
+    updateLayerArtifacts(context, layerParameters, {
+      generateCfnFile: true,
+      updateDescription: false,
+      updateLayerParams: false,
+      updateMeta: false,
+    });
 
     return undefined;
   }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerConfiguration.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerConfiguration.ts
@@ -1,9 +1,8 @@
-import { $TSAny, JSONUtilities, recursiveOmit, stateManager } from 'amplify-cli-core';
+import { $TSAny, JSONUtilities, pathManager, recursiveOmit, stateManager } from 'amplify-cli-core';
 import _ from 'lodash';
 import * as path from 'path';
 import { ephemeralField, deleteVersionsField, layerConfigurationFileName, updateVersionPermissionsField } from './constants';
 import { categoryName } from '../../../constants';
-import { getLayerDirPath } from './layerHelpers';
 import { LayerParameters, LayerPermission, LayerRuntime, PermissionEnum } from './layerParams';
 
 export type LayerConfiguration = Pick<LayerParameters, 'permissions' | 'runtimes' | 'description'>;
@@ -95,12 +94,20 @@ function getLayerDescription(layerName: string): string {
 }
 
 export function loadLayerConfigurationFile(layerName: string, throwIfNotExist = true) {
-  const layerConfigFilePath = path.join(getLayerDirPath(layerName), layerConfigurationFileName);
+  const layerConfigFilePath = path.join(
+    pathManager.getResourceDirectoryPath(undefined, categoryName, layerName),
+    layerConfigurationFileName,
+  );
+
   return JSONUtilities.readJson<$TSAny>(layerConfigFilePath, { throwIfNotExist });
 }
 
 export function writeLayerConfigurationFile(layerName: string, layerConfig: $TSAny) {
-  const layerConfigFilePath = path.join(getLayerDirPath(layerName), layerConfigurationFileName);
+  const layerConfigFilePath = path.join(
+    pathManager.getResourceDirectoryPath(undefined, categoryName, layerName),
+    layerConfigurationFileName,
+  );
+
   JSONUtilities.writeJson(layerConfigFilePath, layerConfig);
 }
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -206,19 +206,19 @@ export function loadStoredLayerParameters(context: $TSContext, layerName: string
   };
 }
 
-export function getLayerDirPath(layerName: string) {
-  return path.join(pathManager.getBackendDirPath(), categoryName, layerName);
-}
-
 export async function isNewVersion(layerName: string) {
   const previousHash = loadPreviousLayerHash(layerName);
-  const currentHash = await hashLayerVersionContents(getLayerDirPath(layerName));
+  const currentHash = await hashLayerVersionContents(pathManager.getResourceDirectoryPath(undefined, categoryName, layerName));
 
   return previousHash !== currentHash;
 }
 
 export function isMultiEnvLayer(layerName: string) {
-  const layerParametersPath = path.join(getLayerDirPath(layerName), LegacyFilename.layerParameters);
+  const layerParametersPath = path.join(
+    pathManager.getResourceDirectoryPath(undefined, categoryName, layerName),
+    LegacyFilename.layerParameters,
+  );
+
   if (fs.existsSync(layerParametersPath)) {
     return false;
   }
@@ -239,7 +239,7 @@ export function getLayerName(context: $TSContext, layerName: string): string {
 
 // Check hash results for content changes, bump version if so
 export async function ensureLayerVersion(context: $TSContext, layerName: string, previousHash: string) {
-  const currentHash = await hashLayerVersionContents(getLayerDirPath(layerName));
+  const currentHash = await hashLayerVersionContents(pathManager.getResourceDirectoryPath(undefined, categoryName, layerName));
 
   if (previousHash !== currentHash) {
     if (previousHash) {
@@ -320,6 +320,6 @@ async function checkLambdaLayerChanges(resource: $TSAny): Promise<boolean> {
   const { resourceName } = resource;
   const previousHash = loadPreviousLayerHash(resourceName);
   if (!previousHash) return true;
-  const currentHash = await hashLayerVersionContents(getLayerDirPath(resourceName));
+  const currentHash = await hashLayerVersionContents(pathManager.getResourceDirectoryPath(undefined, categoryName, resourceName));
   return currentHash !== previousHash;
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
@@ -7,7 +7,6 @@ import { categoryName } from '../../../constants';
 import { layerConfigurationFileName, LegacyFilename, versionHash } from './constants';
 import { loadPluginFromFactory } from './functionPluginLoader';
 import { writeLayerConfigurationFile } from './layerConfiguration';
-import { getLayerDirPath } from './layerHelpers';
 import { defaultLayerPermission, LayerPermission, LayerRuntime, PermissionEnum } from './layerParams';
 
 export const enum LegacyPermissionEnum {
@@ -42,7 +41,7 @@ const enum LegacyState {
 const layerVersionMapKey = 'layerVersionMap';
 
 export async function migrateLegacyLayer(context: $TSContext, layerName: string): Promise<boolean> {
-  const layerDirPath = getLayerDirPath(layerName);
+  const layerDirPath = pathManager.getResourceDirectoryPath(undefined, categoryName, layerName);
   const legacyState = isLegacyLayer(layerName, layerDirPath);
 
   if (legacyState === LegacyState.NOT_LEGACY) {
@@ -63,7 +62,7 @@ This change requires a migration. Amplify will create a new Lambda layer version
   }
 
   const runtimeCloudTemplateValues: string[] = [];
-  const layerConfiguration: { permissions: LayerPermission[]; runtimes: LayerRuntime[]; nonMultiEnv?: boolean } = {
+  const layerConfiguration: { permissions: LayerPermission[]; runtimes: Partial<LayerRuntime>[]; nonMultiEnv?: boolean } = {
     permissions: undefined,
     runtimes: undefined,
   };

--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -109,7 +109,7 @@ export class PathManager {
   getResourceDirectoryPath = (projectPath: string | undefined, category: string, resourceName: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, category, resourceName]);
 
-  getResourceParamatersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
+  getResourceParametersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
     path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.ParametersJsonFileName);
 
   getReadMeFilePath = (projectPath?: string): string =>

--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -100,26 +100,17 @@ export class PathManager {
   getBackendConfigFilePath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.BackendConfigFileName]);
 
-  getTagFilePath = (projectPath?: string): string => {
-    return this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.TagsFileName]);
-  };
+  getTagFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.TagsFileName]);
 
-  getCurrentTagFilePath = (projectPath?: string): string => {
-    return this.constructPath(projectPath, [
-      PathConstants.AmplifyDirName,
-      PathConstants.CurrentCloudBackendDirName,
-      PathConstants.TagsFileName,
-    ]);
-  };
+  getCurrentTagFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName, PathConstants.TagsFileName]);
+
+  getResourceDirectoryPath = (projectPath: string | undefined, category: string, resourceName: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, category, resourceName]);
 
   getResourceParamatersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
-    this.constructPath(projectPath, [
-      PathConstants.AmplifyDirName,
-      PathConstants.BackendDirName,
-      category,
-      resourceName,
-      PathConstants.ParametersJsonFileName,
-    ]);
+    path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.ParametersJsonFileName);
 
   getReadMeFilePath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.ReadMeFileName]);

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -124,7 +124,7 @@ export class StateManager {
     resourceName: string,
     options?: GetOptions<$TSAny>,
   ): $TSAny => {
-    const filePath = pathManager.getResourceParamatersFilePath(projectPath, category, resourceName);
+    const filePath = pathManager.getResourceParametersFilePath(projectPath, category, resourceName);
     const mergedOptions = {
       throwIfNotExist: true,
       ...options,
@@ -217,7 +217,7 @@ export class StateManager {
   };
 
   setResourceParametersJson = (projectPath: string | undefined, category: string, resourceName: string, parameters: $TSAny): void => {
-    const filePath = pathManager.getResourceParamatersFilePath(projectPath, category, resourceName);
+    const filePath = pathManager.getResourceParametersFilePath(projectPath, category, resourceName);
 
     JSONUtilities.writeJson(filePath, parameters);
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change ensures the Lambda layer resource is in the update state after removing an individual version.


#### Description of how you validated changes
Manual testing and yarn test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.