### PR TITLE
fix(cli): prevent re-prompt of info on `amplify pull`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1179,6 +1179,14 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/s3-sse.test.ts
       CLI_REGION: us-west-2
+  pull-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/pull.test.ts
+      CLI_REGION: eu-west-2
   migration-node-function-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1186,7 +1194,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   layer-2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1194,7 +1202,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/layer-2.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   iam-permissions-boundary-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1202,7 +1210,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   function_7-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1210,7 +1218,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_7.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   function_6-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1218,7 +1226,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_6.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   function_5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1226,7 +1234,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
   frontend_config_drift-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1234,7 +1242,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
   configure-project-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1242,7 +1250,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/configure-project.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   api_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1250,7 +1258,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1901,6 +1909,16 @@ jobs:
       TEST_SUITE: src/__tests__/s3-sse.test.ts
       CLI_REGION: us-west-2
     steps: *ref_6
+  pull-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/pull.test.ts
+      CLI_REGION: eu-west-2
+    steps: *ref_6
   migration-node-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1909,7 +1927,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_6
   layer-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1919,7 +1937,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/layer-2.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_6
   iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1929,7 +1947,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_6
   function_7-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1939,7 +1957,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_7.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_6
   function_6-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1949,7 +1967,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_6.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
     steps: *ref_6
   function_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1959,7 +1977,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-2
     steps: *ref_6
   frontend_config_drift-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1969,7 +1987,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: eu-west-2
     steps: *ref_6
   configure-project-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1979,7 +1997,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/configure-project.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_6
   api_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1989,7 +2007,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_6
 workflows:
   version: 2
@@ -2096,61 +2114,61 @@ workflows:
             - analytics-amplify_e2e_tests
             - notifications-amplify_e2e_tests
             - schema-iterative-update-locking-amplify_e2e_tests
-            - function_5-amplify_e2e_tests
+            - function_6-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - tags-amplify_e2e_tests
             - s3-sse-amplify_e2e_tests
-            - frontend_config_drift-amplify_e2e_tests
+            - function_5-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - init-amplify_e2e_tests
-            - migration-node-function-amplify_e2e_tests
-            - configure-project-amplify_e2e_tests
+            - pull-amplify_e2e_tests
+            - frontend_config_drift-amplify_e2e_tests
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
-            - layer-2-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
-            - containers-api-amplify_e2e_tests
+            - migration-node-function-amplify_e2e_tests
+            - configure-project-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - datastore-modelgen-amplify_e2e_tests
-            - iam-permissions-boundary-amplify_e2e_tests
+            - layer-2-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
             - schema-iterative-update-2-amplify_e2e_tests
             - schema-data-access-patterns-amplify_e2e_tests
             - init-special-case-amplify_e2e_tests
-            - function_7-amplify_e2e_tests
+            - iam-permissions-boundary-amplify_e2e_tests
             - feature-flags-amplify_e2e_tests
             - schema-versioned-amplify_e2e_tests
             - plugin-amplify_e2e_tests
-            - function_6-amplify_e2e_tests
+            - function_7-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           requires:
             - analytics-amplify_e2e_tests_pkg_linux
             - notifications-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
-            - function_5-amplify_e2e_tests_pkg_linux
+            - function_6-amplify_e2e_tests_pkg_linux
             - hosting-amplify_e2e_tests_pkg_linux
             - tags-amplify_e2e_tests_pkg_linux
             - s3-sse-amplify_e2e_tests_pkg_linux
-            - frontend_config_drift-amplify_e2e_tests_pkg_linux
+            - function_5-amplify_e2e_tests_pkg_linux
             - amplify-app-amplify_e2e_tests_pkg_linux
             - init-amplify_e2e_tests_pkg_linux
-            - migration-node-function-amplify_e2e_tests_pkg_linux
-            - configure-project-amplify_e2e_tests_pkg_linux
+            - pull-amplify_e2e_tests_pkg_linux
+            - frontend_config_drift-amplify_e2e_tests_pkg_linux
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
-            - layer-2-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
-            - containers-api-amplify_e2e_tests_pkg_linux
+            - migration-node-function-amplify_e2e_tests_pkg_linux
+            - configure-project-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
             - datastore-modelgen-amplify_e2e_tests_pkg_linux
-            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
+            - layer-2-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
             - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
             - init-special-case-amplify_e2e_tests_pkg_linux
