### PR TITLE
Revert "fix: upgrade node default runtime to 14"

### DIFF
--- a/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
+++ b/packages/amplify-category-analytics/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
@@ -229,7 +229,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs12.x",
         "Timeout": "300",
         "Role": {
           "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]

--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -381,7 +381,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt
         - UserPoolClientRole
@@ -507,7 +507,7 @@ Resources:
 
 
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt
         - UserPoolClientRole
@@ -659,7 +659,7 @@ Resources:
             - '} '
 
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt
         - UserPoolClientRole
@@ -758,7 +758,7 @@ Resources:
             - '}'
 
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt
         - UserPoolClientRole
@@ -888,7 +888,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt
         - MFALambdaRole
@@ -1048,7 +1048,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt
         - OpenIdLambdaRole

--- a/packages/amplify-category-auth/resources/cloudformation-templates/user-pool-group-template.json.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/user-pool-group-template.json.ejs
@@ -248,7 +248,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs12.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/assets/identifyCFNGenerate.js
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/assets/identifyCFNGenerate.js
@@ -521,7 +521,7 @@ function generateLambdaAccessForRekognition(identifyCFNFile, functionName, s3Res
         },
       },
       Handler: 'index.handler',
-      Runtime: 'nodejs14.x',
+      Runtime: 'nodejs12.x',
       Timeout: '300',
       Role: {
         'Fn::GetAtt': ['CollectionsLambdaExecutionRole', 'Arn'],

--- a/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/identify-template.json.ejs
+++ b/packages/amplify-category-predictions/provider-utils/awscloudformation/cloudformation-templates/identify-template.json.ejs
@@ -353,7 +353,7 @@
                         }
                     },
                     "Handler": "index.handler",
-                    "Runtime": "nodejs14.x",
+                    "Runtime": "nodejs12.x",
                     "Timeout": "300",
                     "Role": {
                         "Fn::GetAtt": [

--- a/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
@@ -56,7 +56,7 @@ describe('nodejs version migration tests', () => {
     );
     let authStackContent = fs.readFileSync(authStackFileName).toString();
 
-    authStackContent = authStackContent.replace('nodejs14.x', 'nodejs10.x');
+    authStackContent = authStackContent.replace('nodejs12.x', 'nodejs10.x');
 
     fs.writeFileSync(authStackFileName, authStackContent, 'utf-8');
 


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#7700

Node JS 14.x does not support the ZipFile Attribute yet causing failing e2e tests

`Invalid request provided: The ZipFile attribute is not supported for the runtime 'nodejs14.x'`
