### PR TITLE
fix: handle migrated layers with no runtime or multiple runtimes

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
@@ -28,7 +28,13 @@ const parameters_stub: LayerParameters = {
     projectName: 'project',
     service: ServiceName.LambdaLayer,
   },
-  runtimes: [],
+  runtimes: [
+    {
+      name: 'NodeJS',
+      value: 'nodejs',
+      cloudTemplateValues: ['nodejs14x'],
+    },
+  ],
 };
 
 // Not using a snapshot since the LogicalNames will contain random characters

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
@@ -18,6 +18,7 @@ jest.mock('../../../../provider-utils/awscloudformation/utils/layerHelpers', () 
   getChangedResources: jest.fn(),
   ensureLayerVersion: jest.fn().mockReturnValue('newhash'),
 }));
+jest.mock('../../../../provider-utils/awscloudformation/utils/zipResource');
 
 const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
 
@@ -41,7 +42,7 @@ loadLayerConfigurationFile_mock.mockReturnValue({
 const validFilesize_mock = validFilesize as jest.MockedFunction<typeof validFilesize>;
 validFilesize_mock.mockReturnValue(true);
 
-pathManager_mock.getBackendDirPath.mockReturnValue('backend/dir/path');
+pathManager_mock.getResourceDirectoryPath.mockReturnValue('backend/dir/path/testcategory/testResourceName/');
 
 const runtimePlugin_stub = ({
   checkDependencies: jest.fn().mockResolvedValue({ hasRequiredDependencies: true }),

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
@@ -19,6 +19,7 @@ export function generateLayerCfnObj(isNewVersion: boolean, parameters: LayerPara
   const multiEnvLayer = isMultiEnvLayer(parameters.layerName);
   const resourceName = parameters.layerName;
   const layerName = multiEnvLayer ? Fn.Sub(`${parameters.layerName}-` + '${env}', { env: Fn.Ref('env') }) : parameters.layerName;
+  const hasRuntimes = parameters.runtimes.length > 0;
   let logicalName: string;
 
   if (isNewVersion) {
@@ -38,7 +39,7 @@ export function generateLayerCfnObj(isNewVersion: boolean, parameters: LayerPara
       },
     },
   };
-  const cfnObj = getLayerCfnObjBase();
+  const cfnObj = getLayerCfnObjBase(hasRuntimes);
   const { envName } = stateManager.getLocalEnvInfo();
   const layerVersionsToBeRemoved = getLayerVersionsToBeRemovedByCfn(resourceName, envName);
   const skipLayerVersionSet = new Set<number>(layerVersionsToBeRemoved);
@@ -46,7 +47,7 @@ export function generateLayerCfnObj(isNewVersion: boolean, parameters: LayerPara
   for (const layerVersion of versionList.filter(r => !skipLayerVersionSet.has(r.Version))) {
     let shortId: string;
     if (!layerVersion.legacyLayer) {
-      cfnObj.Resources[layerVersion.LogicalName] = constructLayerVersionCfnObject(layerName, layerVersion, resourceName);
+      cfnObj.Resources[layerVersion.LogicalName] = constructLayerVersionCfnObject(layerName, layerVersion, resourceName, hasRuntimes);
       shortId = layerVersion.LogicalName.replace(LayerCfnLogicalNamePrefix.LambdaLayerVersion, '');
     }
     const permissionObjects = constructLayerVersionPermissionObjects(layerVersion, parameters, shortId, envName);
@@ -56,8 +57,8 @@ export function generateLayerCfnObj(isNewVersion: boolean, parameters: LayerPara
   return { ...cfnObj, ...outputObj };
 }
 
-function getLayerCfnObjBase() {
-  return {
+function getLayerCfnObjBase(hasRuntimes: boolean) {
+  const cfnBase = {
     AWSTemplateFormatVersion: '2010-09-09',
     Description: 'Lambda layer resource stack creation using Amplify CLI',
     Parameters: {
@@ -74,22 +75,29 @@ function getLayerCfnObjBase() {
         Type: 'String',
         Default: '',
       },
-      runtimes: {
-        Type: 'List<String>',
-      },
+      runtimes: undefined,
     },
     Resources: {},
   };
+
+  if (hasRuntimes) {
+    cfnBase.Parameters.runtimes = {
+      Type: 'List<String>',
+    };
+  }
+
+  return cfnBase;
 }
 
 function constructLayerVersionCfnObject(
   layerName: string | IntrinsicFunction,
   layerVersion: LayerVersionCfnMetadata,
   resourceName: string,
+  hasRuntimes: boolean,
 ) {
   const description: string | IntrinsicFunction = layerVersion.CreatedDate ? layerVersion.Description : Fn.Ref('description');
   const newLayerVersion = new Lambda.LayerVersion({
-    CompatibleRuntimes: layerVersion.CompatibleRuntimes || Fn.Ref('runtimes'),
+    CompatibleRuntimes: layerVersion.CompatibleRuntimes || (hasRuntimes ? Fn.Ref('runtimes') : undefined),
     Content: {
       S3Bucket: Fn.Ref('deploymentBucketName'),
       S3Key: layerVersion.CreatedDate

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
@@ -96,8 +96,13 @@ function constructLayerVersionCfnObject(
   hasRuntimes: boolean,
 ) {
   const description: string | IntrinsicFunction = layerVersion.CreatedDate ? layerVersion.Description : Fn.Ref('description');
+  let compatibleRuntimes: { CompatibleRuntimes: string[] | IntrinsicFunction };
+  if (hasRuntimes) {
+    compatibleRuntimes = { CompatibleRuntimes: layerVersion.CompatibleRuntimes || Fn.Ref('runtimes') };
+  }
+
   const newLayerVersion = new Lambda.LayerVersion({
-    CompatibleRuntimes: layerVersion.CompatibleRuntimes || (hasRuntimes ? Fn.Ref('runtimes') : undefined),
+    ...compatibleRuntimes,
     Content: {
       S3Bucket: Fn.Ref('deploymentBucketName'),
       S3Key: layerVersion.CreatedDate

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -10,7 +10,7 @@ import uuid from 'uuid';
 import { categoryName } from '../../../constants';
 import { cfnTemplateSuffix, LegacyFilename, parametersFileName, provider, ServiceName, versionHash } from './constants';
 import { getLayerConfiguration, LayerConfiguration, loadLayerConfigurationFile } from './layerConfiguration';
-import { LayerParameters, LayerPermission, LayerVersionMetadata, PermissionEnum } from './layerParams';
+import { LayerParameters, LayerPermission, LayerRuntime, LayerVersionMetadata, PermissionEnum } from './layerParams';
 import { updateLayerArtifacts } from './storeResources';
 
 // These glob patterns cover the resource files Amplify stores in the layer resource's directory,
@@ -301,8 +301,7 @@ export async function getChangedResources(resources: Array<$TSAny>): Promise<Arr
 const getLayerGlobs = async (
   resourcePath: string,
   resourceName: string,
-  runtimeId: string,
-  layerExecutablePath: string,
+  runtimes: LayerRuntime[],
   includeResourceFiles: boolean,
 ): Promise<string[]> => {
   const result: string[] = [];
@@ -311,67 +310,74 @@ const getLayerGlobs = async (
     result.push(...layerResourceGlobs);
   }
 
-  const layerCodePath = path.join(resourcePath, libPathName, layerExecutablePath);
-
   // Add to hashable files/folders
   result.push(optPathName);
 
-  //TODO let function runtimes export globs later instead of hardcoding in here
-  if (runtimeId === 'nodejs') {
-    const packageManager = getPackageManager(layerCodePath);
+  for (const runtime of runtimes) {
+    const { value: runtimeId, layerExecutablePath } = runtime;
+    let layerCodePath: string;
 
-    // If no packagemanager was detected it means no package.json present at the resource path,
-    // so no files to hash related to packages.
-    if (packageManager !== null) {
+    if (layerExecutablePath !== undefined) {
+      layerCodePath = path.join(resourcePath, libPathName, layerExecutablePath);
+    }
+
+    //TODO let function runtimes export globs later instead of hardcoding in here
+    if (runtimeId === 'nodejs') {
+      const packageManager = getPackageManager(layerCodePath);
+
+      // If no packagemanager was detected it means no package.json present at the resource path,
+      // so no files to hash related to packages.
+      if (packageManager !== null) {
+        // Add to hashable files/folders
+        result.push(path.join(libPathName, layerExecutablePath, packageJson));
+
+        // If lock file is present, add to hashable files/folders
+        const lockFilePath = path.join(layerCodePath, packageManager.lockFile);
+
+        if (fs.existsSync(lockFilePath)) {
+          result.push(path.join(libPathName, layerExecutablePath, packageManager.lockFile));
+        }
+      }
+
+      // Add layer direct content from lib/nodejs and exclude well known files from list.
+      // files must be relative to resource folder as that will be used as a base path for hashing.
+      const contentFilePaths = await globby([path.join(libPathName, layerExecutablePath, '**', '*')], {
+        cwd: resourcePath,
+        ignore: ['node_modules', packageJson, 'yarn.lock', 'package-lock.json'].map(name =>
+          path.join(libPathName, layerExecutablePath, name),
+        ),
+      });
+
+      result.push(...contentFilePaths);
+    } else if (runtimeId === 'python') {
       // Add to hashable files/folders
-      result.push(path.join(libPathName, layerExecutablePath, packageJson));
+      const pipfileFilePath = path.join(layerCodePath, pipfile);
+
+      if (fs.existsSync(pipfileFilePath)) {
+        result.push(path.join(libPathName, layerExecutablePath, pipfile));
+      }
 
       // If lock file is present, add to hashable files/folders
-      const lockFilePath = path.join(layerCodePath, packageManager.lockFile);
+      const pipfileLockFilePath = path.join(layerCodePath, pipfileLock);
 
-      if (fs.existsSync(lockFilePath)) {
-        result.push(path.join(libPathName, layerExecutablePath, packageManager.lockFile));
+      if (fs.existsSync(pipfileLockFilePath)) {
+        result.push(path.join(libPathName, layerExecutablePath, pipfileLock));
       }
+
+      // Add layer direct content from lib/python and exclude well known files from list.
+      // files must be relative to resource folder as that will be used as a base path for hashing.
+      const contentFilePaths = await globby([path.join(libPathName, layerExecutablePath, '**', '*')], {
+        cwd: resourcePath,
+        ignore: ['lib', pipfile, pipfileLock].map(name => path.join(libPathName, layerExecutablePath, name)),
+      });
+
+      result.push(...contentFilePaths);
+    } else if (runtimeId !== undefined) {
+      const error = new Error(`Unsupported layer runtime: ${runtimeId} for resource: ${resourceName}`);
+      error.stack = undefined;
+
+      throw error;
     }
-
-    // Add layer direct content from lib/nodejs and exclude well known files from list.
-    // files must be relative to resource folder as that will be used as a base path for hashing.
-    const contentFilePaths = await globby([path.join(libPathName, layerExecutablePath, '**', '*')], {
-      cwd: resourcePath,
-      ignore: ['node_modules', packageJson, 'yarn.lock', 'package-lock.json'].map(name =>
-        path.join(libPathName, layerExecutablePath, name),
-      ),
-    });
-
-    result.push(...contentFilePaths);
-  } else if (runtimeId === 'python') {
-    // Add to hashable files/folders
-    const pipfileFilePath = path.join(layerCodePath, pipfile);
-
-    if (fs.existsSync(pipfileFilePath)) {
-      result.push(path.join(libPathName, layerExecutablePath, pipfile));
-    }
-
-    // If lock file is present, add to hashable files/folders
-    const pipfileLockFilePath = path.join(layerCodePath, pipfileLock);
-
-    if (fs.existsSync(pipfileLockFilePath)) {
-      result.push(path.join(libPathName, layerExecutablePath, pipfileLock));
-    }
-
-    // Add layer direct content from lib/python and exclude well known files from list.
-    // files must be relative to resource folder as that will be used as a base path for hashing.
-    const contentFilePaths = await globby([path.join(libPathName, layerExecutablePath, '**', '*')], {
-      cwd: resourcePath,
-      ignore: ['lib', pipfile, pipfileLock].map(name => path.join(libPathName, layerExecutablePath, name)),
-    });
-
-    result.push(...contentFilePaths);
-  } else {
-    const error = new Error(`Unsupported layer runtime: ${runtimeId} for resource: ${resourceName}`);
-    error.stack = undefined;
-
-    throw error;
   }
 
   return result;
@@ -383,9 +389,7 @@ const hashLayerVersion = async (layerPath: string, layerName: string, includeRes
   const layerConfig: LayerConfiguration = loadLayerConfigurationFile(layerName, false);
 
   if (layerConfig) {
-    const { value: runtimeId, layerExecutablePath } = layerConfig.runtimes[0];
-
-    const layerFilePaths = await getLayerGlobs(layerPath, layerName, runtimeId, layerExecutablePath, includeResourceFiles);
+    const layerFilePaths = await getLayerGlobs(layerPath, layerName, layerConfig.runtimes, includeResourceFiles);
 
     const filePaths = await globby(layerFilePaths, { cwd: layerPath });
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
@@ -128,7 +128,7 @@ This change requires a migration. Amplify will create a new Lambda layer version
   }
 
   stateManager.setResourceParametersJson(undefined, categoryName, layerName, {
-    runtimes: runtimeCloudTemplateValues,
+    runtimes: runtimeCloudTemplateValues.length > 0 ? runtimeCloudTemplateValues : undefined,
     description: '',
   });
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -1,11 +1,12 @@
 import { $TSAny, $TSContext, pathManager } from 'amplify-cli-core';
+import { ZipEntry } from 'amplify-function-plugin-interface';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import chalk from 'chalk';
 import { EOL } from 'os';
 import { Packager } from '../types/packaging-types';
-import { LayerConfiguration, loadLayerConfigurationFile } from './layerConfiguration';
+import { loadLayerConfigurationFile } from './layerConfiguration';
 import { FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
 import { ServiceName, versionHash } from './constants';
 import { LayerCloudState } from './layerCloudState';
@@ -17,22 +18,9 @@ import { updateLayerArtifacts } from './storeResources';
 import { lambdaLayerNewVersionWalkthrough } from '../service-walkthroughs/lambdaLayerWalkthrough';
 
 /**
- * Packages lambda  layer  code and artifacts into a lambda-compatible .zip file
+ * Packages lambda layer code and artifacts into a lambda-compatible .zip file
  */
 export const packageLayer: Packager = async (context, resource) => {
-  const resourcePath = path.join(pathManager.getBackendDirPath(), resource.category, resource.resourceName);
-
-  // call runtime module packaging
-  const layerConfig: LayerConfiguration = loadLayerConfigurationFile(resource.resourceName);
-  const layerCodePath = path.join(resourcePath, 'lib', layerConfig.runtimes[0].layerExecutablePath);
-  const distDir = path.join(resourcePath, 'dist');
-  fs.ensureDirSync(distDir);
-
-  const runtimePlugin: FunctionRuntimeLifecycleManager = (await context.amplify.loadRuntimePlugin(
-    context,
-    layerConfig.runtimes[0].runtimePluginId,
-  )) as FunctionRuntimeLifecycleManager;
-
   const previousHash = loadPreviousLayerHash(resource.resourceName);
   const currentHash = await ensureLayerVersion(context, resource.resourceName, previousHash);
 
@@ -41,24 +29,42 @@ export const packageLayer: Packager = async (context, resource) => {
     return { newPackageCreated: false, zipFilename: undefined, zipFilePath: undefined };
   }
 
-  // prepare package request
+  const resourcePath = pathManager.getResourceDirectoryPath(undefined, resource.category, resource.resourceName);
+
+  const { runtimes } = loadLayerConfigurationFile(resource.resourceName);
+  const distDir = path.join(resourcePath, 'dist');
+  fs.ensureDirSync(distDir);
   const destination = path.join(distDir, 'latest-build.zip');
-  const packageRequest = {
-    env: context.amplify.getEnvInfo().envName,
-    srcRoot: layerCodePath,
-    dstFilename: destination,
-    runtime: layerConfig.runtimes[0].value,
-    lastPackageTimeStamp: resource.lastPackageTimeStamp ? new Date(resource.lastPackageTimeStamp) : undefined,
-    lastBuildTimeStamp: resource.lastBuildTimeStamp ? new Date(resource.lastBuildTimeStamp) : undefined,
-    skipHashing: resource.skipHashing,
-    service: ServiceName.LambdaLayer,
-    currentHash: previousHash !== currentHash,
-  };
-  const packageResult = await runtimePlugin.package(packageRequest);
-  const packageHash = packageResult.packageHash;
-  if (packageHash) {
-    await zipPackage(packageResult.zipEntries, destination);
+  let zipEntries: ZipEntry[] = [{ sourceFolder: path.join(resourcePath, 'opt') }];
+
+  for (const runtime of runtimes) {
+    const layerCodePath = path.join(resourcePath, 'lib', runtime.layerExecutablePath);
+
+    // call runtime module packaging
+    const runtimePlugin: FunctionRuntimeLifecycleManager = (await context.amplify.loadRuntimePlugin(
+      context,
+      runtime.runtimePluginId,
+    )) as FunctionRuntimeLifecycleManager;
+
+    // prepare package request
+    const packageRequest = {
+      env: context.amplify.getEnvInfo().envName,
+      srcRoot: layerCodePath,
+      dstFilename: destination,
+      runtime: runtime.value,
+      lastPackageTimeStamp: resource.lastPackageTimeStamp ? new Date(resource.lastPackageTimeStamp) : undefined,
+      lastBuildTimeStamp: resource.lastBuildTimeStamp ? new Date(resource.lastBuildTimeStamp) : undefined,
+      skipHashing: resource.skipHashing,
+      service: ServiceName.LambdaLayer,
+      currentHash: previousHash !== currentHash,
+    };
+    const packageResult = await runtimePlugin.package(packageRequest);
+
+    if (packageResult.packageHash && packageResult?.zipEntries?.length > 0) {
+      zipEntries = [...zipEntries, ...packageResult.zipEntries];
+    }
   }
+  await zipPackage(zipEntries, destination);
 
   const layerCloudState = LayerCloudState.getInstance(resource.resourceName);
   if (!layerCloudState.latestVersionLogicalId) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -125,7 +125,9 @@ function writeLayerRuntimesToParametersFile(parameters: LayerParameters) {
     runtimes = runtimes.concat(r.cloudTemplateValues);
     return runtimes;
   }, []);
-  stateManager.setResourceParametersJson(undefined, categoryName, parameters.layerName, { runtimes });
+  if (runtimes.length > 0) {
+    stateManager.setResourceParametersJson(undefined, categoryName, parameters.layerName, { runtimes });
+  }
 }
 
 function saveLayerDescription(layerName: string, description?: string): boolean {

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -375,17 +375,20 @@ function waitForLayerSuccessPrintout(
   settings: { layerName?: string; projName?: string; runtimes?: LayerRuntime[] } | $TSAny,
   action: string,
 ) {
-  chain
-    .wait(`✅ Lambda layer folders & files ${action}:`)
-    .wait(path.join('amplify', 'backend', 'function', settings.projName + settings.layerName))
-    .wait('Next steps:')
-    .wait('Move your libraries to the following folder:');
+  chain.wait(`✅ Lambda layer folders & files ${action}:`);
 
-  const runtimes = settings.runtimes && settings.layerName && settings.projName ? settings.runtimes : [];
-  for (const runtime of runtimes) {
-    const { displayName, path } = getLayerRuntimeInfo(runtime);
-    const layerRuntimeDir = `[${displayName}]: amplify/backend/function/${settings.projName + settings.layerName}/${path}`;
-    chain.wait(layerRuntimeDir);
+  if (settings?.runtimes?.length > 0) {
+    chain
+      .wait(path.join('amplify', 'backend', 'function', settings.projName + settings.layerName))
+      .wait('Next steps:')
+      .wait('Move your libraries to the following folder:');
+
+    const runtimes = settings.layerName && settings.projName ? settings.runtimes : [];
+    for (const runtime of runtimes) {
+      const { displayName, path } = getLayerRuntimeInfo(runtime);
+      const layerRuntimeDir = `[${displayName}]: amplify/backend/function/${settings.projName + settings.layerName}/${path}`;
+      chain.wait(layerRuntimeDir);
+    }
   }
 
   chain

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
@@ -144,4 +144,22 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
     await removeLayerVersion(projRoot, { removeLegacyOnly: true }, [1], [1, 2], true);
     expect(validateLayerConfigFilesMigrated(projRoot, layerName)).toBe(true);
   });
+
+  it('migrates a layer with no runtime', async () => {
+    const { projectName: projName } = getProjectConfig(projRoot);
+    const [shortId] = uuid().split('-');
+    const layerName = `test${shortId}`;
+    const layerSettings = {
+      layerName,
+      projName,
+      runtimes: [],
+    };
+
+    await legacyAddLayer(projRoot, layerSettings);
+    legacyAddOptData(projRoot, layerName);
+    await amplifyPushAuth(projRoot, false);
+    await updateLayer(projRoot, { ...layerSettings, dontChangePermissions: true, migrateLegacyLayer: true }, true);
+    await amplifyPushLayer(projRoot, {}, true);
+    expect(validateLayerConfigFilesMigrated(projRoot, layerName)).toBe(true);
+  });
 });

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
@@ -160,6 +160,17 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
     await amplifyPushAuth(projRoot, false);
     await updateLayer(projRoot, { ...layerSettings, dontChangePermissions: true, migrateLegacyLayer: true }, true);
     await amplifyPushLayer(projRoot, {}, true);
+    await updateLayer(
+      projRoot,
+      {
+        ...layerSettings,
+        permissions: ['Public (Anyone on AWS can use this layer)'],
+        changePermissionOnLatestVersion: true,
+      },
+      true,
+    );
+    await amplifyPushLayer(projRoot, {}, true);
+
     expect(validateLayerConfigFilesMigrated(projRoot, layerName)).toBe(true);
   });
 });

--- a/packages/amplify-migration-tests/src/migration-helpers/legacy-lambda-layer.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/legacy-lambda-layer.ts
@@ -53,7 +53,9 @@ export function legacyAddLayer(
       chain.wait('Provide a list of comma-separated AWS organization IDs:').sendLine(settings.orgId);
     }
 
-    chain.wait('Move your libraries to the following folder:');
+    if (settings.runtimes.length > 0) {
+      chain.wait('Move your libraries to the following folder:');
+    }
 
     chain.run((err: Error) => {
       if (!err) {

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyPackage.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyPackage.ts
@@ -30,7 +30,7 @@ export async function packageResource(request: PackageRequest, context: $TSConte
         );
       }
 
-      [optPath, ...libGlob].forEach(folder => {
+      [...libGlob].forEach(folder => {
         if (fs.lstatSync(folder).isDirectory()) {
           zipEntries.push({
             packageFolder: folder,

--- a/packages/amplify-python-function-runtime-provider/src/util/packageUtils.ts
+++ b/packages/amplify-python-function-runtime-provider/src/util/packageUtils.ts
@@ -36,7 +36,7 @@ export async function pythonPackage(context: any, params: PackageRequest): Promi
         );
       }
 
-      [optPath, ...libGlob].forEach(folder => {
+      [...libGlob].forEach(folder => {
         if (fs.lstatSync(folder).isDirectory()) {
           zipEntries.push({ packageFolder: folder });
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Fix handling for migrated layers (created before v5.0.0) that have no associated runtime
- Improve handling of layers that have multiple runtimes

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes https://github.com/aws-amplify/amplify-cli/issues/7555


#### Description of how you validated changes
`yarn test` and ran all migration and e2e tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.