### PR TITLE
fix: change scope of change detection for python layers

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -21,6 +21,8 @@ const layerResourceGlobs = [parametersFileName, `*${cfnTemplateSuffix}`];
 const libPathName = 'lib';
 const optPathName = 'opt';
 const packageJson = 'package.json';
+const pipfile = 'Pipfile';
+const pipfileLock = 'Pipfile.lock';
 
 export interface LayerInputParams {
   layerPermissions?: PermissionEnum[];
@@ -343,7 +345,28 @@ const getLayerGlobs = async (
 
     result.push(...contentFilePaths);
   } else if (runtimeId === 'python') {
-    // No special treatment needed for python yet.
+    // Add to hashable files/folders
+    const pipfileFilePath = path.join(layerCodePath, pipfile);
+
+    if (fs.existsSync(pipfileFilePath)) {
+      result.push(path.join(libPathName, layerExecutablePath, pipfile));
+    }
+
+    // If lock file is present, add to hashable files/folders
+    const pipfileLockFilePath = path.join(layerCodePath, pipfileLock);
+
+    if (fs.existsSync(pipfileLockFilePath)) {
+      result.push(path.join(libPathName, layerExecutablePath, pipfileLockFilePath));
+    }
+
+    // Add layer direct content from lib/python and exclude well known files from list.
+    // files must be relative to resource folder as that will be used as a base path for hashing.
+    const contentFilePaths = await globby([path.join(libPathName, layerExecutablePath, '**', '*')], {
+      cwd: resourcePath,
+      ignore: ['lib', pipfile, pipfileLock].map(name => path.join(libPathName, layerExecutablePath, name)),
+    });
+
+    result.push(...contentFilePaths);
   } else {
     const error = new Error(`Unsupported layer runtime: ${runtimeId} for resource: ${resourceName}`);
     error.stack = undefined;


### PR DESCRIPTION
#### Description of changes

Change the scope of files the CLI checks for python lambda layers.

Now in the layer directory the following files are checked:
- Pipfile (if exists)
- Pipfile.lock (if exists)
- All other files recursively, but exluding `lib` - where `pip install` installs the dependencies 

#### Issue #, if available

N/A

#### Description of how you validated changes

Manual testing


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.