### PR TITLE
fix: pin dependency version in e2e test

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
@@ -437,7 +437,8 @@ describe('nodejs', () => {
         },
         'nodejs',
       );
-      addNodeDependencies(projRoot, fnName, ['aws-appsync', 'isomorphic-fetch', 'graphql-tag']);
+      // Pin aws-appsync to 4.0.3 until https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/647 is fixed.
+      addNodeDependencies(projRoot, fnName, ['aws-appsync@4.0.3', 'isomorphic-fetch', 'graphql-tag']);
       overrideFunctionCodeNode(projRoot, fnName, 'mutation-appsync.js');
       await amplifyPush(projRoot);
       const meta = getProjectMeta(projRoot);


### PR DESCRIPTION
#### Description of changes
One of the e2e tests installs aws-appsync from npm at runtime. A recent breaking change in aws-appsync caused the test to start failing. This commit pins the version of aws-appsync to the last known good version.

#### Issue #, if available

#### Description of how you validated changes
Ran the modified e2e test.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.