### PR TITLE
fix:recommend using of AdministratorAccess-Amplify managed policy instead of AdministratorAccess managed policy

### DIFF
--- a/packages/amplify-category-auth/resources/overrides-resource/auth/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/auth/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"

--- a/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"

--- a/packages/amplify-category-custom/resources/package.json
+++ b/packages/amplify-category-custom/resources/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0",
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0",
       "@aws-cdk/core": "~1.124.0",
       "@aws-cdk/aws-iam": "~1.124.0",
       "@aws-cdk/aws-sns-subscriptions": "~1.124.0",

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
       
     },
     "devDependencies": {

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"


### PR DESCRIPTION
#### Description of changes
As a part of the `amplify configure` command, currently the Amplify CLI recommends using of the AdministratorAccess Managed IAM Policy by opening up the IAM user wizard giving Admin Access to the configured IAM user which is to be used by the Amplify CLI.
Moving forward, we'd like to scope the IAM polices to only the policies required by the Amplify CLI and recommend using the AdministratorAccess-Amplify IAM Managed Policy. This IAM managed policy is scoped down to only the IAM policies required by all the categories in the CLI. This managed policy will contain the policy-list out here - https://docs.amplify.aws/cli/usage/iam
This Managed IAM policy is controlled and moderated by the Amplify team and as and when new functionalities are added in the CLI, the Amplify team can dynamically update the IAM policy list without the customer having to modify or change any IAM configuration on their end to utilize the new functionality with the Amplify CLI.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.