### PR TITLE
Revert "ci: add support for e2e token rotation"

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -17,7 +17,10 @@ node12: &node12
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo-public:latest
+    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo:latest
+      aws_auth:
+        aws_access_key_id: $ECR_ACCESS_KEY
+        aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
   resource_class: large
 
 clean_e2e_resources: &clean_e2e_resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ node12:
 defaults:
   working_directory: ~/repo
   docker: &ref_1
-    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo-public:latest
+    - image: ${AWS_ECR_ACCOUNT_URL}/amplify-cli-e2e-base-image-repo:latest
+      aws_auth:
+        aws_access_key_id: $ECR_ACCESS_KEY
+        aws_secret_access_key: $ECR_SECRET_ACCESS_KEY
   resource_class: large
 clean_e2e_resources: &ref_7
   name: Cleanup resources

--- a/packages/amplify-console-integration-tests/src/profile-helper.ts
+++ b/packages/amplify-console-integration-tests/src/profile-helper.ts
@@ -35,7 +35,6 @@ export function getConfigFromProfile() {
   return {
     accessKeyId: credentials[profileName].aws_access_key_id,
     secretAccessKey: credentials[profileName].aws_secret_access_key,
-    sessionToken: credentials[profileName].aws_session_token,
     region: config[configKeyName].region,
   };
 }
@@ -63,17 +62,15 @@ export function setupAWSProfile() {
   Object.keys(credentials).forEach(key => {
     const keyName = key.trim();
     if (profileName === keyName) {
-      credentials[key].aws_access_key_id = process.env.AWS_ACCESS_KEY_ID;
-      credentials[key].aws_secret_access_key = process.env.AWS_SECRET_ACCESS_KEY;
-      credentials[key].aws_session_token = process.env.AWS_SESSION_TOKEN;
+      credentials[key].aws_access_key_id = process.env.CONSOLE_AWS_ACCESS_KEY_ID;
+      credentials[key].aws_secret_access_key = process.env.CONSOLE_AWS_SECRET_ACCESS_KEY;
       isCredSet = true;
     }
   });
   if (!isCredSet) {
     credentials[profileName] = {
-      aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
-      aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
-      aws_session_token: process.env.AWS_SESSION_TOKEN,
+      aws_access_key_id: process.env.CONSOLE_AWS_ACCESS_KEY_ID,
+      aws_secret_access_key: process.env.CONSOLE_AWS_SECRET_ACCESS_KEY,
     };
   }
 

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -1,11 +1,8 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import * as ini from 'ini';
-
 import { spawnSync, execSync } from 'child_process';
 import { v4 as uuid } from 'uuid';
-import { pathManager } from 'amplify-cli-core';
 
 export * from './configure/';
 export * from './init/';
@@ -32,13 +29,6 @@ export function getCLIPath(testingWithLatestCodebase = false) {
 
 export function isCI(): boolean {
   return process.env.CI && process.env.CIRCLECI ? true : false;
-}
-
-export function injectSessionToken(profileName: string) {
-  const credentialsContents = ini.parse(fs.readFileSync(pathManager.getAWSCredentialsFilePath()).toString());
-  credentialsContents[profileName] = credentialsContents[profileName] || {};
-  credentialsContents[profileName].aws_session_token = process.env.AWS_SESSION_TOKEN;
-  fs.writeFileSync(pathManager.getAWSCredentialsFilePath(), ini.stringify(credentialsContents));
 }
 
 export function npmInstall(cwd: string) {

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -380,13 +380,7 @@ export function amplifyInitYes(cwd: string): Promise<void> {
       env: {
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
-    }).run((err: Error) =>
-      err
-        ? reject(err)
-        : (() => {
-            resolve();
-          })(),
-    );
+    }).run((err: Error) => (err ? reject(err) : resolve()));
   });
 }
 

