### PR TITLE
fix: copy env specific data from ccb on env checkout

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -1,4 +1,14 @@
-import { $TSAny, $TSContext, JSONUtilities, open, PathConstants, pathManager, stateManager } from 'amplify-cli-core';
+import {
+  $TSAny,
+  $TSContext,
+  JSONUtilities,
+  open,
+  PathConstants,
+  pathManager,
+  readCFNTemplate,
+  stateManager,
+  writeCFNTemplate,
+} from 'amplify-cli-core';
 import { FunctionParameters, FunctionTemplate, FunctionTriggerParameters, LambdaLayer } from 'amplify-function-plugin-interface';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
@@ -7,7 +17,7 @@ import { IsMockableResponse } from '../..';
 import { categoryName } from '../../constants';
 import { supportedServices } from '../supported-services';
 import { ServiceConfig } from '../supportedServicesType';
-import { functionParametersFileName, provider, ServiceName, versionHash } from './utils/constants';
+import { cfnTemplateSuffix, functionParametersFileName, provider, ServiceName, versionHash } from './utils/constants';
 import { convertExternalLayersToProjectLayers, convertProjectLayersToExternalLayers } from './utils/convertLayersTypes';
 import { convertToComplete, isComplete, merge } from './utils/funcParamsUtils';
 import { isMultiEnvLayer } from './utils/layerHelpers';
@@ -380,6 +390,31 @@ export async function updateConfigOnEnvInit(context: $TSContext, resourceName: s
     const currentCloudVersionHash: string = _.get(currentAmplifyMeta, [categoryName, resourceName, versionHash], undefined);
     if (currentCloudVersionHash) {
       _.set(amplifyMeta, [categoryName, resourceName, versionHash], currentCloudVersionHash);
+    }
+
+    // Since the CFN template and parameters.json are updated on each new layer version which are specific to each env, we need to update
+    // the files accordingly to ensure the correct status is shown after env checkout. The restore flag already handles this scenario.
+    if (context.input.command === 'env' && context.input?.subCommands.includes('checkout') && !context.exeInfo?.inputParams?.restore) {
+      const cfnFilename = `${resourceName}${cfnTemplateSuffix}`;
+      const currentCloudBackendDirPath = pathManager.getCurrentCloudBackendDirPath(projectPath);
+      const currentCfnTemplatePath = path.join(currentCloudBackendDirPath, categoryName, resourceName, cfnFilename);
+      const currentParametersJsonPath = path.join(
+        currentCloudBackendDirPath,
+        categoryName,
+        resourceName,
+        PathConstants.ParametersJsonFileName,
+      );
+
+      const currentParametersJson = JSONUtilities.readJson<$TSAny>(currentParametersJsonPath, { throwIfNotExist: false }) || undefined;
+      if (currentParametersJson) {
+        const backendParametersJson = stateManager.getResourceParametersJson(projectPath, categoryName, resourceName);
+        backendParametersJson.description = currentParametersJson.description;
+        stateManager.setResourceParametersJson(projectPath, categoryName, resourceName, backendParametersJson);
+      }
+
+      const backendCfnTemplatePath = path.join(pathManager.getResourceDirectoryPath(undefined, categoryName, resourceName), cfnFilename);
+      const { cfnTemplate: currentCfnTemplate } = await readCFNTemplate(currentCfnTemplatePath);
+      await writeCFNTemplate(currentCfnTemplate, backendCfnTemplatePath);
     }
   }
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -396,7 +396,7 @@ export async function updateConfigOnEnvInit(context: $TSContext, resourceName: s
     // the files accordingly to ensure the correct status is shown after env checkout. The restore flag already handles this scenario.
     if (context.input.command === 'env' && context.input?.subCommands.includes('checkout') && !context.exeInfo?.inputParams?.restore) {
       const currentParametersJson =
-        stateManager.getCurrentResourceParametersJson(projectPath, categoryName, resourceName, { throwIfNotExist: false }) || {};
+        stateManager.getCurrentResourceParametersJson(projectPath, categoryName, resourceName, { throwIfNotExist: false }) || undefined;
       if (currentParametersJson) {
         const backendParametersJson = stateManager.getResourceParametersJson(projectPath, categoryName, resourceName);
         backendParametersJson.description = currentParametersJson.description;

--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -39,6 +39,8 @@ export const PathConstants = {
   CLIJSONFileName: 'cli.json',
   CLIJSONFileNameGlob: 'cli*.json',
   CLIJsonWithEnvironmentFileName: (env: string) => `cli.${env}.json`,
+
+  CfnFileName: (resourceName: string) => `${resourceName}-awscloudformation-template.json`,
 };
 
 export class PathManager {
@@ -78,6 +80,12 @@ export class PathManager {
   getCurrentCloudBackendDirPath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName]);
 
+  getCurrentResourceParametersJsonPath = (projectPath: string | undefined, categoryName: string, resourceName: string): string =>
+    path.join(this.getCurrentCloudBackendDirPath(projectPath), categoryName, resourceName, PathConstants.ParametersJsonFileName);
+
+  getCurrentCfnTemplatePath = (projectPath: string | undefined, categoryName: string, resourceName: string): string =>
+    path.join(this.getCurrentCloudBackendDirPath(projectPath), categoryName, resourceName, PathConstants.CfnFileName(resourceName));
+
   getAmplifyRcFilePath = (projectPath?: string): string => this.constructPath(projectPath, [PathConstants.AmplifyRcFileName]);
 
   getGitIgnoreFilePath = (projectPath?: string): string => this.constructPath(projectPath, [PathConstants.GitIgnoreFileName]);
@@ -111,6 +119,9 @@ export class PathManager {
 
   getResourceParametersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
     path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.ParametersJsonFileName);
+
+  getResourceCfnTemplatePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
+    path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.CfnFileName(resourceName));
 
   getReadMeFilePath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.ReadMeFileName]);

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -133,6 +133,21 @@ export class StateManager {
     return this.getData<$TSAny>(filePath, mergedOptions);
   };
 
