### PR TITLE
ci: run e2e test artifact scanning

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -291,6 +291,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration_v4.0.0 --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -314,6 +315,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration_v4.28.2_nonmultienv_layers --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -337,6 +339,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration_v4.52.0_multienv_layers --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -363,6 +366,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration_v4.30.0_auth --maxWorkers=3
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -384,6 +388,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -510,6 +515,7 @@ jobs:
             yarn cypress run --spec $(find . -type f -name 'api_spec*')
       - run: cd .circleci/ && chmod +x delete_api.sh
       - run: expect .circleci/delete_api.exp
+      - run: *scan_e2e_test_artifacts
       - store_artifacts:
           path: /root/aws-amplify-cypress-auth/cypress/videos
       - store_artifacts:
@@ -540,6 +546,7 @@ jobs:
             else
               echo "Skipping deploy."
             fi
+      - run: *scan_e2e_test_artifacts
   github_prerelease:
     <<: *node12
     steps:
@@ -606,6 +613,7 @@ jobs:
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
     working_directory: ~/repo
@@ -623,6 +631,7 @@ jobs:
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
     working_directory: ~/repo

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -31,6 +31,16 @@ clean_e2e_resources: &clean_e2e_resources
     yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
   working_directory: ~/repo
 
+scan_e2e_test_artifacts: &scan_e2e_test_artifacts
+  name: Scan And Cleanup E2E Test Artifacts
+  command: |
+    if ! yarn ts-node .circleci/scan_artifacts.ts; then
+      echo "Cleaning the repository"
+      git clean -fdx
+      exit 1
+    fi
+  when: always
+
 run_e2e_tests: &run_e2e_tests
   name: Run Amplify end-to-end tests
   command: |
@@ -221,6 +231,7 @@ jobs:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run: *install_cli_from_local_registery
       - run: *run_e2e_tests
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
@@ -258,6 +269,7 @@ jobs:
             amplify version
       - run: *install_cli_from_local_registery
       - run: *run_e2e_tests
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
@@ -395,6 +407,7 @@ jobs:
             yarn run console-integration --maxWorkers=3
           name: 'Run Amplify Console integration tests'
           no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-console-integration-tests/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,22 @@ defaults:
         aws_access_key_id: $ECR_ACCESS_KEY
         aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
   resource_class: large
-clean_e2e_resources: &ref_6
+clean_e2e_resources: &ref_7
   name: Cleanup resources
   command: |
     pwd
     cd packages/amplify-e2e-tests
     yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
   working_directory: ~/repo
+scan_e2e_test_artifacts: &ref_4
+  name: Scan And Cleanup E2E Test Artifacts
+  command: |
+    if ! yarn ts-node .circleci/scan_artifacts.ts; then
+      echo "Cleaning the repository"
+      git clean -fdx
+      exit 1
+    fi
+  when: always
 run_e2e_tests: &ref_3
   name: Run Amplify end-to-end tests
   command: |
@@ -221,13 +230,14 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: &ref_4
+    steps: &ref_5
       - attach_workspace:
           at: ./
       - restore_cache:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run: *ref_2
       - run: *ref_3
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
@@ -251,7 +261,7 @@ jobs:
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-    steps: &ref_5
+    steps: &ref_6
       - attach_workspace:
           at: ./
       - restore_cache:
@@ -268,6 +278,7 @@ jobs:
             amplify version
       - run: *ref_2
       - run: *ref_3
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
@@ -413,6 +424,7 @@ jobs:
             yarn run console-integration --maxWorkers=3
           name: Run Amplify Console integration tests
           no_output_timeout: 90m
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-console-integration-tests/
       - store_artifacts:
@@ -651,7 +663,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
       CLI_REGION: us-east-2
@@ -659,7 +671,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_2.test.ts
       CLI_REGION: us-west-2
@@ -667,7 +679,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/storage.test.ts
       CLI_REGION: eu-west-2
@@ -675,7 +687,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
       CLI_REGION: eu-central-1
@@ -683,7 +695,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_1.test.ts
       CLI_REGION: ap-northeast-1
@@ -691,7 +703,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
       CLI_REGION: ap-southeast-1
@@ -699,7 +711,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts
       CLI_REGION: ap-southeast-2
@@ -707,7 +719,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
       CLI_REGION: us-east-2
