### PR TITLE
fix: update DDB data source name in gql transformer v2

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -266,7 +266,8 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
         `${def!.name.value}DS`,
         table,
         {
-          name: `${def!.name.value}DS`,
+          // This name is used by the mock functionality. Changing this can break mock.
+          name: `${def!.name.value}Table`,
         },
         stack,
       );


### PR DESCRIPTION
#### Description of changes
This commit updates the name applied to DDB data sources in GraphQL Transformer v2. This name change allows the data source to work with the mock functionality.

#### Issue #, if available

#### Description of how you validated changes
Manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.