### PR TITLE
fix: disable layer version removal if fn depends on pinned version

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
@@ -26,6 +26,19 @@ describe('remove walkthough test', () => {
       promptConfirmationRemove: jest.fn().mockReturnValue(true),
       stateManager: {
         getLocalEnvInfo: jest.fn().mockReturnValue({ envName }),
+        getMeta: jest.fn().mockReturnValue({
+          function: {
+            mockFunction: {
+              service: 'Lambda',
+              dependsOn: [
+                {
+                  category: 'function',
+                  resourceName: 'depschecktestMyLayer',
+                },
+              ],
+            },
+          },
+        }),
       },
     }));
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
@@ -34,7 +34,7 @@ describe('remove walkthough test', () => {
               dependsOn: [
                 {
                   category: 'function',
-                  resourceName: 'depschecktestMyLayer',
+                  resourceName: 'mockLayer',
                 },
               ],
             },

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/removeWalkthrough.test.ts
@@ -9,6 +9,7 @@ describe('remove walkthough test', () => {
   const saveLayerVersionsToBeRemovedByCfn = jest.fn();
   const selectPromptMock = jest.fn();
   const updateLayerArtifacts = jest.fn();
+  const getLambdaFunctionsDependentOnLayerFromMetaMock = jest.fn().mockReturnValue([]);
 
   beforeEach(() => {
     mockContext = {
@@ -56,6 +57,7 @@ describe('remove walkthough test', () => {
       getLayerName: jest.fn().mockReturnValue(layerName),
       loadLayerDataFromCloud: loadLayerDataFromCloudMock,
       loadStoredLayerParameters: loadStoredLayerParameters,
+      getLambdaFunctionsDependentOnLayerFromMeta: getLambdaFunctionsDependentOnLayerFromMetaMock,
     }));
 
     jest.mock('../../../../provider-utils/awscloudformation/utils/layerCloudState', () => ({

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
@@ -1,11 +1,13 @@
-import { $TSContext, stateManager } from 'amplify-cli-core';
+import { $TSContext, $TSObject, pathManager, stateManager } from 'amplify-cli-core';
 import chalk from 'chalk';
 import inquirer, { QuestionCollection } from 'inquirer';
 import ora from 'ora';
+import { categoryName } from '../../../constants';
 import { LayerCloudState } from '../utils/layerCloudState';
 import { saveLayerVersionsToBeRemovedByCfn } from '../utils/layerConfiguration';
-import { loadStoredLayerParameters, getLayerName } from '../utils/layerHelpers';
+import { getLambdaFunctionsDependentOnLayerFromMeta, getLayerName, loadStoredLayerParameters } from '../utils/layerHelpers';
 import { LayerVersionMetadata } from '../utils/layerParams';
+import { loadFunctionParameters } from '../utils/loadFunctionParameters';
 import { updateLayerArtifacts } from '../utils/storeResources';
 
 const removeLayerQuestion = 'Choose the Layer versions you want to remove.';
@@ -19,8 +21,12 @@ export async function removeWalkthrough(context: $TSContext, layerName: string):
     return layerName;
   }
 
+  // Disable any pinned versions in the version list
+  const lambdaFunctionsDependentOnLayer = getLambdaFunctionsDependentOnLayerFromMeta(layerName, stateManager.getMeta());
+  disablePinnedVersions(lambdaFunctionsDependentOnLayer, layerName, layerVersionList);
+
   const { versions } = await inquirer.prompt(question(layerVersionList));
-  const selectedLayerVersion = versions as LayerVersionMetadata[];
+  const selectedLayerVersion = versions as LayerVersionForPossibleRemoval[];
 
   // if nothing is selected return;
   if (selectedLayerVersion.length === 0) {
@@ -44,7 +50,7 @@ export async function removeWalkthrough(context: $TSContext, layerName: string):
   const totalSelectedVersionsToRemove = newLayerSelectedVersions.length + legacyLayerSelectedVersions.length;
 
   if (legacyLayerSelectedVersions.length > 0) {
-    await deleteLayer(
+    await deleteLayerVersionsWithSdk(
       context,
       getLayerName(context, layerName),
       legacyLayerSelectedVersions.map(r => r.Version),
@@ -77,7 +83,11 @@ export async function removeWalkthrough(context: $TSContext, layerName: string):
   return layerName;
 }
 
-function warnLegacyRemoval(context: $TSContext, legacyLayerVersions: LayerVersionMetadata[], newLayerVersions: LayerVersionMetadata[]) {
+function warnLegacyRemoval(
+  context: $TSContext,
+  legacyLayerVersions: LayerVersionForPossibleRemoval[],
+  newLayerVersions: LayerVersionForPossibleRemoval[],
+) {
   const amplifyPush = chalk.green('amplify push');
   const legacyVersions: number[] = legacyLayerVersions.map(r => r.Version);
 
@@ -97,7 +107,7 @@ function warnLegacyRemoval(context: $TSContext, legacyLayerVersions: LayerVersio
   context.print.info('');
 }
 
-async function deleteLayer(context: $TSContext, layerName: string, versions: number[]) {
+async function deleteLayerVersionsWithSdk(context: $TSContext, layerName: string, versions: number[]) {
   const providerPlugin = await import(context.amplify.getProviderPlugins(context).awscloudformation);
   const lambdaClient = await providerPlugin.getLambdaSdk(context);
   const spinner = ora('Deleting layer version from the cloud...').start();
@@ -112,17 +122,45 @@ async function deleteLayer(context: $TSContext, layerName: string, versions: num
   }
 }
 
-const question = (layerVersionMetadata: LayerVersionMetadata[]): QuestionCollection[] => [
+function disablePinnedVersions(
+  lambdaFunctionsDependentOnLayer: [string, $TSObject][],
+  layerName: string,
+  layerVersionList: LayerVersionForPossibleRemoval[],
+) {
+  lambdaFunctionsDependentOnLayer.forEach(([lambdaFunctionName]: [string, $TSObject]) => {
+    const { lambdaLayers: lambdaLayerDependencies } = loadFunctionParameters(
+      pathManager.getResourceDirectoryPath(undefined, categoryName, lambdaFunctionName),
+    );
+
+    lambdaLayerDependencies.forEach(layerDependency => {
+      if (layerDependency.resourceName === layerName && layerDependency.isLatestVersionSelected === false) {
+        for (const layerVersion of layerVersionList) {
+          if (layerVersion.Version === layerDependency.version) {
+            layerVersion.isPinned = `Can't be removed. ${lambdaFunctionName} depends on this version.`;
+            break;
+          }
+        }
+      }
+    });
+  });
+}
+
+const question = (layerVersionList: LayerVersionForPossibleRemoval[]): QuestionCollection[] => [
   {
     name: 'versions',
     message: removeLayerQuestion,
     type: 'checkbox',
-    choices: layerVersionMetadata
+    choices: layerVersionList
       .sort((versiona, versionb) => versiona.Version - versionb.Version)
       .map(version => ({
+        disabled: version.isPinned,
         name: `${version.Version}: ${version.Description}`,
         short: version.Version.toString(),
         value: version,
       })),
   },
 ];
+
+interface LayerVersionForPossibleRemoval extends LayerVersionMetadata {
+  isPinned?: string;
+}

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, $TSMeta, getPackageManager, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSMeta, $TSObject, getPackageManager, pathManager, stateManager } from 'amplify-cli-core';
 import crypto from 'crypto';
 import { hashElement, HashElementOptions } from 'folder-hash';
 import * as fs from 'fs-extra';
@@ -239,6 +239,14 @@ export function getLayerName(context: $TSContext, layerName: string): string {
   const { envName }: { envName: string } = context.amplify.getEnvInfo();
 
   return isMultiEnvLayer(layerName) ? `${layerName}-${envName}` : layerName;
+}
+
+export function getLambdaFunctionsDependentOnLayerFromMeta(layerName: string, meta: $TSMeta) {
+  return Object.entries(meta[categoryName]).filter(
+    ([_, lambdaFunction]: [string, $TSObject]) =>
+      lambdaFunction.service === ServiceName.LambdaFunction &&
+      lambdaFunction?.dependsOn.filter(dependency => dependency.resourceName === layerName).length > 0,
+  );
 }
 
 // Check hash results for content changes, bump version if so

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -196,7 +196,7 @@ export function removeLayer(cwd: string, versionsToRemove: number[], allVersions
 
 export function removeLayerVersion(
   cwd: string,
-  settings: { removeLegacyOnly?: boolean },
+  settings: { removeLegacyOnly?: boolean; removeNoLayerVersions?: boolean },
   versionsToRemove: number[],
   allVersions: number[],
   testingWithLatestCodebase = false,
@@ -215,7 +215,9 @@ export function removeLayerVersion(
       chain.wait(/Warning: By continuing, these layer versions \[.+\] will be immediately deleted./);
     }
 
-    chain.wait('All new layer versions created with the Amplify CLI will only be deleted on amplify push.');
+    if (!settings.removeNoLayerVersions) {
+      chain.wait('All new layer versions created with the Amplify CLI will only be deleted on amplify push.');
+    }
 
     if (settings.removeLegacyOnly) {
       chain.wait('✔ Layers deleted');

--- a/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
@@ -9,6 +9,7 @@ import {
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
+  ExecutionContext,
   getAppId,
   getCurrentLayerArnFromMeta,
   getProjectConfig,
@@ -18,6 +19,7 @@ import {
   LayerPermissionChoice,
   LayerPermissionName,
   LayerRuntime,
+  removeFunction,
   removeLayer,
   removeLayerVersion,
   updateLayer,
@@ -70,41 +72,6 @@ describe('amplify add lambda layer', () => {
     await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
     await removeLayer(projRoot, [1, 2], [1, 2]);
     expect(validateLayerDir(projRoot, settings, settings.runtimes)).toBe(false);
-  });
-
-  it('init a project, add layer, push 4 layer versions and delete first 3 of them, then push and verify', async () => {
-    const [shortId] = uuid().split('-');
-    const layerName = `simplelayer${shortId}`;
-    const runtime: LayerRuntime = 'nodejs';
-
-    const settings = {
-      runtimes: [runtime],
-      layerName,
-      projName,
-    };
-    const arns: string[] = [];
-    await addLayer(projRoot, settings);
-    expect(validateLayerDir(projRoot, { projName, layerName: settings.layerName }, settings.runtimes)).toBe(true);
-    await amplifyPushLayer(projRoot, {
-      acceptSuggestedLayerVersionConfigurations: true,
-    });
-    arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
-    for (const i in [1, 2, 3]) {
-      updateOptData(projRoot, settings, i);
-      await amplifyPushLayer(projRoot, {
-        acceptSuggestedLayerVersionConfigurations: true,
-      });
-      arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
-    }
-    const removeVersion = [1, 2, 3];
-    await removeLayerVersion(projRoot, {}, removeVersion, [1, 2, 3, 4]);
-    updateOptData(projRoot, settings, 'end');
-    await amplifyPushLayer(projRoot, {
-      acceptSuggestedLayerVersionConfigurations: true,
-    });
-    arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
-    arns.splice(0, 3);
-    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
   });
 
   it('init a project and add/update simple layer and push', async () => {
@@ -254,6 +221,132 @@ describe('amplify add lambda layer', () => {
     await amplifyStatus(projRoot, 'No Change');
     validatePushedVersion(projRoot, settings, expectedPerms);
     await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, integtestArns);
+  });
+});
+
+describe('test amplify remove function', () => {
+  let projRoot: string;
+  let projName: string;
+  const envName = 'integtest';
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('layers');
+    await initJSProjectWithProfile(projRoot, { envName });
+    ({ projectName: projName } = getProjectConfig(projRoot));
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('init a project, add layer, push 4 layer versions and delete first 3 of them, then push and verify', async () => {
+    const [shortId] = uuid().split('-');
+    const layerName = `simplelayer${shortId}`;
+    const runtime: LayerRuntime = 'nodejs';
+
+    const settings = {
+      runtimes: [runtime],
+      layerName,
+      projName,
+    };
+    const arns: string[] = [];
+    await addLayer(projRoot, settings);
+    expect(validateLayerDir(projRoot, { projName, layerName: settings.layerName }, settings.runtimes)).toBe(true);
+    await amplifyPushLayer(projRoot, {
+      acceptSuggestedLayerVersionConfigurations: true,
+    });
+    arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
+    for (const i in [1, 2, 3]) {
+      updateOptData(projRoot, settings, i);
+      await amplifyPushLayer(projRoot, {
+        acceptSuggestedLayerVersionConfigurations: true,
+      });
+      arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
+    }
+    const removeVersion = [1, 2, 3];
+    await removeLayerVersion(projRoot, {}, removeVersion, [1, 2, 3, 4]);
+    updateOptData(projRoot, settings, 'end');
+    await amplifyPushLayer(projRoot, {
+      acceptSuggestedLayerVersionConfigurations: true,
+    });
+    arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
+    arns.splice(0, 3);
+    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
+  });
+
+  it('init a project, add layer, push 2 layer versions, add 2 dependent functions, check that removal is blocked', async () => {
+    const [shortId] = uuid().split('-');
+    const layerName = `simplelayer${shortId}`;
+    const runtime: LayerRuntime = 'nodejs';
+
+    const settings = {
+      runtimes: [runtime],
+      layerName,
+      projName,
+    };
+    const arns: string[] = [];
+    await addLayer(projRoot, settings);
+    expect(validateLayerDir(projRoot, { projName, layerName: settings.layerName }, settings.runtimes)).toBe(true);
+    await amplifyPushLayer(projRoot, { acceptSuggestedLayerVersionConfigurations: true });
+    arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
+    updateOptData(projRoot, settings, 'update');
+    await amplifyPushLayer(projRoot, { acceptSuggestedLayerVersionConfigurations: true });
+    arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
+
+    const fnName1 = `integtestFn1${shortId}`;
+    const fnName2 = `integtestFn2${shortId}`;
+
+    await addFunction(
+      projRoot,
+      {
+        functionTemplate: 'Hello World',
+        name: fnName1,
+        layerOptions: {
+          layerWalkthrough: (chain: ExecutionContext): void => {
+            chain
+              .wait('Provide existing layers')
+              .sendKeyDown()
+              .send(' ')
+              .sendCarriageReturn()
+              .wait(`Select a version for ${projName + layerName}`)
+              .sendKeyDown(2) // Move from Always choose latest version to version 1
+              .sendCarriageReturn();
+          },
+        },
+      },
+      runtime,
+    );
+    await addFunction(
+      projRoot,
+      {
+        functionTemplate: 'Hello World',
+        name: fnName2,
+        layerOptions: {
+          layerWalkthrough: (chain: ExecutionContext): void => {
+            chain
+              .wait('Provide existing layers')
+              .sendKeyDown()
+              .send(' ')
+              .sendCarriageReturn()
+              .wait(`Select a version for ${projName + layerName}`)
+              .sendKeyDown() // Move from Always choose latest version to version 2
+              .sendCarriageReturn();
+          },
+        },
+      },
+      runtime,
+    );
+
+    await removeLayerVersion(projRoot, { removeNoLayerVersions: true }, [1, 2], [1, 2]);
+    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
+
+    await removeFunction(projRoot, fnName1);
+    await removeFunction(projRoot, fnName2);
+
+    await removeLayerVersion(projRoot, {}, [1], [1, 2]);
+    await amplifyPushAuth(projRoot);
+    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns.splice(1));
   });
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Disable the removal of specific Lambda layer versions if a function in the project depends on it.

```
amplify remove function
? Choose the resource you would want to remove testMyLayer (layer)
When you delete a layer version, you can no longer configure functions to use it.
However, any function that already uses the layer version continues to have access to it.
? Choose the Layer versions you want to remove. (Press <space> to select, <a> to toggle all, <i> to invert selection)
 - 2: Updated layer version 2021-06-25T20:45:29.892Z (Can't be removed. myFunction depends on this version.)
❯◯ 3: Updated layer version 2021-06-25T20:50:12.741Z
```


#### Description of how you validated changes
Manual testing and `yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.