### PR TITLE
fix: update auth sms workflow check

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/message-printer.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/message-printer.test.ts
@@ -1,5 +1,6 @@
-import { printSMSSandboxWarning } from '../../../../provider-utils/awscloudformation/utils/message-printer';
+import { doesConfigurationIncludeSMS, printSMSSandboxWarning } from '../../../../provider-utils/awscloudformation/utils/message-printer';
 import { BannerMessage } from 'amplify-cli-core';
+import { ServiceQuestionsResult } from '../../../../provider-utils/awscloudformation/service-walkthrough-types';
 jest.mock('amplify-cli-core');
 const printMock = {
   info: jest.fn(),
@@ -25,5 +26,66 @@ describe('printSMSSandboxWarning', () => {
     await printSMSSandboxWarning(printMock);
     expect(printMock.info).not.toHaveBeenCalled();
     expect(mockedGetMessage).toHaveBeenCalledWith('COGNITO_SMS_SANDBOX_CATEGORY_AUTH_ADD_OR_UPDATE_INFO');
+  });
+});
+
+describe('doesConfigurationIncludeSMS', () => {
+  let request: ServiceQuestionsResult;
+
+  beforeEach(() => {
+    request = {
+      adminQueries: false,
+      authProviders: [],
+      authSelections: 'identityPoolAndUserPool',
+      autoVerifiedAttributes: [],
+      mfaConfiguration: 'OFF',
+      requiredAttributes: [],
+      serviceName: 'Cognito',
+      usernameAttributes: [],
+      thirdPartyAuth: false,
+      useDefault: 'default',
+      userPoolGroups: false,
+      userpoolClientReadAttributes: [],
+      userpoolClientWriteAttributes: [],
+    };
+  });
+
+  it('should return true when MFA is optional and SMS text Message is enabled', () => {
+    request.mfaConfiguration = 'OPTIONAL';
+    request.mfaTypes = ['SMS Text Message', 'TOTP'];
+    expect(doesConfigurationIncludeSMS(request)).toBeTruthy();
+  });
+
+  it('should return true when MFA is ON and SMS text Message is enabled', () => {
+    request.mfaConfiguration = 'ON';
+    request.mfaTypes = ['SMS Text Message', 'TOTP'];
+    expect(doesConfigurationIncludeSMS(request)).toBeTruthy();
+  });
+
+  it('should return false when MFA is on and SMS Text message is not enabled', () => {
+    request.mfaConfiguration = 'ON';
+    request.mfaTypes = ['TOTP'];
+    expect(doesConfigurationIncludeSMS(request)).toBeFalsy();
+  });
+
+  it('should return false when MFA OFF', () => {
+    request.mfaConfiguration = 'OFF';
+    request.mfaTypes = ['TOTP', 'SMS Text Message'];
+    expect(doesConfigurationIncludeSMS(request)).toBeFalsy();
+  });
+
+  it('should return true when userNameAttribute contains phone number', () => {
+    request.usernameAttributes = ['phone_number'];
+    expect(doesConfigurationIncludeSMS(request)).toBeTruthy();
+  });
+
+  it('should return true when userNameAttribute contains phone number', () => {
+    request.usernameAttributes = ['email, phone_number'] as any;
+    expect(doesConfigurationIncludeSMS(request)).toBeTruthy();
+  });
+
+  it('should return false when username attribute does not contain phone number', () => {
+    request.usernameAttributes = ['email'] as any;
+    expect(doesConfigurationIncludeSMS(request)).toBeFalsy();
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/message-printer.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/message-printer.ts
@@ -38,7 +38,14 @@ export const doesConfigurationIncludeSMS = (request: ServiceQuestionsResult): bo
     return true;
   }
 
-  if (request.usernameAttributes?.includes('phone_number')) {
+  if (
+    request.usernameAttributes?.some(str =>
+      str
+        ?.split(',')
+        .map(str => str.trim())
+        .includes('phone_number'),
+    )
+  ) {
     return true;
   }
 


### PR DESCRIPTION
updated Auth SMS workflow check to handle the case when user name can be both email and phone number

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.