### PR TITLE
chore: feature flag for @auth directive provider

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -619,7 +619,13 @@ export class FeatureFlags {
         type: 'boolean',
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
-      }
+      },
+      {
+        name: 'emitAuthProvider',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
     ]);
 
     this.registerFlag('appSync', [


### PR DESCRIPTION
#### Description of changes
This PR adds a new feature flag used by codegen to emit provider value of `@auth` directives in iOS models.
Related amplify-codegen PR:https://github.com/aws-amplify/amplify-codegen/pull/184

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.