### PR TITLE
skip unnecessary prompt for 'amplify update function'

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/determineServiceSelection.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/determineServiceSelection.ts
@@ -1,0 +1,87 @@
+import { determineServiceSelection } from '../../../../provider-utils/awscloudformation/utils/determineServiceSelection';
+import { ServiceName } from '../../../../provider-utils/awscloudformation/utils/constants';
+
+const serviceSelectionPromptMock = jest.fn();
+const mockChooseServiceMessage = 'mockChooseServiceMessage';
+const mockContext = {
+  amplify: {
+    getResourceStatus: async () => {
+      return { allResources: [] };
+    },
+    serviceSelectionPrompt: serviceSelectionPromptMock,
+  },
+};
+
+describe('determineServiceSelection', () => {
+  it('returns LambdaFunction when no resources exists', async () => {
+    const response = await determineServiceSelection(mockContext, mockChooseServiceMessage);
+    expect(response.service === ServiceName.LambdaFunction);
+    expect(serviceSelectionPromptMock).toBeCalledTimes(0);
+  });
+
+  it('returns LambdaFunction when only LambdaFunction resources exists', async () => {
+    mockContext.amplify.getResourceStatus = async () => {
+      return {
+        allResources: [
+          {
+            service: ServiceName.LambdaFunction,
+          },
+        ],
+      };
+    };
+    const response = await determineServiceSelection(mockContext, mockChooseServiceMessage);
+    expect(response.service === ServiceName.LambdaFunction);
+    expect(serviceSelectionPromptMock).toBeCalledTimes(0);
+  });
+
+  it('returns LambdaLayer when only LambdaLayer resources exists', async () => {
+    mockContext.amplify.getResourceStatus = async () => {
+      return {
+        allResources: [
+          {
+            service: ServiceName.LambdaLayer,
+          },
+        ],
+      };
+    };
+    const response = await determineServiceSelection(mockContext, mockChooseServiceMessage);
+    expect(response.service === ServiceName.LambdaLayer);
+    expect(serviceSelectionPromptMock).toBeCalledTimes(0);
+  });
+
+  it('returns LambdaLayer when existing LambdaFunction resources have mobileHubMigrated', async () => {
+    mockContext.amplify.getResourceStatus = async () => {
+      return {
+        allResources: [
+          {
+            service: ServiceName.LambdaLayer,
+          },
+          {
+            service: ServiceName.LambdaFunction,
+            mobileHubMigrated: true,
+          },
+        ],
+      };
+    };
+    const response = await determineServiceSelection(mockContext, mockChooseServiceMessage);
+    expect(response.service === ServiceName.LambdaLayer);
+    expect(serviceSelectionPromptMock).toBeCalledTimes(0);
+  });
+
+  it('prompts for user input when both LambdaFunction and LambdaLayer resources exist', async () => {
+    mockContext.amplify.getResourceStatus = async () => {
+      return {
+        allResources: [
+          {
+            service: ServiceName.LambdaFunction,
+          },
+          {
+            service: ServiceName.LambdaLayer,
+          },
+        ],
+      };
+    };
+    await determineServiceSelection(mockContext, mockChooseServiceMessage);
+    expect(serviceSelectionPromptMock).toBeCalledTimes(1);
+  });
+});

--- a/packages/amplify-category-function/src/commands/function/update.ts
+++ b/packages/amplify-category-function/src/commands/function/update.ts
@@ -1,6 +1,7 @@
 import { supportedServices } from '../../provider-utils/supported-services';
 import { chooseServiceMessageUpdate } from '../../provider-utils/awscloudformation/utils/constants';
 import { categoryName } from '../../constants';
+import { determineServiceSelection } from '../../provider-utils/awscloudformation/utils/determineServiceSelection';
 
 const subcommand = 'update';
 
@@ -8,10 +9,8 @@ module.exports = {
   name: subcommand,
   alias: ['configure'],
   run: async context => {
-    const { amplify } = context;
     const servicesMetadata = supportedServices;
-    return amplify
-      .serviceSelectionPrompt(context, categoryName, servicesMetadata, chooseServiceMessageUpdate)
+    return determineServiceSelection(context, chooseServiceMessageUpdate)
       .then(result => {
         const providerController = servicesMetadata[result.service].providerController;
         if (!providerController) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeFunctionWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeFunctionWalkthrough.ts
@@ -7,6 +7,10 @@ import { ServiceName } from '../utils/constants';
 export async function removeResource(resourceName?: string): Promise<$TSAny> {
   const enabledCategoryResources = getEnabledResources();
 
+  if (enabledCategoryResources.length === 0) {
+    throw new Error('No Lambda function resource to remove. Use "amplify add function" to create a new function.');
+  }
+
   if (resourceName) {
     const resource = enabledCategoryResources.find(categoryResource => categoryResource.value.resourceName === resourceName);
     return resource.value;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/determineServiceSelection.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/determineServiceSelection.ts
@@ -1,0 +1,24 @@
+import { ServiceName } from './constants';
+import { categoryName } from '../../../constants';
+import { supportedServices } from '../../supported-services';
+
+export const determineServiceSelection = async (context, chooseServiceMessage) => {
+  const { allResources } = await context.amplify.getResourceStatus();
+  const lambdaLayerExists = allResources.filter(resource => resource.service === ServiceName.LambdaLayer).length > 0;
+  const lambdaFunctionExists =
+    allResources.filter(resource => resource.service === ServiceName.LambdaFunction && resource.mobileHubMigrated !== true).length > 0;
+
+  if ((!lambdaFunctionExists && !lambdaLayerExists) || (lambdaFunctionExists && !lambdaLayerExists)) {
+    return {
+      service: ServiceName.LambdaFunction,
+    };
+  }
+
+  if (!lambdaFunctionExists && lambdaLayerExists) {
+    return {
+      service: ServiceName.LambdaLayer,
+    };
+  }
+
+  return await context.amplify.serviceSelectionPrompt(context, categoryName, supportedServices, chooseServiceMessage);
+};

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -175,11 +175,7 @@ const coreFunction = (
         selectTemplate(chain, settings.functionTemplate, runtime);
       }
     } else {
-      chain
-        .wait('Select which capability you want to update:')
-        .sendCarriageReturn() // lambda function
-        .wait('Select the Lambda function you want to update')
-        .sendCarriageReturn(); // assumes only one function configured in the project
+      chain.wait('Select the Lambda function you want to update').sendCarriageReturn(); // assumes only one function configured in the project
     }
 
     if (functionConfigCallback) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

When calling `amplify update function`, the user is prompted to select whether they want to update a lambda function or lambda layer. This prompt should be skipped if only one of the two exist, and it should default as though option that exists was selected.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/7308


#### Description of how you validated changes

- manually tested case where only a function exists
- manually tested case where only a layer exists
- manually tested case where both exist
- manually tested case where neither exists
- added unit tests
- updated e2e test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.