### PR TITLE
E2e image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-ecr: johnpc/aws-ecr-orb@1.0.3
+  aws-ecr: johnpc/aws-ecr-orb@1.0.6
 
 jobs:
   build:
@@ -10,9 +10,9 @@ jobs:
     steps:
       - setup_remote_docker
       - aws-ecr/build-and-push-image:
-          aws-access-key-id: ECR_ACCESS_KEY
-          aws-secret-access-key: ECR_SECRET_ACCESS_KEY
-          aws-session-token: ECR_SESSION_TOKEN
+          aws-access-key-id: ECR_PUSH_ACCESS_KEY
+          aws-secret-access-key: ECR_PUSH_SECRET_ACCESS_KEY
+          aws-session-token: ECR_PUSH_SESSION_TOKEN
           region: ECR_REGION
           checkout: true
           create-repo: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@6.15.3
+  aws-ecr: johnpc/aws-ecr-orb@1.0.3
 
 jobs:
   build:
@@ -12,6 +12,7 @@ jobs:
       - aws-ecr/build-and-push-image:
           aws-access-key-id: ECR_ACCESS_KEY
           aws-secret-access-key: ECR_SECRET_ACCESS_KEY
+          aws-session-token: ECR_SESSION_TOKEN
           region: ECR_REGION
           checkout: true
           create-repo: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           checkout: true
           create-repo: false
           dockerfile: Dockerfile
-          repo: amplify-cli-e2e-base-image-repo
+          repo: amplify-cli-e2e-base-image-repo-public
           tag: "latest,${CIRCLE_SHA1}"
 
 workflows:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

In https://github.com/aws-amplify/amplify-cli/pull/7665, we switch to use temporary credentials (including the extra SESSION_TOKEN environment variable) in our e2e suite. 

Since SESSION_TOKEN is required for reading private repos, but is not supported by CircleCI, we also need to make the repo public.

This pull request uses the temporary credentials with SESSION_TOKEN to publish the image, but points to a public instead of private repository so that it can be pulled.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

I published and pulled this image in my own circleci and aws account.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.