### PR TITLE
fix: check for undefined permissions when removing dependent permissions

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/getDependentFunction.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/getDependentFunction.test.ts
@@ -68,7 +68,7 @@ const loadResourceParameters_mock = loadFunctionParameters as jest.MockedFunctio
 
 test('get dependent functions', async () => {
   jest.clearAllMocks();
-  const modelsDeleted = ['model3'];
+  const modelsDeleted = ['model3', 'model2'];
   const FunctionMetaExpected = ['fn2', 'fn3'];
   loadResourceParameters_mock
     .mockReturnValueOnce({
@@ -91,9 +91,9 @@ test('get dependent functions', async () => {
   expect(fnMetaToBeUpdated.map(resource => resource.resourceName).toString()).toBe(FunctionMetaExpected.toString());
 });
 
-test('get dependent functions', async () => {
+test('get dependent functions with empty permissions', async () => {
   jest.clearAllMocks();
-  const modelsDeleted = ['model1', 'model2'];
+  const modelsDeleted = ['model3'];
   const FunctionMetaExpected = ['fn2'];
   loadResourceParameters_mock
     .mockReturnValueOnce({
@@ -105,13 +105,7 @@ test('get dependent functions', async () => {
         },
       },
     })
-    .mockReturnValueOnce({
-      permissions: {
-        storage: {
-          model3: ['create'],
-        },
-      },
-    });
+    .mockReturnValueOnce({});
   const fnMetaToBeUpdated = await lambdasWithApiDependency((contextStub as unknown) as $TSContext, allResources, backendDir, modelsDeleted);
   expect(fnMetaToBeUpdated.map(resource => resource.resourceName).toString()).toBe(FunctionMetaExpected.toString());
 });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/getDependentFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/getDependentFunction.ts
@@ -27,7 +27,7 @@ export async function lambdasWithApiDependency(
     const selectedCategories = currentParameters.permissions;
     let deletedModelFound: boolean;
 
-    if (selectedCategories !== undefined && selectedCategories.length !== 0) {
+    if (typeof selectedCategories === 'object' && selectedCategories !== null) {
       for (const selectedResources of Object.values(selectedCategories)) {
         deletedModelFound = Object.keys(selectedResources).some(r => modelsDeleted.includes(r));
         if (deletedModelFound) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/getDependentFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/getDependentFunction.ts
@@ -27,10 +27,12 @@ export async function lambdasWithApiDependency(
     const selectedCategories = currentParameters.permissions;
     let deletedModelFound: boolean;
 
-    for (const selectedResources of Object.values(selectedCategories)) {
-      deletedModelFound = Object.keys(selectedResources).some(r => modelsDeleted.includes(r));
-      if (deletedModelFound) {
-        dependentFunctions.push(lambda);
+    if (selectedCategories !== undefined && selectedCategories.length !== 0) {
+      for (const selectedResources of Object.values(selectedCategories)) {
+        deletedModelFound = Object.keys(selectedResources).some(r => modelsDeleted.includes(r));
+        if (deletedModelFound) {
+          dependentFunctions.push(lambda);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
added check for undefined permissions when checking for API dependent functions
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #7466 
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
* added a unit tests for the undefined permissions


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.