### PR TITLE
fix(graphql-model-transformer): use modelobject key for mutation resolver creation

### DIFF
--- a/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
@@ -7,8 +7,8 @@ import { KeyTransformer } from 'graphql-key-transformer';
 
 jest.setTimeout(2000000);
 
-let GRAPHQL_ENDPOINT = undefined;
-let GRAPHQL_CLIENT = undefined;
+let GRAPHQL_ENDPOINT: string = undefined;
+let GRAPHQL_CLIENT: GraphQLClient = undefined;
 let ddbEmulator = null;
 let dbPath = null;
 let server;
@@ -351,14 +351,25 @@ test('Test update mutation validation with three part secondary key.', async () 
 });
 
 test('Test Customer Create with list member and secondary key', async () => {
-  const createCustomer1 = await createCustomer('customer1@email.com', ['thing1', 'thing2'], 'customerusr1');
+  await createCustomer('customer1@email.com', ['thing1', 'thing2'], 'customerusr1');
   const getCustomer1 = await getCustomer('customer1@email.com');
   expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing1', 'thing2']);
-  // const items = await onCreateCustomer
+});
+
+test('Test can overwrite customer record with custom primary key', async () => {
+  await createCustomer('customer42@email.com', ['thing1', 'thing2'], 'customerusr42');
+  const response = await createCustomer('customer42@email.com', ['thing2'], 'customerusr43');
+  expect(response.errors).toBeDefined();
+  expect(response.errors[0]).toEqual(
+    expect.objectContaining({
+      message: 'The conditional request failed',
+      errorType: 'DynamoDB:ConditionalCheckFailedException',
+    }),
+  );
 });
 
 test('Test Customer Mutation with list member', async () => {
-  const updateCustomer1 = await updateCustomer('customer1@email.com', ['thing3', 'thing4'], 'new_customerusr1');
+  await updateCustomer('customer1@email.com', ['thing3', 'thing4'], 'new_customerusr1');
   const getCustomer1 = await getCustomer('customer1@email.com');
   expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing3', 'thing4']);
 });

--- a/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
@@ -356,7 +356,7 @@ test('Test Customer Create with list member and secondary key', async () => {
   expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing1', 'thing2']);
 });
 
