### PR TITLE
fix(cli): make delete clean local project if already deleted in cloud

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-env-from-cloud.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-env-from-cloud.test.ts
@@ -62,4 +62,12 @@ describe('remove-env-from-cloud', () => {
 
     await expect(removeEnvFromCloud(context, 'test', false)).rejects.toThrow('deleteEnv error');
   });
+
+  it('does not throw not found error when deleteEnv promise rejected', async () => {
+    const e: any = new Error('deleteEnv error');
+    e.code = 'NotFoundException';
+    deleteEnvMock.mockRejectedValue(e);
+
+    await expect(removeEnvFromCloud(context, 'test', false)).resolves.not.toThrow('deleteEnv error');
+  });
 });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
@@ -35,7 +35,7 @@ export async function deleteProject(context) {
         }
       }
       spinner.succeed('Project deleted in the cloud.');
-    } catch (ex) {
+    } catch (ex: any) {
       if (ex.code === 'NotFoundException') {
         spinner.succeed('Project already deleted in the cloud.');
       } else {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
@@ -30,6 +30,8 @@ export async function removeEnvFromCloud(context, envName, deleteS3) {
     context.print.info('');
     context.print.error(`Error occurred while deleting env: ${envName}.`);
     context.print.info(e.message);
-    throw e;
+    if (e.code !== 'NotFoundException') {
+      throw e;
+    }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes

this commit adds NotFoundException handling to the `amplify delete` operation. If cloud resources
are not found, then that part of the delete must already be done, so we should move on and continue
deletion.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #7515


#### Description of how you validated changes

- unit tests added
- ran `amplify-dev delete` on a project already deleted in the cloud

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.