### PR TITLE
fix: #7587 - resource filtering in same category for crud

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -80,9 +80,12 @@ export const askExecRolePermissionsQuestions = async (
       // A Lambda function cannot depend on itself
       // Lambda layer dependencies are handled seperately, also apply the filter if the selected resource is within the function category
       // but serviceName argument was no passed in
+      const selectedResource = _.get(amplifyMeta, [categoryName, resourceNameToUpdate]);
+
       if (serviceName === ServiceName.LambdaFunction || selectedCategory === categoryName) {
         resourcesList = resourcesList.filter(
-          resourceName => resourceName !== resourceNameToUpdate && amplifyMeta[selectedCategory][resourceName].service === serviceName,
+          resourceName =>
+            resourceName !== resourceNameToUpdate && amplifyMeta[selectedCategory][resourceName].service === selectedResource.service,
         );
       } else {
         resourcesList = resourcesList.filter(
@@ -189,7 +192,6 @@ const selectResourcesInCategory = (choices: DistinctChoice<any>[], currentPermis
   name: 'resources',
   message: `${_.capitalize(category)} has ${choices.length} resources in this project. Select the one you would like your Lambda to access`,
   choices,
-  validate: answers => (_.isEmpty(answers) ? 'You must select at least one resource' : true),
   default: fetchPermissionResourcesForCategory(currentPermissionMap, category),
 });
 


### PR DESCRIPTION
#### Description of changes

When defining access permissions across resources, when the resource is in the same category (function access to function) the filtering expression was incorrect as the checked data was not passed in.

#### Issue #, if available

fixes: #7587 - resource filtering in same category for crud


#### Description of how you validated changes

Manual testing


#### Checklist
- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.