### PR TITLE
fix: lambda layer change handling

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambdaLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambdaLayerWalkthrough.ts
@@ -113,7 +113,7 @@ export async function updateLayerWalkthrough(
 
     // select layer version
     if (layerHasDeployed) {
-      const layerCloudState = LayerCloudState.getInstance();
+      const layerCloudState = LayerCloudState.getInstance(parameters.layerName);
       const layerVersions = await layerCloudState.getLayerVersionsFromCloud(context, parameters.layerName);
       const latestVersionText = 'Future layer versions';
       const layerVersionChoices = [

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
@@ -11,7 +11,7 @@ import { updateLayerArtifacts } from '../utils/storeResources';
 const removeLayerQuestion = 'Choose the Layer versions you want to remove.';
 
 export async function removeWalkthrough(context: $TSContext, layerName: string): Promise<string | undefined> {
-  const layerCloudState = LayerCloudState.getInstance();
+  const layerCloudState = LayerCloudState.getInstance(layerName);
   const layerVersionList = await layerCloudState.getLayerVersionsFromCloud(context, layerName);
 
   // if the layer hasn't been pushed return and remove it

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -83,10 +83,16 @@ export const askLayerSelection = async (
       const previousLayerSelection = _.first(filterProjectLayers(previousSelections).filter(prev => prev.resourceName === layerName));
 
       let defaultLayerSelection: string;
+
       if (previousLayerSelection === undefined || previousLayerSelection.isLatestVersionSelected) {
         defaultLayerSelection = defaultLayerVersionPrompt;
       } else {
-        defaultLayerSelection = mapVersionNumberToChoice(_.first(layerVersions.filter(v => v.Version === previousLayerSelection.version)));
+        const previouslySelectedLayerVersion = _.first(layerVersions.filter(v => v.Version === previousLayerSelection.version));
+
+        // Fallback to defaultLayerVersionPrompt as it is possible that a function is associated with a non-existent layer version
+        defaultLayerSelection = previouslySelectedLayerVersion
+          ? mapVersionNumberToChoice(previouslySelectedLayerVersion)
+          : defaultLayerVersionPrompt;
       }
 
       const versionSelection = (

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -65,7 +65,7 @@ export const askLayerSelection = async (
   layerSelections = layerSelections.filter(selection => selection !== provideExistingARNsPrompt);
 
   for (const layerName of layerSelections) {
-    const layerCloudState = LayerCloudState.getInstance();
+    const layerCloudState = LayerCloudState.getInstance(layerName);
     const layerVersions = await layerCloudState.getLayerVersionsFromCloud(context, layerName);
     const layerVersionChoices = layerVersions.map(mapVersionNumberToChoice);
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
@@ -24,8 +24,8 @@ export function generateLayerCfnObj(isNewVersion: boolean, parameters: LayerPara
   if (isNewVersion) {
     const [shortId] = uuid().split('-');
     logicalName = `${LayerCfnLogicalNamePrefix.LambdaLayerVersion}${shortId}`;
-    const layerCloudState = LayerCloudState.getInstance();
-    layerCloudState.latestVersionLogicalId = logicalName; // Store in singleton so it can be used in zipfile name
+    const layerCloudState = LayerCloudState.getInstance(parameters.layerName);
+    layerCloudState.latestVersionLogicalIds[parameters.layerName] = logicalName; // Store in singleton so it can be used in zipfile name
     versionList.unshift({ LogicalName: logicalName, legacyLayer: false });
   } else {
     logicalName = _.first(versionList).LogicalName;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
@@ -25,7 +25,7 @@ export function generateLayerCfnObj(isNewVersion: boolean, parameters: LayerPara
     const [shortId] = uuid().split('-');
     logicalName = `${LayerCfnLogicalNamePrefix.LambdaLayerVersion}${shortId}`;
     const layerCloudState = LayerCloudState.getInstance(parameters.layerName);
-    layerCloudState.latestVersionLogicalIds[parameters.layerName] = logicalName; // Store in singleton so it can be used in zipfile name
+    layerCloudState.latestVersionLogicalId = logicalName; // Store in the given layer's layerCloudState instance so it can be used in zipfile name
     versionList.unshift({ LogicalName: logicalName, legacyLayer: false });
   } else {
     logicalName = _.first(versionList).LogicalName;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
@@ -6,17 +6,17 @@ import { LegacyPermissionEnum } from './layerMigrationUtils';
 import { LayerVersionMetadata, PermissionEnum } from './layerParams';
 
 export class LayerCloudState {
-  private static instance: LayerCloudState;
+  private static instances: Record<string, LayerCloudState> = {};
   private layerVersionsMetadata: LayerVersionMetadata[];
-  public latestVersionLogicalId: string;
+  public latestVersionLogicalIds: Record<string, string> = {};
 
   private constructor() {}
 
-  static getInstance(): LayerCloudState {
-    if (!LayerCloudState.instance) {
-      LayerCloudState.instance = new LayerCloudState();
+  static getInstance(layerName: string): LayerCloudState {
+    if (!LayerCloudState.instances[layerName]) {
+      LayerCloudState.instances[layerName] = new LayerCloudState();
     }
-    return LayerCloudState.instance;
+    return LayerCloudState.instances[layerName];
   }
 
   private async loadLayerDataFromCloud(context: $TSContext, layerName: string): Promise<LayerVersionMetadata[]> {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
@@ -8,7 +8,7 @@ import { LayerVersionMetadata, PermissionEnum } from './layerParams';
 export class LayerCloudState {
   private static instances: Record<string, LayerCloudState> = {};
   private layerVersionsMetadata: LayerVersionMetadata[];
-  public latestVersionLogicalIds: Record<string, string> = {};
+  public latestVersionLogicalId: string;
 
   private constructor() {}
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -61,12 +61,12 @@ export const packageLayer: Packager = async (context, resource) => {
   }
 
   const layerCloudState = LayerCloudState.getInstance(resource.resourceName);
-  if (!layerCloudState.latestVersionLogicalIds[resource.resourceName]) {
+  if (!layerCloudState.latestVersionLogicalId) {
     // "Should" never be reachable, but sanity check just in case
     throw new Error('LogicalId missing for new layer version.');
   }
 
-  const zipFilename = createLayerZipFilename(resource.resourceName, layerCloudState.latestVersionLogicalIds[resource.resourceName]);
+  const zipFilename = createLayerZipFilename(resource.resourceName, layerCloudState.latestVersionLogicalId);
   // check zip size is less than 250MB
   if (validFilesize(context, destination)) {
     context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename, { resourceKey: versionHash, hashValue: currentHash });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -63,7 +63,7 @@ export const packageLayer: Packager = async (context, resource) => {
   const layerCloudState = LayerCloudState.getInstance(resource.resourceName);
   if (!layerCloudState.latestVersionLogicalId) {
     // "Should" never be reachable, but sanity check just in case
-    throw new Error('LogicalId missing for new layer version.');
+    throw new Error(`LogicalId missing for new layer version: ${resource.resourceName}.`);
   }
 
   const zipFilename = createLayerZipFilename(resource.resourceName, layerCloudState.latestVersionLogicalId);
@@ -112,6 +112,9 @@ export async function checkContentChanges(context: $TSContext, layerResources: A
     for (const layer of changedLayerResources) {
       let { parameters } = layer;
       if (!accepted) {
+        context.print.info('');
+        context.print.info(`Change options layer: ${layer.resourceName}`);
+        context.print.info('');
         parameters = await lambdaLayerNewVersionWalkthrough(parameters, timestampString);
       } else {
         parameters.description = `Updated layer version ${timestampString}`;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -60,13 +60,13 @@ export const packageLayer: Packager = async (context, resource) => {
     await zipPackage(packageResult.zipEntries, destination);
   }
 
-  const layerCloudState = LayerCloudState.getInstance();
-  if (!layerCloudState.latestVersionLogicalId) {
+  const layerCloudState = LayerCloudState.getInstance(resource.resourceName);
+  if (!layerCloudState.latestVersionLogicalIds[resource.resourceName]) {
     // "Should" never be reachable, but sanity check just in case
     throw new Error('LogicalId missing for new layer version.');
   }
 
-  const zipFilename = createLayerZipFilename(resource.resourceName, layerCloudState.latestVersionLogicalId);
+  const zipFilename = createLayerZipFilename(resource.resourceName, layerCloudState.latestVersionLogicalIds[resource.resourceName]);
   // check zip size is less than 250MB
   if (validFilesize(context, destination)) {
     context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename, { resourceKey: versionHash, hashValue: currentHash });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -213,7 +213,10 @@ function ensureLayerRuntimeFolder(layerDirPath: string, runtime: LayerRuntime) {
 }
 
 function createLayerCfnFile(parameters: LayerParameters, layerDirPath: string) {
-  JSONUtilities.writeJson(path.join(layerDirPath, getCfnTemplateFileName(parameters.layerName)), generateLayerCfnObj(true, parameters));
+  const layerCfnObj = generateLayerCfnObj(true, parameters);
+  const layerCfnFilePath = path.join(layerDirPath, getCfnTemplateFileName(parameters.layerName));
+
+  JSONUtilities.writeJson(layerCfnFilePath, layerCfnObj);
 }
 
 async function updateLayerCfnFile(context: $TSContext, parameters: LayerParameters, layerDirPath: string): Promise<$TSObject> {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -220,7 +220,7 @@ async function updateLayerCfnFile(context: $TSContext, parameters: LayerParamete
   let layerVersionList: LayerVersionMetadata[] = [];
 
   if (loadPreviousLayerHash(parameters.layerName)) {
-    const layerCloudState = LayerCloudState.getInstance();
+    const layerCloudState = LayerCloudState.getInstance(parameters.layerName);
 
     layerVersionList = await layerCloudState.getLayerVersionsFromCloud(context, parameters.layerName);
   }


### PR DESCRIPTION
#### Description of changes

This PR fixes 2 issues around lambda functions:
- update function previously failed when the selected function referenced a non-existent lambda layer version
- when project had 2 lambda layers and both of them had changes a push failed because CFN logical resource id was the same

#### Issue #, if available

N/A

#### Description of how you validated changes

Manual testing

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.