### PR TITLE
fix: Move credential validation to the top function call

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -35,6 +35,22 @@ describe('profile tests', () => {
     expect(getProfileCredentials_mock).toHaveBeenCalledTimes(0);
   });
 
+  it('should fail to return profiled aws credentials', async () => {
+    fs_mock.readFileSync.mockImplementationOnce(() => {
+      return '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n';
+    }).mockImplementationOnce(() => {
+      return '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n';
+    });
+    const getProfileCredentials_mock = jest.fn(getProfileCredentials);
+    try {
+      const profile_config =  getProfiledAwsConfig(context_stub, 'fake');
+    } catch (e) {
+      expect(e.message).toEqual("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
+    }
+    // await expect(() => getProfiledAwsConfig(context_stub, 'fake')).toThrow("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
+    expect(getProfileCredentials_mock).toHaveBeenCalledTimes(0);
+  });
+
   it('should return profile credentials with aws prefix snake_case', () => {
     fs_mock.readFileSync.mockImplementationOnce(() => {
       return '[fake]\naws_access_key_id=fakeAccessKey\naws_secret_access_key=fakeSecretKey\n';
@@ -61,26 +77,6 @@ describe('profile tests', () => {
     });
     const creds = getProfileCredentials('fake');
     expect(creds).toBeDefined();
-    expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
-    expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail to return profile credentials', () => {
-    fs_mock.readFileSync.mockImplementationOnce(() => {
-      return '[fake]\nmalformed_access_key_id=fakeAccessKey\naws_secret_access_key=fakeSecretKey\n';
-    });
-    expect(() => getProfileCredentials('fake')).toThrow("Profile configuration for 'fake' is invalid: missing aws_access_key_id");
-    expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
-    expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail to return profile credentials', () => {
-    fs_mock.readFileSync.mockImplementationOnce(() => {
-      return '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n';
-    });
-    expect(() => getProfileCredentials('fake')).toThrowError(
-      "Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key",
-    );
     expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
     expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
   });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -44,7 +44,7 @@ describe('profile tests', () => {
     });
     const getProfileCredentials_mock = jest.fn(getProfileCredentials);
     try {
-      const profile_config =  getProfiledAwsConfig(context_stub, 'fake');
+      const profile_config = await getProfiledAwsConfig(context_stub, 'fake');
     } catch (e) {
       expect(e.message).toEqual("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
     }

--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -43,12 +43,7 @@ describe('profile tests', () => {
       return profile_file_contents;
     });
     const getProfileCredentials_mock = jest.fn(getProfileCredentials);
-    try {
-      const profile_config = await getProfiledAwsConfig(context_stub, 'fake');
-    } catch (e) {
-      expect(e.message).toEqual("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
-    }
-    // await expect(() => getProfiledAwsConfig(context_stub, 'fake')).toThrow("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
+    await expect(() => getProfiledAwsConfig(context_stub, 'fake')).rejects.toThrowError("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
     expect(getProfileCredentials_mock).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -36,18 +36,18 @@ describe('profile tests', () => {
   });
 
   it('should fail to return profiled aws credentials', async () => {
+    const profile_file_contents = '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n'
     fs_mock.readFileSync.mockImplementationOnce(() => {
-      return '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n';
+      return profile_file_contents;
     }).mockImplementationOnce(() => {
-      return '[fake]\nmalformed_key_id=fakeAccessKey\nmalformed_secret_access_key=fakeSecretKey\n';
+      return profile_file_contents;
     });
     const getProfileCredentials_mock = jest.fn(getProfileCredentials);
     try {
-      const profile_config =  getProfiledAwsConfig(context_stub, 'fake');
+      const profile_config = await getProfiledAwsConfig(context_stub, 'fake');
     } catch (e) {
       expect(e.message).toEqual("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
     }
-    // await expect(() => getProfiledAwsConfig(context_stub, 'fake')).toThrow("Profile configuration for 'fake' is invalid: missing aws_access_key_id, aws_secret_access_key");
     expect(getProfileCredentials_mock).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -86,6 +86,7 @@ export async function getProfiledAwsConfig(context: $TSContext, profileName: str
         ...profileConfig,
         ...profileCredentials,
       };
+      validateCredentials(awsConfig, profileName);
     }
   } else {
     const err = new Error(`Profile configuration is missing for: ${profileName}`);
@@ -289,15 +290,11 @@ export function getProfileCredentials(profileName: string) {
     });
   }
   profileCredentials = normalizeKeys(profileCredentials);
-  validateCredentials(profileCredentials, profileName);
   return profileCredentials;
 }
 
 function validateCredentials(credentials: $TSAny, profileName: string) {
   const missingKeys = [];
-  if (credentials?.source_profile && credentials?.role_arn) {
-    return;
-  }
   if (!credentials?.accessKeyId) {
     missingKeys.push('aws_access_key_id');
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Move profile credential validation to the top function, getProfiledAwsCredentials. Prevents erroneous errors on validation when a source profile is used
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
\#7311
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Executed amplify-dev commands locally with and without source_profile configured


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.