### PR TITLE
ci: add support for e2e token rotation

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -17,10 +17,7 @@ node12: &node12
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo:latest
-      aws_auth:
-        aws_access_key_id: $ECR_ACCESS_KEY
-        aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
+    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo-public:latest
   resource_class: large
 
 clean_e2e_resources: &clean_e2e_resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,7 @@ node12:
 defaults:
   working_directory: ~/repo
   docker: &ref_1
-    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo:latest
-      aws_auth:
-        aws_access_key_id: $ECR_ACCESS_KEY
-        aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
+    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo-public:latest
   resource_class: large
 clean_e2e_resources: &ref_7
   name: Cleanup resources

--- a/packages/amplify-console-integration-tests/src/profile-helper.ts
+++ b/packages/amplify-console-integration-tests/src/profile-helper.ts
@@ -35,6 +35,7 @@ export function getConfigFromProfile() {
   return {
     accessKeyId: credentials[profileName].aws_access_key_id,
     secretAccessKey: credentials[profileName].aws_secret_access_key,
+    sessionToken: credentials[profileName].aws_session_token,
     region: config[configKeyName].region,
   };
 }
@@ -62,31 +63,33 @@ export function setupAWSProfile() {
   Object.keys(credentials).forEach(key => {
     const keyName = key.trim();
     if (profileName === keyName) {
-      credentials[key].aws_access_key_id = process.env.CONSOLE_AWS_ACCESS_KEY_ID;
-      credentials[key].aws_secret_access_key = process.env.CONSOLE_AWS_SECRET_ACCESS_KEY;
+      credentials[key].aws_access_key_id = process.env.AWS_ACCESS_KEY_ID;
+      credentials[key].aws_secret_access_key = process.env.AWS_SECRET_ACCESS_KEY;
+      credentials[key].aws_session_token = process.env.AWS_SESSION_TOKEN;
       isCredSet = true;
     }
   });
   if (!isCredSet) {
     credentials[profileName] = {
-      aws_access_key_id: process.env.CONSOLE_AWS_ACCESS_KEY_ID,
-      aws_secret_access_key: process.env.CONSOLE_AWS_SECRET_ACCESS_KEY,
+      aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
+      aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
+      aws_session_token: process.env.AWS_SESSION_TOKEN,
     };
   }
 
-  process.env.CONSOLE_REGION = process.env.CONSOLE_REGION || testRegionPool[Math.floor(Math.random() * testRegionPool.length)];
+  process.env.CLI_REGION = process.env.CLI_REGION || testRegionPool[Math.floor(Math.random() * testRegionPool.length)];
   let isConfigSet = false;
   Object.keys(config).forEach(key => {
     const keyName = key.replace('profile', '').trim();
     if (profileName === keyName) {
-      config[key].region = process.env.CONSOLE_REGION;
+      config[key].region = process.env.CLI_REGION;
       isConfigSet = true;
     }
   });
   if (!isConfigSet) {
     const keyName = profileName === 'default' ? 'default' : `profile ${profileName}`;
     config[keyName] = {
-      region: process.env.CONSOLE_REGION,
+      region: process.env.CLI_REGION,
     };
   }
 

--- a/packages/amplify-console-integration-tests/src/profile-helper.ts
+++ b/packages/amplify-console-integration-tests/src/profile-helper.ts
@@ -77,19 +77,19 @@ export function setupAWSProfile() {
     };
   }
 
