### PR TITLE
feat: port @predictions to GraphQL Transformer v2

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,6 +46,7 @@ module.exports = {
     '<rootDir>/packages/amplify-graphql-docs-generator',
     '<rootDir>/packages/amplify-graphql-function-transformer',
     '<rootDir>/packages/amplify-graphql-http-transformer',
+    '<rootDir>/packages/amplify-graphql-predictions-transformer',
     '<rootDir>/packages/amplify-graphql-searchable-transformer',
     '<rootDir>/packages/amplify-graphql-types-generator',
     '<rootDir>/packages/amplify-provider-awscloudformation',

--- a/packages/amplify-graphql-predictions-transformer/.npmignore
+++ b/packages/amplify-graphql-predictions-transformer/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/amplify-graphql-predictions-transformer/CHANGELOG.md
+++ b/packages/amplify-graphql-predictions-transformer/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/amplify-graphql-predictions-transformer/README.md
+++ b/packages/amplify-graphql-predictions-transformer/README.md
@@ -1,0 +1,19 @@
+# GraphQL @predictions Transformer
+
+# Reference Documentation
+
+### @predictions
+
+The `@predictions` directive allows you to query an orchestration of AI/ML services such as Amazon Rekognition, Amazon Translate, and/or Amazon Polly.
+
+#### Definition
+
+```graphql
+directive @predictions(actions: [PredictionsActions!]!) on FIELD_DEFINITION
+enum PredictionsActions {
+  identifyText # uses Amazon Rekognition to detect text
+  identifyLabels # uses Amazon Rekognition to detect labels
+  convertTextToSpeech # uses Amazon Polly in a lambda to output a presigned url to synthesized speech
+  translateText # uses Amazon Translate to translate text from source to target language
+}
+```

--- a/packages/amplify-graphql-predictions-transformer/assets/predictionsLambda.js
+++ b/packages/amplify-graphql-predictions-transformer/assets/predictionsLambda.js
@@ -1,0 +1,34 @@
+const AWS = require('aws-sdk');
+exports.handler = function (event, context, callback) {
+  if (event && event.action === 'convertTextToSpeech') {
+    convertTextToSpeech(event, callback);
+  } else {
+    callback(Error('Action not configured.'));
+  }
+};
+/**
+ * This function does the following for the textToSpeech action
+ * - Synthesize Speech
+ * - Get a presigned url for that synthesized speech
+ * @param {*} event
+ * @param {*} callback
+ */
+function convertTextToSpeech(event, callback) {
+  const pollyParams = {
+    OutputFormat: 'mp3',
+    SampleRate: '8000',
+    Text: event.text,
+    TextType: 'text',
+    VoiceId: event.voiceID,
+  };
+  const polly = new AWS.Polly();
+  const signer = new AWS.Polly.Presigner(pollyParams, polly);
+  signer.getSynthesizeSpeechUrl(pollyParams, function (err, url) {
+    if (err) {
+      console.log(err, err.stack);
+      callback(Error(err));
+    } else {
+      callback(null, { url: url });
+    }
+  });
+}

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@aws-amplify/graphql-predictions-transformer",
+  "version": "0.1.0",
+  "description": "Amplify GraphQL @predictions tranformer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-cli.git",
+    "directory": "packages/amplify-graphql-predictions-transformer"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "keywords": [
+    "graphql",
+    "cloudformation",
+    "aws",
+    "amplify"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc && cd assets && bestzip --force node ../lib/predictionsLambdaFunction.zip predictionsLambda.js",
+    "watch": "tsc -w",
+    "clean": "rimraf ./lib",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@aws-amplify/graphql-transformer-core": "0.6.1",
+    "@aws-amplify/graphql-transformer-interfaces": "1.6.0",
+    "@aws-cdk/aws-appsync": "~1.72.0",
+    "@aws-cdk/core": "~1.72.0",
+    "@aws-cdk/aws-iam": "~1.72.0",
+    "@aws-cdk/aws-lambda": "~1.72.0",
+    "graphql": "^14.5.8",
+    "graphql-mapping-template": "4.18.1",
+    "graphql-transformer-common": "4.19.3"
+  },
+  "devDependencies": {
+    "@aws-cdk/assert": "~1.72.0",
+    "bestzip": "^2.1.5"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.(ts|tsx)?$": "ts-jest"
+    },
+    "testRegex": "(src/__tests__/.*.test.ts)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true
+  }
+}

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -27,15 +27,15 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/graphql-transformer-core": "0.6.1",
-    "@aws-amplify/graphql-transformer-interfaces": "1.6.0",
+    "@aws-amplify/graphql-transformer-core": "0.6.3",
+    "@aws-amplify/graphql-transformer-interfaces": "1.6.1",
     "@aws-cdk/aws-appsync": "~1.72.0",
     "@aws-cdk/core": "~1.72.0",
     "@aws-cdk/aws-iam": "~1.72.0",
     "@aws-cdk/aws-lambda": "~1.72.0",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.18.1",
