### PR TITLE
fix: added required parameters in Email notifications channel

### DIFF
--- a/packages/amplify-category-notifications/lib/channel-Email.js
+++ b/packages/amplify-category-notifications/lib/channel-Email.js
@@ -100,7 +100,7 @@ function validateInputParams(channelInput) {
 }
 
 async function disable(context) {
-  const channelOutput = context.exeInfo.serviceMeta.output[channelName];
+  const channelOutput = validateInputParams(context.exeInfo.serviceMeta.output[channelName]);
   const params = {
     ApplicationId: context.exeInfo.serviceMeta.output.Id,
     EmailChannelRequest: {

--- a/packages/amplify-category-notifications/lib/channel-Email.js
+++ b/packages/amplify-category-notifications/lib/channel-Email.js
@@ -100,10 +100,13 @@ function validateInputParams(channelInput) {
 }
 
 async function disable(context) {
+  const channelOutput = context.exeInfo.serviceMeta.output[channelName];
   const params = {
     ApplicationId: context.exeInfo.serviceMeta.output.Id,
     EmailChannelRequest: {
       Enabled: false,
+      FromAddress: channelOutput.FromAddress,
+      Identity: channelOutput.Identity,
     },
   };
   spinner.start('Updating Email Channel.');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
FromAddress and Identity are required parameters in UpdateEmailChannel() sdk call which were missing in current Implementation
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #7464
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
* Tested manually


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.