### PR TITLE
test(amplify-migration-tests): fix layer migration for no runtime test

### DIFF
--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
@@ -17,6 +17,7 @@ import {
   initJSProjectWithProfileOldDX,
   legacyAddLayer,
   legacyAddOptData,
+  legacyUpdateOptData,
   validateLayerConfigFilesMigrated,
   versionCheck,
 } from '../../../migration-helpers';
@@ -160,15 +161,7 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
     await amplifyPushAuth(projRoot, false);
     await updateLayer(projRoot, { ...layerSettings, dontChangePermissions: true, migrateLegacyLayer: true }, true);
     await amplifyPushLayer(projRoot, {}, true);
-    await updateLayer(
-      projRoot,
-      {
-        ...layerSettings,
-        permissions: ['Public (Anyone on AWS can use this layer)'],
-        changePermissionOnLatestVersion: true,
-      },
-      true,
-    );
+    legacyUpdateOptData(projRoot, layerName, 'update');
     await amplifyPushLayer(projRoot, {}, true);
 
     expect(validateLayerConfigFilesMigrated(projRoot, layerName)).toBe(true);

--- a/packages/amplify-migration-tests/src/migration-helpers/legacy-lambda-layer.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/legacy-lambda-layer.ts
@@ -71,6 +71,10 @@ export function legacyAddOptData(projRoot: string, layerName: string): void {
   fs.writeFileSync(path.join(projRoot, 'amplify', 'backend', 'function', layerName, 'opt', 'data.txt'), 'data', 'utf8');
 }
 
+export function legacyUpdateOptData(projRoot: string, layerName: string, data: string): void {
+  fs.writeFileSync(path.join(projRoot, 'amplify', 'backend', 'function', layerName, 'opt', 'data.txt'), data, 'utf8');
+}
+
 export function validateLayerConfigFilesMigrated(projRoot: string, layerName: string) {
   const layerDirPath = pathManager.getResourceDirectoryPath(projRoot, 'function', layerName);
   return (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixed the migration test to deploy a new layer version, instead of updating a layer version permission


#### Description of how you validated changes
Ran both 4.52.0 and 4.28.2 layer migration tests locally


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.