-    "graphql-transformer-common": "4.19.3"
+    "graphql-transformer-common": "4.19.4"
   },
   "devDependencies": {
     "@aws-cdk/assert": "~1.72.0",

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -1,0 +1,1465 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can use actions individually and in supported sequences 1`] = `
+"
+type Query {
+  identifyText(input: IdentifyTextInput!): String
+  identifyLabels(input: IdentifyLabelsInput!): [String]
+  convertTextToSpeech(input: ConvertTextToSpeechInput!): String
+  translateText(input: TranslateTextInput!): String
+  speakTranslatedIdentifiedText(input: SpeakTranslatedIdentifiedTextInput!): String
+  speakTranslatedLabelText(input: SpeakTranslatedLabelTextInput!): String
+  speakTranslatedText(input: SpeakTranslatedTextInput!): String
+}
+
+input IdentifyTextIdentifyTextInput {
+  key: String!
+}
+
+input IdentifyTextInput {
+  identifyText: IdentifyTextIdentifyTextInput!
+}
+
+input IdentifyLabelsIdentifyLabelsInput {
+  key: String!
+}
+
+input IdentifyLabelsInput {
+  identifyLabels: IdentifyLabelsIdentifyLabelsInput!
+}
+
+input ConvertTextToSpeechConvertTextToSpeechInput {
+  voiceID: String!
+  text: String!
+}
+
+input ConvertTextToSpeechInput {
+  convertTextToSpeech: ConvertTextToSpeechConvertTextToSpeechInput!
+}
+
+input TranslateTextTranslateTextInput {
+  sourceLanguage: String!
+  targetLanguage: String!
+  text: String!
+}
+
+input TranslateTextInput {
+  translateText: TranslateTextTranslateTextInput!
+}
+
+input SpeakTranslatedIdentifiedTextIdentifyTextInput {
+  key: String!
+}
+
+input SpeakTranslatedIdentifiedTextTranslateTextInput {
+  sourceLanguage: String!
+  targetLanguage: String!
+}
+
+input SpeakTranslatedIdentifiedTextConvertTextToSpeechInput {
+  voiceID: String!
+}
+
+input SpeakTranslatedIdentifiedTextInput {
+  identifyText: SpeakTranslatedIdentifiedTextIdentifyTextInput!
+  translateText: SpeakTranslatedIdentifiedTextTranslateTextInput!
+  convertTextToSpeech: SpeakTranslatedIdentifiedTextConvertTextToSpeechInput!
+}
+
+input SpeakTranslatedLabelTextIdentifyLabelsInput {
+  key: String!
+}
+
+input SpeakTranslatedLabelTextTranslateTextInput {
+  sourceLanguage: String!
+  targetLanguage: String!
+}
+
+input SpeakTranslatedLabelTextConvertTextToSpeechInput {
+  voiceID: String!
+}
+
+input SpeakTranslatedLabelTextInput {
+  identifyLabels: SpeakTranslatedLabelTextIdentifyLabelsInput!
+  translateText: SpeakTranslatedLabelTextTranslateTextInput!
+  convertTextToSpeech: SpeakTranslatedLabelTextConvertTextToSpeechInput!
+}
+
+input SpeakTranslatedTextTranslateTextInput {
+  sourceLanguage: String!
+  targetLanguage: String!
+  text: String!
+}
+
+input SpeakTranslatedTextConvertTextToSpeechInput {
+  voiceID: String!
+}
+
+input SpeakTranslatedTextInput {
+  translateText: SpeakTranslatedTextTranslateTextInput!
+  convertTextToSpeech: SpeakTranslatedTextConvertTextToSpeechInput!
+}
+
+"
+`;
+
+exports[`can use actions individually and in supported sequences 2`] = `
+Object {
+  "Conditions": Object {
+    "HasEnvironmentParameter": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+            },
+            "NONE",
+          ],
+        },
+      ],
+    },
+  },
+  "Parameters": Object {
+    "referencetotransformerrootstackGraphQLAPI20497F53ApiId": Object {
+      "Type": "String",
+    },
+    "referencetotransformerrootstackS3DeploymentBucket7592718ARef": Object {
+      "Type": "String",
+    },
+    "referencetotransformerrootstackS3DeploymentRootKeyA71EA735Ref": Object {
+      "Type": "String",
+    },
+    "referencetotransformerrootstackenv10C5A902Ref": Object {
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "LambdaDataSource4DD51D23": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "LambdaConfig": Object {
+          "LambdaFunctionArn": Object {
+            "Fn::GetAtt": Array [
+              "predictionsLambdahandlerC696C27E",
+              "Arn",
+            ],
+          },
+        },
+        "Name": "LambdaDataSource",
+        "ServiceRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "predictionsIAMRole5BB74A99",
+            "Arn",
+          ],
+        },
+        "Type": "AWS_LAMBDA",
+      },
+      "Type": "AWS::AppSync::DataSource",
+    },
+    "LambdaDataSourceServiceRole81BB3362": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "appsync.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LambdaDataSourceServiceRoleDefaultPolicy00CC76B1": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "predictionsLambdahandlerC696C27E",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LambdaDataSourceServiceRoleDefaultPolicy00CC76B1",
+        "Roles": Array [
+          Object {
+            "Ref": "LambdaDataSourceServiceRole81BB3362",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PredictionsLambdaAccess4D9DA807": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "predictionsLambdahandlerC696C27E",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PredictionsLambdaAccess4D9DA807",
+        "Roles": Array [
+          Object {
+            "Ref": "predictionsIAMRole5BB74A99",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PredictionsStorageAccess68CD5140": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "arn:aws:s3:::myStorage\${hash}-\${env}/public/*",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "arn:aws:s3:::myStorage\${hash}/public/*",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PredictionsStorageAccess68CD5140",
+        "Roles": Array [
+          Object {
+            "Ref": "predictionsIAMRole5BB74A99",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "RekognitionDataSourceC6790FED": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "HttpConfig": Object {
+          "AuthorizationConfig": Object {
+            "AuthorizationType": "AWS_IAM",
+            "AwsIamConfig": Object {
+              "SigningRegion": Object {
+                "Fn::Sub": "\${AWS::Region}",
+              },
+              "SigningServiceName": "rekognition",
+            },
+          },
+          "Endpoint": Object {
+            "Fn::Sub": "https://rekognition.\${AWS::Region}.amazonaws.com",
+          },
+        },
+        "Name": "RekognitionDataSource",
+        "ServiceRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "predictionsIAMRole5BB74A99",
+            "Arn",
+          ],
+        },
+        "Type": "HTTP",
+      },
+      "Type": "AWS::AppSync::DataSource",
+    },
+    "RekognitionDataSourceServiceRole3628B5DB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "appsync.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TranslateDataSource2C33F90C": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "HttpConfig": Object {
+          "AuthorizationConfig": Object {
+            "AuthorizationType": "AWS_IAM",
+            "AwsIamConfig": Object {
+              "SigningRegion": Object {
+                "Fn::Sub": "\${AWS::Region}",
+              },
+              "SigningServiceName": "translate",
+            },
+          },
+          "Endpoint": Object {
+            "Fn::Sub": "https://translate.\${AWS::Region}.amazonaws.com",
+          },
+        },
+        "Name": "TranslateDataSource",
+        "ServiceRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "predictionsIAMRole5BB74A99",
+            "Arn",
+          ],
+        },
+        "Type": "HTTP",
+      },
+      "Type": "AWS::AppSync::DataSource",
+    },
+    "TranslateDataSourceServiceRole2FE48B83": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "appsync.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8": Object {
+      "DependsOn": Array [
+        "LambdaDataSource4DD51D23",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "DataSourceName": Object {
+          "Fn::GetAtt": Array [
+            "LambdaDataSource4DD51D23",
+            "Name",
+          ],
+        },
+        "FunctionVersion": "2018-05-29",
+        "Name": "convertTextToSpeechFunction",
+        "RequestMappingTemplate": "#set( $bucketName = $ctx.stash.get(\\"s3Bucket\\") )
+$util.qr($ctx.stash.put(\\"isList\\", false))
+#set( $text = $util.defaultIfNull($ctx.args.input.convertTextToSpeech.text, $ctx.prev.result) )
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Invoke\\",
+  \\"payload\\":   $util.toJson({
+  \\"uuid\\": \\"$util.autoId()\\",
+  \\"action\\": \\"convertTextToSpeech\\",
+  \\"voiceID\\": $ctx.args.input.convertTextToSpeech.voiceID,
+  \\"text\\": $text
+})
+}",
+        "ResponseMappingTemplate": "#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#end
+#set( $response = $util.parseJson($ctx.result) )
+$util.toJson($ctx.result.url)",
+      },
+      "Type": "AWS::AppSync::FunctionConfiguration",
+    },
+    "identifyLabelsAccess7BFAF94B": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "rekognition:DetectLabels",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "identifyLabelsAccess7BFAF94B",
+        "Roles": Array [
+          Object {
+            "Ref": "predictionsIAMRole5BB74A99",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "DataSourceName": Object {
+          "Fn::GetAtt": Array [
+            "RekognitionDataSourceC6790FED",
+            "Name",
+          ],
+        },
+        "FunctionVersion": "2018-05-29",
+        "Name": "identifyLabelsFunction",
+        "RequestMappingTemplate": "#set( $bucketName = $ctx.stash.get(\\"s3Bucket\\") )
+#set( $identifyLabelKey = $ctx.args.input.identifyLabels.key )
+$util.qr($ctx.stash.put(\\"isList\\", true))
+#set( $identifyLabelsPayload = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+      \\"body\\": {
+          \\"Image\\": {
+              \\"S3Object\\": {
+                  \\"Bucket\\": \\"$bucketName\\",
+                  \\"Name\\": \\"public/$identifyLabelKey\\"
+        }
+      },
+          \\"MaxLabels\\": 10,
+          \\"MinConfidence\\": 55
+    },
+      \\"headers\\": {
+          \\"Content-Type\\": \\"application/x-amz-json-1.1\\",
+          \\"X-Amz-Target\\": \\"RekognitionService.DetectLabels\\"
+    }
+  }
+} )
+$util.toJson($identifyLabelsPayload)",
+        "ResponseMappingTemplate": "#if( $ctx.error )
+$util.error($ctx.error.message)
+#end
+#if( $ctx.result.statusCode == 200 )
+  #set( $labels = \\"\\" )
+  #set( $result = $util.parseJson($ctx.result.body) )
+  #foreach( $label in $result.Labels )
+    #set( $labels = \\"$labels$label.Name, \\" )
+  #end
+  $util.toJson($labels.replaceAll(\\", $\\", \\"\\"))
+#else
+$util.error($ctx.result.body)
+#end",
+      },
+      "Type": "AWS::AppSync::FunctionConfiguration",
+    },
+    "identifyTextAccess5A2D7702": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "rekognition:DetectText",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "identifyTextAccess5A2D7702",
+        "Roles": Array [
+          Object {
+            "Ref": "predictionsIAMRole5BB74A99",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "DataSourceName": Object {
+          "Fn::GetAtt": Array [
+            "RekognitionDataSourceC6790FED",
+            "Name",
+          ],
+        },
+        "FunctionVersion": "2018-05-29",
+        "Name": "identifyTextFunction",
+        "RequestMappingTemplate": "#set( $bucketName = $ctx.stash.get(\\"s3Bucket\\") )
+#set( $identityTextKey = $ctx.args.input.identifyText.key )
+#set( $identifyTextPayload = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+      \\"body\\": {
+          \\"Image\\": {
+              \\"S3Object\\": {
+                  \\"Bucket\\": \\"$bucketName\\",
+                  \\"Name\\": \\"public/$identityTextKey\\"
+        }
+      }
+    },
+      \\"headers\\": {
+          \\"Content-Type\\": \\"application/x-amz-json-1.1\\",
+          \\"X-Amz-Target\\": \\"RekognitionService.DetectText\\"
+    }
+  }
+} )
+$util.toJson($identifyTextPayload)",
+        "ResponseMappingTemplate": "#if( $ctx.error )
+$util.error($ctx.error.message)
+#end
+#if( $ctx.result.statusCode == 200 )
+  #set( $results = $util.parseJson($ctx.result.body) )
+  #set( $finalResult = \\"\\" )
+  #foreach( $item in $results.TextDetections )
+    #if( $item.Type == \\"LINE\\" )
+      #set( $finalResult = \\"$finalResult$item.DetectedText \\" )
+    #end
+  #end
+$util.toJson($finalResult.trim())
+#else
+$utils.error($ctx.result.body)
+#end",
+      },
+      "Type": "AWS::AppSync::FunctionConfiguration",
+    },
+    "predictionsIAMRole5BB74A99": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "appsync.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "RoleName": Object {
+          "Fn::If": Array [
+            "HasEnvironmentParameter",
+            Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "predictionsIAMRole",
+                  Object {
+                    "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+                  },
+                  Object {
+                    "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                  },
+                ],
+              ],
+            },
+            Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "predictionsIAMRole",
+                  Object {
+                    "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "predictionsLambdaIAMRoleB8AC96D3": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "polly:SynthesizeSpeech",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "PollyAccess",
+          },
+        ],
+        "RoleName": Object {
+          "Fn::If": Array [
+            "HasEnvironmentParameter",
+            Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "predictionsLambdaIAMRole",
+                  Object {
+                    "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+                  },
+                  Object {
+                    "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                  },
+                ],
+              ],
+            },
+            Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "predictionsLambdaIAMRole",
+                  Object {
+                    "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "predictionsLambdahandlerC696C27E": Object {
+      "DependsOn": Array [
+        "predictionsLambdaIAMRoleB8AC96D3",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "referencetotransformerrootstackS3DeploymentBucket7592718ARef",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Ref": "referencetotransformerrootstackS3DeploymentRootKeyA71EA735Ref",
+                },
+                "/functions/predictionsLambdaFunction.zip",
+              ],
+            ],
+          },
+        },
+        "Handler": "predictionsLambda.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "predictionsLambdaIAMRoleB8AC96D3",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs12.x",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "queryConvertTextToSpeechResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "convertTextToSpeech",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "queryIdentifyLabelsResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "identifyLabels",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "queryIdentifyTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "identifyText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "querySpeakTranslatedIdentifiedTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "speakTranslatedIdentifiedText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "querySpeakTranslatedLabelTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "speakTranslatedLabelText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "querySpeakTranslatedTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "speakTranslatedText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "queryTranslateTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "translateText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "translateTextAccess74D3AE90": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "translate:TranslateText",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "translateTextAccess74D3AE90",
+        "Roles": Array [
+          Object {
+            "Ref": "predictionsIAMRole5BB74A99",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "DataSourceName": Object {
+          "Fn::GetAtt": Array [
+            "TranslateDataSource2C33F90C",
+            "Name",
+          ],
+        },
+        "FunctionVersion": "2018-05-29",
+        "Name": "translateTextFunction",
+        "RequestMappingTemplate": "#set( $text = $util.defaultIfNull($ctx.args.input.translateText.text, $ctx.prev.result) )
+#set( $translateTextPayload = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+      \\"body\\": {
+          \\"SourceLanguageCode\\": $ctx.args.input.translateText.sourceLanguage,
+          \\"TargetLanguageCode\\": $ctx.args.input.translateText.targetLanguage,
+          \\"Text\\": $text
+    },
+      \\"headers\\": {
+          \\"Content-Type\\": \\"application/x-amz-json-1.1\\",
+          \\"X-Amz-Target\\": \\"AWSShineFrontendService_20170701.TranslateText\\"
+    }
+  }
+} )
+$util.toJson($translateTextPayload)",
+        "ResponseMappingTemplate": "#if( $ctx.error )
+$util.error($ctx.error.message)
+#end
+#if( $ctx.result.statusCode == 200 )
+  #set( $result = $util.parseJson($ctx.result.body) )
+$util.toJson($result.TranslatedText)
+#else
+$util.error($ctx.result.body)
+#end",
+      },
+      "Type": "AWS::AppSync::FunctionConfiguration",
+    },
+  },
+}
+`;
+
+exports[`lambda function is added to pipeline when lambda dependent action is added 1`] = `
+"
+type Query {
+  speakTranslatedText(input: SpeakTranslatedTextInput!): String
+}
+
+input SpeakTranslatedTextTranslateTextInput {
+  sourceLanguage: String!
+  targetLanguage: String!
+  text: String!
+}
+
+input SpeakTranslatedTextConvertTextToSpeechInput {
+  voiceID: String!
+}
+
+input SpeakTranslatedTextInput {
+  translateText: SpeakTranslatedTextTranslateTextInput!
+  convertTextToSpeech: SpeakTranslatedTextConvertTextToSpeechInput!
+}
+
+"
+`;
+
+exports[`return type is a list based on the action 1`] = `
+"
+type Query {
+  translateLabels(input: TranslateLabelsInput!): [String]
+}
+
+input TranslateLabelsIdentifyLabelsInput {
+  key: String!
+}
+
+input TranslateLabelsTranslateTextInput {
+  sourceLanguage: String!
+  targetLanguage: String!
+}
+
+input TranslateLabelsInput {
+  identifyLabels: TranslateLabelsIdentifyLabelsInput!
+  translateText: TranslateLabelsTranslateTextInput!
+}
+
+"
+`;

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer.test.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer.test.ts
@@ -1,0 +1,250 @@
+'use strict';
+import { anything, countResources, expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { parse } from 'graphql';
+import { PredictionsTransformer } from '..';
+
+test('does not generate any resources if @predictions is unused', () => {
+  const schema = `
+    type Query {
+      speakTranslatedText: String
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+
+  const out = transformer.transform(schema);
+  expect(out).toBeDefined();
+  expect(out.stacks).toBeDefined();
+  expect(out.stacks.PredictionsDirectiveStack).toEqual(undefined);
+});
+
+test('lambda function is added to pipeline when lambda dependent action is added', () => {
+  const validSchema = `
+    type Query {
+      speakTranslatedText: String @predictions(actions: [translateText convertTextToSpeech])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks).toBeDefined();
+  parse(out.schema);
+  expect(out.schema).toMatchSnapshot();
+  const stack = out.stacks.PredictionsDirectiveStack;
+  expect(stack).toBeDefined();
+  cdkExpect(stack).to(countResources('AWS::IAM::Role', 4));
+  cdkExpect(stack).to(countResources('AWS::IAM::Policy', 4));
+  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 2));
+  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 2));
+  cdkExpect(stack).to(countResources('AWS::Lambda::Function', 1));
+  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
+  expect(out.schema).toContain('speakTranslatedText(input: SpeakTranslatedTextInput!): String');
+  cdkExpect(stack).to(
+    haveResourceLike('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          {
+            Action: 'sts:AssumeRole',
+            Effect: 'Allow',
+            Principal: {
+              Service: 'appsync.amazonaws.com',
+            },
+          },
+        ],
+        Version: '2012-10-17',
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResourceLike('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 's3:GetObject',
+            Effect: 'Allow',
+            Resource: anything(),
+          },
+        ],
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResourceLike('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'translate:TranslateText',
+            Effect: 'Allow',
+            Resource: '*',
+          },
+        ],
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResourceLike('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'lambda:InvokeFunction',
+            Effect: 'Allow',
+            Resource: { 'Fn::GetAtt': [anything(), 'Arn'] },
+          },
+        ],
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResourceLike('AWS::AppSync::Resolver', {
+      ApiId: { Ref: anything() },
+      FieldName: 'speakTranslatedText',
+      TypeName: 'Query',
+      Kind: 'PIPELINE',
+      PipelineConfig: {
+        Functions: [{ 'Fn::GetAtt': [anything(), 'FunctionId'] }, { 'Fn::GetAtt': [anything(), 'FunctionId'] }],
+      },
+      RequestMappingTemplate: {
+        'Fn::Join': [
+          '\n',
+          [
+            {
+              'Fn::If': [
+                'HasEnvironmentParameter',
+                {
+                  'Fn::Sub': [
+                    '$util.qr($ctx.stash.put("s3Bucket", "myStorage${hash}-${env}"))',
+                    {
+                      hash: {
+                        'Fn::Select': [3, { 'Fn::Split': ['-', { Ref: 'AWS::StackName' }] }],
+                      },
+                      env: { Ref: anything() },
+                    },
+                  ],
+                },
+                {
+                  'Fn::Sub': [
+                    '$util.qr($ctx.stash.put("s3Bucket", "myStorage${hash}"))',
+                    {
+                      hash: {
+                        'Fn::Select': [3, { 'Fn::Split': ['-', { Ref: 'AWS::StackName' }] }],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            '$util.qr($ctx.stash.put("isList", false))\n{}',
+          ],
+        ],
+      },
+      ResponseMappingTemplate:
+        '## If the result is a list return the result as a list **\n#if( $ctx.stash.get("isList") )\n  #set( $result = $ctx.result.split("[ ,]+") )\n  $util.toJson($result)\n#else\n  $util.toJson($ctx.result)\n#end',
+    }),
+  );
+});
+
+test('return type is a list based on the action', () => {
+  const validSchema = `
+    type Query {
+      translateLabels: String @predictions(actions: [identifyLabels translateText])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks).toBeDefined();
+  parse(out.schema);
+  expect(out.schema).toMatchSnapshot();
+  const stack = out.stacks.PredictionsDirectiveStack;
+  expect(stack).toBeDefined();
+  cdkExpect(stack).to(countResources('AWS::IAM::Role', 3));
+  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 2));
+  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 2));
+  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
+  expect(out.schema).toContain('translateLabels(input: TranslateLabelsInput!): [String]');
+});
+
+test('can use actions individually and in supported sequences', () => {
+  const validSchema = `
+    type Query {
+      identifyText: String @predictions(actions: identifyText)
+      identifyLabels: String @predictions(actions: [identifyLabels])
+      convertTextToSpeech: String @predictions(actions: convertTextToSpeech)
+      translateText: String @predictions(actions: translateText)
+      speakTranslatedIdentifiedText: String @predictions(actions: [identifyText translateText convertTextToSpeech])
+      speakTranslatedLabelText: String @predictions(actions: [identifyLabels translateText convertTextToSpeech])
+      speakTranslatedText: String @predictions(actions: [translateText convertTextToSpeech])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks).toBeDefined();
+  parse(out.schema);
+  expect(out.schema).toMatchSnapshot();
+  const stack = out.stacks.PredictionsDirectiveStack;
+  expect(stack).toBeDefined();
+  expect(stack).toMatchSnapshot();
+});
+
+test('throws if storage is not provided', () => {
+  const validSchema = `
+    type Query {
+      speakTranslatedText: String @predictions(actions: [translateText convertTextToSpeech])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer()],
+  });
+
+  expect(() => {
+    transformer.transform(validSchema);
+  }).toThrow('Please configure storage in your project in order to use the @predictions directive');
+});
+
+test('throws if @predictions is used under a non-Query', () => {
+  const schema = `
+    type Mutation {
+      speakTranslatedText: String @predictions(actions: [translateText convertTextToSpeech])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow('@predictions directive only works under Query operations.');
+});
+
+test('throws if no actions are provided', () => {
+  const schema = `
+    type Query {
+      speakTranslatedText: String @predictions(actions: [])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow('@predictions directive requires at least one action.');
+});
+
+test('throws if an unsupported action sequence is provided', () => {
+  const schema = `
+    type Query {
+      speakTranslatedText: String @predictions(actions: [convertTextToSpeech translateText])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow('translateText is not supported in this context!');
+});

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -1,0 +1,700 @@
+import * as path from 'path';
+import { DirectiveWrapper, InvalidDirectiveError, MappingTemplate, TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
+import {
+  TransformerBeforeStepContextProvider,
+  TransformerContextProvider,
+  TransformerSchemaVisitStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import * as appsync from '@aws-cdk/aws-appsync';
+import * as cdk from '@aws-cdk/core';
+import * as iam from '@aws-cdk/aws-iam';
+import * as lambda from '@aws-cdk/aws-lambda';
+import { makeListType, makeNamedType, makeNonNullType, PredictionsResourceIDs, ResourceConstants } from 'graphql-transformer-common';
+import {
+  DirectiveNode,
+  FieldDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  Kind,
+  ObjectTypeDefinitionNode,
+} from 'graphql';
+import {
+  comment,
+  compoundExpression,
+  forEach,
+  HttpMappingTemplate,
+  ifElse,
+  iff,
+  int,
+  obj,
+  print,
+  qref,
+  raw,
+  ref,
+  set,
+  str,
+  toJson,
+} from 'graphql-mapping-template';
+
+type PredictionsDirectiveConfiguration = {
+  actions: string[] | undefined;
+  resolverFieldName: string;
+  resolverTypeName: string;
+};
+
+const PREDICTIONS_DIRECTIVE_STACK = 'PredictionsDirectiveStack';
+const directiveDefinition = /* GraphQL */ `
+  directive @predictions(actions: [PredictionsActions!]!) on FIELD_DEFINITION
+  enum PredictionsActions {
+    identifyText
+    identifyLabels
+    convertTextToSpeech
+    translateText
+  }
+`;
+
+const allowedActions = new Map([
+  ['identifyText', ['translateText']],
+  ['identifyLabels', ['translateText', 'convertTextToSpeech']],
+  ['translateText', ['convertTextToSpeech']],
+  ['convertTextToSpeech', []],
+]);
+
+const actionToDataSourceMap = new Map([
+  ['identifyEntities', 'RekognitionDataSource'],
+  ['identifyText', 'RekognitionDataSource'],
+  ['identifyLabels', 'RekognitionDataSource'],
+  ['translateText', 'TranslateDataSource'],
+  ['convertTextToSpeech', 'LambdaDataSource'],
+]);
+
+const actionToRoleAction = new Map([
+  ['identifyText', 'rekognition:DetectText'],
+  ['identifyLabels', 'rekognition:DetectLabels'],
+  ['translateText', 'translate:TranslateText'],
+]);
+
+export type PredictionsConfig = {
+  bucketName: string;
+};
+
+export class PredictionsTransformer extends TransformerPluginBase {
+  private directiveList: PredictionsDirectiveConfiguration[] = [];
+  private bucketName: string;
+
+  constructor(predictionsConfig?: PredictionsConfig) {
+    super('amplify-predictions-transformer', directiveDefinition);
+    this.bucketName = predictionsConfig?.bucketName ?? '';
+  }
+
+  before = (context: TransformerBeforeStepContextProvider): void => {
+    if (!this.bucketName) {
+      throw new InvalidDirectiveError('Please configure storage in your project in order to use the @predictions directive');
+    }
+  };
+
+  field = (
+    parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    definition: FieldDefinitionNode,
+    directive: DirectiveNode,
+    context: TransformerSchemaVisitStepContextProvider,
+  ): void => {
+    if (parent.name.value !== context.output.getQueryTypeName()) {
+      throw new InvalidDirectiveError('@predictions directive only works under Query operations.');
+    }
+
+    const directiveWrapped = new DirectiveWrapper(directive);
+    const args = directiveWrapped.getArguments({
+      resolverTypeName: parent.name.value,
+      resolverFieldName: definition.name.value,
+    } as PredictionsDirectiveConfiguration);
+
+    if (!Array.isArray(args.actions)) {
+      args.actions = [(args.actions as unknown) as string];
+    }
+
+    validateActions(args.actions);
+    this.directiveList.push(args);
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider): void => {
+    this.directiveList.forEach(directive => {
+      const actionInputObjectFields: InputValueDefinitionNode[] = [];
+      let isList = false;
+
+      directive.actions!.forEach((action, index) => {
+        isList = needsList(action, isList);
+        actionInputObjectFields.push(createInputValueAction(action, directive.resolverFieldName));
+
+        // Add the input type to the schema if it does not already exist.
+        if (!context.output.hasType(getActionInputName(action, directive.resolverFieldName))) {
+          const actionInput = getActionInputType(action, directive.resolverFieldName, index === 0);
+
+          context.output.addInput(actionInput);
+        }
+      });
+
+      // Generate the input type based on operation name.
+      context.output.addInput(makeActionInputObject(directive.resolverFieldName, actionInputObjectFields));
+
+      // Add arguments into operation.
+      const queryTypeName = context.output.getQueryTypeName() ?? '';
+      const type = context.output.getType(queryTypeName) as ObjectTypeDefinitionNode;
+
+      if (queryTypeName && type) {
+        const fields = type.fields ?? [];
+        const field = fields.find(f => f.name.value === directive.resolverFieldName);
+
+        if (field) {
+          const newFields = [
+            ...fields.filter(f => f.name.value !== field.name.value),
+            addInputArgument(field, directive.resolverFieldName, isList),
+          ];
+          const newMutation = {
+            ...type,
+            fields: newFields,
+          };
+          context.output.putType(newMutation);
+        }
+      }
+    });
+  };
+
+  generateResolvers = (context: TransformerContextProvider): void => {
+    if (this.directiveList.length === 0) {
+      return;
+    }
+
+    const stack: cdk.Stack = context.stackManager.createStack(PREDICTIONS_DIRECTIVE_STACK);
+    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const createdResources = new Map<string, any>();
+    const seenActions = new Set<string>();
+    const role = new iam.Role(stack, PredictionsResourceIDs.iamRole, {
+      roleName: joinWithEnv(context, '-', [PredictionsResourceIDs.iamRole, context.api.apiId]),
+      assumedBy: new iam.ServicePrincipal('appsync.amazonaws.com'),
+    });
+
+    role.attachInlinePolicy(
+      new iam.Policy(stack, 'PredictionsStorageAccess', {
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['s3:GetObject'],
+            resources: [getStorageArn(context, this.bucketName)],
+          }),
+        ],
+      }),
+    );
+
+    new cdk.CfnCondition(stack, ResourceConstants.CONDITIONS.HasEnvironmentParameter, {
+      expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(env, ResourceConstants.NONE)),
+    });
+
+    this.directiveList.forEach(directive => {
+      const predictionFunctions: any[] = [];
+
+      directive.actions!.forEach(action => {
+        const datasourceName = actionToDataSourceMap.get(action) as string;
+        const functionName = PredictionsResourceIDs.getPredictionFunctionName(action);
+        const roleAction = actionToRoleAction.get(action);
+        let datasource = context.api.getDataSource(datasourceName);
+
+        if (roleAction && !seenActions.has(action)) {
+          role.attachInlinePolicy(
+            new iam.Policy(stack, `${action}Access`, {
+              statements: [
+                new iam.PolicyStatement({
+                  effect: iam.Effect.ALLOW,
+                  actions: [roleAction],
+                  resources: ['*'],
+                }),
+              ],
+            }),
+          );
+        }
+
+        seenActions.add(action);
+
+        if (!datasource) {
+          let predictionLambda;
+
+          if (action === 'convertTextToSpeech') {
+            predictionLambda = createPredictionsLambda(context, stack);
+            role.attachInlinePolicy(
+              new iam.Policy(stack, 'PredictionsLambdaAccess', {
+                statements: [
+                  new iam.PolicyStatement({
+                    effect: iam.Effect.ALLOW,
+                    actions: ['lambda:InvokeFunction'],
+                    resources: [predictionLambda.functionArn],
+                  }),
+                ],
+              }),
+            );
+          }
+
+          datasource = createPredictionsDataSource(context, stack, action, role, predictionLambda);
+        }
+
+        // Add function configuration if it does not exist.
+        let actionFunction = createdResources.get(functionName);
+
+        if (!actionFunction) {
+          actionFunction = createActionFunction(context, stack, action, datasource.name);
+          createdResources.set(functionName, actionFunction);
+        }
+
+        predictionFunctions.push(actionFunction.functionId);
+      });
+
+      // Create AppSync resolver.
+      createResolver(context, stack, directive, predictionFunctions, this.bucketName);
+    });
+  };
+}
+
+function validateActions(actions: string[]): void {
+  if (actions.length === 0) {
+    throw new InvalidDirectiveError('@predictions directive requires at least one action.');
+  }
+
+  let allowed: string[] | undefined = [];
+
+  actions.forEach((action, index) => {
+    if (index !== 0 && Array.isArray(allowed) && !allowed.includes(action)) {
+      throw new InvalidDirectiveError(`${action} is not supported in this context!`);
+    }
+
+    allowed = allowedActions.get(action);
+  });
+}
+
+function createPredictionsDataSource(
+  context: TransformerContextProvider,
+  stack: cdk.Stack,
+  action: string,
+  role: iam.Role,
+  lambdaFn?: lambda.IFunction,
+): appsync.LambdaDataSource | appsync.HttpDataSource {
+  let datasource;
+
+  switch (action) {
+    case 'identifyEntities':
+    case 'identifyText':
+    case 'identifyLabels':
+      datasource = context.api.addHttpDataSource(
+        'RekognitionDataSource',
+        cdk.Fn.sub('https://rekognition.${AWS::Region}.amazonaws.com'),
+        {
+          authorizationConfig: {
+            signingRegion: cdk.Fn.sub('${AWS::Region}'),
+            signingServiceName: 'rekognition',
+          },
+        } as appsync.DataSourceOptions,
+        stack,
+      );
+      break;
+    case 'translateText':
+      datasource = context.api.addHttpDataSource(
+        'TranslateDataSource',
+        cdk.Fn.sub('https://translate.${AWS::Region}.amazonaws.com'),
+        {
+          authorizationConfig: {
+            signingRegion: cdk.Fn.sub('${AWS::Region}'),
+            signingServiceName: 'translate',
+          },
+        } as appsync.DataSourceOptions,
+        stack,
+      );
+      break;
+    case 'convertTextToSpeech':
+    default:
+      datasource = context.api.addLambdaDataSource(
+        'LambdaDataSource',
+        lambda.Function.fromFunctionAttributes(stack, 'LambdaDataSourceFunction', {
+          functionArn: (lambdaFn as lambda.IFunction)?.functionArn,
+        }),
+        {},
+        stack,
+      );
+      break;
+  }
+
+  datasource.ds.serviceRoleArn = role.roleArn;
+  return datasource;
+}
+
+function createResolver(
+  context: TransformerContextProvider,
+  stack: cdk.Stack,
+  config: PredictionsDirectiveConfiguration,
+  pipelineFunctions: any[],
+  bucketName: string,
+): appsync.CfnResolver {
+  const substitutions: { [key: string]: string } = {
+    hash: cdk.Fn.select(3, cdk.Fn.split('-', cdk.Fn.ref('AWS::StackName'))),
+  };
+
+  if (referencesEnv(bucketName)) {
+    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    substitutions.env = (env as unknown) as string;
+  }
+
+  return context.api.addResolver(
+    config.resolverTypeName,
+    config.resolverFieldName,
+    MappingTemplate.inlineTemplateFromString(
+      (cdk.Fn.join('\n', [
+        (cdk.Fn.conditionIf(
+          ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+          cdk.Fn.sub(`$util.qr($ctx.stash.put("s3Bucket", "${bucketName}"))`, substitutions),
+          cdk.Fn.sub(`$util.qr($ctx.stash.put("s3Bucket", "${removeEnvReference(bucketName)}"))`, {
+            hash: cdk.Fn.select(3, cdk.Fn.split('-', cdk.Fn.ref('AWS::StackName'))),
+          }),
+        ) as unknown) as string,
+        print(compoundExpression([qref('$ctx.stash.put("isList", false)'), obj({})])),
+      ]) as unknown) as string,
+    ),
+    MappingTemplate.inlineTemplateFromString(
+      print(
+        compoundExpression([
+          comment('If the result is a list return the result as a list'),
+          ifElse(
+            ref('ctx.stash.get("isList")'),
+            compoundExpression([set(ref('result'), ref('ctx.result.split("[ ,]+")')), toJson(ref('result'))]),
+            toJson(ref('ctx.result')),
+          ),
+        ]),
+      ),
+    ),
+    undefined,
+    pipelineFunctions,
+    stack,
+  );
+}
+
+function createPredictionsLambda(context: TransformerContextProvider, stack: cdk.Stack): lambda.IFunction {
+  const functionId = PredictionsResourceIDs.lambdaID;
+  const role = new iam.Role(stack, PredictionsResourceIDs.lambdaIAMRole, {
+    roleName: joinWithEnv(context, '-', [PredictionsResourceIDs.lambdaIAMRole, context.api.apiId]),
+    assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    inlinePolicies: {
+      PollyAccess: new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['polly:SynthesizeSpeech'],
+            resources: ['*'],
+          }),
+        ],
+      }),
+    },
+  });
+
+  // Update the runtime to Node 14 once the following issue is resolved:
+  // https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/80#issuecomment-831796699
+  return context.api.addLambdaFunction(
+    PredictionsResourceIDs.lambdaHandlerName,
+    `functions/${functionId}.zip`,
+    PredictionsResourceIDs.lambdaHandlerName,
+    path.join(__dirname, '..', 'lib', 'predictionsLambdaFunction.zip'),
+    lambda.Runtime.NODEJS_12_X,
+    [],
+    role,
+    {},
+    cdk.Duration.seconds(PredictionsResourceIDs.lambdaTimeout),
+    stack,
+  );
+}
+
+function referencesEnv(value: string): boolean {
+  return value.includes('${env}');
+}
+
+function removeEnvReference(value: string): string {
+  return value.replace(/(-\${env})/, '');
+}
+
+function joinWithEnv(context: TransformerContextProvider, separator: string, listToJoin: any[]): string {
+  const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+  return (cdk.Fn.conditionIf(
+    ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+    cdk.Fn.join(separator, [...listToJoin, env]),
+    cdk.Fn.join(separator, listToJoin),
+  ) as unknown) as string;
+}
+
+function needsList(action: string, isCurrentlyList: boolean): boolean {
+  switch (action) {
+    case 'identifyLabels':
+      return true;
+    case 'convertTextToSpeech':
+      return false;
+    default:
+      return isCurrentlyList;
+  }
+}
+
+function capitalizeFirstLetter(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function getActionInputName(action: string, fieldName: string): string {
+  return `${capitalizeFirstLetter(fieldName)}${capitalizeFirstLetter(action)}Input`;
+}
+
+function makeActionInputObject(fieldName: string, fields: InputValueDefinitionNode[]): InputObjectTypeDefinitionNode {
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    name: { kind: 'Name' as const, value: `${capitalizeFirstLetter(fieldName)}Input` },
+    fields,
+    directives: [],
+  };
+}
+
+function createInputValueAction(action: string, fieldName: string): InputValueDefinitionNode {
+  return {
+    kind: Kind.INPUT_VALUE_DEFINITION,
+    name: { kind: 'Name' as const, value: action },
+    type: makeNonNullType(makeNamedType(getActionInputName(action, fieldName))),
+    directives: [],
+  };
+}
+
+function inputValueDefinition(inputValue: string, namedType: string, isNonNull: boolean = false): InputValueDefinitionNode {
+  return {
+    kind: Kind.INPUT_VALUE_DEFINITION,
+    name: { kind: 'Name' as const, value: inputValue },
+    type: isNonNull ? makeNonNullType(makeNamedType(namedType)) : makeNamedType(namedType),
+    directives: [],
+  };
+}
+
+function getActionInputType(action: string, fieldName: string, isFirst: boolean): InputObjectTypeDefinitionNode {
+  const actionInputFields: { [action: string]: InputValueDefinitionNode[] } = {
+    identifyText: [inputValueDefinition('key', 'String', true)],
+    identifyLabels: [inputValueDefinition('key', 'String', true)],
+    translateText: [
+      inputValueDefinition('sourceLanguage', 'String', true),
+      inputValueDefinition('targetLanguage', 'String', true),
+      ...(isFirst ? [inputValueDefinition('text', 'String', true)] : []),
+    ],
+    convertTextToSpeech: [
+      inputValueDefinition('voiceID', 'String', true),
+      ...(isFirst ? [inputValueDefinition('text', 'String', true)] : []),
+    ],
+  };
+
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    name: { kind: 'Name', value: getActionInputName(action, fieldName) },
+    fields: actionInputFields[action],
+    directives: [],
+  };
+}
+
+function addInputArgument(field: FieldDefinitionNode, fieldName: string, isList: boolean): FieldDefinitionNode {
+  return {
+    ...field,
+    arguments: [
+      {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: { kind: 'Name' as const, value: 'input' },
+        type: makeNonNullType(makeNamedType(`${capitalizeFirstLetter(fieldName)}Input`)),
+        directives: [],
+      },
+    ],
+    type: isList ? makeListType(makeNamedType('String')) : makeNamedType('String'),
+  };
+}
+
+function s3ArnKey(name: string): string {
+  return `arn:aws:s3:::${name}/public/*`;
+}
+
+function getStorageArn(context: TransformerContextProvider, bucketName: string): string {
+  const substitutions: { [key: string]: string } = {
+    hash: cdk.Fn.select(3, cdk.Fn.split('-', cdk.Fn.ref('AWS::StackName'))),
+  };
+
+  if (referencesEnv(bucketName)) {
+    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    substitutions.env = (env as unknown) as string;
+  }
+
+  return (cdk.Fn.conditionIf(
+    ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+    cdk.Fn.sub(s3ArnKey(bucketName), substitutions),
+    cdk.Fn.sub(s3ArnKey(removeEnvReference(bucketName)), { hash: cdk.Fn.select(3, cdk.Fn.split('-', cdk.Fn.ref('AWS::StackName'))) }),
+  ) as unknown) as string;
+}
+
+function createActionFunction(context: TransformerContextProvider, stack: cdk.Stack, action: string, datasourceName: string) {
+  const httpPayload = `${action}Payload`;
+  let actionFunctionResolver;
+
+  switch (action) {
+    case 'identifyText':
+      actionFunctionResolver = {
+        request: compoundExpression([
+          set(ref('bucketName'), ref('ctx.stash.get("s3Bucket")')),
+          set(ref('identityTextKey'), ref('ctx.args.input.identifyText.key')),
+          set(
+            ref(httpPayload),
+            HttpMappingTemplate.postRequest({
+              resourcePath: '/',
+              params: obj({
+                body: obj({
+                  Image: obj({
+                    S3Object: obj({
+                      Bucket: str('$bucketName'),
+                      Name: str('public/$identityTextKey'),
+                    }),
+                  }),
+                }),
+                headers: obj({
+                  'Content-Type': str('application/x-amz-json-1.1'),
+                  'X-Amz-Target': str('RekognitionService.DetectText'),
+                }),
+              }),
+            }),
+          ),
+          toJson(ref(httpPayload)),
+        ]),
+        response: compoundExpression([
+          iff(ref('ctx.error'), ref('util.error($ctx.error.message)')),
+          ifElse(
+            raw('$ctx.result.statusCode == 200'),
+            compoundExpression([
+              set(ref('results'), ref('util.parseJson($ctx.result.body)')),
+              set(ref('finalResult'), str('')),
+              forEach(/** for */ ref('item'), /** in */ ref('results.TextDetections'), [
+                iff(raw('$item.Type == "LINE"'), set(ref('finalResult'), str('$finalResult$item.DetectedText '))),
+              ]),
+              ref('util.toJson($finalResult.trim())'),
+            ]),
+            ref('utils.error($ctx.result.body)'),
+          ),
+        ]),
+      };
+      break;
+
+    case 'identifyLabels':
+      actionFunctionResolver = {
+        request: compoundExpression([
+          set(ref('bucketName'), ref('ctx.stash.get("s3Bucket")')),
+          set(ref('identifyLabelKey'), ref('ctx.args.input.identifyLabels.key')),
+          qref('$ctx.stash.put("isList", true)'),
+          set(
+            ref(httpPayload),
+            HttpMappingTemplate.postRequest({
+              resourcePath: '/',
+              params: obj({
+                body: obj({
+                  Image: obj({
+                    S3Object: obj({
+                      Bucket: str('$bucketName'),
+                      Name: str('public/$identifyLabelKey'),
+                    }),
+                  }),
+                  MaxLabels: int(10),
+                  MinConfidence: int(55),
+                }),
+                headers: obj({
+                  'Content-Type': str('application/x-amz-json-1.1'),
+                  'X-Amz-Target': str('RekognitionService.DetectLabels'),
+                }),
+              }),
+            }),
+          ),
+          toJson(ref(httpPayload)),
+        ]),
+        response: compoundExpression([
+          iff(ref('ctx.error'), ref('util.error($ctx.error.message)')),
+          ifElse(
+            raw('$ctx.result.statusCode == 200'),
+            compoundExpression([
+              set(ref('labels'), str('')),
+              set(ref('result'), ref('util.parseJson($ctx.result.body)')),
+              forEach(/** for */ ref('label'), /** in */ ref('result.Labels'), [set(ref('labels'), str('$labels$label.Name, '))]),
+              toJson(ref('labels.replaceAll(", $", "")')), // trim unnessary space
+            ]),
+            ref('util.error($ctx.result.body)'),
+          ),
+        ]),
+      };
+      break;
+
+    case 'translateText':
+      actionFunctionResolver = {
+        request: compoundExpression([
+          set(ref('text'), ref('util.defaultIfNull($ctx.args.input.translateText.text, $ctx.prev.result)')),
+          set(
+            ref(httpPayload),
+            HttpMappingTemplate.postRequest({
+              resourcePath: '/',
+              params: obj({
+                body: obj({
+                  SourceLanguageCode: ref('ctx.args.input.translateText.sourceLanguage'),
+                  TargetLanguageCode: ref('ctx.args.input.translateText.targetLanguage'),
+                  Text: ref('text'),
+                }),
+                headers: obj({
+                  'Content-Type': str('application/x-amz-json-1.1'),
+                  'X-Amz-Target': str('AWSShineFrontendService_20170701.TranslateText'),
+                }),
+              }),
+            }),
+          ),
+          toJson(ref(httpPayload)),
+        ]),
+        response: compoundExpression([
+          iff(ref('ctx.error'), ref('util.error($ctx.error.message)')),
+          ifElse(
+            raw('$ctx.result.statusCode == 200'),
+            compoundExpression([set(ref('result'), ref('util.parseJson($ctx.result.body)')), ref('util.toJson($result.TranslatedText)')]),
+            ref('util.error($ctx.result.body)'),
+          ),
+        ]),
+      };
+      break;
+
+    case 'convertTextToSpeech':
+    default:
+      actionFunctionResolver = {
+        request: compoundExpression([
+          set(ref('bucketName'), ref('ctx.stash.get("s3Bucket")')),
+          qref('$ctx.stash.put("isList", false)'),
+          set(ref('text'), ref('util.defaultIfNull($ctx.args.input.convertTextToSpeech.text, $ctx.prev.result)')),
+          obj({
+            version: str('2018-05-29'),
+            operation: str('Invoke'),
+            payload: toJson(
+              obj({
+                uuid: str('$util.autoId()'),
+                action: str('convertTextToSpeech'),
+                voiceID: ref('ctx.args.input.convertTextToSpeech.voiceID'),
+                text: ref('text'),
+              }),
+            ),
+          }),
+        ]),
+        response: compoundExpression([
+          iff(ref('ctx.error'), ref('util.error($ctx.error.message, $ctx.error.type)')),
+          set(ref('response'), ref('util.parseJson($ctx.result)')),
+          ref('util.toJson($ctx.result.url)'),
+        ]),
+      };
+      break;
+  }
+
+  return context.api.addAppSyncFunction(
+    `${action}Function`,
+    MappingTemplate.inlineTemplateFromString(print(actionFunctionResolver.request)),
+    MappingTemplate.inlineTemplateFromString(print(actionFunctionResolver.response)),
+    datasourceName,
+    stack,
+  );
+}

