### PR TITLE
fix(amplify-category-notifications): trim whitespace from fcm keys

### DIFF
--- a/packages/amplify-category-notifications/__tests__/lib/channel-FCM.test.js
+++ b/packages/amplify-category-notifications/__tests__/lib/channel-FCM.test.js
@@ -1,0 +1,133 @@
+const inquirer = require('inquirer');
+const channelName = 'FCM';
+const channelFCM = require('../../lib/channel-FCM');
+
+const mockInquirer = answers => {
+  inquirer.prompt = async prompts => {
+    [].concat(prompts).forEach(function (prompt) {
+      if (!(prompt.name in answers) && typeof prompt.default !== 'undefined') {
+        answers[prompt.name] = prompt.default;
+      }
+    });
+
+    return answers;
+  };
+};
+
+describe('channel-FCM', () => {
+  const mockServiceOutput = {};
+  const mockChannelOutput = { Enabled: true };
+  mockServiceOutput[channelName] = mockChannelOutput;
+
+  const mockPinpointResponseErr = new Error('channel-FCM.test.js error');
+  const mockPinpointResponseData = {
+    FCMChannelResponse: {},
+  };
+
+  const mockPinpointClient = {
+    updateGcmChannel: jest.fn((_, cb) => {
+      return new Promise(() => {
+        cb(null, mockPinpointResponseData);
+      });
+    }),
+  };
+
+  const mockPinpointClientReject = {
+    updateGcmChannel: jest.fn((_, cb) => {
+      return new Promise(() => {
+        cb(mockPinpointResponseErr);
+      });
+    }),
+  };
+
+  let mockContext = {
+    exeInfo: {
+      serviceMeta: {
+        output: mockServiceOutput,
+      },
+      pinpointClient: mockPinpointClient,
+    },
+    print: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+
+  let mockContextReject = {
+    exeInfo: {
+      serviceMeta: {
+        output: mockServiceOutput,
+      },
+      pinpointClient: mockPinpointClientReject,
+    },
+    print: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+
+  test('configure', async () => {
+    mockChannelOutput.Enabled = true;
+    mockInquirer({ disableChannel: true });
+
+    await channelFCM.configure(mockContext).then(() => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+    });
+
+    mockChannelOutput.Enabled = true;
+    mockInquirer({ disableChannel: false });
+    await channelFCM.configure(mockContext).then(() => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+    });
+
+    mockChannelOutput.Enabled = false;
+    mockInquirer({ enableChannel: true });
+    await channelFCM.configure(mockContext).then(() => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+    });
+  });
+
+  test('enable', async () => {
+    mockInquirer({ ApiKey: 'ApiKey-abc123' });
+    await channelFCM.enable(mockContext, 'successMessage').then(data => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+      expect(data).toEqual(mockPinpointResponseData);
+    });
+  });
+
+  test('enable with newline', async () => {
+    mockInquirer({ ApiKey: 'ApiKey-abc123\n' });
+    await channelFCM.enable(mockContext, 'successMessage').then(data => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalledWith(
+        {
+          ApplicationId: undefined,
+          GCMChannelRequest: {
+            ApiKey: 'ApiKey-abc123',
+            Enabled: true,
+          },
+        },
+        expect.anything(),
+      );
+      expect(data).toEqual(mockPinpointResponseData);
+    });
+  });
+
+  test('enable unsuccessful', async () => {
+    mockInquirer({ ApiKey: 'ApiKey-abc123' });
+    await channelFCM.enable(mockContextReject, 'successMessage').catch(err => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+      expect(err).toEqual(mockPinpointResponseErr);
+    });
+  });
+
+  test('disable', async () => {
+    await channelFCM.disable(mockContext).then(data => {
+      expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+      expect(data).toEqual(mockPinpointResponseData);
+    });
+  });
+
+  test('disable unsuccessful', async () => {
+    await expect(channelFCM.disable(mockContextReject)).rejects.toThrow(mockPinpointResponseErr);
+  });
+});

--- a/packages/amplify-category-notifications/lib/channel-FCM.js
+++ b/packages/amplify-category-notifications/lib/channel-FCM.js
@@ -51,7 +51,7 @@ async function enable(context, successMessage) {
         default: channelOutput.ApiKey,
       },
     ];
-    answers = await inquirer.prompt(questions);
+    answers = trimAnswers(await inquirer.prompt(questions));
   }
 
   const params = {
@@ -104,7 +104,7 @@ async function disable(context) {
         default: channelOutput.ApiKey,
       },
     ];
-    answers = await inquirer.prompt(questions);
+    answers = trimAnswers(await inquirer.prompt(questions));
   }
 
   const params = {
@@ -152,6 +152,15 @@ function pull(context, pinpointApp) {
       spinner.stop();
       throw err;
     });
+}
+
+function trimAnswers(answers) {
+  for (const [key, value] of Object.entries(answers)) {
+    if (typeof answers[key] === 'string') {
+      answers[key] = value.trim();
+    }
+  }
+  return answers;
 }
 
 module.exports = {


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

this PR prevents a copy/paste issue where an extra newline character comes along with an fcm
key. It accomplishes this by trimming the whitespace from the ApiKey string.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

fix #7440

#### Description of how you validated changes

- created new unit test
- ran `amplify add notification` with whitespace in my clipboard, checked that the cli received the trimmed version

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.