### PR TITLE
Revert "test: add ff to gql test transformer"

### DIFF
--- a/packages/amplify-util-mock/src/__e2e__/connections-with-auth-tests.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/connections-with-auth-tests.e2e.test.ts
@@ -1,7 +1,7 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { signUpAddToGroupAndGetJwtToken } from './utils/cognito-utils';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
@@ -112,9 +112,6 @@ type Stage @model @auth(rules: [{ allow: groups, groups: ["Admin"]}]) {
         },
       }),
     ],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
 
   try {

--- a/packages/amplify-util-mock/src/__e2e__/dynamo-db-model-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/dynamo-db-model-transformer.e2e.test.ts
@@ -1,6 +1,6 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, terminateDDB, logDebug } from './utils/index';
 
@@ -59,9 +59,6 @@ beforeAll(async () => {
           },
         }),
       ],
-      featureFlags: {
-        getBoolean: name => (name === 'improvePluralization' ? true : false),
-      } as FeatureFlagProvider,
     });
     const out = await transformer.transform(validSchema);
     let ddbClient;
@@ -182,8 +179,7 @@ test('Test createPost mutation', async () => {
 });
 
 test('Test query on get query with null field', async () => {
-  const createResponse = await GRAPHQL_CLIENT.query(
-    `
+  const createResponse = await GRAPHQL_CLIENT.query(`
     mutation {
       createPost(input: { title: "Cool Post" }) {
         id
@@ -191,24 +187,19 @@ test('Test query on get query with null field', async () => {
         createdAt
         updatedAt
       }
-    }`,
-    {},
-  );
+    }`, {});
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual('Cool Post');
   const postID = createResponse.data.createPost.id;
   try {
-    const queryResponse = await GRAPHQL_CLIENT.query(
-      `
+    const queryResponse = await GRAPHQL_CLIENT.query(`
     query {
       getPost(id: "${postID}") {
         id
         title
         episode
       }
-    }`,
-      {},
-    );
+    }`, {});
     expect(queryResponse.data.getPost.id).toEqual(postID);
     expect(queryResponse.data.getPost.episode).toBeNull();
   } catch (err) {

--- a/packages/amplify-util-mock/src/__e2e__/function-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/function-transformer.e2e.test.ts
@@ -1,6 +1,6 @@
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { FunctionTransformer } from 'graphql-function-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, logDebug } from './utils/index';
 
@@ -36,9 +36,6 @@ beforeAll(async () => {
   try {
     const transformer = new GraphQLTransform({
       transformers: [new DynamoDBModelTransformer(), new FunctionTransformer()],
-      featureFlags: {
-        getBoolean: name => (name === 'improvePluralization' ? true : false),
-      } as FeatureFlagProvider,
     });
     const out = transformer.transform(validSchema);
 
@@ -81,7 +78,7 @@ test('Test simple echo function', async () => {
             fieldName
         }
     }`,
-    {},
+    {}
   );
   logDebug(JSON.stringify(response, null, 4));
   expect(response.data.echo.arguments.msg).toEqual('Hello');
@@ -100,7 +97,7 @@ test('Test simple duplicate function', async () => {
             fieldName
         }
     }`,
-    {},
+    {}
   );
   logDebug(JSON.stringify(response, null, 4));
   expect(response.data.duplicate.arguments.msg).toEqual('Hello');
@@ -113,7 +110,7 @@ test('Test pipeline of @function(s)', async () => {
     `query {
         pipeline(msg: "IGNORED")
     }`,
-    {},
+    {}
   );
   logDebug(JSON.stringify(response, null, 4));
   expect(response.data.pipeline).toEqual('Hello, world!');
@@ -130,7 +127,7 @@ test('Test pipelineReverse of @function(s)', async () => {
             fieldName
         }
     }`,
-    {},
+    {}
   );
   logDebug(JSON.stringify(response, null, 4));
   expect(response.data.pipelineReverse.arguments.msg).toEqual('Hello');

--- a/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-transformer.e2e.test.ts
@@ -2,7 +2,7 @@ import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
 
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { GraphQLClient } from './utils/graphql-client';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { KeyTransformer } from 'graphql-key-transformer';
 
 jest.setTimeout(2000000);
@@ -62,9 +62,6 @@ beforeAll(async () => {
     `;
   const transformer = new GraphQLTransform({
     transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
   const out = transformer.transform(validSchema);
   let ddbClient;

--- a/packages/amplify-util-mock/src/__e2e__/key-with-auth.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-with-auth.e2e.test.ts
@@ -1,7 +1,7 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { KeyTransformer } from 'graphql-key-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { signUpAddToGroupAndGetJwtToken } from './utils/cognito-utils';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
@@ -67,9 +67,6 @@ beforeAll(async () => {
         },
       }),
     ],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
 
   try {

--- a/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
@@ -1,6 +1,6 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { signUpAddToGroupAndGetJwtToken } from './utils/cognito-utils';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
@@ -141,9 +141,6 @@ beforeAll(async () => {
         },
       }),
     ],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
 
   try {

--- a/packages/amplify-util-mock/src/__e2e__/model-connection-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-connection-transformer.e2e.test.ts
@@ -1,7 +1,7 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, terminateDDB, logDebug } from './utils/index';
@@ -49,9 +49,6 @@ beforeAll(async () => {
         }),
         new ModelConnectionTransformer(),
       ],
-      featureFlags: {
-        getBoolean: name => (name === 'improvePluralization' ? true : false),
-      } as FeatureFlagProvider,
     });
     const out = transformer.transform(validSchema);
 
@@ -98,7 +95,7 @@ test('Test queryPost query', async () => {
             title
         }
     }`,
-    {},
+    {}
   );
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual('Test Query');
@@ -113,7 +110,7 @@ test('Test queryPost query', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(createCommentResponse.data.createComment.id).toBeDefined();
   expect(createCommentResponse.data.createComment.content).toEqual('A comment!');
@@ -132,7 +129,7 @@ test('Test queryPost query', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponse.data.getPost).toBeDefined();
   const items = queryResponse.data.getPost.comments.items;
@@ -157,7 +154,7 @@ test('Test queryPost query with sortField', async () => {
             title
         }
     }`,
-    {},
+    {}
   );
   expect(createResponse.data.createPost.id).toBeDefined();
   expect(createResponse.data.createPost.title).toEqual(title);
@@ -176,7 +173,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(createCommentResponse1.data.createSortedComment.id).toBeDefined();
   expect(createCommentResponse1.data.createSortedComment.content).toEqual(comment1);
@@ -199,7 +196,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(createCommentResponse2.data.createSortedComment.id).toBeDefined();
   expect(createCommentResponse2.data.createSortedComment.content).toEqual(comment2);
@@ -220,7 +217,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponse.data.getPost).toBeDefined();
   const items = queryResponse.data.getPost.sortedComments.items;
@@ -242,7 +239,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseDesc.data.getPost).toBeDefined();
   const itemsDesc = queryResponseDesc.data.getPost.sortedComments.items;
@@ -264,7 +261,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyCondition.data.getPost).toBeDefined();
   const itemsDescWithKeyCondition = queryResponseWithKeyCondition.data.getPost.sortedComments.items;