--- a/packages/amplify-graphql-predictions-transformer/src/index.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/index.ts
@@ -1,0 +1,1 @@
+export { PredictionsTransformer } from './graphql-predictions-transformer';

--- a/packages/amplify-graphql-predictions-transformer/src/utils/action-maps.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/utils/action-maps.ts
@@ -1,0 +1,20 @@
+export const allowedActions = new Map([
+  ['identifyText', ['translateText']],
+  ['identifyLabels', ['translateText', 'convertTextToSpeech']],
+  ['translateText', ['convertTextToSpeech']],
+  ['convertTextToSpeech', []],
+]);
+
+export const actionToDataSourceMap = new Map([
+  ['identifyEntities', 'RekognitionDataSource'],
+  ['identifyText', 'RekognitionDataSource'],
+  ['identifyLabels', 'RekognitionDataSource'],
+  ['translateText', 'TranslateDataSource'],
+  ['convertTextToSpeech', 'LambdaDataSource'],
+]);
+
+export const actionToRoleAction = new Map([
+  ['identifyText', 'rekognition:DetectText'],
+  ['identifyLabels', 'rekognition:DetectLabels'],
+  ['translateText', 'translate:TranslateText'],
+]);

--- a/packages/amplify-graphql-predictions-transformer/src/utils/constants.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/utils/constants.ts
@@ -1,0 +1,19 @@
+export const PREDICTIONS_DIRECTIVE_STACK = 'PredictionsDirectiveStack';
+export const directiveDefinition = /* GraphQL */ `
+  directive @predictions(actions: [PredictionsActions!]!) on FIELD_DEFINITION
+  enum PredictionsActions {
+    identifyText
+    identifyLabels
+    convertTextToSpeech
+    translateText
+  }
+`;
+export const identifyEntities = 'identifyEntities';
+export const identifyText = 'identifyText';
+export const identifyLabels = 'identifyLabels';
+export const translateText = 'translateText';
+export const convertTextToSpeech = 'convertTextToSpeech';
+export const identifyTextAmzTarget = 'RekognitionService.DetectText';
+export const identifyLabelsAmzTarget = 'RekognitionService.DetectLabels';
+export const translateTextAmzTarget = 'AWSShineFrontendService_20170701.TranslateText';
+export const amzJsonContentType = 'application/x-amz-json-1.1';