-            - function_7-amplify_e2e_tests_pkg_linux
+            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
             - feature-flags-amplify_e2e_tests_pkg_linux
             - schema-versioned-amplify_e2e_tests_pkg_linux
             - plugin-amplify_e2e_tests_pkg_linux
-            - function_6-amplify_e2e_tests_pkg_linux
+            - function_7-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           context:
             - amplify-ecr-image-pull
@@ -2366,7 +2384,7 @@ workflows:
           filters: *ref_10
           requires:
             - function_2-amplify_e2e_tests
-      - function_5-amplify_e2e_tests:
+      - function_6-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2432,7 +2450,7 @@ workflows:
           filters: *ref_10
           requires:
             - delete-amplify_e2e_tests
-      - frontend_config_drift-amplify_e2e_tests:
+      - function_5-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2492,13 +2510,13 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests
-      - migration-node-function-amplify_e2e_tests:
+      - pull-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-auth-3-amplify_e2e_tests
-      - configure-project-amplify_e2e_tests:
+      - frontend_config_drift-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2558,13 +2576,13 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests
-      - layer-2-amplify_e2e_tests:
+      - migration-node-function-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-iterative-update-1-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - configure-project-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2624,12 +2642,18 @@ workflows:
           filters: *ref_10
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
-      - iam-permissions-boundary-amplify_e2e_tests:
+      - layer-2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - function_3-amplify_e2e_tests
+      - api_4-amplify_e2e_tests:
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
+          requires:
+            - containers-api-amplify_e2e_tests
       - schema-auth-2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -2684,7 +2708,7 @@ workflows:
           filters: *ref_10
           requires:
             - layer-amplify_e2e_tests
-      - function_7-amplify_e2e_tests:
+      - iam-permissions-boundary-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2744,7 +2768,7 @@ workflows:
           filters: *ref_10
           requires:
             - auth_3-amplify_e2e_tests
-      - function_6-amplify_e2e_tests:
+      - function_7-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2824,7 +2848,7 @@ workflows:
           filters: *ref_13
           requires:
             - function_2-amplify_e2e_tests_pkg_linux
-      - function_5-amplify_e2e_tests_pkg_linux:
+      - function_6-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -2894,7 +2918,7 @@ workflows:
           filters: *ref_13
           requires:
             - delete-amplify_e2e_tests_pkg_linux
-      - frontend_config_drift-amplify_e2e_tests_pkg_linux:
+      - function_5-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -2958,13 +2982,13 @@ workflows:
           filters: *ref_13
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
-      - migration-node-function-amplify_e2e_tests_pkg_linux:
+      - pull-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-auth-3-amplify_e2e_tests_pkg_linux
-      - configure-project-amplify_e2e_tests_pkg_linux:
+      - frontend_config_drift-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3028,13 +3052,13 @@ workflows:
           filters: *ref_13
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - layer-2-amplify_e2e_tests_pkg_linux:
+      - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-iterative-update-1-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - configure-project-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3098,12 +3122,18 @@ workflows:
           filters: *ref_13
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
-      - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
+      - layer-2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - function_3-amplify_e2e_tests_pkg_linux
+      - api_4-amplify_e2e_tests_pkg_linux:
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
+          requires:
+            - containers-api-amplify_e2e_tests_pkg_linux
       - schema-auth-2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
@@ -3162,7 +3192,7 @@ workflows:
           filters: *ref_13
           requires:
             - layer-amplify_e2e_tests_pkg_linux
-      - function_7-amplify_e2e_tests_pkg_linux:
+      - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3226,7 +3256,7 @@ workflows:
           filters: *ref_13
           requires:
             - auth_3-amplify_e2e_tests_pkg_linux
-      - function_6-amplify_e2e_tests_pkg_linux:
+      - function_7-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13

--- a/packages/amplify-cli-core/src/errors/index.ts
+++ b/packages/amplify-cli-core/src/errors/index.ts
@@ -17,6 +17,7 @@ export class SchemaDoesNotExistError extends Error {}
 export class AngularConfigNotFoundError extends Error {}
 export class AppIdMismatchError extends Error {}
 export class UnrecognizedFrameworkError extends Error {}
+export class ConfigurationError extends Error {}
 export class NotInitializedError extends Error {
   public constructor() {
     super();

--- a/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
@@ -41,7 +41,9 @@ export async function generateFiles(context: $TSContext) {
     default: {},
   });
 
-  await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta);
+  if (!context.exeInfo.existingLocalEnvInfo?.noUpdateBackend) {
+    await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta);
+  }
 
   return context;
 }
