### PR TITLE
chore(amplify-category-auth): use constants instead of magic strings

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
@@ -267,9 +267,9 @@ const mfaTypeMap: Record<'SMS' | 'TOTP', 'SMS Text Message' | 'TOTP'> = {
 
 const signinAttributeMap: Record<CognitoUserPoolSigninMethod, UsernameAttributes[] | undefined> = {
   [CognitoUserPoolSigninMethod.USERNAME]: undefined,
-  [CognitoUserPoolSigninMethod.EMAIL]: ['email'],
-  [CognitoUserPoolSigninMethod.PHONE_NUMBER]: ['phone_number'],
-  [CognitoUserPoolSigninMethod.EMAIL_AND_PHONE_NUMBER]: ['email', 'phone_number'],
+  [CognitoUserPoolSigninMethod.EMAIL]: [AttributeType.EMAIL],
+  [CognitoUserPoolSigninMethod.PHONE_NUMBER]: [AttributeType.PHONE_NUMBER],
+  [CognitoUserPoolSigninMethod.EMAIL_AND_PHONE_NUMBER]: [AttributeType.EMAIL, AttributeType.PHONE_NUMBER],
 };
 
 const aliasAttributeMap: Record<CognitoUserAliasAttributes, AliasAttributes> = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The build is currently broken because it is using magic strings instead of the typescript-defined enums. This commit switches to use the enums and the build passes.

#### Description of how you validated changes

- ran `yarn setup-dev`, build was successful

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.