### PR TITLE
feat(cli): add consistent support for verb / noun swapping

### DIFF
--- a/packages/amplify-cli/src/input-manager.ts
+++ b/packages/amplify-cli/src/input-manager.ts
@@ -110,17 +110,41 @@ export function verifyInput(pluginPlatform: PluginPlatform, input: Input): Input
         result.helpCommandAvailable = true;
       }
 
+      // verify if `input.command` is an actual command.
       if (commands && commands!.includes(input.command!)) {
         result.verified = true;
         break;
       }
 
+      // verify if `input.command` is an alias for a command.
       if (commandAliases && Object.keys(commandAliases).includes(input.command!)) {
         input.command = commandAliases[input.command!];
         result.verified = true;
         break;
       }
 
+      // if `input.command` is not a command name or an alias for a command, check the
+      // first sub-command for a verb / noun swap (i.e. `env add` versus `add env`).
+      if (commands && input.subCommands && commands!.includes(input.subCommands[0])) {
+        const command = input.subCommands[0];
+        input.subCommands[0] = input.command!;
+        input.command = command;
+
+        result.verified = true;
+        break;
+      }
+
+      // same as above, but check if the first sub-command is an alias.
+      if (commandAliases && input.subCommands && Object.keys(commandAliases).includes(input.subCommands[0])) {
+        const command = commandAliases[input.subCommands[0]];
+        input.subCommands[0] = input.command!;
+        input.command = command;
+
+        result.verified = true;
+        break;
+      }
+
+      // if `input.command` is the default plugin command, check `input.options` for what to do.
       if (input.command! === constants.PLUGIN_DEFAULT_COMMAND) {
         if (commands && commands!.includes(name)) {
           input.command = name;


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Commands in the 'core' plugin that contain sub-commands (env and plugin) now support verb / noun
swapping (i.e. `env add` and `add env` now both work).

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

close #7630

#### Description of how you validated changes

Manually tested in sample Amplify project using `amplify-dev`:
- `amplify-dev add env`
- `amplify-dev remove plugin`
- check that things like `api add` and `add api` still work
- etc.

`yarn test`
`yarn lint`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.