### PR TITLE
fix: amplify-category-api case sensitivity failure

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/check-case-sensitivity.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/check-case-sensitivity.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs-extra';
+import { checkCaseSensitivityIssue } from '../../../../provider-utils/awscloudformation/utils/check-case-sensitivity';
+
+const mockExit = jest.spyOn(process, 'exit').mockImplementation();
+jest.spyOn(fs, 'writeFile').mockImplementation(_ => new Promise(resolve => resolve(true)));
+jest.spyOn(fs, 'unlink').mockImplementation(_ => new Promise(resolve => resolve()));
+jest.spyOn(fs, 'readdir').mockImplementation(_ => new Promise(resolve => resolve(['testBlog', 'testblogcasesensitivefs'])));
+jest.spyOn(fs, 'existsSync').mockImplementation(_ => true);
+
+const contextStub = {
+  amplify: {
+    pathManager: {
+      getBackendDirPath: jest.fn(_ => 'mock/backend/path'),
+    },
+  },
+  print: {
+    error: jest.fn(),
+  },
+};
+
+test('conflict does not exist if the name matches exactly', async () => {
+  await checkCaseSensitivityIssue(contextStub, 'api', 'testBlog');
+  expect(mockExit).toBeCalledTimes(0);
+});
+
+test('conflict does not exist if names do not match whatsoever', async () => {
+  await checkCaseSensitivityIssue(contextStub, 'api', 'newname');
+  expect(mockExit).toBeCalledTimes(0);
+});
+
+test('conflict exists if fs is case insensitive and names are different by case only', async () => {
+  await checkCaseSensitivityIssue(contextStub, 'api', 'testblog');
+  expect(mockExit).toBeCalledTimes(1);
+  mockExit.mockRestore();
+});
+
+test('conflict does not exist if file system is case sensitive', async () => {
+  jest.spyOn(fs, 'existsSync').mockImplementation(_ => false);
+  await checkCaseSensitivityIssue(contextStub, 'api', 'testBlogCaseSensitiveFS');
+  expect(mockExit).toBeCalledTimes(0);
+});

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/check-case-sensitivity.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/check-case-sensitivity.test.ts
@@ -2,10 +2,7 @@ import fs from 'fs-extra';
 import { checkCaseSensitivityIssue } from '../../../../provider-utils/awscloudformation/utils/check-case-sensitivity';
 
 const mockExit = jest.spyOn(process, 'exit').mockImplementation();
-jest.spyOn(fs, 'writeFile').mockImplementation(_ => new Promise(resolve => resolve(true)));
-jest.spyOn(fs, 'unlink').mockImplementation(_ => new Promise(resolve => resolve()));
 jest.spyOn(fs, 'readdir').mockImplementation(_ => new Promise(resolve => resolve(['testBlog', 'testblogcasesensitivefs'])));
