### PR TITLE
fix: improve size checks before packaging Lambda resources

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageFunction.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageFunction.test.ts
@@ -1,5 +1,5 @@
 import { getRuntimeManager } from '../../../../provider-utils/awscloudformation/utils/functionPluginLoader';
-import { $TSContext, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSContext, getFolderSize, pathManager } from 'amplify-cli-core';
 import { packageFunction } from '../../../../provider-utils/awscloudformation/utils/packageFunction';
 import { PackageRequestMeta } from '../../../../provider-utils/awscloudformation/types/packaging-types';
 import { zipPackage } from '../../../../provider-utils/awscloudformation/utils/zipResource';
@@ -17,12 +17,12 @@ const context_stub = {
 };
 
 const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
-const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
 const getRuntimeManager_mock = getRuntimeManager as jest.MockedFunction<typeof getRuntimeManager>;
 const zipPackage_mock = zipPackage as jest.MockedFunction<typeof zipPackage>;
+const getFolderSize_mock = getFolderSize as jest.MockedFunction<typeof getFolderSize>;
 
 pathManager_mock.getResourceDirectoryPath.mockReturnValue('backend/dir/path/testcategory/testResourceName');
-stateManager_mock.getFolderSize.mockResolvedValue(50 * 1024 ** 2);
+getFolderSize_mock.mockResolvedValue(50 * 1024 ** 2);
 
 const runtimeManager_mock = {
   package: jest.fn().mockResolvedValue({
@@ -56,7 +56,7 @@ describe('package function', () => {
   });
 
   it('throws an error when the size of the function is too large', async () => {
-    stateManager_mock.getFolderSize.mockResolvedValueOnce(251 * 1024 ** 2);
-    expect(async () => await packageFunction((context_stub as unknown) as $TSContext, resourceRequest)).rejects.toThrow();
+    getFolderSize_mock.mockResolvedValueOnce(251 * 1024 ** 2);
+    await expect(async () => await packageFunction((context_stub as unknown) as $TSContext, resourceRequest)).rejects.toThrow();
   });
 });

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
@@ -84,10 +84,10 @@ describe('package function', () => {
   });
 
   it('fails to pacakge layer that is greater than 250MB in size', async () => {
-    getFolderSize_mock.mockResolvedValue(200 * 1024 ** 2); // 200MB
-    convertNumBytes_mock.mockReturnValue({ toKB: jest.fn(), toMB: jest.fn().mockReturnValueOnce(400) });
+    getFolderSize_mock.mockResolvedValue(260 * 1024 ** 2); // 260MB
+    convertNumBytes_mock.mockReturnValue({ toKB: jest.fn(), toMB: jest.fn().mockReturnValueOnce(260) });
     await expect(async () => await packageLayer((context_stub as unknown) as $TSContext, resourceRequest)).rejects.toEqual(
-      new Error(`Lambda layer ${resourceRequest.resourceName} is too large: 400/250 MB`),
+      new Error(`Lambda layer ${resourceRequest.resourceName} is too large: 260/250 MB`),
     );
   });
 });

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
@@ -1,10 +1,9 @@
-import { $TSContext, pathManager } from 'amplify-cli-core';
+import { $TSContext, pathManager, stateManager } from 'amplify-cli-core';
 import { FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
 import { packageLayer } from '../../../../provider-utils/awscloudformation/utils/packageLayer';
 import { PackageRequestMeta } from '../../../../provider-utils/awscloudformation/types/packaging-types';
 import { LayerCloudState } from '../../../../provider-utils/awscloudformation/utils/layerCloudState';
 import { loadLayerConfigurationFile } from '../../../../provider-utils/awscloudformation/utils/layerConfiguration';
-import { validFilesize } from '../../../../provider-utils/awscloudformation/utils/layerHelpers';
 
 jest.mock('fs-extra');
 jest.mock('amplify-cli-core');
@@ -13,7 +12,6 @@ jest.mock('../../../../provider-utils/awscloudformation/utils/layerConfiguration
 jest.mock('../../../../provider-utils/awscloudformation/utils/layerCloudState');
 jest.mock('../../../../provider-utils/awscloudformation/utils/layerHelpers', () => ({
   loadPreviousLayerHash: jest.fn(),
-  validFilesize: jest.fn(),
   loadStoredLayerParameters: jest.fn(),
   getChangedResources: jest.fn(),
   ensureLayerVersion: jest.fn().mockReturnValue('newhash'),
@@ -21,6 +19,7 @@ jest.mock('../../../../provider-utils/awscloudformation/utils/layerHelpers', () 
 jest.mock('../../../../provider-utils/awscloudformation/utils/zipResource');
 
 const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
+const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
 
 const loadLayerConfigurationFile_mock = loadLayerConfigurationFile as jest.MockedFunction<typeof loadLayerConfigurationFile>;
 loadLayerConfigurationFile_mock.mockReturnValue({
@@ -38,9 +37,6 @@ loadLayerConfigurationFile_mock.mockReturnValue({
     },
   ],
 });
-
-const validFilesize_mock = validFilesize as jest.MockedFunction<typeof validFilesize>;
-validFilesize_mock.mockReturnValue(true);
 
 pathManager_mock.getResourceDirectoryPath.mockReturnValue('backend/dir/path/testcategory/testResourceName/');
 
@@ -75,12 +71,21 @@ layerCloudState_mock.getInstance.mockReturnValue(({
 
 describe('package function', () => {
   it('delegates packaging to the runtime manager', async () => {
+    stateManager_mock.getFolderSize.mockResolvedValue(100 * 1024 ** 2); // 100MB
     await packageLayer((context_stub as unknown) as $TSContext, resourceRequest);
     expect(runtimePlugin_stub.package.mock.calls[0][0].srcRoot).toEqual('backend/dir/path/testcategory/testResourceName/lib/nodejs');
   });
 
   it('updates amplify meta after packaging', async () => {
+    stateManager_mock.getFolderSize.mockResolvedValue(100 * 1024 ** 2); // 100MB
     await packageLayer((context_stub as unknown) as $TSContext, resourceRequest);
     expect((context_stub.amplify.updateAmplifyMetaAfterPackage as jest.Mock).mock.calls[0][0]).toEqual(resourceRequest);
+  });
+
+  it('fails to pacakge layer that is greater than 250MB in size', async () => {
+    stateManager_mock.getFolderSize.mockResolvedValue(200 * 1024 ** 2); // 200MB
+    expect(async () => await packageLayer((context_stub as unknown) as $TSContext, resourceRequest)).rejects.toEqual(
+      new Error(`Lambda layer ${resourceRequest.resourceName} is too large: 400/250 MB`),
+    );
   });
 });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildFunction.ts
@@ -1,13 +1,11 @@
 import { $TSContext, pathManager } from 'amplify-cli-core';
-import { FunctionRuntimeLifecycleManager, BuildRequest, BuildType } from 'amplify-function-plugin-interface';
-import * as path from 'path';
+import { BuildRequest, BuildType, FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
 import { categoryName } from '../../../constants';
 
 export const buildFunction = async (
   context: $TSContext,
   { resourceName, lastBuildTimestamp, buildType = BuildType.PROD }: BuildRequestMeta,
 ) => {
-  const resourcePath = path.join(pathManager.getBackendDirPath(), categoryName, resourceName);
   const breadcrumbs = context.amplify.readBreadcrumbs(categoryName, resourceName);
 
   const runtimePlugin: FunctionRuntimeLifecycleManager = (await context.amplify.loadRuntimePlugin(
@@ -31,7 +29,7 @@ export const buildFunction = async (
   } else {
     const buildRequest: BuildRequest = {
       buildType,
-      srcRoot: resourcePath,
+      srcRoot: pathManager.getResourceDirectoryPath(undefined, categoryName, resourceName),
       runtime: breadcrumbs.functionRuntime,
       legacyBuildHookParams: {
         projectRoot: pathManager.findProjectRoot(),

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/constants.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/constants.ts
@@ -17,6 +17,8 @@ export const ephemeralField = 'ephemeral';
 export const versionHash = 'latestPushedVersionHash';
 export const cfnTemplateSuffix = '-awscloudformation-template.json';
 
+export const lambdaPackageLimitInMB = 250;
+
 export const enum LayerCfnLogicalNamePrefix {
   LambdaLayerVersion = 'LambdaLayerVersion',
   LambdaLayerVersionPermission = 'LambdaLayerPermission',

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -271,17 +271,6 @@ export function loadPreviousLayerHash(layerName: string): string | undefined {
   return previousHash;
 }
 
-export function validFilesize(context: $TSContext, zipPath: string, maxSize = 250) {
-  try {
-    const { size } = fs.statSync(zipPath);
-    const fileSize = Math.round(size / 1024 ** 2);
-    return fileSize < maxSize;
-  } catch (error) {
-    context.print.error(error);
-    return new Error(`Calculating file size failed: ${zipPath}`);
-  }
-}
-
 // hashes all of the layer contents as well as the files in the layer path (CFN, parameters, etc)
 export const hashLayerResource = async (layerPath: string, resourceName: string): Promise<string> => {
   return await hashLayerVersion(layerPath, resourceName, true);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
@@ -42,8 +42,7 @@ export const packageFunction: Packager = async (context, resource) => {
     // Add up all the project lib/opt folders
     if (layer.type === 'ProjectLayer') {
       const layerDirPath = pathManager.getResourceDirectoryPath(undefined, categoryName, layer.resourceName);
-      layersSizeInBytes += await getFolderSize(path.join(layerDirPath, 'lib'));
-      layersSizeInBytes += await getFolderSize(path.join(layerDirPath, 'opt'));
+      layersSizeInBytes += await getFolderSize([path.join(layerDirPath, 'lib'), path.join(layerDirPath, 'opt')]);
     }
   }
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
@@ -1,19 +1,21 @@
-import { pathManager } from 'amplify-cli-core';
-import * as path from 'path';
+import { pathManager, stateManager } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
+import * as path from 'path';
+import { categoryName } from '../../../constants';
 import { Packager } from '../types/packaging-types';
 import { getRuntimeManager } from './functionPluginLoader';
+import { loadFunctionParameters } from './loadFunctionParameters';
 import { zipPackage } from './zipResource';
 
 /**
  * Packages lambda source code and artifacts into a lambda-compatible .zip file
  */
 export const packageFunction: Packager = async (context, resource) => {
-  const resourcePath = path.join(pathManager.getBackendDirPath(), resource.category, resource.resourceName);
+  const resourcePath = pathManager.getResourceDirectoryPath(undefined, categoryName, resource.resourceName);
   const runtimeManager = await getRuntimeManager(context, resource.resourceName);
-  const distDir = path.join(resourcePath, 'dist');
-  fs.ensureDirSync(distDir);
-  const destination = path.join(distDir, 'latest-build.zip');
+  const distDirPath = path.join(resourcePath, 'dist');
+  fs.ensureDirSync(distDirPath);
+  const destination = path.join(distDirPath, 'latest-build.zip');
   const packageRequest = {
     env: context.amplify.getEnvInfo().envName,
     srcRoot: resourcePath,
@@ -28,6 +30,29 @@ export const packageFunction: Packager = async (context, resource) => {
   if (packageHash) {
     await zipPackage(packageResult.zipEntries, destination);
   }
+
+  const functionSizeInBytes = await stateManager.getFolderSize(path.join(resourcePath, 'src'));
+  let layersSizeInBytes = 0;
+
+  const functionParameters = loadFunctionParameters(resourcePath);
+
+  for (const layer of functionParameters?.lambdaLayers || []) {
+    // Add up all the lib/opt folders
+    const layerDirPath = pathManager.getResourceDirectoryPath(undefined, categoryName, layer.resourceName);
+    layersSizeInBytes += await stateManager.getFolderSize(path.join(layerDirPath, 'lib'));
+    layersSizeInBytes += await stateManager.getFolderSize(path.join(layerDirPath, 'opt'));
+  }
+
+  if (functionSizeInBytes + layersSizeInBytes > 250 * 1024 ** 2) {
+    throw new Error(
+      `Total size of Lambda function ${
+        resource.resourceName
+      } plus it's dependent layers exceeds 250MB limit. Lambda function is ${stateManager
+        .convertNumBytes(functionSizeInBytes)
+        .toMB()}MB. Dependent Lambda layers are ${stateManager.convertNumBytes(layersSizeInBytes).toMB()}MB.`,
+    );
+  }
+
   const zipFilename = packageHash
     ? `${resource.resourceName}-${packageHash}-build.zip`
     : resource.distZipFilename ?? `${resource.category}-${resource.resourceName}-build.zip`;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -37,8 +37,7 @@ export const packageLayer: Packager = async (context, resource) => {
   // check total layer size is less than 250MB
   let layerSizeInBytes = 0;
   // Add up all the lib/opt folders
-  layerSizeInBytes += await getFolderSize(path.join(resourcePath, 'lib'));
-  layerSizeInBytes += await getFolderSize(path.join(resourcePath, 'opt'));
+  layerSizeInBytes += await getFolderSize([path.join(resourcePath, 'lib'), path.join(resourcePath, 'opt')]);
 
   if (layerSizeInBytes > lambdaPackageLimitInMB * 1024 ** 2) {
     throw new Error(

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, pathManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, pathManager, stateManager } from 'amplify-cli-core';
 import { ZipEntry } from 'amplify-function-plugin-interface';
 import * as path from 'path';
 import * as fs from 'fs-extra';
@@ -10,7 +10,7 @@ import { loadLayerConfigurationFile } from './layerConfiguration';
 import { FunctionRuntimeLifecycleManager } from 'amplify-function-plugin-interface';
 import { ServiceName, versionHash } from './constants';
 import { LayerCloudState } from './layerCloudState';
-import { loadPreviousLayerHash, ensureLayerVersion, validFilesize, loadStoredLayerParameters, getChangedResources } from './layerHelpers';
+import { loadPreviousLayerHash, ensureLayerVersion, loadStoredLayerParameters, getChangedResources } from './layerHelpers';
 import { defaultLayerPermission } from './layerParams';
 import { zipPackage } from './zipResource';
 import { accessPermissions, description } from './constants';
@@ -35,6 +35,17 @@ export const packageLayer: Packager = async (context, resource) => {
   const distDir = path.join(resourcePath, 'dist');
   fs.ensureDirSync(distDir);
   const destination = path.join(distDir, 'latest-build.zip');
+
+  // check total layer size is less than 250MB
+  let layerSizeInBytes = 0;
+  // Add up all the lib/opt folders
+  layerSizeInBytes += await stateManager.getFolderSize(path.join(resourcePath, 'lib'));
+  layerSizeInBytes += await stateManager.getFolderSize(path.join(resourcePath, 'opt'));
+
+  if (layerSizeInBytes > 250 * 1024 ** 2) {
+    throw new Error(`Lambda layer ${resource.resourceName} is too large: ${stateManager.convertNumBytes(layerSizeInBytes).toMB()}/250 MB`);
+  }
+
   let zipEntries: ZipEntry[] = [{ sourceFolder: path.join(resourcePath, 'opt') }];
 
   for (const runtime of runtimes) {
@@ -64,6 +75,7 @@ export const packageLayer: Packager = async (context, resource) => {
       zipEntries = [...zipEntries, ...packageResult.zipEntries];
     }
   }
+
   await zipPackage(zipEntries, destination);
 
   const layerCloudState = LayerCloudState.getInstance(resource.resourceName);
@@ -73,12 +85,7 @@ export const packageLayer: Packager = async (context, resource) => {
   }
 
   const zipFilename = createLayerZipFilename(resource.resourceName, layerCloudState.latestVersionLogicalId);
-  // check zip size is less than 250MB
-  if (validFilesize(context, destination)) {
-    context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename, { resourceKey: versionHash, hashValue: currentHash });
-  } else {
-    throw new Error('File size greater than 250MB');
-  }
+  context.amplify.updateAmplifyMetaAfterPackage(resource, zipFilename, { resourceKey: versionHash, hashValue: currentHash });
   return { newPackageCreated: true, zipFilename, zipFilePath: destination };
 };
 

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
 import _ from 'lodash';
-import * as path from 'path';
 import { $TSAny, $TSMeta, $TSTeamProviderInfo, DeploymentSecrets } from '..';
 import { SecretFileMode } from '../cliConstants';
 import { JSONUtilities } from '../jsonUtilities';

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -295,33 +295,6 @@ export class StateManager {
     return resources[0];
   };
 
-  convertNumBytes = (numBytes: number) => ({
-    toKB: () => Math.round(numBytes / 1024),
-    toMB: () => Math.round(numBytes / 1024 ** 2),
-  });
-
-  getFolderSize = async (filePath: string) => {
-    try {
-      const fsStats = await fs.stat(filePath);
-      if (fsStats.isFile()) {
-        const { size } = fsStats;
-        return size;
-      }
-      if (!fsStats.isDirectory()) {
-        throw new Error(`Unrecognized file type [${filePath}]`);
-      }
-      const dir = await fs.readdir(filePath);
-      let totalSizeInBytes = 0;
-      for (const dirEntry of dir) {
-        const fullPath = path.join(filePath, dirEntry);
-        totalSizeInBytes += await this.getFolderSize(fullPath);
-      }
-      return totalSizeInBytes;
-    } catch (error) {
-      throw new Error(`Calculating file size failed for [${filePath}]: ${error.message || error}`);
-    }
-  };
-
   private filterResourcesFromMeta = (
     amplifyMeta: Record<string, any>,
     categoryName: string,

--- a/packages/amplify-cli-core/src/utils/fileSize.ts
+++ b/packages/amplify-cli-core/src/utils/fileSize.ts
@@ -1,0 +1,21 @@
+import globby from 'globby';
+import * as fs from 'fs-extra';
+
+export const convertNumBytes = (numBytes: number) => ({
+  toKB: () => Math.round(numBytes / 1024),
+  toMB: () => Math.round(numBytes / 1024 ** 2),
+});
+
+export async function getFolderSize(filePaths: string | string[]) {
+  const paths = await globby(filePaths, { followSymbolicLinks: false });
+  let totalSizeInBytes = 0;
+  for (const path of paths) {
+    try {
+      const { size } = await fs.stat(path);
+      totalSizeInBytes += size;
+    } catch (error) {
+      // skip file in size calculation
+    }
+  }
+  return totalSizeInBytes;
+}

--- a/packages/amplify-cli-core/src/utils/index.ts
+++ b/packages/amplify-cli-core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './fileSize';
 export * from './open';
 export * from './packageManager';
 export * from './recursiveOmit';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Do a best effort size check on Lambda functions and Lambda layers so that we can catch some size limitation errors and can fast fail.


#### Description of how you validated changes
Manual testing with a project with various large files across layers and functions, `yarn test` passes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.