### PR TITLE
fix: #7569 - make hashing predictable by sorting files first

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -389,6 +389,10 @@ const hashLayerVersion = async (layerPath: string, layerName: string, includeRes
 
     const filePaths = await globby(layerFilePaths, { cwd: layerPath });
 
+    // Sort the globbed files to make sure subsequent hashing on the same set of files will be ending
+    // up in the same hash
+    filePaths.sort();
+
     return filePaths
       .map(filePath => fs.readFileSync(path.join(layerPath, filePath), 'binary'))
       .reduce((acc, it) => acc.update(it), crypto.createHash('sha256'))


### PR DESCRIPTION
#### Description of changes

This PR fixes an issue with layer hashing when it was non-deterministic in every case as file globbing returned files in different order occasionally, by adding sorting after file discovery the issue is solved. 

#### Issue #, if available
fixes: #7569


#### Description of how you validated changes
Manual testing as the issue surfacing was highly dependent on the underlying hardware and filesystem. 

#### Checklist

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.