--- a/packages/amplify-e2e-core/src/utils/envVars.ts
+++ b/packages/amplify-e2e-core/src/utils/envVars.ts
@@ -1,7 +1,6 @@
 type AWSCredentials = {
-  AWS_ACCESS_KEY_ID?: string;
-  AWS_SECRET_ACCESS_KEY?: string;
-  AWS_SESSION_TOKEN?: string;
+  ACCESS_KEY_ID?: string;
+  SECRET_ACCESS_KEY?: string;
 };
 type SocialProviders = {
   FACEBOOK_APP_ID?: string;

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -14,7 +14,6 @@ const settings = {
   startCmd: '\r',
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  sessionToken: process.env.AWS_SESSION_TOKEN,
   region: process.env.CLI_REGION,
   pinpointResourceName: 'testpinpoint',
 };
@@ -47,7 +46,6 @@ export async function pinpointAppExist(pinpointProjectId: string): Promise<boole
   const pinpointClient = new Pinpoint({
     accessKeyId: settings.accessKeyId,
     secretAccessKey: settings.secretAccessKey,
-    sessionToken: settings.sessionToken,
     region: _.get(serviceRegionMap, settings.region, defaultPinpointRegion),
   });
 

--- a/packages/amplify-e2e-tests/sample.env
+++ b/packages/amplify-e2e-tests/sample.env
@@ -1,7 +1,10 @@
 # Used for setting up a new profile
 AWS_ACCESS_KEY_ID=<your-access-key>
 AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
-AWS_SESSION_TOKEN=<optional-session-token>
+
+# Used for profile less init
+ACCESS_KEY_ID=<your-access-key>
+SECRET_ACCESS_KEY=<your-secret-access-key>
 
 # Used for Auth Hosted UI
 FACEBOOK_APP_ID=<your-facebook-app-id>

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
@@ -324,9 +324,9 @@ describe('auth import userpool only', () => {
     // Set it to make sure deleteProject error will be ignored
     ignoreProjectDeleteErrors = true;
 
-    const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = getEnvVars();
-    if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
-      throw new Error('Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY either in .env file or as Environment variable');
+    const { ACCESS_KEY_ID, SECRET_ACCESS_KEY } = getEnvVars();
+    if (!ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
+      throw new Error('Set AWS_ACCESS_KEY_ID and SECRET_ACCESS_KEY either in .env file or as Environment variable');
     }
 
     const newProjectRegion = process.env.CLI_REGION === 'us-west-2' ? 'us-east-2' : 'us-west-2';
@@ -334,8 +334,8 @@ describe('auth import userpool only', () => {
     await initProjectWithAccessKey(projectRoot, {
       ...projectSettings,
       envName: 'integtest',
-      accessKeyId: AWS_ACCESS_KEY_ID,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY,
+      accessKeyId: ACCESS_KEY_ID,
+      secretAccessKey: SECRET_ACCESS_KEY,
       region: newProjectRegion,
     } as any);
 

--- a/packages/amplify-e2e-tests/src/__tests__/init.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init.test.ts
@@ -83,13 +83,13 @@ describe('amplify init', () => {
   });
 
   it('should init project without profile', async () => {
-    const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = getEnvVars();
-    if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
-      throw new Error('Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY either in .env file or as Environment variable');
+    const { ACCESS_KEY_ID, SECRET_ACCESS_KEY } = getEnvVars();
+    if (!ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
+      throw new Error('Set ACCESS_KEY_ID and SECRET_ACCESS_KEY either in .env file or as Environment variable');
     }
     await initProjectWithAccessKey(projRoot, {
-      accessKeyId: AWS_ACCESS_KEY_ID,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY,
+      accessKeyId: ACCESS_KEY_ID,
+      secretAccessKey: SECRET_ACCESS_KEY,
     });
 
     const meta = getProjectMeta(projRoot).providers.awscloudformation;
@@ -103,8 +103,8 @@ describe('amplify init', () => {
     // init new env
     await initNewEnvWithAccessKey(projRoot, {
       envName: 'foo',
-      accessKeyId: AWS_ACCESS_KEY_ID,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY,
+      accessKeyId: ACCESS_KEY_ID,
+      secretAccessKey: SECRET_ACCESS_KEY,
     });
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
 

--- a/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
+++ b/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
@@ -36,7 +36,6 @@ export const toHaveValidPolicyConditionMatchingIdpId = async (roleName: string, 
     const iam = new IAM({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-      sessionToken: process.env.AWS_SESSION_TOKEN,
     });
 
     const { Role: role } = await iam.getRole({ RoleName: roleName }).promise();
@@ -56,7 +55,9 @@ export const toHaveValidPolicyConditionMatchingIdpId = async (roleName: string, 
         return false;
       }
     });
+    
     message = pass ? 'Found Matching Condition' : 'Matching Condition does not exist';
+   
   } catch (e) {
     pass = false;
     message = 'IAM GetRole threw Error: ' + e.message;

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -79,7 +79,6 @@ const configureAws = (): void => {
     credentials: {
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-      sessionToken: process.env.AWS_SESSION_TOKEN,
       ...(process.env.AWS_SESSION_TOKEN ? { sessionToken: process.env.AWS_SESSION_TOKEN } : {}),
     },
     maxRetries: 10,

--- a/packages/amplify-e2e-tests/src/configure_tests.ts
+++ b/packages/amplify-e2e-tests/src/configure_tests.ts
@@ -1,4 +1,4 @@
-import { amplifyConfigure as configure, injectSessionToken, isCI } from 'amplify-e2e-core';
+import { amplifyConfigure as configure, isCI } from 'amplify-e2e-core';
 
 async function setupAmplify() {
   if (isCI()) {
@@ -14,9 +14,6 @@ async function setupAmplify() {
       profileName: 'amplify-integ-test-user',
       region: REGION,
     });
-    if (process.env.AWS_SESSION_TOKEN) {
-      injectSessionToken('amplify-integ-test-user');
-    }
   } else {
     console.log('AWS Profile is already configured');
   }

--- a/packages/amplify-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-e2e-tests/src/init-special-cases/index.ts
@@ -7,7 +7,6 @@ export async function initWithoutCredentialFileAndNoNewUserSetup(projRoot) {
   const settings = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-west-2',
   };
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -70,7 +70,6 @@ export function getConfiguredCognitoClient(): CognitoIdentityServiceProvider {
   const awsconfig = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.CLI_REGION,
   };
 
@@ -125,7 +124,6 @@ export function getConfiguredAppsyncClientIAMAuth(url: string, region: string): 
       credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
       },
     },
   });

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -45,7 +45,6 @@ async function uploadImageFile(projectDir: string) {
   const s3Client = new aws.S3({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.AWS_DEFAULT_REGION,
   });
 

--- a/packages/amplify-migration-tests/sample.env
+++ b/packages/amplify-migration-tests/sample.env
@@ -1,7 +1,10 @@
 # Used for setting up a new profile
 AWS_ACCESS_KEY_ID=<your-access-key>
 AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
-AWS_SESSION_TOKEN=<optional-session-token>
+
+# Used for profile less init
+ACCESS_KEY_ID=<your-access-key>
+SECRET_ACCESS_KEY=<your-secret-access-key>
 
 # Used for Auth Hosted UI
 FACEBOOK_APP_ID=<your-facebook-app-id>

--- a/packages/amplify-migration-tests/src/configure_tests.ts
+++ b/packages/amplify-migration-tests/src/configure_tests.ts
@@ -1,4 +1,4 @@
-import { amplifyConfigure as configure, isCI, installAmplifyCLI, injectSessionToken } from 'amplify-e2e-core';
+import { amplifyConfigure as configure, isCI, installAmplifyCLI } from 'amplify-e2e-core';
 
 /*
  *  Migration tests must be run without publishing to local registry
@@ -21,9 +21,6 @@ async function setupAmplify(version: string = 'latest') {
       secretAccessKey: AWS_SECRET_ACCESS_KEY,
       profileName: 'amplify-integ-test-user',
     });
-    if (process.env.AWS_SESSION_TOKEN) {
-      injectSessionToken('amplify-integ-test-user');
-    }
   } else {
     console.log('AWS Profile is already configured');
   }

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -217,7 +217,6 @@ async function initialize(context: $TSContext, authConfig?: AuthFlowConfig) {
     ) {
       awsConfigInfo.config.accessKeyId = awsConfigInfo.config.accessKeyId || authConfig.accessKeyId;
       awsConfigInfo.config.secretAccessKey = awsConfigInfo.config.secretAccessKey || authConfig.secretAccessKey;
-      awsConfigInfo.config.sessionToken = awsConfigInfo.config.sessionToken || authConfig.sessionToken;
       awsConfigInfo.config.region = awsConfigInfo.config.region || authConfig.region;
     } else {
       await promptForAuthConfig(context, authConfig);
@@ -431,7 +430,6 @@ async function promptForAuthConfig(context: $TSContext, authConfig?: AuthFlowCon
   if (!obfuscateUtil.isObfuscated(answers.secretAccessKey)) {
     awsConfigInfo.config.secretAccessKey = answers.secretAccessKey;
   }
-  awsConfigInfo.config.sessionToken = awsConfigInfo.config.sessionToken || process.env.AWS_SESSION_TOKEN;
   awsConfigInfo.config.region = answers.region;
 }
 
@@ -457,7 +455,6 @@ async function validateConfig(context: $TSContext) {
         credentials: {
           accessKeyId: awsConfigInfo.config.accessKeyId,
           secretAccessKey: awsConfigInfo.config.secretAccessKey,
-          sessionToken: awsConfigInfo.config.sessionToken,
         },
       });
       try {
@@ -498,7 +495,6 @@ function persistLocalEnvConfig(context: $TSContext) {
       const awsSecrets = {
         accessKeyId: awsConfigInfo.config.accessKeyId,
         secretAccessKey: awsConfigInfo.config.secretAccessKey,
-        sessionToken: awsConfigInfo.config.sessionToken,
         region: awsConfigInfo.config.region,
       };
       const sharedConfigDirPath = path.join(pathManager.getHomeDotAmplifyDirPath(), constants.ProviderName);
@@ -778,7 +774,6 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
       resultAWSConfigInfo = {
         accessKeyId: awsConfigInfo.config.accessKeyId,
         secretAccessKey: awsConfigInfo.config.secretAccessKey,
-        sessionToken: awsConfigInfo.config.sessionToken,
         region: awsConfigInfo.config.region,
       };
     }

--- a/packages/amplify-provider-awscloudformation/src/setup-new-user.js
+++ b/packages/amplify-provider-awscloudformation/src/setup-new-user.js
@@ -12,7 +12,6 @@ async function run(context) {
   const awsConfigInfo = {
     accessKeyId: constants.DefaultAWSAccessKeyId,
     secretAccessKey: constants.DefaultAWSSecretAccessKey,
-    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: constants.DefaultAWSRegion,
   };
 

--- a/packages/amplify-util-mock/src/utils/dynamo-db/index.ts
+++ b/packages/amplify-util-mock/src/utils/dynamo-db/index.ts
@@ -42,7 +42,6 @@ export function configureDDBDataSource(config, ddbConfig) {
           region: ddbConfig.region,
           accessKeyId: ddbConfig.accessKeyId,
           secretAccessKey: ddbConfig.secretAccessKey,
-          sessionToken: ddbConfig.sessionToken || process.env.AWS_SESSION_TOKEN,
         },
       };
     }),

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -548,7 +548,6 @@ beforeAll(async () => {
         credentials: {
           accessKeyId: unauthCredentials.accessKeyId,
           secretAccessKey: unauthCredentials.secretAccessKey,
-          sessionToken: unauthCredentials.sessionToken,
         },
       },
       offlineConfig: {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
@@ -401,7 +401,6 @@ beforeAll(async () => {
       credentials: {
         accessKeyId: unauthCredentials.accessKeyId,
         secretAccessKey: unauthCredentials.secretAccessKey,
-        sessionToken: unauthCredentials.sessionToken,
       },
     },
     offlineConfig: {


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#7665

This is not ready to merge because the container at 363619784618.dkr.ecr.us-east-1.amazonaws.com/amplify-cli-e2e-base-image-repo-public has not been uploaded yet.