### PR TITLE
fix: let mock start successfully with gql transformer v2

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -123,7 +123,8 @@ export function processTransformerStacks(transformResult, params = {}): AmplifyA
 
   const cfnTemplateFetcher: CloudFormationTemplateFetcher = {
     getCloudFormationStackTemplate: (templateName: string): CloudFormationTemplate => {
-      const template = templateName.replace('https://s3.amazonaws.com/${S3DeploymentBucket}/${S3DeploymentRootKey}/stacks/', '');
+      const templateRegex = new RegExp('^https://s3.(.+\\.)?amazonaws.com/\\${S3DeploymentBucket}/\\${S3DeploymentRootKey}/stacks/');
+      const template = templateName.replace(templateRegex, '');
       const stackTemplate = Object.keys(transformResult.stacks).includes(template)
         ? transformResult.stacks[template]
         : transformResult.stacks[template.replace('.json', '')];

--- a/packages/amplify-util-mock/src/CFNParser/intrinsic-functions.ts
+++ b/packages/amplify-util-mock/src/CFNParser/intrinsic-functions.ts
@@ -103,10 +103,12 @@ export function cfnRef(valNode, { params, resources }: CloudFormationParseContex
   }
 
   if (Object.keys(resources).includes(key)) {
-    if (!('ref' in resources[key].result)) {
+    const result = resources[key]?.result ?? {};
+    const refKey = Object.keys(result).find(k => k.toLowerCase() === 'ref');
+    if (!refKey) {
       throw new Error(`Ref is missing in resource ${key}`);
     }
-    return resources[key].result.ref;
+    return result[refKey];
   }
   console.warn(`Could not find ref for ${JSON.stringify(valNode)}. Using unsubstituted value.`);
   return key;


### PR DESCRIPTION
#### Description of changes
This commit updates the mock functionality so that it can start successfully with GraphQL Transformer v2. The changes here reflect the fact that v2 includes the region in the S3 URL, and the Ref key is not always lowercase.

Note - successful startup also depends on https://github.com/aws-amplify/amplify-cli/pull/7416.

#### Issue #, if available

#### Description of how you validated changes
Manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.