--- a/packages/amplify-graphql-predictions-transformer/tsconfig.json
+++ b/packages/amplify-graphql-predictions-transformer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [
+    {"path": "../amplify-graphql-transformer-core"},
+    {"path": "../amplify-graphql-transformer-interfaces"},
+    {"path": "../graphql-mapping-template"},
+    {"path": "../graphql-transformer-common"}
+  ]
+}

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
@@ -40,6 +40,7 @@ export const createLambda = (
     ],
     lambdaRole,
     enviroment,
+    undefined,
     stack,
   );
 };

--- a/packages/amplify-graphql-transformer-core/src/graphql-api.ts
+++ b/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -297,6 +297,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
     layers?: ILayerVersion[],
     role?: IRole,
     environment?: { [key: string]: string },
+    timeout?: Duration,
     stack?: Stack,
   ): IFunction {
     const dummycode = `if __name__ == "__main__":`; // assing dummy code so as to be overriden later
@@ -307,6 +308,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
       role,
       layers,
       environment,
+      timeout,
     });
     fn.addLayers();
     const functionCode = new S3MappingFunctionCode(functionKey, filePath).bind(fn);

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -1,7 +1,7 @@
 import { NoneDataSource, HttpDataSource, DynamoDbDataSource, LambdaDataSource, BaseDataSource, CfnResolver } from '@aws-cdk/aws-appsync';
 import { IFunction, ILayerVersion, Runtime } from '@aws-cdk/aws-lambda';
 import { ITable } from '@aws-cdk/aws-dynamodb';
