### PR TITLE
fix: remove extra $ output of model transformer v2

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/query.ts
@@ -55,7 +55,7 @@ export const generateListRequestTemplate = (): string => {
       compoundExpression([
         set(
           ref(`filterExpression`),
-          methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('$ctx.args.filter'))),
+          methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('ctx.args.filter'))),
         ),
         iff(
           not(methodCall(ref('util.isNullOrBlank'), ref('filterExpression.expression'))),
@@ -70,7 +70,7 @@ export const generateListRequestTemplate = (): string => {
       ]),
     ),
     ifElse(
-      not(methodCall(ref('$util.isNull'), ref(modelQueryObj))),
+      not(methodCall(ref('util.isNull'), ref(modelQueryObj))),
       compoundExpression([
         set(
           ref('Query'),

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -573,7 +573,7 @@ $util.toJson($GetRequest)
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
 #if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($$ctx.args.filter)) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -581,7 +581,7 @@ $util.toJson($GetRequest)
     #set( $ListRequest.filter = $filterExpression )
   #end
 #end
-#if( !$$util.isNull($ctx.stash.modelQuery) )
+#if( !$util.isNull($ctx.stash.modelQuery) )
   #set( $Query = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.modelQuery)) )
   $util.qr($ListRequest.put(\\"operation\\", \\"Query\\"))
   $util.qr($ListRequest.put(\\"query\\", $Query))


### PR DESCRIPTION
#### Description of changes
This commit removes an extra $ that was being generated in two places by the model transformer v2.

#### Issue #, if available

#### Description of how you validated changes
Manual testing and unit testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.