-jest.spyOn(fs, 'existsSync').mockImplementation(_ => true);
 
 const contextStub = {
   amplify: {
@@ -28,14 +25,8 @@ test('conflict does not exist if names do not match whatsoever', async () => {
   expect(mockExit).toBeCalledTimes(0);
 });
 
-test('conflict exists if fs is case insensitive and names are different by case only', async () => {
+test('conflict exists if names are different by case only', async () => {
   await checkCaseSensitivityIssue(contextStub, 'api', 'testblog');
   expect(mockExit).toBeCalledTimes(1);
   mockExit.mockRestore();
-});
-
-test('conflict does not exist if file system is case sensitive', async () => {
-  jest.spyOn(fs, 'existsSync').mockImplementation(_ => false);
-  await checkCaseSensitivityIssue(contextStub, 'api', 'testBlogCaseSensitiveFS');
-  expect(mockExit).toBeCalledTimes(0);
 });

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -17,6 +17,7 @@ import uuid from 'uuid';
 import _ from 'lodash';
 import { getAppSyncResourceName, getAppSyncAuthConfig, checkIfAuthExists, authConfigHasApiKey } from './utils/amplify-meta-utils';
 import { printApiKeyWarnings } from './utils/print-api-key-warnings';
+import { checkCaseSensitivityIssue } from './utils/check-case-sensitivity';
 
 // keep in sync with ServiceName in amplify-category-function, but probably it will not change
 const FunctionServiceNameLambdaFunction = 'Lambda';
@@ -48,6 +49,9 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
       throw new Error(`GraphQL API ${existingApiName} already exists in the project. Use 'amplify update api' to make modifications.`);
     }
     const serviceConfig = request.serviceConfiguration;
+
+    checkCaseSensitivityIssue(this.context, 'api', serviceConfig.apiName);
+
     const resourceDir = this.getResourceDir(serviceConfig.apiName);
 
     // Ensure the project directory exists and create the stacks & resolvers directories.

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/legacy-add-resource.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/legacy-add-resource.ts
@@ -1,5 +1,6 @@
 import { JSONUtilities } from 'amplify-cli-core';
 import { serviceMetadataFor } from './utils/dynamic-imports';
+import { checkCaseSensitivityIssue } from './utils/check-case-sensitivity';
 import fs from 'fs-extra';
 import path from 'path';
 import { parametersFileName, cfnParametersFilename, rootAssetDir } from './aws-constants';
@@ -31,6 +32,9 @@ export const legacyAddResource = async (serviceWalkthroughPromise: Promise<any>,
 
     const parameters = { ...answers };
     const resourceDirPath = path.join(projectBackendDirPath, category, parameters.resourceName);
+
+    checkCaseSensitivityIssue(context, category, parameters.resourceName);
+
     fs.ensureDirSync(resourceDirPath);
 
     const parametersFilePath = path.join(resourceDirPath, parametersFileName);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/check-case-sensitivity.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/check-case-sensitivity.ts
@@ -1,0 +1,29 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+export const checkCaseSensitivityIssue = async (context: any, category: string, resourceName: string) => {
+  const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
+
+  const fsIsCaseSensitive = async () => {
+    const tempFileName = '/tmp/AMPLIFY-TEMP';
+    await fs.writeFile(tempFileName, 'deleteme');
+    const lowercaseVersionExists = fs.existsSync(tempFileName.toLowerCase());
+    await fs.unlink(tempFileName);
+    return !lowercaseVersionExists;
+  };
+
+  const caseSensitiveMatchExists = async () => {
+    const basePath = path.join(projectBackendDirPath, category);
+    const filenames = await fs.readdir(basePath);
+    const matchExistsWhenAllLowercase = filenames.map(name => name.toLowerCase()).includes(resourceName.toLowerCase());
+    const matchExistsDirectly = filenames.includes(resourceName);
+    return !matchExistsDirectly && matchExistsWhenAllLowercase;
+  };
+
+  if (!(await fsIsCaseSensitive()) && (await caseSensitiveMatchExists())) {
+    context.print.error(
+      `Unable to create resource with name ${resourceName} since your filesystem is case-insensitive and a case-sensitive match already exists.`,
+    );
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This pull request addresses https://github.com/aws-amplify/amplify-cli/issues/6354 by throwing an error when an api will not be created properly due to a case sensitivity issue.

Amplify resource names are case-insensitive.

This pull request _only_ addresses the creation of APIs. It does not concern itself with other types of amplify resources.

**NOTE**: This commit uses `process.exit` directly from the helper util. I am not sure how to achieve this another way, but it feels wrong, so advice on that would be appreciated.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

fix #6354

#### Description of how you validated changes

- unit tests added 
- `amplify-dev add api` attempted to create various combinations of valid and invalid amplify resources. Ex. `testblog` (succeeds) then `testBlog` (fails with error message), then `testblog` (update code path succeeds), then `test` (succeeds).



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.