-test('Test can overwrite customer record with custom primary key', async () => {
+test('Test cannot overwrite customer record with custom primary key', async () => {
   await createCustomer('customer42@email.com', ['thing1', 'thing2'], 'customerusr42');
   const response = await createCustomer('customer42@email.com', ['thing2'], 'customerusr43');
   expect(response.errors).toBeDefined();

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/OperationsArgument.test.ts.snap
@@ -63,12 +63,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -423,7 +440,8 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
   #if( $modelObjectKey )
     #set( $condition = {
   \\"expression\\": \\"\\",
-  \\"expressionNames\\": {}
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
 } )
     #foreach( $entry in $modelObjectKey.entrySet() )
       #if( $velocityCount == 1 )
@@ -438,7 +456,8 @@ exports[`Test "create", "update", "delete" auth operations 5`] = `
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
   #end
 #end
@@ -708,12 +727,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -1068,7 +1104,8 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
   #if( $modelObjectKey )
     #set( $condition = {
   \\"expression\\": \\"\\",
-  \\"expressionNames\\": {}
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
 } )
     #foreach( $entry in $modelObjectKey.entrySet() )
       #if( $velocityCount == 1 )
@@ -1083,7 +1120,8 @@ exports[`Test that operation overwrites queries in auth operations 5`] = `
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
   #end
 #end

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -618,7 +618,7 @@ test('DynamoDB transformer should add default primary key when not defined', () 
   expect(getBaseType(defaultIdField.type)).toEqual('ID');
 });
 
-test('DynamoDB transformer should add not default primary key when ID is defined', () => {
+test('DynamoDB transformer should not add default primary key when ID is defined', () => {
   const validSchema = `
   type Post @model{
     id: Int

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -152,7 +152,7 @@ type Subscription {
 "
 `;
 
-exports[`DynamoDB transformer should add not default primary key when ID is defined 1`] = `
+exports[`DynamoDB transformer should not add default primary key when ID is defined 1`] = `
 "## [Start] Set default values. **
 #set( $createdAt = $util.time.nowISO8601() )
 ## Automatically set the createdAt timestamp. **
@@ -162,12 +162,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 ## [End] Set default values. **
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -320,12 +337,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 ## [End] Set default values. **
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -600,12 +634,29 @@ $util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.i
 ## [End] Set default values. **
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -900,12 +951,29 @@ $util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.i
 ## [End] Set default values. **
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -1304,12 +1372,29 @@ $util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.
 ## [End] Set default values. **
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -804,7 +804,7 @@ export class ResourceFactory {
    */
 
   private addDefaultConditionExpression = (operation: string): Expression => {
-    let attributeCheck = operation === 'create' ? 'attribute_not_exists' : 'attribute_exists';
+    const attributeCheck = operation === 'create' ? 'attribute_not_exists' : 'attribute_exists';
     return ifElse(
       ref(ResourceConstants.SNIPPETS.ModelObjectKey),
       compoundExpression([

--- a/packages/graphql-dynamodb-transformer/src/resources.ts
+++ b/packages/graphql-dynamodb-transformer/src/resources.ts
@@ -20,6 +20,7 @@ import {
   forEach,
   and,
   RESOLVER_VERSION_ID,
+  Expression,
 } from 'graphql-mapping-template';
 import {
   ResourceConstants,
@@ -395,15 +396,7 @@ export class ResourceFactory {
       RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
         compoundExpression([
           qref(`$context.args.input.put("__typename", "${type}")`),
-          set(
-            ref('condition'),
-            obj({
-              expression: str('attribute_not_exists(#id)'),
-              expressionNames: obj({
-                '#id': str('id'),
-              }),
-            }),
-          ),
+          this.addDefaultConditionExpression('create'),
           iff(
             ref('context.args.condition'),
             compoundExpression([
@@ -501,38 +494,7 @@ export class ResourceFactory {
                 ]),
               ),
             ]),
-            ifElse(
-              ref(ResourceConstants.SNIPPETS.ModelObjectKey),
-              compoundExpression([
-                set(
-                  ref('condition'),
-                  obj({
-                    expression: str(''),
-                    expressionNames: obj({}),
-                    expressionValues: obj({}),
-                  }),
-                ),
-                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
-                  ifElse(
-                    raw('$velocityCount == 1'),
-                    qref('$condition.put("expression", "attribute_exists(#keyCondition$velocityCount)")'),
-                    qref('$condition.put(\
-"expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
-                  ),
-                  qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")'),
-                ]),
-              ]),
-              set(
-                ref('condition'),
-                obj({
-                  expression: str('attribute_exists(#id)'),
-                  expressionNames: obj({
-                    '#id': str('id'),
-                  }),
-                  expressionValues: obj({}),
-                }),
-              ),
-            ),
+            this.addDefaultConditionExpression('update'),
           ),
           ...(timestamps && timestamps.updatedAtField
             ? [
@@ -776,36 +738,7 @@ export class ResourceFactory {
                 ]),
               ),
             ]),
-            ifElse(
-              ref(ResourceConstants.SNIPPETS.ModelObjectKey),
-              compoundExpression([
-                set(
-                  ref('condition'),
-                  obj({
-                    expression: str(''),
-                    expressionNames: obj({}),
-                  }),
-                ),
-                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
-                  ifElse(
-                    raw('$velocityCount == 1'),
-                    qref('$condition.put("expression", "attribute_exists(#keyCondition$velocityCount)")'),
-                    qref('$condition.put(\
-"expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
-                  ),
-                  qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")'),
-                ]),
-              ]),
-              set(
-                ref('condition'),
-                obj({
-                  expression: str('attribute_exists(#id)'),
-                  expressionNames: obj({
-                    '#id': str('id'),
-                  }),
-                }),
-              ),
-            ),
+            this.addDefaultConditionExpression('delete'),
           ),
           iff(
             ref(ResourceConstants.SNIPPETS.VersionedCondition),
@@ -864,4 +797,44 @@ export class ResourceFactory {
       ...(syncConfig && { SyncConfig: SyncUtils.syncResolverConfig(syncConfig) }),
     });
   }
+
+  /**
+   * Adds the default Condition Expression uses ModelObjectkey if @key is used
+   * @returns
+   */
+
+  private addDefaultConditionExpression = (operation: string): Expression => {
+    let attributeCheck = operation === 'create' ? 'attribute_not_exists' : 'attribute_exists';
+    return ifElse(
+      ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+      compoundExpression([
+        set(
+          ref('condition'),
+          obj({
+            expression: str(''),
+            expressionNames: obj({}),
+            expressionValues: obj({}),
+          }),
+        ),
+        forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
+          ifElse(
+            raw('$velocityCount == 1'),
+            qref(`$condition.put("expression", "${attributeCheck}(#keyCondition$velocityCount)")`),
+            qref('$condition.put(' + `"expression", "$condition.expression AND ${attributeCheck}(#keyCondition$velocityCount)")`),
+          ),
+          qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")'),
+        ]),
+      ]),
+      set(
+        ref('condition'),
+        obj({
+          expression: str(`${attributeCheck}(#id)`),
+          expressionNames: obj({
+            '#id': str('id'),
+          }),
+          expressionValues: obj({}),
+        }),
+      ),
+    );
+  };
 }

--- a/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
+++ b/packages/graphql-key-transformer/src/__tests__/__snapshots__/KeyTransformer.test.ts.snap
@@ -29,12 +29,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -86,7 +103,8 @@ $util.toJson($ctx.result)
   #if( $modelObjectKey )
     #set( $condition = {
   \\"expression\\": \\"\\",
-  \\"expressionNames\\": {}
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
 } )
     #foreach( $entry in $modelObjectKey.entrySet() )
       #if( $velocityCount == 1 )
@@ -101,7 +119,8 @@ $util.toJson($ctx.result)
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
   #end
 #end
@@ -636,12 +655,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 $util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${ctx.args.input.status}#\${ctx.args.input.createdAt}\\"))
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Item\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
@@ -693,7 +729,8 @@ $util.toJson($ctx.result)
   #if( $modelObjectKey )
     #set( $condition = {
   \\"expression\\": \\"\\",
-  \\"expressionNames\\": {}
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
 } )
     #foreach( $entry in $modelObjectKey.entrySet() )
       #if( $velocityCount == 1 )