@@ -715,7 +727,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-connection.test.ts
       CLI_REGION: us-west-2
@@ -723,7 +735,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
       CLI_REGION: eu-west-2
@@ -731,7 +743,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-model.test.ts
       CLI_REGION: eu-central-1
@@ -739,7 +751,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-function.test.ts
       CLI_REGION: ap-northeast-1
@@ -747,7 +759,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_4.test.ts
       CLI_REGION: ap-southeast-1
@@ -755,7 +767,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
       CLI_REGION: ap-southeast-2
@@ -763,7 +775,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_1.test.ts
       CLI_REGION: us-east-2
@@ -771,7 +783,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
       CLI_REGION: us-west-2
@@ -779,7 +791,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
       CLI_REGION: eu-west-2
@@ -787,7 +799,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
       CLI_REGION: eu-central-1
@@ -795,7 +807,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/auth_2.test.ts
       CLI_REGION: ap-northeast-1
@@ -803,7 +815,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/env.test.ts
       CLI_REGION: ap-southeast-1
@@ -811,7 +823,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-rollback-2.test.ts
       CLI_REGION: ap-southeast-2
@@ -819,7 +831,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
       CLI_REGION: us-east-2
@@ -827,7 +839,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
       CLI_REGION: us-west-2
@@ -835,7 +847,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/import_s3_1.test.ts
       CLI_REGION: eu-west-2
@@ -843,7 +855,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
       CLI_REGION: eu-central-1
@@ -851,7 +863,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
       CLI_REGION: ap-northeast-1
@@ -859,7 +871,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_3.test.ts
       CLI_REGION: ap-southeast-1
@@ -867,7 +879,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
       CLI_REGION: ap-southeast-2
@@ -875,7 +887,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
       CLI_REGION: us-east-2
@@ -883,7 +895,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
       CLI_REGION: us-west-2
@@ -891,7 +903,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
       CLI_REGION: eu-west-2
@@ -899,7 +911,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/auth_4.test.ts
       CLI_REGION: eu-central-1
@@ -907,7 +919,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
       CLI_REGION: ap-northeast-1
@@ -915,7 +927,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/layer.test.ts
       CLI_REGION: ap-southeast-1
@@ -923,7 +935,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/auth_3.test.ts
       CLI_REGION: ap-southeast-2
@@ -931,7 +943,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_2.test.ts
       CLI_REGION: us-east-2
@@ -939,7 +951,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/delete.test.ts
       CLI_REGION: us-west-2
@@ -947,7 +959,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
       CLI_REGION: eu-west-2
@@ -955,7 +967,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts
       CLI_REGION: eu-central-1
@@ -963,7 +975,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_3.test.ts
       CLI_REGION: ap-northeast-1
@@ -971,7 +983,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/auth_5.test.ts
       CLI_REGION: ap-southeast-1
@@ -979,7 +991,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/auth_1.test.ts
       CLI_REGION: ap-southeast-2
@@ -987,7 +999,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-key.test.ts
       CLI_REGION: us-east-2
@@ -995,7 +1007,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
       CLI_REGION: us-west-2
@@ -1003,7 +1015,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
       CLI_REGION: eu-west-2
@@ -1011,7 +1023,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/predictions.test.ts
       CLI_REGION: eu-central-1
@@ -1019,7 +1031,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/containers-api.test.ts
       CLI_REGION: ap-northeast-1
@@ -1027,7 +1039,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts
       CLI_REGION: ap-southeast-1
@@ -1035,7 +1047,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/feature-flags.test.ts
       CLI_REGION: ap-southeast-2
@@ -1043,7 +1055,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/analytics.test.ts
       CLI_REGION: us-east-2
@@ -1051,7 +1063,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/hosting.test.ts
       CLI_REGION: us-west-2
@@ -1059,7 +1071,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/amplify-app.test.ts
       CLI_REGION: eu-west-2
@@ -1067,7 +1079,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
       CLI_REGION: eu-central-1
@@ -1075,7 +1087,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/interactions.test.ts
       CLI_REGION: ap-northeast-1
@@ -1083,7 +1095,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
       CLI_REGION: ap-southeast-1
@@ -1091,7 +1103,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
       CLI_REGION: ap-southeast-2
@@ -1099,7 +1111,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/notifications.test.ts
       CLI_REGION: us-east-2
