### PR TITLE
fix: checkout into existing env with new LL

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -405,14 +405,9 @@ export async function updateConfigOnEnvInit(context: $TSContext, resourceName: s
       }
 
       const currentCfnTemplatePath = pathManager.getCurrentCfnTemplatePath(projectPath, categoryName, resourceName);
-      try {
-        const { cfnTemplate: currentCfnTemplate } = await readCFNTemplate(currentCfnTemplatePath);
+      const { cfnTemplate: currentCfnTemplate } = (await readCFNTemplate(currentCfnTemplatePath, { throwIfNotExist: false })) || {};
+      if (currentCfnTemplate !== undefined) {
         await writeCFNTemplate(currentCfnTemplate, pathManager.getResourceCfnTemplatePath(projectPath, categoryName, resourceName));
-      } catch (e) {
-        if (e.message === `No CloudFormation template found at ${currentCfnTemplatePath}`) {
-          return; // If the file doesn't exist, env just doesn't have the resource yet
-        }
-        throw e;
       }
     }
   }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -405,8 +405,15 @@ export async function updateConfigOnEnvInit(context: $TSContext, resourceName: s
       }
 
       const currentCfnTemplatePath = pathManager.getCurrentCfnTemplatePath(projectPath, categoryName, resourceName);
-      const { cfnTemplate: currentCfnTemplate } = await readCFNTemplate(currentCfnTemplatePath);
-      await writeCFNTemplate(currentCfnTemplate, pathManager.getResourceCfnTemplatePath(projectPath, categoryName, resourceName));
+      try {
+        const { cfnTemplate: currentCfnTemplate } = await readCFNTemplate(currentCfnTemplatePath);
+        await writeCFNTemplate(currentCfnTemplate, pathManager.getResourceCfnTemplatePath(projectPath, categoryName, resourceName));
+      } catch (e) {
+        if (e.message === `No CloudFormation template found at ${currentCfnTemplatePath}`) {
+          return; // If the file doesn't exist, env just doesn't have the resource yet
+        }
+        throw e;
+      }
     }
   }
 }

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cfn-template-utils.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cfn-template-utils.test.ts
@@ -10,7 +10,7 @@ pathManager_mock.getBackendDirPath.mockReturnValue('/test/path');
 
 describe('get existing table column names', () => {
   it('returns empty array when no template exists', async () => {
-    readCFNTemplate_mock.mockRejectedValueOnce('the template does not exist');
+    readCFNTemplate_mock.mockResolvedValueOnce(undefined);
     const result = await getExistingTableColumnNames('testResource');
     expect(result).toEqual([]);
   });

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cfn-template-utils.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cfn-template-utils.ts
@@ -30,12 +30,8 @@ const loadCfnTemplateSafe = async (resourceName?: string): Promise<Template | un
   if (!resourceName) {
     return undefined;
   }
-  try {
-    const { cfnTemplate } = await readCFNTemplate(getCloudFormationTemplatePath(resourceName));
-    return cfnTemplate;
-  } catch {
-    return undefined;
-  }
+  const { cfnTemplate } = (await readCFNTemplate(getCloudFormationTemplatePath(resourceName), { throwIfNotExist: false })) || {};
+  return cfnTemplate;
 };
 
 const getTableFromTemplate = (cfnTemplate?: Template): Table | undefined => {

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -4,24 +4,27 @@ import * as yaml from 'js-yaml';
 import * as path from 'path';
 import { JSONUtilities } from './jsonUtilities';
 
+const defaultReadCFNTemplateOptions = { throwIfNotExist: true };
+
 export async function readCFNTemplate(filePath: string): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template }>;
 export async function readCFNTemplate(
   filePath: string,
   options: { throwIfNotExist: boolean },
 ): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template } | undefined>;
 
