### PR TITLE
ci: add support for automatic tagged release

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -526,7 +526,7 @@ jobs:
           path: /root/aws-amplify-cypress-api/cypress/screenshots
 
   deploy:
-    <<: *defaults
+    <<: *node12
     steps:
       - attach_workspace:
           at: ./
@@ -539,13 +539,7 @@ jobs:
       - run:
           name: Publish Amplify CLI
           command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              git config --global user.email $GITHUB_EMAIL
-              git config --global user.name $GITHUB_USER
-              npm run publish:$CIRCLE_BRANCH
-            else
-              echo "Skipping deploy."
-            fi
+            bash ./.circleci/publish.sh
       - run: *scan_e2e_test_artifacts
   github_prerelease:
     <<: *node12
@@ -694,8 +688,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
-                - iterative-update
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
             - mock_e2e_tests
@@ -707,8 +701,9 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
                 - beta
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
             - mock_e2e_tests
@@ -717,12 +712,10 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
                 - beta
-                - backendManager
-                - iterative-update
                 - release
-                - compute-functions
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - build_pkg_binaries:
@@ -736,6 +729,8 @@ workflows:
             branches:
               only:
                 - master
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
       - amplify_e2e_tests:
           context:
             - amplify-ecr-image-pull
@@ -748,9 +743,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
-                - compute-functions
-                - iterative-update
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - publish_to_local_registry
       - done_with_node_e2e_tests:
@@ -768,6 +762,8 @@ workflows:
             branches:
               only:
                 - master
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries
@@ -784,6 +780,8 @@ workflows:
             branches:
               only:
                 - master
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_v4:
@@ -796,7 +794,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_v4_30_0:
@@ -809,10 +808,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
-                - graphqlschemae2e
-                - feat-import
-                - test-fix-status
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_non_multi_env_layers:
@@ -825,7 +822,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_multi_env_layers:
@@ -838,7 +836,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_console_integration_tests:
@@ -907,6 +906,8 @@ workflows:
                 - release
                 - master
                 - beta
+                - /tagged-release\/.*/
+                - /tagged-release-without-e2e-tests\/.*/
       - github_release:
           context: github-publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,7 +549,7 @@ jobs:
           path: /root/aws-amplify-cypress-api/cypress/screenshots
   deploy:
     working_directory: ~/repo
-    docker: *ref_1
+    docker: *ref_0
     resource_class: large
     steps:
       - attach_workspace:
@@ -563,13 +563,7 @@ jobs:
       - run:
           name: Publish Amplify CLI
           command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              git config --global user.email $GITHUB_EMAIL
-              git config --global user.name $GITHUB_USER
-              npm run publish:$CIRCLE_BRANCH
-            else
-              echo "Skipping deploy."
-            fi
+            bash ./.circleci/publish.sh
       - run: *ref_4
   github_prerelease:
     working_directory: ~/repo
@@ -2057,8 +2051,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
-                - iterative-update
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
             - mock_e2e_tests
@@ -2070,8 +2064,9 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
                 - beta
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
             - mock_e2e_tests
@@ -2080,12 +2075,10 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
                 - beta
-                - backendManager
-                - iterative-update
                 - release
-                - compute-functions
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - build_pkg_binaries:
@@ -2099,6 +2092,8 @@ workflows:
             branches:
               only:
                 - master
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
       - done_with_node_e2e_tests:
           requires:
             - analytics-amplify_e2e_tests
@@ -2169,6 +2164,8 @@ workflows:
             branches:
               only:
                 - master
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_v4:
@@ -2181,7 +2178,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_v4_30_0:
@@ -2194,10 +2192,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
-                - graphqlschemae2e
-                - feat-import
-                - test-fix-status
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_non_multi_env_layers:
@@ -2210,7 +2206,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_migration_tests_multi_env_layers:
@@ -2223,7 +2220,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - build
       - amplify_console_integration_tests:
@@ -2291,6 +2289,8 @@ workflows:
                 - release
                 - master
                 - beta
+                - /tagged-release\/.*/
+                - /tagged-release-without-e2e-tests\/.*/
       - github_release:
           context: github-publish
           requires:
@@ -2311,9 +2311,8 @@ workflows:
             branches:
               only:
                 - master
-                - func-env-vars-secrets
-                - compute-functions
-                - iterative-update
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - publish_to_local_registry
       - schema-auth-6-amplify_e2e_tests:
@@ -2766,6 +2765,8 @@ workflows:
             branches:
               only:
                 - master
+                - /tagged-release\/.*/
+                - /run-e2e\/*./
           requires:
             - done_with_node_e2e_tests
             - build_pkg_binaries

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+  git config --global user.email $GITHUB_EMAIL
+  git config --global user.name $GITHUB_USER
+  if [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
+    if [[ "$CIRCLE_BRANCH" =~ ^tagged-release-without-e2e-tests\/.* ]]; then
+        # Remove tagged-release-without-e2e-tests/
+      export NPM_TAG="${CIRCLE_BRANCH/tagged-release-without-e2e-tests\//}"
+    elif [[ "$CIRCLE_BRANCH" =~ ^tagged-release\/.* ]]; then
+      # Remove tagged-release/
+      export NPM_TAG="${CIRCLE_BRANCH/tagged-release\//}"
+    fi
+    if [ -z "$NPM_TAG" ]; then
+        echo "Tag name is missing. Name your banch with either tagged-release/<tag-name> or tagged-release-without-e2e-tests/<tag-name>"
+        exit 1
+      fi
+      echo "Publishing to NPM with tag $NPM_TAG"
+      yarn publish:tag
+  else
+    yarn publish:$CIRCLE_BRANCH
+  fi
+else
+  echo "Skipping deploy."
+fi

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pkg-all-local": "yarn verdaccio-start && yarn verdaccio-connect && yarn publish-to-verdaccio && yarn pkg-all && yarn verdaccio-disconnect",
     "publish:master": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes",
     "publish:beta": "lerna publish --exact --dist-tag=beta --preid=beta --conventional-commits --conventional-prerelease --message 'chore(release): Publish [ci skip]' --no-verify-access --yes",
+    "publish:tag": "lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message 'chore(release): Publish tagged release $NPM_TAG [ci skip]' --no-verify-access --yes",
     "publish:release": "lerna publish --conventional-commits --exact --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
     "postpublish:release": "git fetch . release:master && git push origin master",
     "yarn-use-bash": "yarn config set script-shell /bin/bash",


### PR DESCRIPTION
Do an automatic tagged NPM release when a branch name is prefixed with `tagged-release/` or `tagged-release-without-e2e-tests/` . The release will run the full test suites (except for console-e2e-tests) when its in `tagged-release/*`. The tag name will be based on the branch name after the prefix

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.