+  getCurrentResourceParametersJson = (
+    projectPath: string | undefined,
+    category: string,
+    resourceName: string,
+    options?: GetOptions<$TSAny>,
+  ): $TSAny => {
+    const filePath = pathManager.getCurrentResourceParametersJsonPath(projectPath, category, resourceName);
+    const mergedOptions = {
+      throwIfNotExist: true,
+      ...options,
+    };
+
+    return this.getData<$TSAny>(filePath, mergedOptions);
+  };
+
   getAmplifyAdminConfigEntry = (appId: string, options?: GetOptions<$TSAny>) => {
     const mergedOptions = {
       throwIfNotExist: false,

--- a/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
@@ -1,29 +1,30 @@
 import {
-  addLayer,
   addFunction,
+  addLayer,
   addOptData,
   amplifyPull,
   amplifyPushAuth,
   amplifyPushLayer,
+  amplifyStatus,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
-  initJSProjectWithProfile,
   getAppId,
+  getCurrentLayerArnFromMeta,
+  getProjectConfig,
   getProjectMeta,
+  initJSProjectWithProfile,
   LayerPermission,
   LayerPermissionChoice,
   LayerPermissionName,
   LayerRuntime,
   removeLayer,
+  removeLayerVersion,
   updateLayer,
   updateOptData,
   validateLayerDir,
   validateLayerMetadata,
   validatePushedVersion,
-  getCurrentLayerArnFromMeta,
-  getProjectConfig,
-  removeLayerVersion,
 } from 'amplify-e2e-core';
 import { v4 as uuid } from 'uuid';
 import { addEnvironment, checkoutEnvironment, listEnvironment } from '../environment/env';
@@ -71,7 +72,7 @@ describe('amplify add lambda layer', () => {
     expect(validateLayerDir(projRoot, settings, settings.runtimes)).toBe(false);
   });
 
-  it('init a project add 4 layers and delete first 3 of them and push and verify', async () => {
+  it('init a project, add layer, push 4 layer versions and delete first 3 of them, then push and verify', async () => {
     const [shortId] = uuid().split('-');
     const layerName = `simplelayer${shortId}`;
     const runtime: LayerRuntime = 'nodejs';
@@ -236,11 +237,13 @@ describe('amplify add lambda layer', () => {
     await amplifyPushLayer(projRoot, {
       acceptSuggestedLayerVersionConfigurations: true,
     });
+    await amplifyStatus(projRoot, 'No Change');
     layerTestArns.push(getCurrentLayerArnFromMeta(projRoot, settings));
     validatePushedVersion(projRoot, settings, expectedPerms);
     await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), newEnvName, layerTestArns);
 
     await checkoutEnvironment(projRoot, { envName });
+    await amplifyStatus(projRoot, 'No Change');
     validatePushedVersion(projRoot, settings, expectedPerms);
     await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, integtestArns);
   });
@@ -309,6 +312,7 @@ describe('amplify add lambda layer - with amplify console app', () => {
     }
 
     await amplifyPull(projRoot, {});
+    await amplifyStatus(projRoot, 'No Change');
 
     validatePushedVersion(projRoot, settings, expectedPerms);
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
After an `amplify env checkout`, the displayed `amplify status` would sometimes incorrectly show Updated instead of No Changes when layer content remained untouched. This PR fixes that by copying the Cloudformation file and the description field stored in the `#current-cloud-backend` directory. This bug only affected the displayed status, and did not result in new layer versions being created on a subsequent push.

Also updated an inaccurate e2e test description.

#### Description of how you validated changes
Updated multi-environment e2e tests to check `amplify status`, which pass locally. Unit tests also pass locally.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.