@@ -1107,7 +1119,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/tags.test.ts
       CLI_REGION: us-west-2
@@ -1115,7 +1127,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/init.test.ts
       CLI_REGION: eu-west-2
@@ -1123,7 +1135,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
       CLI_REGION: eu-central-1
@@ -1131,7 +1143,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
       CLI_REGION: ap-northeast-1
@@ -1139,7 +1151,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/init-special-case.test.ts
       CLI_REGION: ap-southeast-1
@@ -1147,7 +1159,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-southeast-2
@@ -1155,7 +1167,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
       CLI_REGION: us-east-2
@@ -1163,7 +1175,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/s3-sse.test.ts
       CLI_REGION: us-west-2
@@ -1171,7 +1183,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
       CLI_REGION: eu-west-2
@@ -1179,7 +1191,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/layer-2.test.ts
       CLI_REGION: eu-central-1
@@ -1187,7 +1199,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
       CLI_REGION: ap-northeast-1
@@ -1195,7 +1207,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: ap-southeast-1
@@ -1203,7 +1215,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/configure-project.test.ts
       CLI_REGION: ap-southeast-2
@@ -1211,7 +1223,7 @@ jobs:
     working_directory: ~/repo
     docker: *ref_1
     resource_class: large
-    steps: *ref_4
+    steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-east-2
@@ -1224,7 +1236,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   api_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1234,7 +1246,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_2.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   storage-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1244,7 +1256,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/storage.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1254,7 +1266,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   api_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1264,7 +1276,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_1.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1274,7 +1286,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-iterative-update-3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1284,7 +1296,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-6-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1294,7 +1306,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   schema-connection-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1304,7 +1316,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-connection.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1314,7 +1326,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-model-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1324,7 +1336,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-model.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   schema-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1334,7 +1346,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-function.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   function_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1344,7 +1356,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_4.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1354,7 +1366,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   function_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1364,7 +1376,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_1.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1374,7 +1386,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-11-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1384,7 +1396,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-9-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1394,7 +1406,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   auth_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1404,7 +1416,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_2.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   env-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1414,7 +1426,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/env.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-iterative-rollback-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1424,7 +1436,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-rollback-2.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   schema-iterative-rollback-1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1434,7 +1446,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   import_dynamodb_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1444,7 +1456,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   import_s3_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1454,7 +1466,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_s3_1.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   import_auth_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1464,7 +1476,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   import_auth_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1474,7 +1486,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   api_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1484,7 +1496,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_3.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1494,7 +1506,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   schema-searchable-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1504,7 +1516,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-8-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1514,7 +1526,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-7-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1524,7 +1536,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   auth_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1534,7 +1546,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_4.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1544,7 +1556,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   layer-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1554,7 +1566,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/layer.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   auth_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1564,7 +1576,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_3.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   function_2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1574,7 +1586,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_2.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   delete-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1584,7 +1596,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/delete.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1594,7 +1606,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-iterative-update-1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1604,7 +1616,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   function_3-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1614,7 +1626,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_3.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   auth_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1624,7 +1636,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_5.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   auth_1-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1634,7 +1646,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_1.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   schema-key-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1644,7 +1656,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-key.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   schema-auth-10-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1654,7 +1666,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   hostingPROD-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1664,7 +1676,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   predictions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1674,7 +1686,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/predictions.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   containers-api-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1684,7 +1696,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/containers-api.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-iterative-update-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1694,7 +1706,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   feature-flags-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1704,7 +1716,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/feature-flags.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   analytics-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1714,7 +1726,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/analytics.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   hosting-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1724,7 +1736,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/hosting.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   amplify-app-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1734,7 +1746,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/amplify-app.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   schema-predictions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1744,7 +1756,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   interactions-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1754,7 +1766,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/interactions.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-data-access-patterns-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1764,7 +1776,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   schema-versioned-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1774,7 +1786,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   notifications-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1784,7 +1796,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/notifications.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   tags-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1794,7 +1806,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/tags.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   init-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1804,7 +1816,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/init.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   amplify-configure-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1814,7 +1826,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   datastore-modelgen-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1824,7 +1836,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   init-special-case-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1834,7 +1846,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/init-special-case.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   plugin-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1844,7 +1856,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1854,7 +1866,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
   s3-sse-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1864,7 +1876,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/s3-sse.test.ts
       CLI_REGION: us-west-2