-export async function readCFNTemplate(filePath: string, options: { throwIfNotExist: boolean } = { throwIfNotExist: true }) {
-  const errorMessage = `No CloudFormation template found at ${filePath}`;
-  if (!fs.existsSync(filePath)) {
+export async function readCFNTemplate(
+  filePath: string,
+  options: Partial<typeof defaultReadCFNTemplateOptions> = defaultReadCFNTemplateOptions,
+) {
+  options = { ...defaultReadCFNTemplateOptions, ...options };
+
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile) {
     if (options.throwIfNotExist === false) {
       return undefined;
     }
-    throw new Error(errorMessage);
+    throw new Error(`No CloudFormation template found at ${filePath}`);
   }
 
-  if (!fs.statSync(filePath).isFile) {
-    throw new Error(errorMessage);
-  }
   const fileContent = await fs.readFile(filePath, 'utf8');
   // We use the first character to determine if the content is json or yaml because historically the CLI could
   // have emitted JSON with YML extension, so we can't rely on filename extension.

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -9,7 +9,7 @@ const defaultReadCFNTemplateOptions = { throwIfNotExist: true };
 export async function readCFNTemplate(filePath: string): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template }>;
 export async function readCFNTemplate(
   filePath: string,
-  options: { throwIfNotExist: boolean },
+  options: Partial<typeof defaultReadCFNTemplateOptions>,
 ): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template } | undefined>;
 
 export async function readCFNTemplate(

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -1,12 +1,26 @@
-import * as yaml from 'js-yaml';
 import { Template } from 'cloudform-types';
-import { JSONUtilities } from './jsonUtilities';
 import * as fs from 'fs-extra';
+import * as yaml from 'js-yaml';
 import * as path from 'path';
+import { JSONUtilities } from './jsonUtilities';
 
-export async function readCFNTemplate(filePath: string): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template }> {
-  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile) {
-    throw new Error(`No CloudFormation template found at ${filePath}`);
+export async function readCFNTemplate(filePath: string): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template }>;
+export async function readCFNTemplate(
+  filePath: string,
+  options: { throwIfNotExist: boolean },
+): Promise<{ templateFormat: CFNTemplateFormat; cfnTemplate: Template } | undefined>;
+
+export async function readCFNTemplate(filePath: string, options: { throwIfNotExist: boolean } = { throwIfNotExist: true }) {
+  const errorMessage = `No CloudFormation template found at ${filePath}`;
+  if (!fs.existsSync(filePath)) {
+    if (options.throwIfNotExist === false) {
+      return undefined;
+    }
+    throw new Error(errorMessage);
+  }
+
+  if (!fs.statSync(filePath).isFile) {
+    throw new Error(errorMessage);
   }
   const fileContent = await fs.readFile(filePath, 'utf8');
   // We use the first character to determine if the content is json or yaml because historically the CLI could

--- a/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer.test.ts
@@ -214,6 +214,12 @@ describe('amplify add lambda layer', () => {
       numLayers: 1,
       projName,
     };
+
+    const noLayerEnv = 'nolayerenv';
+
+    await addEnvironment(projRoot, { envName: noLayerEnv });
+    await checkoutEnvironment(projRoot, { envName });
+
     const integtestArns: string[] = [];
     const expectedPerms: LayerPermission[] = [{ type: LayerPermissionName.public }];
     await addLayer(projRoot, settings);
@@ -233,14 +239,16 @@ describe('amplify add lambda layer', () => {
     const layerTestArns: string[] = [];
     const newEnvName = 'layertest';
     await addEnvironment(projRoot, { envName: newEnvName, numLayers: 1 });
-    await listEnvironment(projRoot, { numEnv: 2 });
-    await amplifyPushLayer(projRoot, {
-      acceptSuggestedLayerVersionConfigurations: true,
-    });
+    await listEnvironment(projRoot, { numEnv: 3 });
+    await amplifyPushLayer(projRoot, { acceptSuggestedLayerVersionConfigurations: true });
     await amplifyStatus(projRoot, 'No Change');
     layerTestArns.push(getCurrentLayerArnFromMeta(projRoot, settings));
     validatePushedVersion(projRoot, settings, expectedPerms);
     await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), newEnvName, layerTestArns);
+
+    // Test to make sure we can checkout and push a previously created env where the layer does not exist yet
+    await checkoutEnvironment(projRoot, { envName: noLayerEnv });
+    await amplifyPushLayer(projRoot, { acceptSuggestedLayerVersionConfigurations: true });
 
     await checkoutEnvironment(projRoot, { envName });
     await amplifyStatus(projRoot, 'No Change');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Handle non-existing CFN template in `#current-cloud-backend` when running `amplify env checkout` with a LL present that is not in the target environment.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes #7640


#### Description of how you validated changes
Manual testing, local e2e test passes, yarn test passes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.