### PR TITLE
test: update verbose flag to filter spinner output, update flag name

### DIFF
--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -457,7 +457,7 @@ function chain(context: Context): ExecutionContext {
 
         if (process.env && process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED) {
           const spinnerRegex = new RegExp(/.*(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏).*/);
-          if (spinnerRegex.test(data) === false && strip(data).replace(EOL, '').trim().length > 0) {
+          if (spinnerRegex.test(data) === false && strip(data).trim().length > 0) {
             console.log(data);
           }
         }

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -13,7 +13,7 @@ declare global {
   }
 }
 
-import { isRegExp, format } from 'util';
+import { types, format } from 'util';
 import { Recorder } from '../asciinema-recorder';
 import { AssertionError } from 'assert';
 import strip = require('strip-ansi');
@@ -189,34 +189,34 @@ function chain(context: Context): ExecutionContext {
       return chain(context);
     },
     sendKeyDown: function (repeat?: number): ExecutionContext {
-      const repeatitions = repeat ? Math.max(1, repeat) : 1;
+      const repetitions = repeat ? Math.max(1, repeat) : 1;
       var _send: ExecutionStep = {
         fn: () => {
-          for (let i = 0; i < repeatitions; i++) {
+          for (let i = 0; i < repetitions; ++i) {
             context.process.write(KEY_DOWN_ARROW);
           }
           return true;
         },
         name: '_send',
         shift: true,
-        description: `'[send] <Down> (${repeatitions})`,
+        description: `'[send] <Down> (${repetitions})`,
         requiresInput: false,
       };
       context.queue.push(_send);
       return chain(context);
     },
     sendKeyUp: function (repeat?: number): ExecutionContext {
-      const repeatitions = repeat ? Math.max(1, repeat) : 1;
+      const repetitions = repeat ? Math.max(1, repeat) : 1;
       var _send: ExecutionStep = {
         fn: () => {
-          for (let i = 0; i < repeatitions; i++) {
+          for (let i = 0; i < repetitions; ++i) {
             context.process.write(KEY_UP_ARROW);
           }
           return true;
         },
         name: '_send',
         shift: true,
-        description: `'[send] <Up> (${repeatitions})`,
+        description: `'[send] <Up> (${repetitions})`,
         requiresInput: false,
       };
       context.queue.push(_send);
@@ -454,9 +454,14 @@ function chain(context: Context): ExecutionContext {
       function onLine(data: string | Buffer) {
         noOutputTimer.reschedule(context.noOutputTimeout);
         data = data.toString();
-        if (process.env && process.env.VERBOSE_LOGGING_DO_NOT_USE_OR_YOU_WILL_BE_FIRED) {
-          console.log(data);
+
+        if (process.env && process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED) {
+          const spinnerRegex = new RegExp(/.*(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏).*/);
+          if (spinnerRegex.test(data) === false && strip(data).replace(EOL, '').trim().length > 0) {
+            console.log(data);
+          }
         }
+
         if (context.stripColors) {
           data = strip(data);
         }
@@ -550,7 +555,7 @@ function chain(context: Context): ExecutionContext {
 }
 
 function testExpectation(data: string, expectation: string | RegExp, context: Context): boolean {
-  if (isRegExp(expectation)) {
+  if (types.isRegExp(expectation)) {
     return expectation.test(data);
   } else if (context.ignoreCase) {
     return data.toLowerCase().indexOf(expectation.toLowerCase()) > -1;
@@ -574,7 +579,7 @@ function createUnexpectedEndError(message: string, remainingQueue: ExecutionStep
 
 function createExpectationError(expected: string | RegExp, actual: string) {
   var expectation;
-  if (isRegExp(expected)) {
+  if (types.isRegExp(expected)) {
     expectation = 'to match ' + expected;
   } else {
     expectation = 'to contain ' + JSON.stringify(expected);

--- a/packages/amplify-e2e-tests/Readme.md
+++ b/packages/amplify-e2e-tests/Readme.md
@@ -24,14 +24,14 @@ npm run e2e __tests__/init.test.ts
 
 E2E tests internally use a forked version of [nexpect](https://www.npmjs.com/package/nexpect) to run the CLI. There are helper methods that helps you to set up and delete project. The recommended pattern is to create a helper method that creates a resources as a helper method so these method could be used in other tests. For instance, `initJSProjectWithProfile` is a helper method that is used in `init` tests and also used in all the other tests to initalize a new Javascript project. The tests should have all the assertions to make sure the resource created by the helper method is setup correctly. We recommend using `aws-sdk` to make assert the resource configuration.
 
-If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` to `true` and the output from the CLI will be printed on to the screen. Please refrain (as the variable name suggest) setting this in CI as test report will have all the CLI execution logs.
+If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED` to `true` and the output from the CLI will be printed on to the screen. Please refrain (as the variable name suggest) setting this in CI as test report will have all the CLI execution logs.
 
 ```sh
-env VERBOSE_LOGGING_DO_NOT_USE_OR_YOU_WILL_BE_FIRED=true yarn e2e
+env VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED=true yarn e2e
 ```
 
 ```typescript
-import { initJSProjectWithProfile, deleteProject, amplifyPush } from '../init';
+import { amplifyPush, deleteProject, initJSProjectWithProfile } from '../init';
 import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../utils';
 
 describe('amplify your test', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Change verbose flag name to be clear it can be used for local testing
- Filter ora spinner output so that the output can be sifted through easily
- Filter lines that only have invisible chalk characters
- Fix use of deprecated `isRegExp()` => `types.isRegExp()`
- Fixed some typos


Until now, output would have giant spans of text every time the spinner animation changed:
```bash
⠹ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log
⠸ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log
⠼ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log
    ⠴ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log
⠦ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log
⠧ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log
    ⠇ Deleting resources from the cloud. This may take a few minutes...

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

  console.log


      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:460:21)

```


Instead:
```bash
  console.log
    ? Are you sure you want to continue? This CANNOT be undone. (This will delete all the environments of the project from t
    he cloud and wipe out all the local files created by Amplify CLI) Yes

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:461:21)

  console.log
    Deleting env:integtest

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:461:21)

  console.log
    ✔ Project deleted in the cloud

      at onLine (../amplify-e2e-core/src/utils/nexpect.ts:461:21)

  console.log
    Project deleted locally.

```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.