### PR TITLE
chore: stalebot to not close pending-triage issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   - question
   - RFC
   - security
+  - pending-triage
 staleLabel: pending-close-response-required
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds `pending-triage` to list of exempt labels for Stalebot to ensure issues that have not been triaged are not closed.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

n/a

#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.