### PR TITLE
fix: support AWS::URLSuffix CFN pseudo-param in mock

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -9,6 +9,7 @@ const CFN_DEFAULT_PARAMS = {
   'AWS::AccountId': '12345678910',
   'AWS::StackId': 'fake-stackId',
   'AWS::StackName': 'local-testing',
+  'AWS::URLSuffix': 'amazonaws.com',
 };
 
 const RESOLVER_TEMPLATE_LOCATION_PREFIX = 's3://${S3DeploymentBucket}/${S3DeploymentRootKey}/';

--- a/packages/amplify-util-mock/src/CFNParser/stack/index.ts
+++ b/packages/amplify-util-mock/src/CFNParser/stack/index.ts
@@ -19,6 +19,7 @@ export const CFN_PSEUDO_PARAMS = {
   'AWS::AccountId': '12345678910',
   'AWS::StackId': 'fake-stackId',
   'AWS::StackName': 'local-testing',
+  'AWS::URLSuffix': 'amazonaws.com',
 };
 
 export function nestedStackHandler(

--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/populate-cfn-params.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/populate-cfn-params.test.ts
@@ -77,6 +77,7 @@ describe('populate cfn params', () => {
       'AWS::AccountId': '1234',
       'AWS::StackId': 'arn:aws:cloudformation:us-test-1:1234:stack/my-test-stack',
       'AWS::StackName': 'test-stack-name',
+      'AWS::URLSuffix': 'amazonaws.com',
     });
   });
 
@@ -93,6 +94,7 @@ describe('populate cfn params', () => {
       'AWS::AccountId': '12345678910',
       'AWS::StackId': 'fake-stack-id',
       'AWS::StackName': 'local-testing',
+      'AWS::URLSuffix': 'amazonaws.com',
     });
   });
 

--- a/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
@@ -32,6 +32,7 @@ const getCfnPseudoParams = (): Record<string, string> => {
     'AWS::AccountId': accountId,
     'AWS::StackId': stackId,
     'AWS::StackName': stackName,
+    'AWS::URLSuffix': 'amazonaws.com',
   };
 };
 


### PR DESCRIPTION
#### Description of changes
This commit adds mock support for the CFN pseudo-parameter `AWS::URLSuffix`, which is used by the GraphQL transformer v2.

#### Issue #, if available

#### Description of how you validated changes
Manual and unit testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.