@@ -285,7 +282,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyConditionEq.data.getPost).toBeDefined();
   const itemsDescWithKeyConditionEq = queryResponseWithKeyConditionEq.data.getPost.sortedComments.items;
@@ -306,7 +303,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyConditionGt.data.getPost).toBeDefined();
   const itemsDescWithKeyConditionGt = queryResponseWithKeyConditionGt.data.getPost.sortedComments.items;
@@ -327,7 +324,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyConditionGe.data.getPost).toBeDefined();
   const itemsDescWithKeyConditionGe = queryResponseWithKeyConditionGe.data.getPost.sortedComments.items;
@@ -349,7 +346,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyConditionLe.data.getPost).toBeDefined();
   const itemsDescWithKeyConditionLe = queryResponseWithKeyConditionLe.data.getPost.sortedComments.items;
@@ -371,7 +368,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyConditionLt.data.getPost).toBeDefined();
   const itemsDescWithKeyConditionLt = queryResponseWithKeyConditionLt.data.getPost.sortedComments.items;
@@ -392,7 +389,7 @@ test('Test queryPost query with sortField', async () => {
             }
         }
     }`,
-    {},
+    {}
   );
   expect(queryResponseWithKeyConditionBetween.data.getPost).toBeDefined();
   const itemsDescWithKeyConditionBetween = queryResponseWithKeyConditionBetween.data.getPost.sortedComments.items;
@@ -414,7 +411,7 @@ test('Test create comment without a post and then querying the comment.', async 
                 }
             }
         }`,
