### PR TITLE
test(amplify-console-integration-tests): handle no session token

### DIFF
--- a/packages/amplify-console-integration-tests/src/profile-helper.ts
+++ b/packages/amplify-console-integration-tests/src/profile-helper.ts
@@ -65,7 +65,9 @@ export function setupAWSProfile() {
     if (profileName === keyName) {
       credentials[key].aws_access_key_id = process.env.AWS_ACCESS_KEY_ID;
       credentials[key].aws_secret_access_key = process.env.AWS_SECRET_ACCESS_KEY;
-      credentials[key].aws_session_token = process.env.AWS_SESSION_TOKEN;
+      if (process.env.AWS_SESSION_TOKEN) {
+        credentials[key].aws_session_token = process.env.AWS_SESSION_TOKEN;
+      }
       isCredSet = true;
     }
   });
@@ -73,8 +75,10 @@ export function setupAWSProfile() {
     credentials[profileName] = {
       aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
       aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
-      aws_session_token: process.env.AWS_SESSION_TOKEN,
     };
+    if (process.env.AWS_SESSION_TOKEN) {
+      credentials[profileName].aws_session_token = process.env.AWS_SESSION_TOKEN;
+    }
   }
 
   process.env.CONSOLE_REGION = process.env.CONSOLE_REGION || testRegionPool[Math.floor(Math.random() * testRegionPool.length)];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The nightly integ tests did not have handling for the case where we're _not_ using the session token yet. This commit adds it so that the nightly tests will pass regardless of temporary vs permanent auth tokens



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.