### PR TITLE
test(amplify-e2e-tests): remove unneeded deleteProject call

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
@@ -20,7 +20,6 @@ describe('amplify pull', () => {
   afterEach(async () => {
     await deleteProject(projRoot);
     deleteProjectDir(projRoot);
-    await deleteProject(projRoot2);
     deleteProjectDir(projRoot2);
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This commit removes an extraneous call to `deleteProject` in the e2e test `pull.test.ts`. Since the test does not maintain the amplify meta file, this `deleteProject` call fails and therefore the e2e test suite fails.

#### Description of how you validated changes

- ran e2e test, it passes now

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.