@@ -64,7 +66,7 @@ function generateNonRuntimeFiles(context: $TSContext) {
 }
 
 function generateProjectConfigFile(context: $TSContext) {
-  if (context.exeInfo.isNewProject) {
+  if (context.exeInfo.isNewProject || context.exeInfo.existingLocalEnvInfo?.noUpdateBackend) {
     const { projectPath } = context.exeInfo.localEnvInfo;
 
     stateManager.setProjectConfig(projectPath, context.exeInfo.projectConfig);
@@ -74,6 +76,10 @@ function generateProjectConfigFile(context: $TSContext) {
 function generateTeamProviderInfoFile(context: $TSContext) {
   const { projectPath, envName } = context.exeInfo.localEnvInfo;
   const { existingTeamProviderInfo, teamProviderInfo } = context.exeInfo;
+
+  if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend) {
+    return stateManager.setTeamProviderInfo(projectPath, existingTeamProviderInfo);
+  }
 
   if (existingTeamProviderInfo) {
     if (existingTeamProviderInfo[envName]) {

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -30,7 +30,7 @@ export async function attachBackend(context: $TSContext, inputParams) {
     await generateFiles(context);
     await onSuccess(context);
   } catch (e) {
-    removeFolderStructure();
+    removeAmplifyFolderStructure();
     restoreOriginalAmplifyFolder();
 
     context.print.error('Failed to pull the backend.');
@@ -59,11 +59,11 @@ async function onSuccess(context: $TSContext) {
   await postPullCodegen(context);
 
   if (!inputParams.yes) {
-    const confirmKeepCodebase = context.exeInfo.existingLocalEnvInfo?.noUpdateBackend
+    const shouldKeepAmplifyDir = context.exeInfo.existingLocalEnvInfo?.noUpdateBackend
       ? !context.exeInfo.existingLocalEnvInfo.noUpdateBackend
       : await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true);
 
-    if (confirmKeepCodebase) {
+    if (shouldKeepAmplifyDir) {
       if (stateManager.currentMetaFileExists()) {
         await initializeEnv(context, stateManager.getCurrentMeta());
       }
@@ -76,7 +76,7 @@ async function onSuccess(context: $TSContext) {
       context.print.info('');
     } else {
       stateManager.setLocalEnvInfo(process.cwd(), { ...context.exeInfo.localEnvInfo, noUpdateBackend: true });
-      removeFolderStructure(true);
+      removeAmplifyFolderStructure(true);
 
       context.print.info('');
       context.print.success(`Added backend environment config object to your project.`);
@@ -153,7 +153,7 @@ function setupFolderStructure(): void {
   fs.ensureDirSync(backendDirPath);
 }
 
-function removeFolderStructure(partial = false) {
+function removeAmplifyFolderStructure(partial = false) {
   const projectPath = process.cwd();
   if (partial) {
     fs.removeSync(pathManager.getBackendDirPath(projectPath));

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -59,7 +59,9 @@ async function onSuccess(context: $TSContext) {
   await postPullCodegen(context);
 
   if (!inputParams.yes) {
-    const confirmKeepCodebase = await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true);
+    const confirmKeepCodebase = context.exeInfo.existingLocalEnvInfo?.noUpdateBackend
+      ? !context.exeInfo.existingLocalEnvInfo.noUpdateBackend
+      : await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true);
 
     if (confirmKeepCodebase) {
       if (stateManager.currentMetaFileExists()) {
@@ -73,7 +75,8 @@ async function onSuccess(context: $TSContext) {
       context.print.info(`Run 'amplify pull' to sync future upstream changes.`);
       context.print.info('');
     } else {
-      removeFolderStructure();
+      stateManager.setLocalEnvInfo(process.cwd(), { ...context.exeInfo.localEnvInfo, noUpdateBackend: true });
+      removeFolderStructure(true);
 
       context.print.info('');
       context.print.success(`Added backend environment config object to your project.`);
@@ -150,12 +153,15 @@ function setupFolderStructure(): void {
   fs.ensureDirSync(backendDirPath);
 }
 
-function removeFolderStructure() {
+function removeFolderStructure(partial = false) {
   const projectPath = process.cwd();
-
-  const amplifyDirPath = pathManager.getAmplifyDirPath(projectPath);
-
-  fs.removeSync(amplifyDirPath);
+  if (partial) {
+    fs.removeSync(pathManager.getBackendDirPath(projectPath));
+    fs.removeSync(pathManager.getCurrentCloudBackendDirPath(projectPath));
+  } else {
+    const amplifyDirPath = pathManager.getAmplifyDirPath(projectPath);
+    fs.removeSync(amplifyDirPath);
+  }
 }
 
 function prepareContext(context: $TSContext, inputParams) {
@@ -175,5 +181,39 @@ function prepareContext(context: $TSContext, inputParams) {
     existingTeamProviderInfo: stateManager.getTeamProviderInfo(projectPath, {
       throwIfNotExist: false,
     }),
+    existingLocalEnvInfo: stateManager.getLocalEnvInfo(projectPath, {
+      throwIfNotExist: false,
+    }),
+    existingLocalAwsInfo: stateManager.getLocalAWSInfo(projectPath, {
+      throwIfNotExist: false,
+    }),
   };
+  updateContextForNoUpdateBackendProjects(context);
+}
+
+function updateContextForNoUpdateBackendProjects(context) {
+  if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend) {
+    const envName = context.exeInfo.existingLocalEnvInfo.envName;
+    context.exeInfo.isNewProject = false;
+    context.exeInfo.localEnvInfo = context.exeInfo.existingLocalEnvInfo;
+    context.exeInfo.projectConfig = context.exeInfo.existingProjectConfig;
+    context.exeInfo.awsConfigInfo = context.exeInfo.existingLocalAwsInfo[envName];
+    context.exeInfo.awsConfigInfo.config = { ...context.exeInfo.existingLocalAwsInfo[envName] };
+    context.exeInfo.teamProviderInfo = context.exeInfo.existingTeamProviderInfo;
+    context.exeInfo.inputParams = context.exeInfo.inputParams || {};
+    context.exeInfo.inputParams.amplify = context.exeInfo.inputParams.amplify || {};
+
+    context.exeInfo.inputParams.amplify.defaultEditor =
+      context.exeInfo.inputParams.amplify.defaultEditor || context.exeInfo.existingLocalEnvInfo.defaultEditor;
+    context.exeInfo.inputParams.amplify.projectName =
+      context.exeInfo.inputParams.amplify.projectName || context.exeInfo.existingProjectConfig.projectName;
+    context.exeInfo.inputParams.amplify.envName = context.exeInfo.inputParams.amplify.envName || envName;
+    context.exeInfo.inputParams.amplify.frontend =
+      context.exeInfo.inputParams.amplify.frontend || context.exeInfo.existingProjectConfig.frontend;
+    context.exeInfo.inputParams.amplify.appId =
+      context.exeInfo.inputParams.amplify.appId || context.exeInfo.existingTeamProviderInfo[envName].awscloudformation?.AmplifyAppId;
+    context.exeInfo.inputParams[context.exeInfo.inputParams.amplify.frontend] =
+      context.exeInfo.inputParams[context.exeInfo.inputParams.amplify.frontend] ||
+      context.exeInfo.existingProjectConfig[context.exeInfo.inputParams.amplify.frontend];
+  }
 }

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -1,6 +1,6 @@
 import sequential from 'promise-sequential';
 import ora from 'ora';
-import { $TSAny, $TSContext, $TSObject, stateManager, exitOnNextTick } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSObject, stateManager, exitOnNextTick, ConfigurationError } from 'amplify-cli-core';
 import { getProviderPlugins } from '../extensions/amplify-helpers/get-provider-plugins';
 
 const spinner = ora('');
@@ -41,6 +41,9 @@ async function syncCurrentCloudBackend(context: $TSContext) {
 export const run = async (context: $TSContext) => {
   try {
     context.amplify.constructExeInfo(context);
+    if (context.exeInfo.localEnvInfo.noUpdateBackend) {
+      throw new ConfigurationError('This local environment was configured to not publish backend updates.');
+    }
     if (context.parameters.options.force) {
       context.exeInfo.forcePush = true;
     }

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -42,7 +42,7 @@ export const run = async (context: $TSContext) => {
   try {
     context.amplify.constructExeInfo(context);
     if (context.exeInfo.localEnvInfo.noUpdateBackend) {
-      throw new ConfigurationError('This local environment was configured to not publish backend updates.');
+      throw new ConfigurationError('The local environment configuration does not allow backend updates.');
     }
     if (context.parameters.options.force) {
       context.exeInfo.forcePush = true;

--- a/packages/amplify-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPull.ts
@@ -2,7 +2,7 @@ import { getCLIPath, nspawn as spawn } from '..';
 
 export function amplifyPull(
   cwd: string,
-  settings: { override?: boolean; emptyDir?: boolean; appId?: string; withRestore?: boolean },
+  settings: { override?: boolean; emptyDir?: boolean; appId?: string; withRestore?: boolean; noUpdateBackend?: boolean },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const tableHeaderRegex = /\|\sCategory\s+\|\sResource\sname\s+\|\sOperation\s+\|\sProvider\splugin\s+\|/;
@@ -41,8 +41,8 @@ export function amplifyPull(
         .wait('Start Command:')
         .sendCarriageReturn()
         .wait('Do you plan on modifying this backend?')
-        .sendLine('y');
-    } else {
+        .sendLine(settings.noUpdateBackend ? 'n' : 'y');
+    } else if (!settings.noUpdateBackend) {
       chain.wait('Pre-pull status').wait('Current Environment').wait(tableHeaderRegex).wait(tableSeperator);
     }
 
@@ -54,7 +54,9 @@ export function amplifyPull(
         .sendLine('y');
     }
 
-    if (settings.emptyDir) {
+    if (settings.noUpdateBackend) {
+      chain.wait('Added backend environment config object to your project.').wait("Run 'amplify pull' to sync future upstream changes.");
+    } else if (settings.emptyDir) {
       chain.wait(/Successfully pulled backend environment .+ from the cloud\./).wait("Run 'amplify pull' to sync future upstream changes.");
     } else {
       chain.wait('Post-pull status').wait('Current Environment').wait(tableHeaderRegex).wait(tableSeperator);

--- a/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
@@ -31,13 +31,5 @@ describe('amplify pull', () => {
     const appId = getAppId(projRoot);
     await amplifyPull(projRoot2, { appId, emptyDir: true, noUpdateBackend: true });
     await amplifyPull(projRoot2, { appId, noUpdateBackend: true });
-    let error = false;
-    try {
-      // This will fail: An error occurred during the push operation: The local environment configuration does not allow backend updates.
-      await amplifyPush(projRoot2);
-    } catch {
-      error = true;
-    }
-    expect(error).toBeTruthy();
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
@@ -1,0 +1,43 @@
+import {
+  getAppId,
+  addApiWithSchema,
+  amplifyPull,
+  amplifyPush,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+} from 'amplify-e2e-core';
+
+describe('amplify pull', () => {
+  let projRoot: string;
+  let projRoot2: string;
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('pull-test');
+    projRoot2 = await createNewProjectDir('pull-test-2');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+    await deleteProject(projRoot2);
+    deleteProjectDir(projRoot2);
+  });
+
+  it('pulling twice with noUpdateBackend does not re-prompt', async () => {
+    await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false });
+    await addApiWithSchema(projRoot, 'simple_model.graphql');
+    await amplifyPush(projRoot);
+    const appId = getAppId(projRoot);
+    await amplifyPull(projRoot2, { appId, emptyDir: true, noUpdateBackend: true });
+    await amplifyPull(projRoot2, { appId, noUpdateBackend: true });
+    let error = false;
+    try {
+      // This will fail: An error occurred during the push operation: The local environment configuration does not allow backend updates.
+      await amplifyPush(projRoot2);
+    } catch {
+      error = true;
+    }
+    expect(error).toBeTruthy();
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -48,7 +48,7 @@ const defaultAWSConfig: AwsConfig = {
 };
 
 export async function init(context: $TSContext) {
-  if (!context.exeInfo.isNewProject && doesAwsConfigExists(context)) {
+  if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend || (!context.exeInfo.isNewProject && doesAwsConfigExists(context))) {
     return context;
   }
   normalizeInputParams(context);


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
 When the developer runs `amplify pull` and chooses "no" when prompted: "Do you plan on modifying this backend?", the cli should not prompt for all the project configuration settings when `amplify pull` is called again to receive updates. Since the entire `amplify/` dir is removed when this option is selected, we lose project configuration context.

This change keeps the `amplify/` dir around, only deleting the backend directories, and maintains the state of the project configuration.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A


#### Description of how you validated changes

Ran `amplify pull` multiple times for admin ui, profile, and access key authenticated apps

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.