-      {},
+      {}
     );
     expect(createCommentResponse1.data.createComment.id).toBeDefined();
     expect(createCommentResponse1.data.createComment.content).toEqual(comment1);
@@ -430,7 +427,7 @@ test('Test create comment without a post and then querying the comment.', async 
                 }
             }
         }`,
-      {},
+      {}
     );
     expect(queryResponseDesc.data.getComment).toBeDefined();
     expect(queryResponseDesc.data.getComment.post).toBeNull();
@@ -453,7 +450,7 @@ test('Test default limit is 50', async () => {
       }
     }
     `,
-    {},
+    {}
   );
   expect(createPost.data.createPost).toBeDefined();
   expect(createPost.data.createPost.id).toEqual(postID);
@@ -472,7 +469,7 @@ test('Test default limit is 50', async () => {
           }
         }      
       `,
-      {},
+      {}
     );
   }
 
@@ -493,7 +490,7 @@ test('Test default limit is 50', async () => {
           }
         }
       }`,
-    { id: postID },
+    { id: postID }
   );
 
   expect(getPost.data.getPost.comments.items.length).toEqual(50);

--- a/packages/amplify-util-mock/src/__e2e__/model-connection-with-key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-connection-with-key-transformer.e2e.test.ts
@@ -2,7 +2,7 @@ import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { KeyTransformer } from 'graphql-key-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, terminateDDB, logDebug } from './utils/index';
@@ -113,9 +113,6 @@ beforeAll(async () => {
           },
         }),
       ],
-      featureFlags: {
-        getBoolean: name => (name === 'improvePluralization' ? true : false),
-      } as FeatureFlagProvider,
     });
     const out = transformer.transform(validSchema);
 
@@ -164,7 +161,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:1', asy
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -176,7 +173,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:1', asy
         }
     }
     `,
-    {},
+    {}
   );
 
   const queryResponse = await GRAPHQL_CLIENT.query(
@@ -194,7 +191,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:1', asy
         }
     }
     `,
-    {},
+    {}
   );
   expect(queryResponse.data.listAProjects).toBeDefined();
   const items = queryResponse.data.listAProjects.items;
@@ -214,7 +211,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:M', asy
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -226,7 +223,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:M', asy
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -238,7 +235,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:M', asy
         }
     }
     `,
-    {},
+    {}
   );
 
   const queryResponse = await GRAPHQL_CLIENT.query(
@@ -258,7 +255,7 @@ test('Unnamed connection 1 way navigation, with primary @key directive 1:M', asy
         }
     }
     `,
-    {},
+    {}
   );
   expect(queryResponse.data.listBProjects).toBeDefined();
   const items = queryResponse.data.listBProjects.items;
@@ -281,7 +278,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:1', asyn
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -293,7 +290,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:1', asyn
         }
     }
     `,
-    {},
+    {}
   );
 
   const queryResponse = await GRAPHQL_CLIENT.query(
@@ -315,7 +312,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:1', asyn
         }
     }
     `,
-    {},
+    {}
   );
   expect(queryResponse.data.listCProjects).toBeDefined();
   const items = queryResponse.data.listCProjects.items;
@@ -337,7 +334,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:M', asyn
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -349,7 +346,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:M', asyn
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -361,7 +358,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:M', asyn
         }
     }
     `,
-    {},
+    {}
   );
 
   const queryResponse = await GRAPHQL_CLIENT.query(
@@ -385,7 +382,7 @@ test('Named connection 2 way navigation, with with custom @key fields 1:M', asyn
         }
     }
     `,