-    steps: *ref_5
+    steps: *ref_6
   migration-node-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1874,7 +1886,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
       CLI_REGION: eu-west-2
-    steps: *ref_5
+    steps: *ref_6
   layer-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1884,7 +1896,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/layer-2.test.ts
       CLI_REGION: eu-central-1
-    steps: *ref_5
+    steps: *ref_6
   iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1894,7 +1906,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
       CLI_REGION: ap-northeast-1
-    steps: *ref_5
+    steps: *ref_6
   function_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1904,7 +1916,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: ap-southeast-1
-    steps: *ref_5
+    steps: *ref_6
   configure-project-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1914,7 +1926,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/configure-project.test.ts
       CLI_REGION: ap-southeast-2
-    steps: *ref_5
+    steps: *ref_6
   api_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1924,7 +1936,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-east-2
-    steps: *ref_5
+    steps: *ref_6
 workflows:
   version: 2
   nightly_console_integration_tests:
@@ -2152,7 +2164,7 @@ workflows:
             - console-e2e-test
             - e2e-test-context
           post-steps:
-            - run: *ref_6
+            - run: *ref_7
           filters:
             branches:
               only:
@@ -2218,14 +2230,14 @@ workflows:
               only:
                 - release
       - schema-iterative-update-4-amplify_e2e_tests:
-          context: &ref_7
+          context: &ref_8
             - amplify-ecr-image-pull
             - clean_e2e_resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps: &ref_8
-            - run: *ref_6
-          filters: &ref_9
+          post-steps: &ref_9
+            - run: *ref_7
+          filters: &ref_10
             branches:
               only:
                 - master
@@ -2234,434 +2246,434 @@ workflows:
           requires:
             - publish_to_local_registry
       - schema-auth-6-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - function_1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-iterative-rollback-1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-searchable-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-update-4-amplify_e2e_tests
       - function_2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-6-amplify_e2e_tests
       - schema-key-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_1-amplify_e2e_tests
       - analytics-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-rollback-1-amplify_e2e_tests
       - notifications-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-searchable-amplify_e2e_tests
       - schema-iterative-update-locking-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_2-amplify_e2e_tests
       - api_4-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-key-amplify_e2e_tests
       - api_2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-connection-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - migration-api-key-migration2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - import_dynamodb_1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-auth-8-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - api_2-amplify_e2e_tests
       - delete-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-connection-amplify_e2e_tests
       - schema-auth-10-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - migration-api-key-migration2-amplify_e2e_tests
       - hosting-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_dynamodb_1-amplify_e2e_tests
       - tags-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-8-amplify_e2e_tests
       - s3-sse-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - delete-amplify_e2e_tests
       - storage-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - migration-api-connection-migration-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-auth-11-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - import_s3_1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-auth-7-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - storage-amplify_e2e_tests
       - schema-auth-3-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - migration-api-connection-migration-amplify_e2e_tests
       - hostingPROD-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-11-amplify_e2e_tests
       - amplify-app-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_s3_1-amplify_e2e_tests
       - init-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests
       - migration-node-function-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-3-amplify_e2e_tests
       - schema-auth-5-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-model-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-auth-9-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - import_auth_2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - auth_4-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-5-amplify_e2e_tests
       - schema-iterative-update-1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-model-amplify_e2e_tests
       - predictions-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-9-amplify_e2e_tests
       - schema-predictions-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_auth_2-amplify_e2e_tests
       - amplify-configure-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests
       - layer-2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-update-1-amplify_e2e_tests
       - api_1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-function-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - auth_2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - import_auth_1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - migration-api-key-migration1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - api_1-amplify_e2e_tests
       - function_3-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-function-amplify_e2e_tests
       - containers-api-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_2-amplify_e2e_tests
       - interactions-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - import_auth_1-amplify_e2e_tests
       - datastore-modelgen-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
       - iam-permissions-boundary-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_3-amplify_e2e_tests
       - schema-auth-2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - function_4-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - env-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - api_3-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - layer-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-2-amplify_e2e_tests
       - auth_5-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - function_4-amplify_e2e_tests
       - schema-iterative-update-2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - env-amplify_e2e_tests
       - schema-data-access-patterns-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - api_3-amplify_e2e_tests
       - init-special-case-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - layer-amplify_e2e_tests
       - function_5-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_5-amplify_e2e_tests
       - schema-iterative-update-3-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-auth-1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-iterative-rollback-2-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - schema-auth-4-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - publish_to_local_registry
       - auth_3-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-update-3-amplify_e2e_tests
       - auth_1-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-1-amplify_e2e_tests
       - feature-flags-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-iterative-rollback-2-amplify_e2e_tests
       - schema-versioned-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - schema-auth-4-amplify_e2e_tests
       - plugin-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_3-amplify_e2e_tests
       - configure-project-amplify_e2e_tests:
