### PR TITLE
test(amplify-category-auth): use AttributeType enum in test

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-sms-workflow-helper.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-sms-workflow-helper.test.ts
@@ -1,4 +1,4 @@
-import { ServiceQuestionsResult } from '../../../../provider-utils/awscloudformation/service-walkthrough-types';
+import { ServiceQuestionsResult, AttributeType } from '../../../../provider-utils/awscloudformation/service-walkthrough-types';
 import { doesConfigurationIncludeSMS } from '../../../../provider-utils/awscloudformation/utils/auth-sms-workflow-helper';
 
 describe('doesConfigurationIncludeSMS', () => {
@@ -47,17 +47,17 @@ describe('doesConfigurationIncludeSMS', () => {
   });
 
   it('should return true when userNameAttribute contains phone number', () => {
-    request.usernameAttributes = ['phone_number'];
+    request.usernameAttributes = [AttributeType.PHONE_NUMBER];
     expect(doesConfigurationIncludeSMS(request)).toBeTruthy();
   });
 
   it('should return true when userNameAttribute contains phone number', () => {
-    request.usernameAttributes = ['email, phone_number'] as any;
+    request.usernameAttributes = [AttributeType.EMAIL, AttributeType.PHONE_NUMBER] as any;
     expect(doesConfigurationIncludeSMS(request)).toBeTruthy();
   });
 
   it('should return false when username attribute does not contain phone number', () => {
-    request.usernameAttributes = ['email'] as any;
+    request.usernameAttributes = [AttributeType.EMAIL] as any;
     expect(doesConfigurationIncludeSMS(request)).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

use `AttributeType` enum in tests instead of magic strings

#### Description of how you validated changes

- ran clean and unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.