### PR TITLE
feat: display migration info when legacy layers are present in env

### DIFF
--- a/packages/amplify-cli/src/__tests__/test-aborting.test.ts
+++ b/packages/amplify-cli/src/__tests__/test-aborting.test.ts
@@ -34,6 +34,7 @@ describe('test SIGINT with execute', () => {
       },
       BannerMessage: {
         initialize: jest.fn(),
+        getMessage: jest.fn(),
       },
       PathConstants: {
         TeamProviderFileName: 'team-provider-info.json',

--- a/packages/amplify-cli/src/display-banner-messages.ts
+++ b/packages/amplify-cli/src/display-banner-messages.ts
@@ -1,7 +1,13 @@
 import { BannerMessage, pathManager, stateManager } from 'amplify-cli-core';
+import { isCI } from 'ci-info';
 import { print } from './context-extensions';
+import { Input } from './domain/input';
 
-export async function displayBannerMessages() {
+export async function displayBannerMessages(input: Input) {
+  const excludedCommands = ['delete', 'env', 'help', 'logout', 'version'];
+  if (isCI || (input.command && excludedCommands.includes(input.command))) {
+    return;
+  }
   await displayLayerMigrationMessage();
 }
 

--- a/packages/amplify-cli/src/display-banner-messages.ts
+++ b/packages/amplify-cli/src/display-banner-messages.ts
@@ -1,0 +1,31 @@
+import { BannerMessage, pathManager, stateManager } from 'amplify-cli-core';
+import { print } from './context-extensions';
+
+export async function displayBannerMessages() {
+  await displayLayerMigrationMessage();
+}
+
+async function displayLayerMigrationMessage() {
+  const layerMigrationBannerMessage = await BannerMessage.getMessage('LAMBDA_LAYER_MIGRATION_WARNING');
+
+  const rootPath = pathManager.findProjectRoot();
+
+  if (rootPath === undefined) {
+    // Not in a valid project
+    return;
+  }
+
+  const meta = stateManager.getMeta(rootPath, { throwIfNotExist: false });
+  const layerResources =
+    meta !== undefined
+      ? Object.keys(meta?.function).filter(
+          resource => meta.function[resource]?.service === 'LambdaLayer' && meta.function[resource]?.layerVersionMap !== undefined,
+        )
+      : [];
+
+  if (layerResources.length > 0 && layerMigrationBannerMessage) {
+    print.info('');
+    print.warning(layerMigrationBannerMessage);
+    print.info('');
+  }
+}

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -1,15 +1,15 @@
 import {
   $TSAny,
   $TSContext,
+  BannerMessage,
   CLIContextEnvironmentProvider,
   exitOnNextTick,
   FeatureFlags,
+  JSONUtilities,
   JSONValidationError,
   pathManager,
   stateManager,
   TeamProviderInfoMigrateError,
-  BannerMessage,
-  JSONUtilities,
 } from 'amplify-cli-core';
 import { isCI } from 'ci-info';
 import { EventEmitter } from 'events';
@@ -18,6 +18,7 @@ import * as path from 'path';
 import { logInput } from './conditional-local-logging-init';
 import { print } from './context-extensions';
 import { attachUsageData, constructContext, persistContext } from './context-manager';
+import { displayBannerMessages } from './display-banner-messages';
 import { constants } from './domain/constants';
 import { Context } from './domain/context';
 import { Input } from './domain/input';
@@ -40,7 +41,7 @@ Error.stackTraceLimit = Number.MAX_SAFE_INTEGER;
 
 let errorHandler = (e: Error) => {};
 
-process.on('uncaughtException', function(error) {
+process.on('uncaughtException', function (error) {
   // Invoke the configured error handler if it is already configured
   if (errorHandler) {
     errorHandler(error);
@@ -59,7 +60,7 @@ process.on('uncaughtException', function(error) {
 });
 
 // In this handler we have to rethrow the error otherwise the process stucks there.
-process.on('unhandledRejection', function(error) {
+process.on('unhandledRejection', function (error) {
   throw error;
 });
 
@@ -79,6 +80,9 @@ export async function run() {
     // Initialize Banner messages. These messages are set on the server side
     const pkg = JSONUtilities.readJson<$TSAny>(path.join(__dirname, '..', 'package.json'));
     BannerMessage.initialize(pkg.version);
+
+    // Display messages meant for all executions
+    await displayBannerMessages();
 
     ensureFilePermissions(pathManager.getAWSCredentialsFilePath());
     ensureFilePermissions(pathManager.getAWSConfigFilePath());

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -81,9 +81,6 @@ export async function run() {
     const pkg = JSONUtilities.readJson<$TSAny>(path.join(__dirname, '..', 'package.json'));
     BannerMessage.initialize(pkg.version);
 
-    // Display messages meant for all executions
-    await displayBannerMessages();
-
     ensureFilePermissions(pathManager.getAWSCredentialsFilePath());
     ensureFilePermissions(pathManager.getAWSConfigFilePath());
 
@@ -146,6 +143,9 @@ export async function run() {
       // Double casting until we have properly typed context
       return 1;
     }
+
+    // Display messages meant for most executions
+    await displayBannerMessages(input);
 
     await executeCommand(context);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Display layer migration message when deprecated layer versions are present


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.