### PR TITLE
fix(amplify-category-auth): \n made OS specific

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "**/build": true,
     "**/coverage": true
   },
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "eslint.alwaysShowStatus": true,
   "eslint.format.enable": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "**/build": true,
     "**/coverage": true
   },
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "eslint.alwaysShowStatus": true,
   "eslint.format.enable": true,

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/message-printer.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/message-printer.test.ts
@@ -1,5 +1,6 @@
 import { printSMSSandboxWarning } from '../../../../provider-utils/awscloudformation/utils/message-printer';
 import { BannerMessage } from 'amplify-cli-core';
+import os from 'os';
 jest.mock('amplify-cli-core');
 const printMock = {
   warning: jest.fn(),
@@ -16,7 +17,7 @@ describe('printSMSSandboxWarning', () => {
     const message = 'BannerMessage';
     mockedGetMessage.mockResolvedValueOnce(message);
     await printSMSSandboxWarning(printMock);
-    expect(printMock.warning).toHaveBeenCalledWith(`${message}\n`);
+    expect(printMock.warning).toHaveBeenCalledWith(`${message}${os.EOL}`);
     expect(mockedGetMessage).toHaveBeenCalledWith('COGNITO_SMS_SANDBOX_CATEGORY_AUTH_ADD_OR_UPDATE_INFO');
   });
 


### PR DESCRIPTION
#### Description of changes
\n changed to EOL to make OS specific newline escape sequence
Instead of using \n changed to os.EOL allowing OS to take care of newline escape sequences

#### Issue #, if available
#7662 

#### Description of how you validated changes
yarn test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.