### PR TITLE
fix: ensure REST API CFN outputs the API ID

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -248,8 +248,7 @@ function updateExistingApiCfn(context: $TSContext, api: $TSObject): void {
   const parameterJson = JSONUtilities.readJson(paramsFile, { throwIfNotExist: false }) ?? {};
 
   if (!cfn) {
-    // This should not happen. If it does, nothing else will work anyway so just bail out.
-    return;
+    throw new Error(`CloudFormation template missing for REST API ${resourceName}`);
   }
 
   const parameters = cfn.Parameters ?? {};

--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -246,8 +246,14 @@ function updateExistingApiCfn(context: $TSContext, api: $TSObject): void {
   const apiParamsFile = path.join(resourceDir, API_PARAMS_FILE);
   const cfn: any = JSONUtilities.readJson(cfnTemplate, { throwIfNotExist: false }) ?? {};
   const parameterJson = JSONUtilities.readJson(paramsFile, { throwIfNotExist: false }) ?? {};
-  const parameters = cfn?.Parameters ?? {};
-  const resources = cfn?.Resources ?? {};
+
+  if (!cfn) {
+    // This should not happen. If it does, nothing else will work anyway so just bail out.
+    return;
+  }
+
+  const parameters = cfn.Parameters ?? {};
+  const resources = cfn.Resources ?? {};
   let modified = false;
 
   for (const parameterName in parameters) {
@@ -278,6 +284,17 @@ function updateExistingApiCfn(context: $TSContext, api: $TSObject): void {
           delete resources[resourceName];
           modified = true;
         }
+      }
+    } else if (resource.Type === 'AWS::ApiGateway::RestApi') {
+      cfn.Outputs ??= {};
+
+      // Ensure that th REST API's ID is an output of the stack.
+      if (!cfn.Outputs.ApiId) {
+        cfn.Outputs.ApiId = {
+          Description: 'API ID (prefix of API URL)',
+          Value: { Ref: resourceName },
+        };
+        modified = true;
       }
     }
   }


### PR DESCRIPTION
#### Description of changes
This commit updates the REST API migration logic to ensure that the API ID is a CFN Output, as the policy consolidation logic will rely on this during push.

#### Issue #, if available

#### Description of how you validated changes
Manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.