### PR TITLE
test: use build cli for integ test

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -357,27 +357,36 @@ jobs:
 
   integration_test:
     working_directory: ~/repo
+    resource_class: large
     docker:
       - image: cypress/base:12
         environment:
           TERM: dumb
-    resource_class: large
     steps:
-      - checkout
-      - run: apt-get update
-      - run: apt-get install -y sudo
-      - run: sudo apt-get install -y tcl
-      - run: sudo apt-get install -y expect
-      - run: sudo apt-get install -y zip
-      - run: sudo apt-get install -y lsof
-      - run: sudo apt-get install -y python
-      - run: sudo apt-get install -y python-pip libpython-dev
-      - run: sudo apt-get install -y jq
-      - run: pip install awscli
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Setup Dependencies
+          command: |
+            apt-get update
+            apt-get install -y sudo
+            sudo apt-get install -y tcl
+            sudo apt-get install -y expect
+            sudo apt-get install -y zip
+            sudo apt-get install -y lsof
+            sudo apt-get install -y python python-pip libpython-dev
+            sudo apt-get install -y jq
+            pip install awscli
       - run: cd .circleci/ && chmod +x aws.sh
       - run: expect .circleci/aws_configure.exp
-      - run: yarn setup-dev
-      - run: amplify-dev
+      - run:
+          name: Configure Amplify CLI
+          command: |
+            yarn rm-dev-link && yarn link-dev && yarn rm-aa-dev-link && yarn link-aa-dev
+            echo 'export PATH="$(yarn global bin):$PATH"' >> $BASH_ENV
+            amplify-dev
       - run:
           name: Clone auth test package
           command: |
@@ -408,7 +417,7 @@ jobs:
             yarn add cypress@6.8.0 --save
             cp ../repo/cypress.json .
             cp -R ../repo/cypress .
-            node_modules/.bin/cypress run --spec $(find . -type f -name 'auth_spec*')
+            yarn cypress run --spec $(find . -type f -name 'auth_spec*')
       - run: sudo kill -9 $(lsof -t -i:3000)
       - run: cd .circleci/ && chmod +x delete_auth.sh
       - run: expect .circleci/delete_auth.exp
@@ -435,21 +444,21 @@ jobs:
       - run:
           name: Run cypress tests for api
           command: |
-            cd ../aws-amplify-cypress-auth
+            cd ../aws-amplify-cypress-api
             yarn add cypress@6.8.0 --save
             cp ../repo/cypress.json .
             cp -R ../repo/cypress .
-            node_modules/.bin/cypress run --spec $(find . -type f -name 'api_spec*')
+            yarn cypress run --spec $(find . -type f -name 'api_spec*')
       - run: cd .circleci/ && chmod +x delete_api.sh
       - run: expect .circleci/delete_api.exp
       - store_artifacts:
-          path: ../../aws-amplify-cypress-auth/cypress/videos
+          path: /root/aws-amplify-cypress-auth/cypress/videos
       - store_artifacts:
-          path: ../aws-amplify-cypress-auth/cypress/screenshots
+          path: /root/aws-amplify-cypress-auth/cypress/screenshots
       - store_artifacts:
-          path: ../aws-amplify-cypress-api/cypress/videos
+          path: /root/aws-amplify-cypress-api/cypress/videos
       - store_artifacts:
-          path: ../aws-amplify-cypress-api/cypress/screenshots
+          path: /root/aws-amplify-cypress-api/cypress/screenshots
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,27 +366,39 @@ jobs:
             ~/repo/packages/amplify-console-integration-tests/console-integration-reports
   integration_test:
     working_directory: ~/repo
+    resource_class: large
     docker:
       - image: cypress/base:12
         environment:
           TERM: dumb
-    resource_class: large
     steps:
-      - checkout
-      - run: apt-get update
-      - run: apt-get install -y sudo
-      - run: sudo apt-get install -y tcl
-      - run: sudo apt-get install -y expect
-      - run: sudo apt-get install -y zip
-      - run: sudo apt-get install -y lsof
-      - run: sudo apt-get install -y python
-      - run: sudo apt-get install -y python-pip libpython-dev
-      - run: sudo apt-get install -y jq
-      - run: pip install awscli
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Setup Dependencies
+          command: |
+            apt-get update
+            apt-get install -y sudo
+            sudo apt-get install -y tcl
+            sudo apt-get install -y expect
+            sudo apt-get install -y zip
+            sudo apt-get install -y lsof
+            sudo apt-get install -y python python-pip libpython-dev
+            sudo apt-get install -y jq
+            pip install awscli
       - run: cd .circleci/ && chmod +x aws.sh
       - run: expect .circleci/aws_configure.exp
-      - run: yarn setup-dev
-      - run: amplify-dev
+      - run:
+          name: Configure Amplify CLI
+          command: >
+            yarn rm-dev-link && yarn link-dev && yarn rm-aa-dev-link && yarn
+            link-aa-dev
+
+            echo 'export PATH="$(yarn global bin):$PATH"' >> $BASH_ENV
+
+            amplify-dev
       - run:
           name: Clone auth test package
           command: |
@@ -414,17 +426,12 @@ jobs:
       - run: cat $(find ../repo -type f -name 'auth_spec*')
       - run:
           name: Run cypress tests for auth
-          command: >
+          command: |
             cd ../aws-amplify-cypress-auth
-
             yarn add cypress@6.8.0 --save
-
             cp ../repo/cypress.json .
-
             cp -R ../repo/cypress .
-
-            node_modules/.bin/cypress run --spec $(find . -type f -name
-            'auth_spec*')
+            yarn cypress run --spec $(find . -type f -name 'auth_spec*')
       - run: sudo kill -9 $(lsof -t -i:3000)
       - run: cd .circleci/ && chmod +x delete_auth.sh
       - run: expect .circleci/delete_auth.exp
@@ -452,27 +459,22 @@ jobs:
           background: true
       - run:
           name: Run cypress tests for api
-          command: >
-            cd ../aws-amplify-cypress-auth
-
+          command: |
+            cd ../aws-amplify-cypress-api
             yarn add cypress@6.8.0 --save
-
             cp ../repo/cypress.json .
-
             cp -R ../repo/cypress .
-
-            node_modules/.bin/cypress run --spec $(find . -type f -name
-            'api_spec*')
+            yarn cypress run --spec $(find . -type f -name 'api_spec*')
       - run: cd .circleci/ && chmod +x delete_api.sh
       - run: expect .circleci/delete_api.exp
       - store_artifacts:
-          path: ../../aws-amplify-cypress-auth/cypress/videos
+          path: /root/aws-amplify-cypress-auth/cypress/videos
       - store_artifacts:
-          path: ../aws-amplify-cypress-auth/cypress/screenshots
+          path: /root/aws-amplify-cypress-auth/cypress/screenshots
       - store_artifacts:
-          path: ../aws-amplify-cypress-api/cypress/videos
+          path: /root/aws-amplify-cypress-api/cypress/videos
       - store_artifacts:
-          path: ../aws-amplify-cypress-api/cypress/screenshots
+          path: /root/aws-amplify-cypress-api/cypress/screenshots
   deploy:
     working_directory: ~/repo
     docker: *ref_1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- change integration tests to use dev cli from the build job
- fix artifact path for screenshots and video


#### Description of how you validated changes
- Ran integ tests on fork



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.