### PR TITLE
fix: unique api name check works when no existing apis

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -17,7 +17,7 @@ import uuid from 'uuid';
 import _ from 'lodash';
 import { getAppSyncResourceName, getAppSyncAuthConfig, checkIfAuthExists, authConfigHasApiKey } from './utils/amplify-meta-utils';
 import { printApiKeyWarnings } from './utils/print-api-key-warnings';
-import { checkCaseSensitivityIssue } from './utils/check-case-sensitivity';
+import { isNameUnique } from './utils/check-case-sensitivity';
 
 // keep in sync with ServiceName in amplify-category-function, but probably it will not change
 const FunctionServiceNameLambdaFunction = 'Lambda';
@@ -50,7 +50,7 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
     }
     const serviceConfig = request.serviceConfiguration;
 
-    checkCaseSensitivityIssue(this.context, 'api', serviceConfig.apiName);
+    isNameUnique('api', serviceConfig.apiName);
 
     const resourceDir = this.getResourceDir(serviceConfig.apiName);
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/legacy-add-resource.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/legacy-add-resource.ts
@@ -1,6 +1,6 @@
 import { JSONUtilities } from 'amplify-cli-core';
 import { serviceMetadataFor } from './utils/dynamic-imports';
-import { checkCaseSensitivityIssue } from './utils/check-case-sensitivity';
+import { isNameUnique } from './utils/check-case-sensitivity';
 import fs from 'fs-extra';
 import path from 'path';
 import { parametersFileName, cfnParametersFilename, rootAssetDir } from './aws-constants';
@@ -33,7 +33,7 @@ export const legacyAddResource = async (serviceWalkthroughPromise: Promise<any>,
     const parameters = { ...answers };
     const resourceDirPath = path.join(projectBackendDirPath, category, parameters.resourceName);
 
-    checkCaseSensitivityIssue(context, category, parameters.resourceName);
+    isNameUnique(category, parameters.resourceName);
 
     fs.ensureDirSync(resourceDirPath);
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -6,6 +6,7 @@ import uuid from 'uuid';
 import { rootAssetDir } from '../aws-constants';
 import { checkForPathOverlap, validatePathName, formatCFNPathParamsForExpressJs } from '../utils/rest-api-path-utils';
 import { ResourceDoesNotExistError, exitOnNextTick, $TSContext, stateManager, open } from 'amplify-cli-core';
+import { isNameUnique } from '../utils/check-case-sensitivity';
 
 // keep in sync with ServiceName in amplify-category-function, but probably it will not change
 const FunctionServiceNameLambdaFunction = 'Lambda';
@@ -183,21 +184,25 @@ async function pathFlow(context, answers, currentPath?) {
 
 async function askApiNames(context, defaults) {
   const { amplify } = context;
-  // TODO: Check if default name is already taken
+  const apiNameValidator = (input: string) => {
+    const amplifyValidatorOutput = amplify.inputValidation({
+      validation: {
+        operator: 'regex',
+        value: '^[a-zA-Z0-9]+$',
+        onErrorMsg: 'Resource name should be alphanumeric',
+      },
+      required: true,
+    })(input);
+    const uniqueCheck = isNameUnique(category, input, false);
+    return typeof amplifyValidatorOutput === 'string' ? amplifyValidatorOutput : typeof uniqueCheck === 'string' ? uniqueCheck : true;
+  };
   const answer: { apiName?: string; resourceName: string } = await inquirer.prompt([
     {
       name: 'resourceName',
       type: 'input',
       message: 'Provide a friendly name for your resource to be used as a label for this category in the project:',
       default: defaults.resourceName,
-      validate: amplify.inputValidation({
-        validation: {
-          operator: 'regex',
-          value: '^[a-zA-Z0-9]+$',
-          onErrorMsg: 'Resource name should be alphanumeric',
-        },
-        required: true,
-      }),
+      validate: apiNameValidator,
     },
   ]);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixing test failures: https://12990-145880460-gh.circle-artifacts.com/0/~/repo/packages/amplify-e2e-tests/amplify-e2e-reports/index.html

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Ran locally


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.