### PR TITLE
fix(graphql-searchable-transformer): fix for awstimestamp issues with elastic search

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
@@ -183,6 +183,8 @@ def _lambda_handler(event, context):
         logger.debug(image_name + ': %s', ddb[image_name])
         # Deserialize DynamoDB type to Python types
         doc_fields = ddb_deserializer.deserialize({'M': ddb[image_name]})
+        if '_lastChangedAt' in doc_fields:
+            doc_fields['_lastChangedAt'] = int(doc_fields['_lastChangedAt'])
         
         # Sync enabled APIs do soft delete. We need to delete the record in ES if _deleted field is set
         if ES_USE_EXTERNAL_VERSIONING and event_name == 'MODIFY' and '_deleted' in  doc_fields and doc_fields['_deleted']:

--- a/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
@@ -40,6 +40,8 @@ class DDBTypesEncoder(json.JSONEncoder):
 class StreamTypeDeserializer(TypeDeserializer):
     def _deserialize_n(self, value):
         try:
+            if value != int(value): # check if casting truncates decimals
+                return float(value)
             return int(value)
         except ValueError:
             return float(value)

--- a/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
@@ -39,12 +39,11 @@ class DDBTypesEncoder(json.JSONEncoder):
 # Subclass of boto's TypeDeserializer for DynamoDB to adjust for DynamoDB Stream format.
 class StreamTypeDeserializer(TypeDeserializer):
     def _deserialize_n(self, value):
-        try:
-            if value != int(value): # check if casting truncates decimals
-                return float(value)
+        val = float(value)
+        if (val.is_integer()):
             return int(value)
-        except ValueError:
-            return float(value)
+        else:
+            return val
 
     def _deserialize_b(self, value):
         return value  # Already in Base64

--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -41,6 +41,8 @@ class DDBTypesEncoder(json.JSONEncoder):
 class StreamTypeDeserializer(TypeDeserializer):
     def _deserialize_n(self, value):
         try:
+            if value != int(value): # check if casting truncates decimals
+                return float(value)
             return int(value)
         except ValueError:
             return float(value)

--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -185,6 +185,8 @@ def _lambda_handler(event, context):
         logger.debug(image_name + ': %s', ddb[image_name])
         # Deserialize DynamoDB type to Python types
         doc_fields = ddb_deserializer.deserialize({'M': ddb[image_name]})
+        if '_lastChangedAt' in doc_fields:
+            doc_fields['_lastChangedAt'] = int(doc_fields['_lastChangedAt'])
         
         # Sync enabled APIs do soft delete. We need to delete the record in ES if _deleted field is set
         if ES_USE_EXTERNAL_VERSIONING and event_name == 'MODIFY' and '_deleted' in  doc_fields and doc_fields['_deleted']:

--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -40,7 +40,10 @@ class DDBTypesEncoder(json.JSONEncoder):
 # Subclass of boto's TypeDeserializer for DynamoDB to adjust for DynamoDB Stream format.
 class StreamTypeDeserializer(TypeDeserializer):
     def _deserialize_n(self, value):
-        return float(value)
+        try:
+            return int(value)
+        except ValueError:
+            return float(value)
 
     def _deserialize_b(self, value):
         return value  # Already in Base64
@@ -185,8 +188,6 @@ def _lambda_handler(event, context):
         logger.debug(image_name + ': %s', ddb[image_name])
         # Deserialize DynamoDB type to Python types
         doc_fields = ddb_deserializer.deserialize({'M': ddb[image_name]})
-        if '_lastChangedAt' in doc_fields:
-            doc_fields['_lastChangedAt'] = int(doc_fields['_lastChangedAt'])
         
         # Sync enabled APIs do soft delete. We need to delete the record in ES if _deleted field is set
         if ES_USE_EXTERNAL_VERSIONING and event_name == 'MODIFY' and '_deleted' in  doc_fields and doc_fields['_deleted']:

--- a/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/graphql-elasticsearch-transformer/streaming-lambda/python_streaming_function.py
@@ -40,12 +40,11 @@ class DDBTypesEncoder(json.JSONEncoder):
 # Subclass of boto's TypeDeserializer for DynamoDB to adjust for DynamoDB Stream format.
 class StreamTypeDeserializer(TypeDeserializer):
     def _deserialize_n(self, value):
-        try:
-            if value != int(value): # check if casting truncates decimals
-                return float(value)
+        val = float(value)
+        if (val.is_integer()):
             return int(value)
-        except ValueError:
-            return float(value)
+        else:
+            return val
 
     def _deserialize_b(self, value):
         return value  # Already in Base64


### PR DESCRIPTION
#### Description of changes
Fixes the issue with elastic search trying to cast the version control field _lastChangedAt to a float instead of an integer. Works with other epoch fields too.  Changes the serializer from blind casting every "dynamodb number" to float to attempting to serialize as an int first and then falling back to float.


#### Issue
aws-amplify/amplify-category-api#371



#### Description of how you validated changes
Have the same changes already on my deployed environments


#### Checklist
- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.