### PR TITLE
refactor: change layer hashing method, generalize it, add e2e

### DIFF
--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -29,7 +29,7 @@
     "enquirer": "^2.3.6",
     "folder-hash": "^4.0.1",
     "fs-extra": "^8.1.0",
-    "globby": "^11.0.1",
+    "globby": "^11.0.3",
     "graphql-transformer-core": "6.28.9",
     "inquirer": "^7.3.3",
     "inquirer-datepicker": "^2.0.0",

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, $TSMeta, getPackageManager, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSMeta, getPackageManager, pathManager, stateManager } from 'amplify-cli-core';
 import crypto from 'crypto';
 import { hashElement, HashElementOptions } from 'folder-hash';
 import * as fs from 'fs-extra';
@@ -21,9 +21,6 @@ const layerResourceGlobs = [parametersFileName, `*${cfnTemplateSuffix}`];
 const libPathName = 'lib';
 const optPathName = 'opt';
 const packageJson = 'package.json';
-const nodeModules = 'node_modules';
-const yarnLock = 'yarn.lock';
-const packageLockJson = 'package-lock.json';
 
 export interface LayerInputParams {
   layerPermissions?: PermissionEnum[];
@@ -403,14 +400,14 @@ const legacyContentHashing = async (layerPath: string): Promise<string> => {
     return '';
   };
 
-  const nodePath = path.join(layerPath, 'lib', 'nodejs');
+  const nodePath = path.join(layerPath, libPathName, 'nodejs');
   const nodeHashOptions = {
     files: {
-      include: ['package.json'],
+      include: [packageJson],
     },
   };
-  const pyPath = path.join(layerPath, 'lib', 'python');
-  const optPath = path.join(layerPath, 'opt');
+  const pyPath = path.join(layerPath, libPathName, 'python');
+  const optPath = path.join(layerPath, optPathName);
 
   const joinedHashes = (await Promise.all([safeHash(nodePath, nodeHashOptions), safeHash(pyPath), safeHash(optPath)])).join();
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, $TSMeta, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSMeta, getPackageManager, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
 import crypto from 'crypto';
 import { hashElement, HashElementOptions } from 'folder-hash';
 import * as fs from 'fs-extra';
@@ -9,13 +9,21 @@ import * as path from 'path';
 import uuid from 'uuid';
 import { categoryName } from '../../../constants';
 import { cfnTemplateSuffix, LegacyFilename, parametersFileName, provider, ServiceName, versionHash } from './constants';
-import { getLayerConfiguration, loadLayerConfigurationFile } from './layerConfiguration';
+import { getLayerConfiguration, LayerConfiguration, loadLayerConfigurationFile } from './layerConfiguration';
 import { LayerParameters, LayerPermission, LayerVersionMetadata, PermissionEnum } from './layerParams';
 import { updateLayerArtifacts } from './storeResources';
 
 // These glob patterns cover the resource files Amplify stores in the layer resource's directory,
 // layer-parameters.json must NOT be there.
 const layerResourceGlobs = [parametersFileName, `*${cfnTemplateSuffix}`];
+
+// File path literals
+const libPathName = 'lib';
+const optPathName = 'opt';
+const packageJson = 'package.json';
+const nodeModules = 'node_modules';
+const yarnLock = 'yarn.lock';
+const packageLockJson = 'package-lock.json';
 
 export interface LayerInputParams {
   layerPermissions?: PermissionEnum[];
@@ -208,7 +216,7 @@ export function loadStoredLayerParameters(context: $TSContext, layerName: string
 
 export async function isNewVersion(layerName: string) {
   const previousHash = loadPreviousLayerHash(layerName);
-  const currentHash = await hashLayerVersionContents(pathManager.getResourceDirectoryPath(undefined, categoryName, layerName));
+  const currentHash = await hashLayerVersion(pathManager.getResourceDirectoryPath(undefined, categoryName, layerName), layerName);
 
   return previousHash !== currentHash;
 }
@@ -239,7 +247,7 @@ export function getLayerName(context: $TSContext, layerName: string): string {
 
 // Check hash results for content changes, bump version if so
 export async function ensureLayerVersion(context: $TSContext, layerName: string, previousHash: string) {
-  const currentHash = await hashLayerVersionContents(pathManager.getResourceDirectoryPath(undefined, categoryName, layerName));
+  const currentHash = await hashLayerVersion(pathManager.getResourceDirectoryPath(undefined, categoryName, layerName), layerName);
 
   if (previousHash !== currentHash) {
     if (previousHash) {
@@ -261,10 +269,140 @@ export function loadPreviousLayerHash(layerName: string): string | undefined {
   return previousHash;
 }
 
+export function validFilesize(context: $TSContext, zipPath: string, maxSize = 250) {
+  try {
+    const { size } = fs.statSync(zipPath);
+    const fileSize = Math.round(size / 1024 ** 2);
+    return fileSize < maxSize;
+  } catch (error) {
+    context.print.error(error);
+    return new Error(`Calculating file size failed: ${zipPath}`);
+  }
+}
+
+// hashes all of the layer contents as well as the files in the layer path (CFN, parameters, etc)
+export const hashLayerResource = async (layerPath: string, resourceName: string): Promise<string> => {
+  return await hashLayerVersion(layerPath, resourceName, true);
+};
+
+export async function getChangedResources(resources: Array<$TSAny>): Promise<Array<$TSAny>> {
+  const checkLambdaLayerChanges = async (resource: $TSAny): Promise<boolean> => {
+    const { resourceName } = resource;
+    const previousHash = loadPreviousLayerHash(resourceName);
+
+    if (!previousHash) {
+      return true;
+    }
+
+    const currentHash = await hashLayerVersion(pathManager.getResourceDirectoryPath(undefined, categoryName, resourceName), resourceName);
+
+    return currentHash !== previousHash;
+  };
+
+  const resourceCheck = await Promise.all(resources.map(checkLambdaLayerChanges));
+
+  return resources.filter((_, i) => resourceCheck[i]);
+}
+
+const getLayerGlobs = async (
+  resourcePath: string,
+  resourceName: string,
+  runtimeId: string,
+  layerExecutablePath: string,
+  includeResourceFiles: boolean,
+): Promise<string[]> => {
+  const result: string[] = [];
+
+  if (includeResourceFiles) {
+    result.push(...layerResourceGlobs);
+  }
+
+  const layerCodePath = path.join(resourcePath, libPathName, layerExecutablePath);
+
+  // Add to hashable files/folders
+  result.push(optPathName);
+
+  //TODO let function runtimes export globs later instead of hardcoding in here
+  if (runtimeId === 'nodejs') {
+    const packageManager = getPackageManager(layerCodePath);
+
+    // If no packagemanager was detected it means no package.json present at the resource path,
+    // so no files to hash related to packages.
+    if (packageManager !== null) {
+      // Add to hashable files/folders
+      result.push(path.join(libPathName, layerExecutablePath, packageJson));
+
+      // If lock file is present, add to hashable files/folders
+      const lockFilePath = path.join(layerCodePath, packageManager.lockFile);
+
+      if (fs.existsSync(lockFilePath)) {
+        result.push(path.join(libPathName, layerExecutablePath, packageManager.lockFile));
+      }
+    }
+
+    // Add layer direct content from lib/nodejs and exclude well known files from list.
+    // files must be relative to resource folder as that will be used as a base path for hashing.
+    const contentFilePaths = await globby([path.join(libPathName, layerExecutablePath, '**', '*')], {
+      cwd: resourcePath,
+      ignore: [
+        path.join(libPathName, layerExecutablePath, 'node_modules'),
+        path.join(libPathName, layerExecutablePath, packageJson),
+        path.join(libPathName, layerExecutablePath, 'yarn.lock'),
+        path.join(libPathName, layerExecutablePath, 'package-lock.json'),
+      ],
+    });
+
+    result.push(...contentFilePaths);
+  } else if (runtimeId === 'python') {
+    // No special treatment needed for python yet.
+  } else {
+    const error = new Error(`Unsupported layer runtime: ${runtimeId} for resource: ${resourceName}`);
+    error.stack = undefined;
+
+    throw error;
+  }
+
+  return result;
+};
+
 // hashes just the content that will be zipped into the layer version.
 // for efficiency, it only hashes package.json files in the node_modules folder of nodejs layers
-export const hashLayerVersionContents = async (layerPath: string): Promise<string> => {
-  // TODO don't use hardcoded paths
+const hashLayerVersion = async (layerPath: string, layerName: string, includeResourceFiles: boolean = false): Promise<string> => {
+  const layerConfig: LayerConfiguration = loadLayerConfigurationFile(layerName, false);
+
+  if (layerConfig) {
+    const { value: runtimeId, layerExecutablePath } = layerConfig.runtimes[0];
+
+    const layerFilePaths = await getLayerGlobs(layerPath, layerName, runtimeId, layerExecutablePath, includeResourceFiles);
+
+    const filePaths = await globby(layerFilePaths, { cwd: layerPath });
+
+    return filePaths
+      .map(filePath => fs.readFileSync(path.join(layerPath, filePath), 'binary'))
+      .reduce((acc, it) => acc.update(it), crypto.createHash('sha256'))
+      .digest('hex');
+  } else {
+    // Do legacy hashing
+    return includeResourceFiles ? await legacyResourceHashing(layerPath) : await legacyContentHashing(layerPath);
+  }
+};
+
+// hashes just the content that will be zipped into the layer version.
+// for efficiency, it only hashes package.json files in the node_modules folder of nodejs layers
+const legacyContentHashing = async (layerPath: string): Promise<string> => {
+  // wrapper around hashElement that will return an empty string if the path does not exist
+  const safeHash = async (path: string, opts?: HashElementOptions): Promise<string> => {
+    if (fs.pathExistsSync(path)) {
+      return (
+        await hashElement(path, opts).catch(() => {
+          throw new Error(`An error occurred hashing directory ${path}`);
+        })
+      ).hash;
+    }
+
+    return '';
+  };
+
   const nodePath = path.join(layerPath, 'lib', 'nodejs');
   const nodeHashOptions = {
     files: {
@@ -279,47 +417,14 @@ export const hashLayerVersionContents = async (layerPath: string): Promise<strin
   return crypto.createHash('sha256').update(joinedHashes).digest('base64');
 };
 
-// wrapper around hashElement that will return an empty string if the path does not exist
-const safeHash = async (path: string, opts?: HashElementOptions): Promise<string> => {
-  if (fs.pathExistsSync(path)) {
-    return (
-      await hashElement(path, opts).catch(() => {
-        throw new Error(`An error occurred hashing directory ${path}`);
-      })
-    ).hash;
-  }
-  return '';
-};
+const legacyResourceHashing = async (layerPath: string): Promise<string> => {
+  const files = await globby(layerResourceGlobs, { cwd: layerPath });
 
-export function validFilesize(context: $TSContext, zipPath: string, maxSize = 250) {
-  try {
-    const { size } = fs.statSync(zipPath);
-    const fileSize = Math.round(size / 1024 ** 2);
-    return fileSize < maxSize;
-  } catch (error) {
-    context.print.error(error);
-    return new Error(`Calculating file size failed: ${zipPath}`);
-  }
-}
-
-// hashes all of the layer contents as well as the files in the layer path (CFN, parameters, etc)
-export const hashLayerResource = async (layerPath: string): Promise<string> => {
-  return (await globby(layerResourceGlobs, { cwd: layerPath }))
+  const hash = files
     .map(filePath => fs.readFileSync(path.join(layerPath, filePath), 'utf8'))
     .reduce((acc, it) => acc.update(it), crypto.createHash('sha256'))
-    .update(await hashLayerVersionContents(layerPath))
+    .update(await legacyContentHashing(layerPath))
     .digest('base64');
+
+  return hash;
 };
-
-export async function getChangedResources(resources: Array<$TSAny>): Promise<Array<$TSAny>> {
-  const resourceCheck = await Promise.all(resources.map(checkLambdaLayerChanges));
-  return resources.filter((_, i) => resourceCheck[i]);
-}
-
-async function checkLambdaLayerChanges(resource: $TSAny): Promise<boolean> {
-  const { resourceName } = resource;
-  const previousHash = loadPreviousLayerHash(resourceName);
-  if (!previousHash) return true;
-  const currentHash = await hashLayerVersionContents(pathManager.getResourceDirectoryPath(undefined, categoryName, resourceName));
-  return currentHash !== previousHash;
-}

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status.ts
@@ -8,7 +8,7 @@ import { getEnvInfo } from './get-env-info';
 import { CLOUD_INITIALIZED, CLOUD_NOT_INITIALIZED, getCloudInitStatus } from './get-cloud-init-status';
 import { ServiceName as FunctionServiceName, hashLayerResource } from 'amplify-category-function';
 import { removeGetUserEndpoints } from '../amplify-helpers/remove-pinpoint-policy';
-import { pathManager, stateManager, $TSMeta, $TSAny, Tag, NotInitializedError } from 'amplify-cli-core';
+import { pathManager, stateManager, $TSMeta, $TSAny, NotInitializedError } from 'amplify-cli-core';
 
 async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPushTimeStamp, hashFunction) {
   // Pushing the resource for the first time hence no lastPushTimeStamp
@@ -23,8 +23,8 @@ async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPus
     return false;
   }
 
-  const localDirHash = await hashFunction(localBackendDir);
-  const cloudDirHash = await hashFunction(cloudBackendDir);
+  const localDirHash = await hashFunction(localBackendDir, resourceName);
+  const cloudDirHash = await hashFunction(cloudBackendDir, resourceName);
 
   return localDirHash !== cloudDirHash;
 }

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -39,7 +39,7 @@ export function validateLayerDir(projRoot: string, layerProjName: LayerDirectory
 }
 
 export function getLayerDirectoryName({ layerName, projName }: { layerName: string; projName: string }): string {
-  return projName + layerName;
+  return `${projName}${layerName}`;
 }
 
 export function validatePushedVersion(projRoot: string, layerProjName: LayerDirectoryType, permissions: LayerPermission[]) {

--- a/packages/amplify-migration-tests/src/__tests__/update_tests/function_migration_update.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/update_tests/function_migration_update.test.ts
@@ -8,8 +8,10 @@ import {
   deleteProject,
   deleteProjectDir,
   getCurrentLayerArnFromMeta,
+  getProjectConfig,
   getProjectMeta,
   invokeFunction,
+  LayerRuntime,
   loadFunctionTestFile,
   overrideFunctionSrcNode,
   updateFunction,
@@ -21,8 +23,13 @@ import { initJSProjectWithProfile } from '../../migration-helpers';
 
 describe('amplify function migration', () => {
   let projRoot: string;
+  let projName: string;
+
   beforeEach(async () => {
     projRoot = await createNewProjectDir('functions');
+
+    const { projectName } = getProjectConfig(projRoot);
+    projName = projectName;
   });
 
   afterEach(async () => {
@@ -98,9 +105,9 @@ describe('amplify function migration', () => {
 
     const layerName = `test${shortId}`;
     const layerSettings = {
+      runtimes: ['nodejs' as LayerRuntime],
       layerName,
-      versionChanged: true,
-      runtimes: ['nodejs'],
+      projName,
     };
     await addLayer(projRoot, layerSettings, true);
     await updateFunction(
@@ -117,7 +124,7 @@ describe('amplify function migration', () => {
       'nodejs',
     );
     await amplifyPushAuth(projRoot, true);
-    const arns: string[] = [getCurrentLayerArnFromMeta(projRoot, { layerName: layerName, projName: projRoot })];
+    const arns: string[] = [getCurrentLayerArnFromMeta(projRoot, { layerName: layerName, projName: projRoot }), layerName];
 
     const meta = getProjectMeta(projRoot);
     await validateLayerMetadata(projRoot, { layerName: layerName, projName: projRoot }, meta, 'integtest', arns);
@@ -128,9 +135,9 @@ describe('amplify function migration', () => {
     await initJSProjectWithProfile(projRoot, {});
     const layerName = `test${shortId}`;
     const layerSettings = {
+      runtimes: ['nodejs' as LayerRuntime],
       layerName,
-      versionChanged: true,
-      runtimes: ['nodejs'],
+      projName,
     };
     await addLayer(projRoot, layerSettings);
     await amplifyPushAuth(projRoot);

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -43,9 +43,9 @@ function runPackageManager(cwd: string, scriptName?: string) {
   const packageManager = getPackageManager(cwd);
 
   if (packageManager === null) {
-    throw new Error(
-      `Packaging lambda failed function failed. Could not find 'npm' or 'yarn' executable in the PATH or no 'package.json' file exists in the function's directory.`,
-    );
+    // If no package manager was detected, it means that this functions or layer has no package.json, so no package operations
+    // should be done.
+    return;
   }
 
   const useYarn = packageManager.packageManager === 'yarn';


### PR DESCRIPTION
#### Description of changes

- Refactor layer hashing functionality to be more generic and handle the new design while for legacy layers preserve the old hashing for change detection
- Add new E2E test for lock file and `node_modules` removal
- Change the behavior of legacy function build to don't error out if no package manager was detected

#### Description of how you validated changes

- Manual testing
- New E2E test


#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.