### PR TITLE
bug(amplify-cli):resource-test file location issue resolved

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
@@ -3,7 +3,7 @@ import { stateManager, exitOnNextTick, ResourceDoesNotExistError, MissingParamet
 import * as inquirer from 'inquirer';
 import { updateBackendConfigAfterResourceRemove } from '../../../extensions/amplify-helpers/update-backend-config';
 import { removeResourceParameters } from '../../../extensions/amplify-helpers/envResourceParams';
-
+const path = require('path');
 jest.mock('../../../extensions/amplify-helpers/envResourceParams');
 jest.mock('../../../extensions/amplify-helpers/update-backend-config');
 
@@ -215,7 +215,7 @@ describe('remove-resource', () => {
           },
         },
       });
-      expect(context.filesystem.remove).toBeCalledWith('backendDirPath/function/lambda1');
+      expect(context.filesystem.remove).toBeCalledWith(path.join("backendDirPath", "function","lambda1"));
       expect(removeResourceParameters).toBeCalledWith(context, 'function', 'lambda1');
       expect(updateBackendConfigAfterResourceRemove).toBeCalledWith('function', 'lambda1');
       expect(context.print.success).toBeCalledWith('Successfully removed resource');

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
@@ -1,9 +1,10 @@
+import * as path from 'path';
 import { removeResource, forceRemoveResource } from '../../../extensions/amplify-helpers/remove-resource';
 import { stateManager, exitOnNextTick, ResourceDoesNotExistError, MissingParametersError } from 'amplify-cli-core';
 import * as inquirer from 'inquirer';
 import { updateBackendConfigAfterResourceRemove } from '../../../extensions/amplify-helpers/update-backend-config';
 import { removeResourceParameters } from '../../../extensions/amplify-helpers/envResourceParams';
-import * as path from 'path';
+
 jest.mock('../../../extensions/amplify-helpers/envResourceParams');
 jest.mock('../../../extensions/amplify-helpers/update-backend-config');
 

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
@@ -3,7 +3,7 @@ import { stateManager, exitOnNextTick, ResourceDoesNotExistError, MissingParamet
 import * as inquirer from 'inquirer';
 import { updateBackendConfigAfterResourceRemove } from '../../../extensions/amplify-helpers/update-backend-config';
 import { removeResourceParameters } from '../../../extensions/amplify-helpers/envResourceParams';
-const path = require('path');
+import * as path from 'path';
 jest.mock('../../../extensions/amplify-helpers/envResourceParams');
 jest.mock('../../../extensions/amplify-helpers/update-backend-config');
 
@@ -215,7 +215,7 @@ describe('remove-resource', () => {
           },
         },
       });
-      expect(context.filesystem.remove).toBeCalledWith(path.join("backendDirPath", "function","lambda1"));
+      expect(context.filesystem.remove).toBeCalledWith(path.join('backendDirPath', 'function', 'lambda1'));
       expect(removeResourceParameters).toBeCalledWith(context, 'function', 'lambda1');
       expect(updateBackendConfigAfterResourceRemove).toBeCalledWith('function', 'lambda1');
       expect(context.print.success).toBeCalledWith('Successfully removed resource');


### PR DESCRIPTION
#### Description of changes
Solved failing resource-test case issues by making all function input parameter file locations OS-specific

#### Issue #, if available
#7711 

#### Description of how you validated changes
1. cd packages/amplify-cli
2. yarn test 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.