### PR TITLE
fix: add/update function when some LL are not yet migrated

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../provider-utils/awscloudformation/utils/layerCloudState');
 jest.mock('../../../../provider-utils/awscloudformation/utils/layerConfiguration', () => ({
   getLayerRuntimes: jest.fn(),
 }));
+jest.mock('../../../../provider-utils/awscloudformation/utils/layerMigrationUtils');
 
 const getLayerRuntimes_mock = getLayerRuntimes as jest.MockedFunction<typeof getLayerRuntimes>;
 const inquirer_mock = inquirer as jest.Mocked<typeof inquirer>;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -53,7 +53,7 @@ export const askLayerSelection = async (
     };
   }
 
-  const disabledMessage = 'Layer requires migration. Run "amplify update function" and choose this layer to migrate.';
+  const disabledMessage = 'Layer requires migration. Run "amplify function update" and choose this layer to migrate.';
   const currentResourceNames = filterProjectLayers(previousSelections).map(sel => (sel as ProjectLayer).resourceName);
   const choices = layerOptions.map(op => ({
     name: op,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -39,8 +39,10 @@ export const askLayerSelection = async (
   const layerOptions = _.keys(functionMeta)
     .filter(key => functionMeta[key].service === ServiceName.LambdaLayer)
     .filter(key => {
-      // filter by compatible runtimes
-      return isRuntime(runtimeValue).inRuntimes(functionMeta[key].runtimes || getLayerRuntimes(key));
+      // filter by compatible runtimes - unless no runtimes are present for the given Lambda layer
+      // since any Lambda function can depend on /opt folder content if there is no runtime.
+      const runtimes = functionMeta[key].runtimes || getLayerRuntimes(key);
+      return Array.isArray(runtimes) && (_.isEmpty(runtimes) || isRuntime(runtimeValue).inRuntimes(runtimes));
     });
 
   if (layerOptions.length === 0) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
@@ -170,7 +170,7 @@ export function readLegacyRuntimes(layerName: string, legacyState: LegacyState):
   }
 }
 
-export function removeLayerFromTeamProviderInfo(envName: string, layerName: string, projectRoot?: string) {
+export function removeLayerFromTeamProviderInfo(projectRoot: string | undefined, envName: string, layerName: string) {
   const nonCfnDataKey = 'nonCFNdata';
   const teamProviderInfo = stateManager.getTeamProviderInfo(projectRoot);
 
@@ -190,7 +190,7 @@ function readLegacyLayerParametersJson(layerDirPath: string) {
 
 function migrateAmplifyProjectFiles(layerName: string, latestLegacyHash: string, envName?: string) {
   const projectRoot = pathManager.findProjectRoot();
-  removeLayerFromTeamProviderInfo(envName, layerName, projectRoot);
+  removeLayerFromTeamProviderInfo(projectRoot, envName, layerName);
   const meta = stateManager.getMeta(projectRoot);
 
   if (meta?.[categoryName]?.[layerName]?.[layerVersionMapKey]) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
@@ -9,6 +9,12 @@ import { loadPluginFromFactory } from './functionPluginLoader';
 import { writeLayerConfigurationFile } from './layerConfiguration';
 import { defaultLayerPermission, LayerPermission, LayerRuntime, PermissionEnum } from './layerParams';
 
+export const enum LegacyState {
+  NOT_LEGACY,
+  MULTI_ENV_LEGACY,
+  SINGLE_ENV_LEGACY,
+}
+
 export const enum LegacyPermissionEnum {
   AwsAccounts = 'awsAccounts',
   AwsOrg = 'awsOrg',
@@ -32,17 +38,16 @@ type LegacyVersionMap = {
   };
 };
 
-const enum LegacyState {
-  NOT_LEGACY,
-  MULTI_ENV_LEGACY,
-  SINGLE_ENV_LEGACY,
-}
+type LegacyLayerParametersJson = {
+  [layerVersionMapKey]: LegacyVersionMap;
+  runtimes: LegacyRuntime[];
+};
 
 const layerVersionMapKey = 'layerVersionMap';
 
 export async function migrateLegacyLayer(context: $TSContext, layerName: string): Promise<boolean> {
   const layerDirPath = pathManager.getResourceDirectoryPath(undefined, categoryName, layerName);
-  const legacyState = getLegacyLayerState(layerName, layerDirPath);
+  const legacyState = getLegacyLayerState(layerName);
 
   if (legacyState === LegacyState.NOT_LEGACY) {
     return false;
@@ -69,13 +74,10 @@ This change requires a migration. Amplify will create a new Lambda layer version
   let layerVersionMap: LegacyVersionMap;
 
   if (legacyState === LegacyState.MULTI_ENV_LEGACY) {
-    legacyRuntimeArray = JSONUtilities.readJson<LegacyRuntime[]>(path.join(layerDirPath, LegacyFilename.layerRuntimes));
+    legacyRuntimeArray = readLegacyRuntimes(layerName, legacyState);
     layerVersionMap = stateManager.getMeta()?.[categoryName]?.[layerName]?.[layerVersionMapKey] ?? {};
   } else {
-    ({ layerVersionMap, runtimes: legacyRuntimeArray } = JSONUtilities.readJson<{
-      [layerVersionMapKey]: LegacyVersionMap;
-      runtimes: LegacyRuntime[];
-    }>(path.join(layerDirPath, LegacyFilename.layerParameters)));
+    ({ layerVersionMap, runtimes: legacyRuntimeArray } = readLegacyLayerParametersJson(layerDirPath));
     layerConfiguration.nonMultiEnv = true;
   }
 
@@ -140,7 +142,8 @@ This change requires a migration. Amplify will create a new Lambda layer version
   return true;
 }
 
-function getLegacyLayerState(layerName: string, layerDirPath: string): LegacyState {
+export function getLegacyLayerState(layerName: string): LegacyState {
+  const layerDirPath = pathManager.getResourceDirectoryPath(undefined, categoryName, layerName);
   if (fs.existsSync(path.join(layerDirPath, LegacyFilename.layerParameters))) {
     return LegacyState.SINGLE_ENV_LEGACY;
   }
@@ -157,17 +160,14 @@ function getLegacyLayerState(layerName: string, layerDirPath: string): LegacySta
 ${chalk.red('Ensure your layer content is backed up!')}`);
 }
 
-function migrateAmplifyProjectFiles(layerName: string, latestLegacyHash: string, envName?: string) {
-  const projectRoot = pathManager.findProjectRoot();
-  removeLayerFromTeamProviderInfo(envName, layerName, projectRoot);
-  const meta = stateManager.getMeta(projectRoot);
-
-  if (meta?.[categoryName]?.[layerName]?.[layerVersionMapKey]) {
-    meta[categoryName][layerName][layerVersionMapKey] = undefined;
+export function readLegacyRuntimes(layerName: string, legacyState: LegacyState): LegacyRuntime[] {
+  const layerDirPath = pathManager.getResourceDirectoryPath(undefined, categoryName, layerName);
+  if (legacyState === LegacyState.SINGLE_ENV_LEGACY) {
+    return readLegacyLayerParametersJson(layerDirPath).runtimes;
   }
-
-  _.set(meta, [categoryName, layerName, versionHash], latestLegacyHash);
-  stateManager.setMeta(projectRoot, meta);
+  if (legacyState === LegacyState.MULTI_ENV_LEGACY) {
+    return JSONUtilities.readJson<LegacyRuntime[]>(path.join(layerDirPath, LegacyFilename.layerRuntimes));
+  }
 }
 
 export function removeLayerFromTeamProviderInfo(envName: string, layerName: string, projectRoot?: string) {
@@ -182,4 +182,21 @@ export function removeLayerFromTeamProviderInfo(envName: string, layerName: stri
     }
   }
   stateManager.setTeamProviderInfo(projectRoot, teamProviderInfo);
+}
+
+function readLegacyLayerParametersJson(layerDirPath: string) {
+  return JSONUtilities.readJson<LegacyLayerParametersJson>(path.join(layerDirPath, LegacyFilename.layerParameters));
+}
+
+function migrateAmplifyProjectFiles(layerName: string, latestLegacyHash: string, envName?: string) {
+  const projectRoot = pathManager.findProjectRoot();
+  removeLayerFromTeamProviderInfo(envName, layerName, projectRoot);
+  const meta = stateManager.getMeta(projectRoot);
+
+  if (meta?.[categoryName]?.[layerName]?.[layerVersionMapKey]) {
+    meta[categoryName][layerName][layerVersionMapKey] = undefined;
+  }
+
+  _.set(meta, [categoryName, layerName, versionHash], latestLegacyHash);
+  stateManager.setMeta(projectRoot, meta);
 }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -86,7 +86,7 @@ export const updateLayerArtifacts = async (
 
 export function removeLayerArtifacts(context: $TSContext, layerName: string) {
   if (isMultiEnvLayer(layerName)) {
-    removeLayerFromTeamProviderInfo(context.amplify.getEnvInfo().envName, layerName);
+    removeLayerFromTeamProviderInfo(undefined, context.amplify.getEnvInfo().envName, layerName);
   }
 }
 

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -142,7 +142,7 @@ export type CoreFunctionSettings = {
   expectFailure?: boolean;
   additionalPermissions?: any;
   schedulePermissions?: any;
-  layerOptions?: any;
+  layerOptions?: LayerOptions;
   environmentVariables?: any;
   secretsConfig?: AddSecretInput | UpdateSecretInput | DeleteSecretInput;
   triggerType?: string;
@@ -335,7 +335,7 @@ export const functionBuild = (cwd: string, settings: any): Promise<void> => {
   });
 };
 
-export const selectRuntime = (chain: any, runtime: FunctionRuntimes) => {
+export const selectRuntime = (chain: ExecutionContext, runtime: FunctionRuntimes) => {
   const runtimeName = getRuntimeDisplayName(runtime);
   chain.wait('Choose the runtime that you want to use:');
 
@@ -345,7 +345,7 @@ export const selectRuntime = (chain: any, runtime: FunctionRuntimes) => {
   singleSelect(chain, runtimeName, runtimeChoices);
 };
 
-export const selectTemplate = (chain: any, functionTemplate: string, runtime: FunctionRuntimes) => {
+export const selectTemplate = (chain: ExecutionContext, functionTemplate: string, runtime: FunctionRuntimes) => {
   const templateChoices = getTemplateChoices(runtime);
   chain.wait('Choose the function template that you want to use');
 

--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -379,7 +379,7 @@ function waitForLayerSuccessPrintout(
 
   if (settings?.runtimes?.length > 0) {
     chain
-      .wait(path.join('amplify', 'backend', 'function', settings.projName + settings.layerName))
+      .wait(path.join('amplify', 'backend', 'function', (settings.projName || '') + settings.layerName))
       .wait('Next steps:')
       .wait('Move your libraries to the following folder:');
 

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
@@ -1,4 +1,5 @@
 import {
+  addFunction,
   amplifyPushAuth,
   amplifyPushLayer,
   amplifyStatus,
@@ -10,6 +11,7 @@ import {
   LayerRuntime,
   LayerPermissionChoice,
   removeLayerVersion,
+  updateFunction,
   updateLayer,
 } from 'amplify-e2e-core';
 import { v4 as uuid } from 'uuid';
@@ -99,13 +101,11 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
   });
 
   it('migrate layer in Update state with "amplify push"', async () => {
-    const { projectName: projName } = getProjectConfig(projRoot);
     const [shortId] = uuid().split('-');
     const layerName = `test${shortId}`;
     const layerRuntime: LayerRuntime = 'nodejs';
     const layerSettings = {
       layerName,
-      projName,
       runtimes: [layerRuntime],
     };
 
@@ -118,13 +118,11 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
   });
 
   it('migrate layer in No Change state with "amplify update function" by updating permissions', async () => {
-    const { projectName: projName } = getProjectConfig(projRoot);
     const [shortId] = uuid().split('-');
     const layerName = `test${shortId}`;
     const layerRuntime: LayerRuntime = 'nodejs';
     const layerSettings = {
       layerName,
-      projName,
       runtimes: [layerRuntime],
     };
 
@@ -147,12 +145,10 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
   });
 
   it('migrates a layer with no runtime', async () => {
-    const { projectName: projName } = getProjectConfig(projRoot);
     const [shortId] = uuid().split('-');
     const layerName = `test${shortId}`;
     const layerSettings = {
       layerName,
-      projName,
       runtimes: [],
     };
 
@@ -165,5 +161,22 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
     await amplifyPushLayer(projRoot, {}, true);
 
     expect(validateLayerConfigFilesMigrated(projRoot, layerName)).toBe(true);
+  });
+
+  it('handle add and update function when legacy layer is present', async () => {
+    const [shortId] = uuid().split('-');
+    const layerName = `test${shortId}`;
+    const layerRuntime: LayerRuntime = 'nodejs';
+    const functionSettings = {
+      testingWithLatestCodebase: true,
+      layerOptions: {
+        select: [],
+        expectedListOptions: [layerName],
+      },
+    };
+
+    await legacyAddLayer(projRoot, { layerName: layerName, runtimes: [layerRuntime] });
+    await addFunction(projRoot, { ...functionSettings, functionTemplate: 'Hello World' }, layerRuntime);
+    await updateFunction(projRoot, functionSettings, layerRuntime);
   });
 });

--- a/packages/amplify-migration-tests/src/migration-helpers/legacy-lambda-layer.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/legacy-lambda-layer.ts
@@ -20,7 +20,6 @@ export function legacyAddLayer(
     permissions?: LayerPermissionChoice[];
     accountId?: string;
     orgId?: string;
-    projName: string;
     runtimes: LayerRuntime[];
   },
 ): Promise<void> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Handle loading, and disabling of non-migrated LL in add/update function flows:

```
? Do you want to configure advanced settings? Yes
...
? Do you want to enable Lambda layers for this function? Yes
? Provide existing layers or select layers in this project to access from this function (pick up to 5): (Press <space> to select, <a> to toggle all, 
<i> to invert selection)
❯◯ Provide existing Lambda layer ARNs
 ◯ LayerA123
 - LayerB123 (Layer requires migration. Run "amplify function update" and choose this layer to migrate.)
```

#### Description of how you validated changes
Manual testing, yarn test, added migration test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.