### PR TITLE
fix: #7441 - init from git prompts for credentials twice

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/ssmClientWrapper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/ssmClientWrapper.ts
@@ -102,8 +102,15 @@ export class SSMClientWrapper {
 
 const getSSMClient = async (context: $TSContext) => {
   const spinner = ora('Initializing SSM Client');
-  spinner.start();
-  const { client } = await context.amplify.invokePluginMethod(context, 'awscloudformation', undefined, 'getConfiguredSSMClient', [context]);
-  spinner.stop();
-  return client as aws.SSM;
+  try {
+    spinner.start();
+
+    const { client } = await context.amplify.invokePluginMethod(context, 'awscloudformation', undefined, 'getConfiguredSSMClient', [
+      context,
+    ]);
+
+    return client as aws.SSM;
+  } finally {
+    spinner.stop();
+  }
 };

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
@@ -35,10 +35,10 @@ export async function deleteProject(context) {
         }
       }
     } catch (ex) {
-      spinner.fail('Project delete failed');
+      spinner.fail('Project delete failed.');
       throw ex;
     }
-    spinner.succeed('Project deleted in the cloud');
+    spinner.succeed('Project deleted in the cloud.');
     // Remove amplify dir
     const { frontend } = context.amplify.getProjectConfig();
     const frontendPlugins = getFrontendPlugins(context);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
