### PR TITLE
fix(cli): use more explicit amplify pragma in .gitignore

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/git-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/git-manager.test.ts
@@ -9,7 +9,8 @@ const fsMock = fs as jest.Mocked<typeof fs>;
 fsMock.readFileSync.mockImplementation(() => 'test');
 fsMock.writeFileSync.mockImplementation();
 
-const amplifyMark = '#amplify';
+const amplifyMark = '#amplify-do-not-edit-begin';
+const amplifyEndMark = '#amplify-do-not-edit-end';
 
 const ignoreList = [
   'amplify/\\#current-cloud-backend',
@@ -32,7 +33,7 @@ const ignoreList = [
   '.secret-*',
 ];
 
-const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}`;
+const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}${os.EOL + amplifyEndMark + os.EOL}`;
 
 describe('git-manager', () => {
   beforeEach(() => {

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/git-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/git-manager.test.ts
@@ -11,7 +11,7 @@ fsMock.writeFileSync.mockImplementation();
 
 const amplifyMark = '#amplify-do-not-edit-begin';
 const amplifyEndMark = '#amplify-do-not-edit-end';
-const legacyAmplifyMark = '#amplify';
+const deprecatedAmplifyMark = '#amplify';
 
 const ignoreList = [
   'amplify/\\#current-cloud-backend',
@@ -35,7 +35,7 @@ const ignoreList = [
 ];
 
 const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}${os.EOL + amplifyEndMark + os.EOL}`;
-const legacyToAppend = `${os.EOL + os.EOL + legacyAmplifyMark + os.EOL}${ignoreList.join(os.EOL)}`;
+const legacyToAppend = `${os.EOL + os.EOL + deprecatedAmplifyMark + os.EOL}${ignoreList.join(os.EOL)}`;
 describe('git-manager', () => {
   beforeEach(() => {
     fsMock.writeFileSync.mockClear();
@@ -48,24 +48,24 @@ describe('git-manager', () => {
     fsMock.existsSync.mockImplementation(() => true);
     fsMock.readFileSync.mockImplementation(() => 'amplify/');
     insertAmplifyIgnore(gitIgnoreFilePath);
-    expect(fsMock.writeFileSync.mock.calls[0][0]).toEqual('testPath');
+    expect(fsMock.writeFileSync.mock.calls[0][0]).toEqual(gitIgnoreFilePath);
     expect(fsMock.writeFileSync.mock.calls[0][1]).toEqual('amplify/');
-    expect(fsMock.appendFileSync.mock.calls[0][0]).toEqual('testPath');
+    expect(fsMock.appendFileSync.mock.calls[0][0]).toEqual(gitIgnoreFilePath);
     expect(fsMock.appendFileSync.mock.calls[0][1]).toEqual(toAppend);
   });
   test('create a new .gitignore', () => {
     fsMock.existsSync.mockImplementation(() => false);
     insertAmplifyIgnore(gitIgnoreFilePath);
-    expect(fsMock.writeFileSync.mock.calls[0][0]).toEqual('testPath');
+    expect(fsMock.writeFileSync.mock.calls[0][0]).toEqual(gitIgnoreFilePath);
     expect(fsMock.writeFileSync.mock.calls[0][1]).toEqual(toAppend.trim());
   });
   test('legacy .gitignore files reformat themselves when accessed by a newer version of the CLI', () => {
     fsMock.existsSync.mockImplementation(() => true);
     fsMock.readFileSync.mockImplementation(() => 'amplify/' + os.EOL + legacyToAppend.trim());
     insertAmplifyIgnore(gitIgnoreFilePath);
-    expect(fsMock.writeFileSync.mock.calls[0][0]).toEqual('testPath');
+    expect(fsMock.writeFileSync.mock.calls[0][0]).toEqual(gitIgnoreFilePath);
     expect(fsMock.writeFileSync.mock.calls[0][1]).toEqual('amplify/');
-    expect(fsMock.appendFileSync.mock.calls[0][0]).toEqual('testPath');
+    expect(fsMock.appendFileSync.mock.calls[0][0]).toEqual(gitIgnoreFilePath);
     expect(fsMock.appendFileSync.mock.calls[0][1]).toEqual(toAppend);
   });
 });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
@@ -4,10 +4,10 @@ import { LocalLogDirectory } from 'amplify-cli-logger';
 
 const amplifyMark = '#amplify-do-not-edit-begin';
 const amplifyEndMark = '#amplify-do-not-edit-end';
-const legacyAmplifyMark = '#amplify';
+const deprecatedAmplifyMark = '#amplify';
 const amplifyMarkRegExp = new RegExp(`^${amplifyMark}`);
 const amplifyEndMarkRegExp = new RegExp(`^${amplifyEndMark}`);
-const legacyAmplifyMarkRegExp = new RegExp(`^${legacyAmplifyMark}`);
+const deprecatedAmplifyMarkRegExp = new RegExp(`^${deprecatedAmplifyMark}`);
 
 export function insertAmplifyIgnore(gitIgnoreFilePath: string): void {
   if (fs.existsSync(gitIgnoreFilePath)) {
@@ -33,7 +33,7 @@ function removeAmplifyIgnore(gitIgnoreFilePath: string): void {
         if (amplifyEndMarkRegExp.test(newLine) || newLine.length === 0) {
           isInRemoval = false;
         }
-      } else if (amplifyMarkRegExp.test(newLine) || legacyAmplifyMarkRegExp.test(newLine)) {
+      } else if (amplifyMarkRegExp.test(newLine) || deprecatedAmplifyMarkRegExp.test(newLine)) {
         isInRemoval = true;
       } else {
         newGitIgnoreString += newLine + os.EOL;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
@@ -2,8 +2,12 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import { LocalLogDirectory } from 'amplify-cli-logger';
 
-const amplifyMark = '#amplify';
+const amplifyMark = '#amplify-do-not-edit-begin';
+const amplifyEndMark = '#amplify-do-not-edit-end';
+const legacyAmplifyMark = '#amplify';
 const amplifyMarkRegExp = new RegExp(`^${amplifyMark}`);
+const amplifyEndMarkRegExp = new RegExp(`^${amplifyEndMark}`);
+const legacyAmplifyMarkRegExp = new RegExp(`^${legacyAmplifyMark}`);
 
 export function insertAmplifyIgnore(gitIgnoreFilePath: string): void {
   if (fs.existsSync(gitIgnoreFilePath)) {
@@ -26,10 +30,10 @@ function removeAmplifyIgnore(gitIgnoreFilePath: string): void {
       const newLine = gitIgnoreStringArray[i].trim();
 
       if (isInRemoval) {
-        if (newLine.length === 0) {
+        if (amplifyEndMarkRegExp.test(newLine) || newLine.length === 0) {
           isInRemoval = false;
         }
-      } else if (amplifyMarkRegExp.test(newLine)) {
+      } else if (amplifyMarkRegExp.test(newLine) || legacyAmplifyMarkRegExp.test(newLine)) {
         isInRemoval = true;
       } else {
         newGitIgnoreString += newLine + os.EOL;
@@ -64,7 +68,7 @@ function getGitIgnoreAppendString() {
     '.secret-*',
   ];
 
-  const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}`;
+  const toAppend = `${os.EOL + os.EOL + amplifyMark + os.EOL}${ignoreList.join(os.EOL)}${os.EOL + amplifyEndMark + os.EOL}`;
 
   return toAppend;
 }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
@@ -11,7 +11,7 @@ const deprecatedAmplifyMarkRegExp = new RegExp(`^${deprecatedAmplifyMark}`);
 
 export function insertAmplifyIgnore(gitIgnoreFilePath: string): void {
   if (fs.existsSync(gitIgnoreFilePath)) {
-    removeAmplifyIgnore(gitIgnoreFilePath);
+    rebuildAmplifyIgnore(gitIgnoreFilePath);
 
     fs.appendFileSync(gitIgnoreFilePath, getGitIgnoreAppendString());
   } else {
@@ -19,7 +19,7 @@ export function insertAmplifyIgnore(gitIgnoreFilePath: string): void {
   }
 }
 
-function removeAmplifyIgnore(gitIgnoreFilePath: string): void {
+function rebuildAmplifyIgnore(gitIgnoreFilePath: string): void {
   if (fs.existsSync(gitIgnoreFilePath)) {
     let newGitIgnoreString = '';
     const gitIgnoreStringArray = fs.readFileSync(gitIgnoreFilePath, 'utf8').split(os.EOL);


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes

Previously, we used the #amplify pragma to show which block of .gitignore was managed by amplify.
This causes confusion for customers who think it is safe to add or remove lines this section of
their gitignore. The cli will blitz any changes to this section on amplify init or amplify pull. By
using a more explicit pragma, customers will realize they should not touch this section of the
gitignore.

docs https://github.com/aws-amplify/docs/pull/3330


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

fix #7250


#### Description of how you validated changes

created a new project and checked that .gitignore file was manipulated as expected

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.