### PR TITLE
fix: suppress error in mock to match appsync

### DIFF
--- a/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/dynamo-db/index.ts
@@ -36,7 +36,16 @@ export class DynamoDBDataLoader implements AmplifyAppSyncSimulatorDataLoader {
         case 'UpdateItem':
           return await this.updateItem(payload);
         case 'DeleteItem':
-          return await this.deleteItem(payload);
+          try {
+            return await this.deleteItem(payload);
+          } catch (err) {
+            // These errors are reported in the DDB metrics, but AppSync suppresses them.
+            if (err.code === 'ConditionalCheckFailedException') {
+              return null;
+            }
+
+            throw err;
+          }
         case 'Query':
           return await this.query(payload);
         case 'Scan':

--- a/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
@@ -515,9 +515,7 @@ test('Test deletePost mutation when not authorized', async () => {
     {},
   );
   expect(deleteResponse.data.deletePost).toEqual(null);
-  expect(deleteResponse.errors.length).toEqual(1);
-  expect((deleteResponse.errors[0] as any).data).toBeNull();
-  expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  expect(deleteResponse.errors).toBeUndefined();
 });
 
 test('Test listPosts query when authorized', async () => {
@@ -714,9 +712,7 @@ test(`Test deleteSalary w/ Admin group protection not authorized`, async () => {
     }
     `);
   expect(req2.data.deleteSalary).toEqual(null);
-  expect(req2.errors.length).toEqual(1);
-  expect((req2.errors[0] as any).data).toBeNull();
-  expect((req2.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  expect(req2.errors).toBeUndefined();
 });
 
 test(`Test and Admin can get a salary created by any user`, async () => {
@@ -2598,7 +2594,7 @@ test("Test deleteOwnerCreateUpdateDeleteProtected with 'update' operation set", 
   );
   logDebug(response2);
   expect(response2.data.deleteOwnerCreateUpdateDeleteProtected).toBeNull();
-  expect(response2.errors).toHaveLength(1);
+  expect(response2.errors).toBeUndefined();
 
   const response3 = await GRAPHQL_CLIENT_1.query(
     `mutation {

--- a/packages/amplify-util-mock/src/__e2e__/versioned-model-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/versioned-model-transformer.e2e.test.ts
@@ -207,7 +207,6 @@ test('Test deletePost mutation with wrong version', async () => {
     }`,
     {},
   );
-  expect(deleteResponse.errors.length).toEqual(1);
-  expect((deleteResponse.errors[0] as any).data).toBeNull();
-  expect((deleteResponse.errors[0] as any).errorType).toEqual('DynamoDB:ConditionalCheckFailedException');
+  expect(deleteResponse.data.deletePost).toBeNull();
+  expect(deleteResponse.errors).toBeUndefined();
 });


### PR DESCRIPTION
#### Description of changes
This commit updates the AppSync simulator's error handling logic to suppress `ConditionalCheckFailedException` on `DeleteItem` operations to match AppSync's behavior.

For context, I originally submitted the simulator changes in #7574 because I noticed the delete behavior was different between the GraphQL Transformer v2 and AppSync. The test suite failed because we are testing for this behavior, so the changes are unrelated to v2 of the Transformer. I'm guessing that AppSync used to error in this scenario, but that no longer seems to be the case.

#### Issue #, if available

#### Description of how you validated changes
`yarn test` and amplify-util-mock's `yarn e2e`

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.