@@ -8,7 +8,7 @@ export async function removeEnvFromCloud(context, envName, deleteS3) {
   const providerPlugins = getProviderPlugins(context);
   const providerPromises: (() => Promise<any>)[] = [];
   context.print.info('');
-  context.print.info(`Deleting env:${envName}`);
+  context.print.info(`Deleting env: ${envName}.`);
 
   // Pinpoint attaches an IAM policy to several roles, which blocks CFN from
   // deleting the roles. Work around that by deleting Pinpoint first.
@@ -28,7 +28,7 @@ export async function removeEnvFromCloud(context, envName, deleteS3) {
     await raiseIntenralOnlyPostEnvRemoveEvent(context, envName);
   } catch (e) {
     context.print.info('');
-    context.print.error(`Error in deleting env:${envName}`);
+    context.print.error(`Error occurred while deleting env: ${envName}.`);
     context.print.info(e.message);
     throw e;
   }

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-migrate.js
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-migrate.js
@@ -11,7 +11,7 @@ async function run(context) {
   let projectDetails;
   let currentAmplifyMetaFilePath;
   let currentAmplifyMeta;
-  let awsConfig;
+  let awsConfigInfo;
 
   let isProjectFullySetUp = false;
 
@@ -19,7 +19,7 @@ async function run(context) {
     projectDetails = context.amplify.getProjectDetails();
     currentAmplifyMetaFilePath = context.amplify.pathManager.getCurrentAmplifyMetaFilePath();
     currentAmplifyMeta = context.amplify.readJsonFile(currentAmplifyMetaFilePath);
-    awsConfig = await configurationManager.getAwsConfig(context);
+    awsConfigInfo = await configurationManager.getAwsConfig(context);
     isProjectFullySetUp = true;
   } catch (e) {
     isProjectFullySetUp = false;
@@ -38,10 +38,10 @@ async function run(context) {
     return;
   }
 
-  const amplifyClient = await getConfiguredAmplifyClient(context, awsConfig);
+  const amplifyClient = await getConfiguredAmplifyClient(context, awsConfigInfo);
   if (!amplifyClient) {
     // This happens when the Amplify service is not available in the region
-    const message = `Amplify service is not available in the region ${awsConfig.region ? awsConfig.region : ''}`;
+    const message = `Amplify service is not available in the region ${awsConfigInfo.region ? awsConfigInfo.region : ''}`;
     context.print.error(message);
     throw new Error(message);
   }

--- a/packages/amplify-provider-awscloudformation/src/attach-backend.js
+++ b/packages/amplify-provider-awscloudformation/src/attach-backend.js
@@ -18,7 +18,7 @@ const logger = fileLogger('attach-backend');
 
 async function run(context) {
   let appId;
-  let awsConfig;
+  let awsConfigInfo;
   let isAdminApp = false;
   try {
     appId = resolveAppId(context);
@@ -44,20 +44,20 @@ async function run(context) {
   }
 
   if (isAdminApp) {
-    context.exeInfo.awsConfig = {
+    context.exeInfo.awsConfigInfo = {
       configLevel: 'amplifyAdmin',
       config: {},
     };
-    awsConfig = await configurationManager.loadConfigurationForEnv(context, envName, appId);
+    awsConfigInfo = await configurationManager.loadConfigurationForEnv(context, envName, appId);
   } else {
     await configurationManager.init(context);
-    awsConfig = await configurationManager.getAwsConfig(context);
+    awsConfigInfo = await configurationManager.getAwsConfig(context);
   }
 
-  const amplifyClient = await getConfiguredAmplifyClient(context, awsConfig);
+  const amplifyClient = await getConfiguredAmplifyClient(context, awsConfigInfo);
   if (!amplifyClient) {
     // This happens when the Amplify service is not available in the region
-    const region = awsConfig && awsConfig.region ? awsConfig.region : '<unknown>';
+    const region = awsConfigInfo && awsConfigInfo.region ? awsConfigInfo.region : '<unknown>';
     const message = `Amplify service is not available in the region ${region}`;
     context.print.error(message);
     throw new Error(message);
@@ -74,15 +74,15 @@ async function run(context) {
 
   const backendEnv = await getBackendEnv(context, amplifyClient, amplifyApp);
 
-  await downloadBackend(context, backendEnv, awsConfig);
-  const currentAmplifyMeta = await ensureAmplifyMeta(context, amplifyApp, awsConfig);
+  await downloadBackend(context, backendEnv, awsConfigInfo);
+  const currentAmplifyMeta = await ensureAmplifyMeta(context, amplifyApp, awsConfigInfo);
 
   context.exeInfo.projectConfig.projectName = amplifyApp.name;
   context.exeInfo.localEnvInfo.envName = backendEnv.environmentName;
   context.exeInfo.teamProviderInfo[backendEnv.environmentName] = currentAmplifyMeta.providers;
 }
 
-async function ensureAmplifyMeta(context, amplifyApp, awsConfig) {
+async function ensureAmplifyMeta(context, amplifyApp, awsConfigInfo) {
   // check if appId is present in the provider section of the metadata
   // if not, it's a migration case and we need to
   // 1. insert the appId
@@ -99,15 +99,15 @@ async function ensureAmplifyMeta(context, amplifyApp, awsConfig) {
     fs.writeFileSync(amplifyMetaFilePath, jsonString, 'utf8');
 
     const { DeploymentBucketName } = currentAmplifyMeta.providers[constants.ProviderName];
-    await storeArtifactsForAmplifyService(context, awsConfig, DeploymentBucketName);
+    await storeArtifactsForAmplifyService(context, awsConfigInfo, DeploymentBucketName);
   }
 
   return currentAmplifyMeta;
 }
 
-async function storeArtifactsForAmplifyService(context, awsConfig, deploymentBucketName) {
+async function storeArtifactsForAmplifyService(context, awsConfigInfo, deploymentBucketName) {
   const projectPath = process.cwd();
-  const s3Client = new aws.S3(awsConfig);
+  const s3Client = new aws.S3(awsConfigInfo);
   const amplifyMetaFilePath = context.amplify.pathManager.getCurrentAmplifyMetaFilePath(projectPath);
   const backendConfigFilePath = context.amplify.pathManager.getCurrentBackendConfigFilePath(projectPath);
   await uploadFile(s3Client, deploymentBucketName, amplifyMetaFilePath);
@@ -297,7 +297,7 @@ async function getBackendEnv(context, amplifyClient, amplifyApp) {
   throw ex;
 }
 
-async function downloadBackend(context, backendEnv, awsConfig) {
+async function downloadBackend(context, backendEnv, awsConfigInfo) {
   if (!backendEnv) {
     return;
   }
@@ -308,7 +308,7 @@ async function downloadBackend(context, backendEnv, awsConfig) {
   const backendDir = context.amplify.pathManager.getBackendDirPath(projectPath);
   const zipFileName = constants.S3BackendZipFileName;
 
-  const s3Client = new aws.S3(awsConfig);
+  const s3Client = new aws.S3(awsConfigInfo);
   const deploymentBucketName = backendEnv.deploymentArtifacts;
 
   const params = {

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -64,6 +64,11 @@ export async function init(context: $TSContext) {
       configLevel: 'project',
       config: { useProfile: false },
     };
+  } else if (authTypeConfig.type === 'general') {
+    context.exeInfo.awsConfigInfo = {
+      configLevel: 'general',
+      config: {},
+    };
   } else {
     context.exeInfo.awsConfigInfo = {
       configLevel: 'project',
@@ -522,7 +527,7 @@ function getCurrentConfig(context: $TSContext) {
 }
 
 function getConfigForEnv(context: $TSContext, envName: string) {
-  const projectConfigInfo: ProjectConfig = context?.exeInfo?.awsConfig || {
+  const projectConfigInfo: ProjectConfig = context?.exeInfo?.awsConfigInfo || {
     configLevel: 'general',
     config: {},
   };
@@ -599,11 +604,13 @@ function loadConfigFromPath(profilePath: string): AwsSdkConfig {
 
 export async function loadConfigurationForEnv(context: $TSContext, env: string, appId?: string): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo || {};
+
   if (awsConfigInfo?.config?.accessKeyId && awsConfigInfo?.config?.secretAccessKey) {
     // Already loaded config
     if (!awsConfigInfo.region) {
       awsConfigInfo.region = resolveRegion();
     }
+
     return awsConfigInfo.config;
   }
 
@@ -614,6 +621,7 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
   if (authType.type === 'admin') {
     projectConfigInfo.configLevel = 'amplifyAdmin';
     appId = appId || authType.appId;
+
     try {
       awsConfig = await getTempCredsWithAdminTokens(context, appId);
     } catch (e) {
@@ -632,6 +640,7 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
   } else if (authType.type === 'accessKeys') {
     awsConfig = loadConfigFromPath(projectConfigInfo.config.awsConfigFilePath);
   }
+
   return awsConfig;
 }
 
@@ -649,6 +658,7 @@ export function resolveRegion(): string {
   // For details of how aws region is set, check the following link
   // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
   let region: string;
+
   if (process.env.AWS_REGION) {
     region = process.env.AWS_REGION;
   }
@@ -659,6 +669,7 @@ export function resolveRegion(): string {
     const profileName = process.env.AWS_PROFILE || 'default';
     region = systemConfigManager.getProfileRegion(profileName);
   }
+
   return region;
 }
 
@@ -694,6 +705,7 @@ async function newUserCheck(context: $TSContext) {
 
 function scanConfig(context: $TSContext) {
   let configSource: string = getConfigLevel(context);
+
   if (!configSource) {
     const namedProfiles: $TSAny = systemConfigManager.getNamedProfiles();
     if (namedProfiles && Object.keys(namedProfiles).length > 0) {
@@ -715,6 +727,7 @@ function scanConfig(context: $TSContext) {
 
 function getConfigLevel(context: $TSContext): ProjectType {
   let configLevel: ProjectType;
+
   try {
     const namedProfiles = systemConfigManager.getNamedProfiles();
     const configInfoFilePath = pathManager.getLocalAWSInfoFilePath();
@@ -738,6 +751,7 @@ function getConfigLevel(context: $TSContext): ProjectType {
   } catch (e) {
     // no need to do anything
   }
+
   return configLevel;
 }
 
@@ -745,18 +759,19 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
 
-  let awsConfig: AwsSdkConfig;
+  let resultAWSConfigInfo: AwsSdkConfig;
+
   if (awsConfigInfo.configLevel === 'project') {
     if (awsConfigInfo.config.useProfile) {
       try {
-        awsConfig = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
+        resultAWSConfigInfo = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
       } catch (e) {
         context.print.error(`Failed to get profile: ${e.message || e}`);
         await context.usageData.emitError(e);
         exitOnNextTick(1);
       }
     } else {
-      awsConfig = {
+      resultAWSConfigInfo = {
         accessKeyId: awsConfigInfo.config.accessKeyId,
         secretAccessKey: awsConfigInfo.config.secretAccessKey,
         region: awsConfigInfo.config.region,
@@ -765,7 +780,7 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
   } else if (awsConfigInfo.configLevel === 'amplifyAdmin') {
     const appId = resolveAppId(context);
     try {
-      awsConfig = await getTempCredsWithAdminTokens(context, appId);
+      resultAWSConfigInfo = await getTempCredsWithAdminTokens(context, appId);
     } catch (err) {
       context.print.error('Failed to fetch Amplify Admin credentials');
       throw new Error(err);
@@ -773,13 +788,13 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
   }
 
   if (httpProxy) {
-    awsConfig = {
-      ...awsConfig,
+    resultAWSConfigInfo = {
+      ...resultAWSConfigInfo,
       httpOptions: { agent: proxyAgent(httpProxy) },
     };
   }
 
-  return awsConfig;
+  return resultAWSConfigInfo;
 }
 
 async function determineAuthFlow(context: $TSContext, projectConfig?: ProjectConfig): Promise<AuthFlowConfig> {
@@ -807,6 +822,12 @@ async function determineAuthFlow(context: $TSContext, projectConfig?: ProjectCon
   useProfile = useProfile ?? projectConfig?.config?.useProfile;
   profileName = profileName ?? projectConfig?.config?.profileName;
 
+  const generalCreds = projectConfig?.configLevel === 'general';
+
+  if (generalCreds) {
+    return { type: 'general' };
+  }
+
   if (useProfile && profileName) {
     return { type: 'profile', profileName };
   }
@@ -816,8 +837,8 @@ async function determineAuthFlow(context: $TSContext, projectConfig?: ProjectCon
   }
 
   if (projectConfig?.config?.awsConfigFilePath) {
-    const awsConfig = loadConfigFromPath(projectConfig.config.awsConfigFilePath);
-    return { ...awsConfig, type: 'accessKeys' };
+    const awsConfigInfo = loadConfigFromPath(projectConfig.config.awsConfigFilePath);
+    return { ...awsConfigInfo, type: 'accessKeys' };
   }
 
   let appId: string;

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -29,13 +29,13 @@ export async function run(context) {
     const timeStamp = `${moment().format('Hmmss')}`;
     const { envName = '' } = context.exeInfo.localEnvInfo;
     let stackName = normalizeStackName(`amplify-${projectName}-${envName}-${timeStamp}`);
-    const awsConfig = await configurationManager.getAwsConfig(context);
+    const awsConfigInfo = await configurationManager.getAwsConfig(context);
 
     await configurePermissionsBoundaryForInit(context);
 
     const amplifyServiceParams = {
       context,
-      awsConfig,
+      awsConfigInfo,
       projectName,
       envName,
       stackName,
@@ -80,7 +80,7 @@ export async function run(context) {
     spinner.start('Initializing project in the cloud...');
 
     try {
-      const cfnItem = await new Cloudformation(context, 'init', awsConfig);
+      const cfnItem = await new Cloudformation(context, 'init', awsConfigInfo);
       const stackDescriptionData = await cfnItem.createResourceStack(params);
 
       processStackCreationData(context, amplifyAppId, stackDescriptionData);

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -13,7 +13,7 @@ const logger = fileLogger('system-config-manager');
 const credentialsFilePath = pathManager.getAWSCredentialsFilePath();
 const configFilePath = pathManager.getAWSConfigFilePath();
 
-export function setProfile(awsConfig: $TSAny, profileName: string) {
+export function setProfile(awsConfigInfo: $TSAny, profileName: string) {
   fs.ensureDirSync(pathManager.getDotAWSDirPath());
 
   let credentials = {};
@@ -34,15 +34,15 @@ export function setProfile(awsConfig: $TSAny, profileName: string) {
   Object.keys(credentials).forEach(key => {
     const keyName = key.trim();
     if (profileName === keyName) {
-      credentials[key].aws_access_key_id = awsConfig.accessKeyId;
-      credentials[key].aws_secret_access_key = awsConfig.secretAccessKey;
+      credentials[key].aws_access_key_id = awsConfigInfo.accessKeyId;
+      credentials[key].aws_secret_access_key = awsConfigInfo.secretAccessKey;
       isCredSet = true;
     }
   });
   if (!isCredSet) {
     credentials[profileName] = {
-      aws_access_key_id: awsConfig.accessKeyId,
-      aws_secret_access_key: awsConfig.secretAccessKey,
+      aws_access_key_id: awsConfigInfo.accessKeyId,
+      aws_secret_access_key: awsConfigInfo.secretAccessKey,
     };
   }
 
@@ -50,14 +50,14 @@ export function setProfile(awsConfig: $TSAny, profileName: string) {
   Object.keys(config).forEach(key => {
     const keyName = key.replace('profile', '').trim();
     if (profileName === keyName) {
-      config[key].region = awsConfig.region;
+      config[key].region = awsConfigInfo.region;
       isConfigSet = true;
     }
   });
   if (!isConfigSet) {
     const keyName = profileName === 'default' ? 'default' : `profile ${profileName}`;
     config[keyName] = {
-      region: awsConfig.region,
+      region: awsConfigInfo.region,
     };
   }
   logger('setProfile.writecredetialsFilePath', [credentialsFilePath])();
@@ -66,7 +66,7 @@ export function setProfile(awsConfig: $TSAny, profileName: string) {
 }
 
 export async function getProfiledAwsConfig(context: $TSContext, profileName: string, isRoleSourceProfile?: boolean) {
-  let awsConfig;
+  let awsConfigInfo;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
   const profileConfig = getProfileConfig(profileName);
   if (profileConfig) {
@@ -75,18 +75,18 @@ export async function getProfiledAwsConfig(context: $TSContext, profileName: str
       const roleCredentials = await getRoleCredentials(context, profileName, profileConfig);
       delete profileConfig.role_arn;
       delete profileConfig.source_profile;
-      awsConfig = {
+      awsConfigInfo = {
         ...profileConfig,
         ...roleCredentials,
       };
     } else {
       logger('getProfiledAwsConfig.getProfileCredentials', [profileName]);
       const profileCredentials = getProfileCredentials(profileName);
-      awsConfig = {
+      awsConfigInfo = {
         ...profileConfig,
         ...profileCredentials,
       };
-      validateCredentials(awsConfig, profileName);
+      validateCredentials(awsConfigInfo, profileName);
     }
   } else {
     const err = new Error(`Profile configuration is missing for: ${profileName}`);
@@ -95,13 +95,13 @@ export async function getProfiledAwsConfig(context: $TSContext, profileName: str
   }
 
   if (httpProxy) {
-    awsConfig = {
-      ...awsConfig,
+    awsConfigInfo = {
+      ...awsConfigInfo,
       httpOptions: { agent: proxyAgent(httpProxy) },
     };
   }
 
-  return awsConfig;
+  return awsConfigInfo;
 }
 
 function makeFileOwnerReadWrite(filePath: string) {
@@ -232,7 +232,8 @@ function isCredentialsExpired(roleCredentials: $TSAny) {
 }
 
 export async function resetCache(context: $TSContext, profileName: string) {
-  let awsConfig;
+  let awsConfigInfo;
+
   const profileConfig = getProfileConfig(profileName);
   const cacheFilePath = getCacheFilePath();
   if (profileConfig && profileConfig.role_arn && fs.existsSync(cacheFilePath)) {
@@ -251,7 +252,8 @@ export async function resetCache(context: $TSContext, profileName: string) {
     context.print.info('  No temp credentials are cached for the project.');
     context.print.info('');
   }
-  return awsConfig;
+
+  return awsConfigInfo;
 }
 
 function getCacheFilePath() {

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -35,8 +35,10 @@ export async function getTempCredsWithAdminTokens(context: $TSContext, appId: st
   const authConfig = await getRefreshedTokens(context, appId);
   const { idToken, IdentityId, region } = authConfig;
   // use tokens to get creds and assign to config
-  const awsConfig = await getAdminCognitoCredentials(idToken, IdentityId, region);
-  aws.config.update(awsConfig);
+  const awsConfigInfo = await getAdminCognitoCredentials(idToken, IdentityId, region);
+
+  aws.config.update(awsConfigInfo);
+
   // need to use Cognito creds to get STS creds - otherwise
   // users will not be able to provision Cognito resources
   return await getAdminStsCredentials(idToken, region);

--- a/packages/amplify-provider-awscloudformation/src/utils/auth-types.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auth-types.ts
@@ -1,6 +1,6 @@
 import { $TSAny } from 'amplify-cli-core';
 
-export type AuthFlow = 'admin' | 'profile' | 'accessKeys';
+export type AuthFlow = 'admin' | 'profile' | 'accessKeys' | 'general';
 export interface AuthFlowConfig extends Partial<AwsSdkConfig> {
   type: AuthFlow;
   appId?: string;

--- a/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts
@@ -28,11 +28,11 @@ const getAwsCredentials = async (_, context: $TSContext): Promise<Record<string,
   } catch {
     // swallow no appId found as it's not necessary for mocking
   }
-  const awsConfig = await loadConfigurationForEnv(context, env, appId);
+  const awsConfigInfo = await loadConfigurationForEnv(context, env, appId);
   return {
-    AWS_ACCESS_KEY_ID: awsConfig.accessKeyId,
-    AWS_SECRET_ACCESS_KEY: awsConfig.secretAccessKey,
-    AWS_SESSION_TOKEN: awsConfig.sessionToken,
+    AWS_ACCESS_KEY_ID: awsConfigInfo.accessKeyId,
+    AWS_SECRET_ACCESS_KEY: awsConfigInfo.secretAccessKey,
+    AWS_SESSION_TOKEN: awsConfigInfo.sessionToken,
   };
 };
 


### PR DESCRIPTION
#### Description of changes

- reference to `awsConfigInfo` with this name everywhere
- add `general` authType support when determining the auth type for a project
- added cleanup of Amplify state files after cloning a project to make sure other developers' resources are not leaking into the project (which later can lead to Forbidden or other errors during delete for example).
- guard spinner destruction when doing SSM operations

#### Issue #, if available

fixes: #7441 - init from git prompts for credentials twice

#### Description of how you validated changes

Manual testing of init and delete with various projects.

#### Checklist

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.