-          context: *ref_7
-          post-steps: *ref_8
-          filters: *ref_9
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
           requires:
             - auth_1-amplify_e2e_tests
       - schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
-          context: &ref_10
+          context: &ref_11
             - amplify-ecr-image-pull
             - clean_e2e_resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps: &ref_11
-            - run: *ref_6
-          filters: &ref_12
+          post-steps: &ref_12
+            - run: *ref_7
+          filters: &ref_13
             branches:
               only:
                 - master
@@ -2669,449 +2681,449 @@ workflows:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-6-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - function_1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-iterative-rollback-1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-searchable-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-iterative-update-4-amplify_e2e_tests_pkg_linux
       - function_2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-6-amplify_e2e_tests_pkg_linux
       - schema-key-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - function_1-amplify_e2e_tests_pkg_linux
       - analytics-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-iterative-rollback-1-amplify_e2e_tests_pkg_linux
       - notifications-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-searchable-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - function_2-amplify_e2e_tests_pkg_linux
       - api_4-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-key-amplify_e2e_tests_pkg_linux
       - api_2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-connection-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - migration-api-key-migration2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_dynamodb_1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-8-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - api_2-amplify_e2e_tests_pkg_linux
       - delete-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-connection-amplify_e2e_tests_pkg_linux
       - schema-auth-10-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - migration-api-key-migration2-amplify_e2e_tests_pkg_linux
       - hosting-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - import_dynamodb_1-amplify_e2e_tests_pkg_linux
       - tags-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-8-amplify_e2e_tests_pkg_linux
       - s3-sse-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - delete-amplify_e2e_tests_pkg_linux
       - storage-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - migration-api-connection-migration-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-11-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_s3_1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-7-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - storage-amplify_e2e_tests_pkg_linux
       - schema-auth-3-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - migration-api-connection-migration-amplify_e2e_tests_pkg_linux
       - hostingPROD-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-11-amplify_e2e_tests_pkg_linux
       - amplify-app-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - import_s3_1-amplify_e2e_tests_pkg_linux
       - init-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
       - migration-node-function-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-3-amplify_e2e_tests_pkg_linux
       - schema-auth-5-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-model-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-9-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_auth_2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - auth_4-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-5-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-model-amplify_e2e_tests_pkg_linux
       - predictions-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-9-amplify_e2e_tests_pkg_linux
       - schema-predictions-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - import_auth_2-amplify_e2e_tests_pkg_linux
       - amplify-configure-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
       - layer-2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-iterative-update-1-amplify_e2e_tests_pkg_linux
       - api_1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-function-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - auth_2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - import_auth_1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - migration-api-key-migration1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - api_1-amplify_e2e_tests_pkg_linux
       - function_3-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-function-amplify_e2e_tests_pkg_linux
       - containers-api-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - auth_2-amplify_e2e_tests_pkg_linux
       - interactions-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - import_auth_1-amplify_e2e_tests_pkg_linux
       - datastore-modelgen-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
       - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - function_3-amplify_e2e_tests_pkg_linux
       - schema-auth-2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - function_4-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - env-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - api_3-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - layer-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-2-amplify_e2e_tests_pkg_linux
       - auth_5-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - function_4-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - env-amplify_e2e_tests_pkg_linux
       - schema-data-access-patterns-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - api_3-amplify_e2e_tests_pkg_linux
       - init-special-case-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - layer-amplify_e2e_tests_pkg_linux
       - function_5-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - auth_5-amplify_e2e_tests_pkg_linux
       - schema-iterative-update-3-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-iterative-rollback-2-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - schema-auth-4-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
       - auth_3-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-iterative-update-3-amplify_e2e_tests_pkg_linux
       - auth_1-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-1-amplify_e2e_tests_pkg_linux
       - feature-flags-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-iterative-rollback-2-amplify_e2e_tests_pkg_linux
       - schema-versioned-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - schema-auth-4-amplify_e2e_tests_pkg_linux
       - plugin-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - auth_3-amplify_e2e_tests_pkg_linux
       - configure-project-amplify_e2e_tests_pkg_linux:
