### PR TITLE
fix: correct 'tranformer' typo

### DIFF
--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/graphql-function-transformer",
   "version": "0.3.2",
-  "description": "Amplify GraphQL @function tranformer",
+  "description": "Amplify GraphQL @function transformer",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-cli.git",

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/graphql-http-transformer",
   "version": "0.3.2",
-  "description": "Amplify GraphQL @http tranformer",
+  "description": "Amplify GraphQL @http transformer",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-cli.git",

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@aws-amplify/graphql-model-transformer",
     "version": "0.4.1",
-    "description": "Amplfy graphql @model tranformer",
+    "description": "Amplify graphql @model transformer",
     "repository": {
         "type": "git",
         "url": "https://github.com/aws-amplify/amplify-cli.git",

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -6,7 +6,7 @@ import {
   MutationFieldType,
   QueryFieldType,
   SubscriptionFieldType,
-  TranformerTransformSchemaStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
   TransformerContextProvider,
   TransformerModelProvider,
   TransformerPrepareStepContextProvider,
@@ -170,7 +170,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     }
   };
 
-  transformSchema = (ctx: TranformerTransformSchemaStepContextProvider): void => {
+  transformSchema = (ctx: TransformerTransformSchemaStepContextProvider): void => {
     // Create Non Model input types
 
     // add the model input conditions
@@ -497,7 +497,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   };
 
   getQueryFieldNames = (
-    ctx: TranformerTransformSchemaStepContextProvider,
+    ctx: TransformerTransformSchemaStepContextProvider,
     type: ObjectTypeDefinitionNode,
   ): Set<{ fieldName: string; typeName: string; type: QueryFieldType }> => {
     const typeName = type.name.value;
@@ -528,7 +528,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   };
 
   getMutationFieldNames = (
-    ctx: TranformerTransformSchemaStepContextProvider,
+    ctx: TransformerTransformSchemaStepContextProvider,
     type: ObjectTypeDefinitionNode,
   ): Set<{ fieldName: string; typeName: string; type: MutationFieldType }> => {
     // Todo: get fields names from the directives
@@ -562,7 +562,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   };
 
   getSubscriptionFieldNames = (
-    ctx: TranformerTransformSchemaStepContextProvider,
+    ctx: TransformerTransformSchemaStepContextProvider,
     type: ObjectTypeDefinitionNode,
   ): Set<{
     fieldName: string;
@@ -641,7 +641,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   };
 
   getInputs = (
-    ctx: TranformerTransformSchemaStepContextProvider,
+    ctx: TransformerTransformSchemaStepContextProvider,
     type: ObjectTypeDefinitionNode,
     operation: {
       fieldName: string;
@@ -731,7 +731,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   };
 
   getOutputType = (
-    ctx: TranformerTransformSchemaStepContextProvider,
+    ctx: TransformerTransformSchemaStepContextProvider,
     type: ObjectTypeDefinitionNode,
     operation: {
       fieldName: string;
@@ -763,7 +763,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     return outputType;
   };
 
-  private createNonModelInputs = (ctx: TranformerTransformSchemaStepContextProvider, obj: ObjectTypeDefinitionNode): void => {
+  private createNonModelInputs = (ctx: TransformerTransformSchemaStepContextProvider, obj: ObjectTypeDefinitionNode): void => {
     for (let field of obj.fields || []) {
       if (!isScalar(field.type)) {
         const def = ctx.output.getType(getBaseType(field.type));
@@ -789,7 +789,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
    * Model directive automatically adds id, created and updated time stamps to the filed, if they are configured
    * @param name Name of the type
    */
-  private addAutoGeneratableFields = (ctx: TranformerTransformSchemaStepContextProvider, name: string): void => {
+  private addAutoGeneratableFields = (ctx: TransformerTransformSchemaStepContextProvider, name: string): void => {
     const modelDirectiveConfig = this.modelDirectiveConfig.get(name);
     const typeObj = ctx.output.getObject(name);
     if (!typeObj) {

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/common.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/common.ts
@@ -1,10 +1,10 @@
-import { TranformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   EnumTypeDefinitionNode,
   FieldDefinitionNode,
   InputObjectTypeDefinitionNode,
   ObjectTypeDefinitionNode,
-  TypeDefinitionNode
+  TypeDefinitionNode,
 } from 'graphql';
 import {
   DEFAULT_SCALARS,
@@ -13,7 +13,7 @@ import {
   makeField,
   makeNamedType,
   makeValueNode,
-  toPascalCase
+  toPascalCase,
 } from 'graphql-transformer-common';
 import {
   ATTRIBUTE_TYPES,
@@ -27,13 +27,13 @@ import {
   INT_FUNCTIONS,
   SIZE_CONDITIONS,
   STRING_CONDITIONS,
-  STRING_FUNCTIONS
+  STRING_FUNCTIONS,
 } from '../definitions';
 import {
   EnumWrapper,
   InputFieldWraper,
   InputObjectDefinitionWrapper,
-  ObjectDefinationWrapper
+  ObjectDefinationWrapper,
 } from '../wrappers/object-definition-wrapper';
 
 /**
@@ -43,7 +43,7 @@ import {
  * @param object ModelObjectDefination
  */
 export const makeConditionFilterInput = (
-  ctx: TranformerTransformSchemaStepContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   name: string,
   object: ObjectTypeDefinitionNode,
 ): InputObjectDefinitionWrapper => {
@@ -74,7 +74,7 @@ export const makeConditionFilterInput = (
   return input;
 };
 
-export const addModelConditionInputs = (ctx: TranformerTransformSchemaStepContextProvider): void => {
+export const addModelConditionInputs = (ctx: TransformerTransformSchemaStepContextProvider): void => {
   const conditionsInput: TypeDefinitionNode[] = ['String', 'Int', 'Float', 'Boolean', 'ID'].map(scalarName =>
     makeModelScalarFilterInputObject(scalarName, true),
   );
@@ -101,7 +101,7 @@ export function generateModelScalarFilterInputName(typeName: string, includeFilt
   return `Model${typeName}${includeFilter ? 'Filter' : ''}Input`;
 }
 export const createEnumModelFilters = (
-  ctx: TranformerTransformSchemaStepContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   type: ObjectTypeDefinitionNode,
 ): InputObjectTypeDefinitionNode[] => {
   // add enum type if present

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
@@ -1,4 +1,4 @@
-import { TranformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ObjectTypeDefinitionNode, InputObjectTypeDefinitionNode } from 'graphql';
 import { toPascalCase } from 'graphql-transformer-common';
 import { ModelDirectiveConfiguration } from '../graphql-model-transformer';
@@ -128,14 +128,14 @@ export const makeCreateInputField = (
 };
 
 export const makeMutationConditionInput = (
-  ctx: TranformerTransformSchemaStepContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   name: string,
   object: ObjectTypeDefinitionNode,
 ): InputObjectTypeDefinitionNode => {
   const input = makeConditionFilterInput(ctx, name, object);
-  const idField = input.fields.find(f => f.name === 'id' && f.getTypeName() === 'ID')
-  if(idField) {
-    input.removeField(idField)
+  const idField = input.fields.find(f => f.name === 'id' && f.getTypeName() === 'ID');
+  if (idField) {
+    input.removeField(idField);
   }
   return input.serialize();
 };

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/query.ts
@@ -1,9 +1,9 @@
-import { TranformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { InputObjectTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { FieldWrapper, ObjectDefinationWrapper } from '../wrappers/object-definition-wrapper';
 import { makeConditionFilterInput } from './common';
 export const makeListQueryFilterInput = (
-  ctx: TranformerTransformSchemaStepContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   name: string,
   object: ObjectTypeDefinitionNode,
 ): InputObjectTypeDefinitionNode => {

--- a/packages/amplify-graphql-transformer-interfaces/src/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/index.ts
@@ -9,7 +9,7 @@ export {
   StackManagerProvider,
   TransformerResolversManagerProvider,
   DataSourceInstance,
-  TranformerTransformSchemaStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
   TransformerBeforeStepContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerSchemaVisitStepContextProvider,

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
@@ -1,15 +1,19 @@
-export { DataSourceProvider, TransformerDataSourceManagerProvider, AppSyncDataSourceType, DataSourceInstance } from './transformer-datasource-provider';
+export {
+  DataSourceProvider,
+  TransformerDataSourceManagerProvider,
+  AppSyncDataSourceType,
+  DataSourceInstance,
+} from './transformer-datasource-provider';
 export { TransformerContextOutputProvider } from './transformer-context-output-provider';
 export { TransformerProviderRegistry } from './transformer-provider-registry';
 export { TransformerResolverProvider, TransformerResolversManagerProvider } from './transformer-resolver-provider';
-export { TransformerResourceProvider as TransformerResourceHelperProvider } from './resource-resource-provider'
+export { TransformerResourceProvider as TransformerResourceHelperProvider } from './resource-resource-provider';
 export {
   TransformerContextProvider,
-  TranformerTransformSchemaStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
   TransformerBeforeStepContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerSchemaVisitStepContextProvider,
   TransformerValidationStepContextProvider,
 } from './transformer-context-provider';
 export { StackManagerProvider } from './stack-manager-provider';
-

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -31,4 +31,4 @@ export type TransformerValidationStepContextProvider = Pick<
   'inputDocument' | 'output' | 'providerRegistry' | 'dataSources' | 'featureFlags'
 >;
 export type TransformerPrepareStepContextProvider = TransformerValidationStepContextProvider;
-export type TranformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;
+export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-plugin-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-plugin-provider.ts
@@ -18,7 +18,7 @@ import {
   TransformerPrepareStepContextProvider,
   TransformerSchemaVisitStepContextProvider,
   TransformerValidationStepContextProvider,
-  TranformerTransformSchemaStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
 } from './transformer-context/transformer-context-provider';
 
 export enum TransformerPluginType {
@@ -121,7 +121,7 @@ export interface TransformerPluginProvider {
   /**
    * Update the schema with additional queries and input types
    */
-  transformSchema?: (context: TranformerTransformSchemaStepContextProvider) => void;
+  transformSchema?: (context: TransformerTransformSchemaStepContextProvider) => void;
 
   /**
    * generate resolvers

--- a/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
+++ b/packages/graphql-dynamodb-transformer/src/DynamoDBModelTransformer.ts
@@ -706,7 +706,7 @@ export class DynamoDBModelTransformer extends Transformer {
   }
 
   // Due to the current architecture of Transformers we've to handle the 'id' field removal
-  // here, because KeyTranformer will not be invoked if there are no @key directives declared
+  // here, because KeyTransformer will not be invoked if there are no @key directives declared
   // on the type.
   private updateMutationConditionInput(ctx: TransformerContext, type: ObjectTypeDefinitionNode): void {
     if (this.supportsConditions(ctx)) {


### PR DESCRIPTION
#### Description of changes
This commit updates the GraphQL v2 Transformer to correct a typo: tranformer -> transformer

#### Issue #, if available

#### Description of how you validated changes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.