-import { CfnResource, Construct, IAsset, IConstruct, Stack } from '@aws-cdk/core';
+import { CfnResource, Construct, Duration, IAsset, IConstruct, Stack } from '@aws-cdk/core';
 import { Grant, IGrantable, IRole } from '@aws-cdk/aws-iam';
 
 export interface AppSyncFunctionConfigurationProvider extends IConstruct {
@@ -90,6 +90,7 @@ export interface GraphQLAPIProvider {
     layers?: ILayerVersion[],
     role?: IRole,
     environment?: { [key: string]: string },
+    timeout?: Duration,
     stack?: Stack,
   ) => IFunction;
 

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -27,6 +27,7 @@
     "@aws-amplify/graphql-function-transformer": "0.3.4",
     "@aws-amplify/graphql-http-transformer": "0.4.0",
     "@aws-amplify/graphql-model-transformer": "0.4.3",
+    "@aws-amplify/graphql-predictions-transformer": "0.1.0",
     "@aws-amplify/graphql-searchable-transformer": "0.2.3",
     "@aws-amplify/graphql-transformer-core": "0.6.3",
     "@aws-amplify/graphql-transformer-interfaces": "1.6.1",

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -13,8 +13,8 @@ import {
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { FunctionTransformer } from '@aws-amplify/graphql-function-transformer';
 import { HttpTransformer } from '@aws-amplify/graphql-http-transformer';
+import { PredictionsTransformer } from '@aws-amplify/graphql-predictions-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
-
 import { ProviderName as providerName } from '../constants';
 import { hashDirectory } from '../upload-appsync-files';
 import { writeDeploymentToDisk } from './utils';
@@ -51,6 +51,7 @@ function getTransformerFactory(context, resourceDir) {
       new ModelTransformer(),
       new FunctionTransformer(),
       new HttpTransformer(),
+      new PredictionsTransformer(options?.storageConfig),
       // TODO: initialize transformer plugins
     ];
 


### PR DESCRIPTION
#### Description of changes
This commit ports the `@predictions` directive to v2 of the GraphQL Transformer.

#### Issue #, if available

#### Description of how you validated changes
Unit tests and manual testing.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.