-    {},
+    {}
   );
   expect(queryResponse.data.listDProjects).toBeDefined();
   const items = queryResponse.data.listDProjects.items;
@@ -413,7 +410,7 @@ test('Unnamed connection with sortField parameter only #2100', async () => {
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -426,7 +423,7 @@ test('Unnamed connection with sortField parameter only #2100', async () => {
         }
     }
     `,
-    {},
+    {}
   );
 
   await GRAPHQL_CLIENT.query(
@@ -438,7 +435,7 @@ test('Unnamed connection with sortField parameter only #2100', async () => {
         }
     }
     `,
-    {},
+    {}
   );
 
   const queryResponse = await GRAPHQL_CLIENT.query(
@@ -454,7 +451,7 @@ test('Unnamed connection with sortField parameter only #2100', async () => {
         }
     }
     `,
-    {},
+    {}
   );
   expect(queryResponse.data.getModel2).toBeDefined();
   const item = queryResponse.data.getModel2;

--- a/packages/amplify-util-mock/src/__e2e__/multi-auth-model-auth-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/multi-auth-model-auth-transformer.e2e.test.ts
@@ -3,7 +3,7 @@ import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import gql from 'graphql-tag';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { signUpAddToGroupAndGetJwtToken } from './utils/cognito-utils';
 import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
 
@@ -128,9 +128,6 @@ beforeAll(async () => {
         },
       }),
     ],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
 
   try {

--- a/packages/amplify-util-mock/src/__e2e__/per-field-auth-tests.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/per-field-auth-tests.e2e.test.ts
@@ -1,7 +1,7 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, logDebug, terminateDDB } from './utils/index';
 import { signUpAddToGroupAndGetJwtToken } from './utils/cognito-utils';
@@ -121,9 +121,6 @@ beforeAll(async () => {
         },
       }),
     ],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
 
   try {

--- a/packages/amplify-util-mock/src/__e2e__/subscriptions-with-auth.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/subscriptions-with-auth.e2e.test.ts
@@ -1,6 +1,6 @@
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { deploy, launchDDBLocal, terminateDDB } from './utils/index';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { signUpAddToGroupAndGetJwtToken } from './utils/cognito-utils';
@@ -129,9 +129,6 @@ beforeAll(async () => {
         },
       }),
     ],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
 
   try {

--- a/packages/amplify-util-mock/src/__e2e__/util-method-e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/util-method-e2e.test.ts
@@ -2,7 +2,7 @@ import { AmplifyAppSyncSimulator } from 'amplify-appsync-simulator';
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { not } from 'graphql-mapping-template';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { values } from 'lodash';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, terminateDDB, logDebug, reDeploy } from './utils/index';
@@ -17,9 +17,6 @@ jest.setTimeout(2000000);
 const runTransformer = async (validSchema: string) => {
   const transformer = new GraphQLTransform({
     transformers: [new DynamoDBModelTransformer()],
-    featureFlags: {
-      getBoolean: name => (name === 'improvePluralization' ? true : false),
-    } as FeatureFlagProvider,
   });
   const out = await transformer.transform(validSchema);
   return out;

--- a/packages/amplify-util-mock/src/__e2e__/versioned-model-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/versioned-model-transformer.e2e.test.ts
@@ -1,5 +1,5 @@
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
-import { FeatureFlagProvider, GraphQLTransform } from 'graphql-transformer-core';
+import { GraphQLTransform } from 'graphql-transformer-core';
 import { VersionedModelTransformer } from 'graphql-versioned-transformer';
 import { GraphQLClient } from './utils/graphql-client';
 import { deploy, launchDDBLocal, terminateDDB, logDebug } from './utils/index';
@@ -25,9 +25,6 @@ beforeAll(async () => {
   try {
     const transformer = new GraphQLTransform({
       transformers: [new DynamoDBModelTransformer(), new VersionedModelTransformer()],
-      featureFlags: {
-        getBoolean: name => (name === 'improvePluralization' ? true : false),
-      } as FeatureFlagProvider,
     });
     const out = transformer.transform(validSchema);
 


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#7572

#7572 fixed some e2e tests that were broken due to #7258 but #7258 had to be reverted due to other failing tests, so reverting this as well