-  process.env.CLI_REGION = process.env.CLI_REGION || testRegionPool[Math.floor(Math.random() * testRegionPool.length)];
+  process.env.CONSOLE_REGION = process.env.CONSOLE_REGION || testRegionPool[Math.floor(Math.random() * testRegionPool.length)];
   let isConfigSet = false;
   Object.keys(config).forEach(key => {
     const keyName = key.replace('profile', '').trim();
     if (profileName === keyName) {
-      config[key].region = process.env.CLI_REGION;
+      config[key].region = process.env.CONSOLE_REGION;
       isConfigSet = true;
     }
   });
   if (!isConfigSet) {
     const keyName = profileName === 'default' ? 'default' : `profile ${profileName}`;
     config[keyName] = {
-      region: process.env.CLI_REGION,
+      region: process.env.CONSOLE_REGION,
     };
   }
 

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect, injectSessionToken } from '..';
+import { nspawn as spawn, getCLIPath, singleSelect } from '..';
 
 type AmplifyConfiguration = {
   accessKeyId: string;
@@ -66,7 +66,6 @@ export function amplifyConfigure(settings: AmplifyConfiguration): Promise<void> 
       .wait('Successfully set up the new user.')
       .run((err: Error) => {
         if (!err) {
-          injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -126,7 +125,6 @@ export function amplifyConfigureProject(settings: {
 
     chain.wait('Successfully made configuration changes to your project.').run((err: Error) => {
       if (!err) {
-        injectSessionToken();
         resolve();
       } else {
         reject(err);

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect } from '..';
+import { nspawn as spawn, getCLIPath, singleSelect, injectSessionToken } from '..';
 
 type AmplifyConfiguration = {
   accessKeyId: string;
@@ -66,6 +66,7 @@ export function amplifyConfigure(settings: AmplifyConfiguration): Promise<void> 
       .wait('Successfully set up the new user.')
       .run((err: Error) => {
         if (!err) {
+          injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -125,6 +126,7 @@ export function amplifyConfigureProject(settings: {
 
     chain.wait('Successfully made configuration changes to your project.').run((err: Error) => {
       if (!err) {
+        injectSessionToken();
         resolve();
       } else {
         reject(err);

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -34,11 +34,10 @@ export function isCI(): boolean {
   return process.env.CI && process.env.CIRCLECI ? true : false;
 }
 
-export function injectSessionToken() {
+export function injectSessionToken(profileName: string) {
   const credentialsContents = ini.parse(fs.readFileSync(pathManager.getAWSCredentialsFilePath()).toString());
-  for (const key of Object.keys(credentialsContents)) {
-    credentialsContents[key].aws_session_token = process.env.AWS_SESSION_TOKEN;
-  }
+  credentialsContents[profileName] = credentialsContents[profileName] || {};
+  credentialsContents[profileName].aws_session_token = process.env.AWS_SESSION_TOKEN;
   fs.writeFileSync(pathManager.getAWSCredentialsFilePath(), ini.stringify(credentialsContents));
 }
 

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { spawnSync, execSync } from 'child_process';
 import { v4 as uuid } from 'uuid';
+import { pathManager } from 'amplify-cli-core';
 
 export * from './configure/';
 export * from './init/';
@@ -29,6 +30,12 @@ export function getCLIPath(testingWithLatestCodebase = false) {
 
 export function isCI(): boolean {
   return process.env.CI && process.env.CIRCLECI ? true : false;
+}
+
+export function injectSessionToken() {
+  if (!fs.readFileSync(pathManager.getAWSCredentialsFilePath()).toString().includes('aws_session_token')) {
+    fs.appendFileSync(pathManager.getAWSCredentialsFilePath(), `aws_session_token=${process.env.AWS_SESSION_TOKEN}`);
+  }
 }
 
 export function npmInstall(cwd: string) {

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -1,6 +1,8 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs-extra';
+import * as ini from 'ini';
+
 import { spawnSync, execSync } from 'child_process';
 import { v4 as uuid } from 'uuid';
 import { pathManager } from 'amplify-cli-core';
@@ -33,9 +35,11 @@ export function isCI(): boolean {
 }
 
 export function injectSessionToken() {
-  if (!fs.readFileSync(pathManager.getAWSCredentialsFilePath()).toString().includes('aws_session_token')) {
-    fs.appendFileSync(pathManager.getAWSCredentialsFilePath(), `aws_session_token=${process.env.AWS_SESSION_TOKEN}`);
+  const credentialsContents = ini.parse(fs.readFileSync(pathManager.getAWSCredentialsFilePath()).toString());
+  for (const key of Object.keys(credentialsContents)) {
+    credentialsContents[key].aws_session_token = process.env.AWS_SESSION_TOKEN;
   }
+  fs.writeFileSync(pathManager.getAWSCredentialsFilePath(), ini.stringify(credentialsContents));
 }
 
 export function npmInstall(cwd: string) {

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags, injectSessionToken } from '..';
+import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';
 import { KEY_DOWN_ARROW } from '../utils';
 import { amplifyRegions } from '../configure';
 
@@ -78,7 +78,6 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (err) {
-        injectSessionToken();
         reject(err);
       } else {
         resolve();
@@ -122,7 +121,6 @@ export function initAndroidProjectWithProfile(cwd: string, settings: Object): Pr
         if (!err) {
           addCircleCITags(cwd);
 
-          injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -164,7 +162,6 @@ export function initIosProjectWithProfile(cwd: string, settings: Object): Promis
         if (!err) {
           addCircleCITags(cwd);
 
-          injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -203,7 +200,6 @@ export function initFlutterProjectWithProfile(cwd: string, settings: Object): Pr
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
-        injectSessionToken();
         resolve();
       } else {
         reject(err);
@@ -264,7 +260,6 @@ export function initProjectWithAccessKey(
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
-        injectSessionToken();
         resolve();
       } else {
         reject(err);
@@ -304,7 +299,6 @@ export function initNewEnvWithAccessKey(cwd: string, s: { envName: string; acces
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
-        injectSessionToken();
         resolve();
       } else {
         reject(err);
@@ -336,7 +330,6 @@ export function initNewEnvWithProfile(cwd: string, s: { envName: string }): Prom
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
-        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -371,7 +364,6 @@ export function amplifyInitSandbox(cwd: string, settings: {}): Promise<void> {
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
-        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -388,12 +380,13 @@ export function amplifyInitYes(cwd: string): Promise<void> {
       env: {
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
-    }).run((err: Error) => (err ? reject(err) :
-      (() => {
-        injectSessionToken();
-        resolve();
-      })()
-    ));
+    }).run((err: Error) =>
+      err
+        ? reject(err)
+        : (() => {
+            resolve();
+          })(),
+    );
   });
 }
 
@@ -403,7 +396,6 @@ export function amplifyVersion(cwd: string, expectedVersion: string, testingWith
       .wait(expectedVersion)
       .run((err: Error) => {
         if (!err) {
-        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -423,7 +415,6 @@ export function amplifyStatusWithMigrate(cwd: string, expectedStatus: string, te
       .sendLine('\r')
       .run((err: Error) => {
         if (!err) {
-        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -440,7 +431,6 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
       .sendLine('\r')
       .run((err: Error) => {
         if (!err) {
-        injectSessionToken();
           resolve();
         } else {
           reject(err);

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';
+import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags, injectSessionToken } from '..';
 import { KEY_DOWN_ARROW } from '../utils';
 import { amplifyRegions } from '../configure';
 
@@ -78,6 +78,7 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (err) {
+        injectSessionToken();
         reject(err);
       } else {
         resolve();
@@ -121,6 +122,7 @@ export function initAndroidProjectWithProfile(cwd: string, settings: Object): Pr
         if (!err) {
           addCircleCITags(cwd);
 
+          injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -162,6 +164,7 @@ export function initIosProjectWithProfile(cwd: string, settings: Object): Promis
         if (!err) {
           addCircleCITags(cwd);
 
+          injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -200,6 +203,7 @@ export function initFlutterProjectWithProfile(cwd: string, settings: Object): Pr
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
+        injectSessionToken();
         resolve();
       } else {
         reject(err);
@@ -260,6 +264,7 @@ export function initProjectWithAccessKey(
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
+        injectSessionToken();
         resolve();
       } else {
         reject(err);
@@ -299,6 +304,7 @@ export function initNewEnvWithAccessKey(cwd: string, s: { envName: string; acces
 
     chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
+        injectSessionToken();
         resolve();
       } else {
         reject(err);
@@ -330,6 +336,7 @@ export function initNewEnvWithProfile(cwd: string, s: { envName: string }): Prom
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
+        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -364,6 +371,7 @@ export function amplifyInitSandbox(cwd: string, settings: {}): Promise<void> {
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
+        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -380,7 +388,12 @@ export function amplifyInitYes(cwd: string): Promise<void> {
       env: {
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
-    }).run((err: Error) => (err ? reject(err) : resolve()));
+    }).run((err: Error) => (err ? reject(err) :
+      (() => {
+        injectSessionToken();
+        resolve();
+      })()
+    ));
   });
 }
 
@@ -390,6 +403,7 @@ export function amplifyVersion(cwd: string, expectedVersion: string, testingWith
       .wait(expectedVersion)
       .run((err: Error) => {
         if (!err) {
+        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -409,6 +423,7 @@ export function amplifyStatusWithMigrate(cwd: string, expectedStatus: string, te
       .sendLine('\r')
       .run((err: Error) => {
         if (!err) {
+        injectSessionToken();
           resolve();
         } else {
           reject(err);
@@ -425,6 +440,7 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
       .sendLine('\r')
       .run((err: Error) => {
         if (!err) {
+        injectSessionToken();
           resolve();
         } else {
           reject(err);

--- a/packages/amplify-e2e-core/src/utils/envVars.ts
+++ b/packages/amplify-e2e-core/src/utils/envVars.ts
@@ -1,6 +1,7 @@
 type AWSCredentials = {
-  ACCESS_KEY_ID?: string;
-  SECRET_ACCESS_KEY?: string;
+  AWS_ACCESS_KEY_ID?: string;
+  AWS_SECRET_ACCESS_KEY?: string;
+  AWS_SESSION_TOKEN?: string;
 };
 type SocialProviders = {
   FACEBOOK_APP_ID?: string;

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -14,6 +14,7 @@ const settings = {
   startCmd: '\r',
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  sessionToken: process.env.AWS_SESSION_TOKEN,
   region: process.env.CLI_REGION,
   pinpointResourceName: 'testpinpoint',
 };
@@ -46,6 +47,7 @@ export async function pinpointAppExist(pinpointProjectId: string): Promise<boole
   const pinpointClient = new Pinpoint({
     accessKeyId: settings.accessKeyId,
     secretAccessKey: settings.secretAccessKey,
+    sessionToken: settings.sessionToken,
     region: _.get(serviceRegionMap, settings.region, defaultPinpointRegion),
   });
 

--- a/packages/amplify-e2e-tests/sample.env
+++ b/packages/amplify-e2e-tests/sample.env
@@ -1,10 +1,7 @@
 # Used for setting up a new profile
 AWS_ACCESS_KEY_ID=<your-access-key>
 AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
-
-# Used for profile less init
-ACCESS_KEY_ID=<your-access-key>
-SECRET_ACCESS_KEY=<your-secret-access-key>
+AWS_SESSION_TOKEN=<optional-session-token>
 
 # Used for Auth Hosted UI
 FACEBOOK_APP_ID=<your-facebook-app-id>

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
@@ -324,9 +324,9 @@ describe('auth import userpool only', () => {
     // Set it to make sure deleteProject error will be ignored
     ignoreProjectDeleteErrors = true;
 
-    const { ACCESS_KEY_ID, SECRET_ACCESS_KEY } = getEnvVars();
-    if (!ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
-      throw new Error('Set AWS_ACCESS_KEY_ID and SECRET_ACCESS_KEY either in .env file or as Environment variable');
+    const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = getEnvVars();
+    if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
+      throw new Error('Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY either in .env file or as Environment variable');
     }
 
     const newProjectRegion = process.env.CLI_REGION === 'us-west-2' ? 'us-east-2' : 'us-west-2';
@@ -334,8 +334,8 @@ describe('auth import userpool only', () => {
     await initProjectWithAccessKey(projectRoot, {
       ...projectSettings,
       envName: 'integtest',
-      accessKeyId: ACCESS_KEY_ID,
-      secretAccessKey: SECRET_ACCESS_KEY,
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY,
       region: newProjectRegion,
     } as any);
 

--- a/packages/amplify-e2e-tests/src/__tests__/init.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init.test.ts
@@ -83,13 +83,13 @@ describe('amplify init', () => {
   });
 
   it('should init project without profile', async () => {
-    const { ACCESS_KEY_ID, SECRET_ACCESS_KEY } = getEnvVars();
-    if (!ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
-      throw new Error('Set ACCESS_KEY_ID and SECRET_ACCESS_KEY either in .env file or as Environment variable');
+    const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = getEnvVars();
+    if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
+      throw new Error('Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY either in .env file or as Environment variable');
     }
     await initProjectWithAccessKey(projRoot, {
-      accessKeyId: ACCESS_KEY_ID,
-      secretAccessKey: SECRET_ACCESS_KEY,
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY,
     });
 
     const meta = getProjectMeta(projRoot).providers.awscloudformation;
@@ -103,8 +103,8 @@ describe('amplify init', () => {
     // init new env
     await initNewEnvWithAccessKey(projRoot, {
       envName: 'foo',
-      accessKeyId: ACCESS_KEY_ID,
-      secretAccessKey: SECRET_ACCESS_KEY,
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY,
     });
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
 

--- a/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
+++ b/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
@@ -36,6 +36,7 @@ export const toHaveValidPolicyConditionMatchingIdpId = async (roleName: string, 
     const iam = new IAM({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
     });
 
     const { Role: role } = await iam.getRole({ RoleName: roleName }).promise();
@@ -55,9 +56,7 @@ export const toHaveValidPolicyConditionMatchingIdpId = async (roleName: string, 
         return false;
       }
     });
-    
     message = pass ? 'Found Matching Condition' : 'Matching Condition does not exist';
-   
   } catch (e) {
     pass = false;
     message = 'IAM GetRole threw Error: ' + e.message;

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -79,6 +79,7 @@ const configureAws = (): void => {
     credentials: {
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
       ...(process.env.AWS_SESSION_TOKEN ? { sessionToken: process.env.AWS_SESSION_TOKEN } : {}),
     },
     maxRetries: 10,

--- a/packages/amplify-e2e-tests/src/configure_tests.ts
+++ b/packages/amplify-e2e-tests/src/configure_tests.ts
@@ -1,4 +1,4 @@
-import { amplifyConfigure as configure, isCI } from 'amplify-e2e-core';
+import { amplifyConfigure as configure, injectSessionToken, isCI } from 'amplify-e2e-core';
 
 async function setupAmplify() {
   if (isCI()) {
@@ -14,6 +14,9 @@ async function setupAmplify() {
       profileName: 'amplify-integ-test-user',
       region: REGION,
     });
+    if (process.env.AWS_SESSION_TOKEN) {
+      injectSessionToken('amplify-integ-test-user');
+    }
   } else {
     console.log('AWS Profile is already configured');
   }

--- a/packages/amplify-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-e2e-tests/src/init-special-cases/index.ts
@@ -7,6 +7,7 @@ export async function initWithoutCredentialFileAndNoNewUserSetup(projRoot) {
   const settings = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-west-2',
   };
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -70,6 +70,7 @@ export function getConfiguredCognitoClient(): CognitoIdentityServiceProvider {
   const awsconfig = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.CLI_REGION,
   };
 
@@ -124,6 +125,7 @@ export function getConfiguredAppsyncClientIAMAuth(url: string, region: string): 
       credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        sessionToken: process.env.AWS_SESSION_TOKEN,
       },
     },
   });

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -45,6 +45,7 @@ async function uploadImageFile(projectDir: string) {
   const s3Client = new aws.S3({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.AWS_DEFAULT_REGION,
   });
 

--- a/packages/amplify-migration-tests/sample.env
+++ b/packages/amplify-migration-tests/sample.env
@@ -1,10 +1,7 @@
 # Used for setting up a new profile
 AWS_ACCESS_KEY_ID=<your-access-key>
 AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
-
-# Used for profile less init
-ACCESS_KEY_ID=<your-access-key>
-SECRET_ACCESS_KEY=<your-secret-access-key>
+AWS_SESSION_TOKEN=<optional-session-token>
 
 # Used for Auth Hosted UI
 FACEBOOK_APP_ID=<your-facebook-app-id>

--- a/packages/amplify-migration-tests/src/configure_tests.ts
+++ b/packages/amplify-migration-tests/src/configure_tests.ts
@@ -21,12 +21,12 @@ async function setupAmplify(version: string = 'latest') {
       secretAccessKey: AWS_SECRET_ACCESS_KEY,
       profileName: 'amplify-integ-test-user',
     });
-    injectSessionToken();
+    if (process.env.AWS_SESSION_TOKEN) {
+      injectSessionToken('amplify-integ-test-user');
+    }
   } else {
     console.log('AWS Profile is already configured');
-    injectSessionToken();
   }
-
 }
 
 process.nextTick(async () => {

--- a/packages/amplify-migration-tests/src/configure_tests.ts
+++ b/packages/amplify-migration-tests/src/configure_tests.ts
@@ -1,4 +1,4 @@
-import { amplifyConfigure as configure, isCI, installAmplifyCLI } from 'amplify-e2e-core';
+import { amplifyConfigure as configure, isCI, installAmplifyCLI, injectSessionToken } from 'amplify-e2e-core';
 
 /*
  *  Migration tests must be run without publishing to local registry
@@ -21,9 +21,12 @@ async function setupAmplify(version: string = 'latest') {
       secretAccessKey: AWS_SECRET_ACCESS_KEY,
       profileName: 'amplify-integ-test-user',
     });
+    injectSessionToken();
   } else {
     console.log('AWS Profile is already configured');
+    injectSessionToken();
   }
+
 }
 
 process.nextTick(async () => {

--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -1,4 +1,4 @@
-import { addCircleCITags, getCLIPath, nspawn as spawn, injectSessionToken } from 'amplify-e2e-core';
+import { addCircleCITags, getCLIPath, nspawn as spawn } from 'amplify-e2e-core';
 
 const defaultSettings = {
   name: '\r',
@@ -107,7 +107,6 @@ export function initJSProjectWithProfile(cwd: string, settings: Object, testingW
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
-          injectSessionToken();
           resolve();
         } else {
           reject(err);

--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -1,4 +1,4 @@
-import { addCircleCITags, getCLIPath, nspawn as spawn } from 'amplify-e2e-core';
+import { addCircleCITags, getCLIPath, nspawn as spawn, injectSessionToken } from 'amplify-e2e-core';
 
 const defaultSettings = {
   name: '\r',
@@ -107,6 +107,7 @@ export function initJSProjectWithProfile(cwd: string, settings: Object, testingW
       .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
+          injectSessionToken();
           resolve();
         } else {
           reject(err);

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -217,6 +217,7 @@ async function initialize(context: $TSContext, authConfig?: AuthFlowConfig) {
     ) {
       awsConfigInfo.config.accessKeyId = awsConfigInfo.config.accessKeyId || authConfig.accessKeyId;
       awsConfigInfo.config.secretAccessKey = awsConfigInfo.config.secretAccessKey || authConfig.secretAccessKey;
+      awsConfigInfo.config.sessionToken = awsConfigInfo.config.sessionToken || authConfig.sessionToken;
       awsConfigInfo.config.region = awsConfigInfo.config.region || authConfig.region;
     } else {
       await promptForAuthConfig(context, authConfig);
@@ -430,6 +431,7 @@ async function promptForAuthConfig(context: $TSContext, authConfig?: AuthFlowCon
   if (!obfuscateUtil.isObfuscated(answers.secretAccessKey)) {
     awsConfigInfo.config.secretAccessKey = answers.secretAccessKey;
   }
+  awsConfigInfo.config.sessionToken = awsConfigInfo.config.sessionToken || process.env.AWS_SESSION_TOKEN;
   awsConfigInfo.config.region = answers.region;
 }
 
@@ -455,6 +457,7 @@ async function validateConfig(context: $TSContext) {
         credentials: {
           accessKeyId: awsConfigInfo.config.accessKeyId,
           secretAccessKey: awsConfigInfo.config.secretAccessKey,
+          sessionToken: awsConfigInfo.config.sessionToken,
         },
       });
       try {
@@ -495,6 +498,7 @@ function persistLocalEnvConfig(context: $TSContext) {
       const awsSecrets = {
         accessKeyId: awsConfigInfo.config.accessKeyId,
         secretAccessKey: awsConfigInfo.config.secretAccessKey,
+        sessionToken: awsConfigInfo.config.sessionToken,
         region: awsConfigInfo.config.region,
       };
       const sharedConfigDirPath = path.join(pathManager.getHomeDotAmplifyDirPath(), constants.ProviderName);
@@ -774,6 +778,7 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
       resultAWSConfigInfo = {
         accessKeyId: awsConfigInfo.config.accessKeyId,
         secretAccessKey: awsConfigInfo.config.secretAccessKey,
+        sessionToken: awsConfigInfo.config.sessionToken,
         region: awsConfigInfo.config.region,
       };
     }

--- a/packages/amplify-provider-awscloudformation/src/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/src/setup-new-user.js
@@ -12,6 +12,7 @@ async function run(context) {
   const awsConfigInfo = {
     accessKeyId: constants.DefaultAWSAccessKeyId,
     secretAccessKey: constants.DefaultAWSSecretAccessKey,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: constants.DefaultAWSRegion,
   };
 

--- a/packages/amplify-util-mock/src/utils/dynamo-db/index.ts
+++ b/packages/amplify-util-mock/src/utils/dynamo-db/index.ts
@@ -42,6 +42,7 @@ export function configureDDBDataSource(config, ddbConfig) {
           region: ddbConfig.region,
           accessKeyId: ddbConfig.accessKeyId,
           secretAccessKey: ddbConfig.secretAccessKey,
+          sessionToken: ddbConfig.sessionToken || process.env.AWS_SESSION_TOKEN,
         },
       };
     }),

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -548,6 +548,7 @@ beforeAll(async () => {
         credentials: {
           accessKeyId: unauthCredentials.accessKeyId,
           secretAccessKey: unauthCredentials.secretAccessKey,
+          sessionToken: unauthCredentials.sessionToken,
         },
       },
       offlineConfig: {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
@@ -401,6 +401,7 @@ beforeAll(async () => {
       credentials: {
         accessKeyId: unauthCredentials.accessKeyId,
         secretAccessKey: unauthCredentials.secretAccessKey,
+        sessionToken: unauthCredentials.sessionToken,
       },
     },
     offlineConfig: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Currently we use long-lived, manually generated access tokens to set up AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables allowing our tests to run. This is a bad practice - authorization tokens should be automatically rotated to minimize risk of the tokens landing in the wrong hands.

This PR sets up the Amplify CLI codebase to use temporary credentials during CI. Temporary STS credentials use an additional parameter, AWS_SESSION_TOKEN, to authorize the requests.

The token rotator itself is a lambda that runs every hour:

https://github.com/johnpc/amplify-e2e-token-rotation-lambda

#### Description of how you validated changes

This has been tested in CI on my fork and all tests pass:

https://app.circleci.com/pipelines/github/johnpc/amplify-cli/144/workflows/fb12f075-d881-4c92-8cf7-f8647afb909e


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.