-          context: *ref_10
-          post-steps: *ref_11
-          filters: *ref_12
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
           requires:
             - auth_1-amplify_e2e_tests_pkg_linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration_v4.0.0 --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -327,6 +328,7 @@ jobs:
             yarn run migration_v4.28.2_nonmultienv_layers --maxWorkers=3
             $TEST_SUITE
           no_output_timeout: 90m
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -354,6 +356,7 @@ jobs:
             yarn run migration_v4.52.0_multienv_layers --maxWorkers=3
             $TEST_SUITE
           no_output_timeout: 90m
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -380,6 +383,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration_v4.30.0_auth --maxWorkers=3
           no_output_timeout: 90m
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -401,6 +405,7 @@ jobs:
             cd packages/amplify-migration-tests
             yarn run migration --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 90m
+      - run: *ref_4
       - store_test_results:
           path: packages/amplify-migration-tests/
       - store_artifacts:
@@ -533,6 +538,7 @@ jobs:
             yarn cypress run --spec $(find . -type f -name 'api_spec*')
       - run: cd .circleci/ && chmod +x delete_api.sh
       - run: expect .circleci/delete_api.exp
+      - run: *ref_4
       - store_artifacts:
           path: /root/aws-amplify-cypress-auth/cypress/videos
       - store_artifacts:
@@ -564,6 +570,7 @@ jobs:
             else
               echo "Skipping deploy."
             fi
+      - run: *ref_4
   github_prerelease:
     working_directory: ~/repo
     docker: *ref_0
@@ -640,6 +647,7 @@ jobs:
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources
           no_output_timeout: 90m
+      - run: *ref_4
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
   cleanup_resources_after_e2e_runs:
@@ -657,6 +665,7 @@ jobs:
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
           no_output_timeout: 90m
+      - run: *ref_4
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
   schema-iterative-update-4-amplify_e2e_tests:

--- a/.circleci/scan_artifacts.ts
+++ b/.circleci/scan_artifacts.ts
@@ -1,0 +1,34 @@
+import * as execa from 'execa';
+import * as path from 'path';
+const DEFAULT_SEARCH_FOLDER = path.normalize(path.join(__dirname, '..'));
+export const hasMatchingContentInFolder = (
+  patterns: string[],
+  folder = DEFAULT_SEARCH_FOLDER,
+  excludeFolder = '{*/node_modules,.git}',
+): boolean => {
+  const patternParam = patterns.reduce<string[]>((acc, v) => [...acc, '-e', v], []);
+  try {
+    execa.sync('grep', ['-r', `--exclude-dir=${excludeFolder}`, ...patternParam, folder]);
+    return true;
+  } catch (e) {
+    // When there is no match exit code is set to 1
+    if (e.exitCode === 1) {
+      return false;
+    }
+    throw new Error('Scanning artifacts failed');
+  }
+};
+
+const main = () => {
+  const envVarNameWithCredentialValues = (process.env.ENV_VAR_WITH_SECRETS || '').split(',').map(v => v.trim());
+  const values = envVarNameWithCredentialValues.map(v => process.env[v]).filter(Boolean);
+  if (values.length) {
+    const hasContent = hasMatchingContentInFolder(values);
+    if (hasContent) {
+      console.log('Scanning artifact has found secret value. Failing the build');
+      process.exit(1);
+    }
+  }
+};
+
+main();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adding a additional step in E2E test to scan the test artifacts and if any of them are found, fail the build and delete the artifacts to prevent them from getting stored in CircleCI. The secret values scanned can be configured by setting up a comma separate environment variable `ENV_VAR_WITH_SECRETS` which contains the list of enviroment variables that has the secret values. For instance if the secret are stored in `MY_SECRET_ENV_1`, `MY_SECRET_ENV_2` then set `ENV_VAR_WITH_SECRETS` to `MY_SECRET_ENV_1, MY_SECRET_ENV_2`




#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.