@@ -708,7 +745,8 @@ $util.toJson($ctx.result)
   \\"expression\\": \\"attribute_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
   #end
 #end
@@ -1557,12 +1595,29 @@ $util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.
 $util.qr($ctx.args.input.put(\\"firstName#lastName\\",\\"\${ctx.args.input.firstName}#\${ctx.args.input.lastName}\\"))
 ## [Start] Prepare DynamoDB PutItem Request. **
 $util.qr($context.args.input.put(\\"__typename\\", \\"Person\\"))
-#set( $condition = {
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
   \\"expression\\": \\"attribute_not_exists(#id)\\",
   \\"expressionNames\\": {
       \\"#id\\": \\"id\\"
-  }
+  },
+  \\"expressionValues\\": {}
 } )
+#end
 #if( $context.args.condition )
   #set( $condition.expressionValues = {} )
   #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -381,14 +381,31 @@ test('Test create/update mutation validation with three part secondary key.', as
 });
 
 test('Test Customer Create with list member and secondary key', async () => {
-  const createCustomer1 = await createCustomer('customer1@email.com', ['thing1', 'thing2'], 'customerusr1');
+  await createCustomer('customer1@email.com', ['thing1', 'thing2'], 'customerusr1');
   const getCustomer1 = await getCustomer('customer1@email.com');
   expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing1', 'thing2']);
-  // const items = await onCreateCustomer
+});
+
+test('Test can overwrite customer record with custom primary key', async () => {
+  await createCustomer('customer42@email.com', ['thing1', 'thing2'], 'customerusr42');
+  const response = await createCustomer('customer42@email.com', ['thing2'], 'customerusr43');
+  expect(response.errors).toBeDefined();
+  expect(response.errors[0]).toEqual(
+    expect.objectContaining({
+      errorType: 'DynamoDB:ConditionalCheckFailedException',
+      message: expect.stringContaining('The conditional request failed'),
+    }),
+  );
 });
 
 test('Test Customer Mutation with list member', async () => {
-  const updateCustomer1 = await updateCustomer('customer1@email.com', ['thing3', 'thing4'], 'new_customerusr1');
+  await updateCustomer('customer1@email.com', ['thing3', 'thing4'], 'new_customerusr1');
+  const getCustomer1 = await getCustomer('customer1@email.com');
+  expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing3', 'thing4']);
+});
+
+test('Test Customer Mutation with list member', async () => {
+  await updateCustomer('customer1@email.com', ['thing3', 'thing4'], 'new_customerusr1');
   const getCustomer1 = await getCustomer('customer1@email.com');
   expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing3', 'thing4']);
 });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -386,7 +386,7 @@ test('Test Customer Create with list member and secondary key', async () => {
   expect(getCustomer1.data.getCustomer.addresslist).toEqual(['thing1', 'thing2']);
 });
 
-test('Test can overwrite customer record with custom primary key', async () => {
+test('Test cannot overwrite customer record with custom primary key', async () => {
   await createCustomer('customer42@email.com', ['thing1', 'thing2'], 'customerusr42');
   const response = await createCustomer('customer42@email.com', ['thing2'], 'customerusr43');
   expect(response.errors).toBeDefined();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- create update and delete resolvers should check for model object key
- update unit tests to the new resolver change
- update mock and e2e packages to test change


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

- fix #7414 

#### Description of how you validated changes

- ran unit, mock, and e2e tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.