### PR TITLE
feat(amplify-category-auth): use EnabledMFAs to only configure TOTP

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -182,11 +182,27 @@ Resources:
       AliasAttributes: !Ref aliasAttributes
       <% } %>
       MfaConfiguration: !Ref mfaConfiguration
+      <% if(props.useEnabledMfas && props.mfaConfiguration != 'OFF') {%>
+      EnabledMfas:
+        <% if(props.mfaTypes.includes('SMS Text Message') ||
+        props.autoVerifiedAttributes.includes('phone_number') ||
+        props.requiredAttributes.includes('phone_number')) {%> 
+        - SMS_MFA
+        <% } %>
+        <% if(props.mfaTypes.includes('TOTP')) {%>
+        - SOFTWARE_TOKEN_MFA
+        <% } %>
+      <% } %>  
+      <% if(!props.useEnabledMfas || 
+      (props.mfaConfiguration != 'OFF' && props.mfaTypes.includes('SMS Text Message')) || 
+      props.autoVerifiedAttributes.includes('phone_number') ||
+      props.requiredAttributes.includes('phone_number')) {%> 
       SmsVerificationMessage: !Ref smsVerificationMessage
       SmsAuthenticationMessage: !Ref smsAuthenticationMessage
       SmsConfiguration:
         SnsCallerArn: !GetAtt SNSRole.Arn
         ExternalId: <%=`${props.resourceNameTruncated}_role_external_id`%>
+      <% } %>
     <%if (props.mfaConfiguration != 'OFF') { %>
     DependsOn: SNSRole
     <% } %>
@@ -818,7 +834,7 @@ Resources:
     DependsOn: OAuthCustomResourceLogPolicy
   <% } %>
 
-  <%if (props.mfaConfiguration != 'OFF') { %>
+  <%if (!props.useEnabledMfas && props.mfaConfiguration != 'OFF') { %>
   # BEGIN MFA LAMBDA RESOURCES
   MFALambdaRole:
   # Created to execute Lambda which sets MFA config values

--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -1,4 +1,5 @@
 <% var autoVerifiedAttributes = props.autoVerifiedAttributes ? props.autoVerifiedAttributes.concat(props.aliasAttributes).filter((attr, i, aliasAttributeArray) => ['email', 'phone_number'].includes(attr) && aliasAttributeArray.indexOf(attr) === i) : [] %>
+<% var configureSMS = ((props.autoVerifiedAttributes && props.autoVerifiedAttributes.includes('phone_number')) || (props.mfaConfiguration != 'OFF' && props.mfaTypes && props.mfaTypes.includes('SMS Text Message')) || (props.requiredAttributes && props.requiredAttributes.includes('phone_number'))) %> 
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
@@ -78,6 +79,7 @@ Resources:
             MaxAge: 3000
   <% } %>
   <%if (props.authSelections !== 'identityPoolOnly') { %>
+  <% if(!props.useEnabledMfas || configureSMS) { %>
   # BEGIN SNS ROLE RESOURCE
   SNSRole:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
@@ -107,6 +109,7 @@ Resources:
                 Action:
                   - "sns:Publish"
                 Resource: "*"
+  <% } %> 
   # BEGIN USER POOL RESOURCES
   UserPool:
   # Created upon user selection
@@ -184,26 +187,21 @@ Resources:
       MfaConfiguration: !Ref mfaConfiguration
       <% if(props.useEnabledMfas && props.mfaConfiguration != 'OFF') {%>
       EnabledMfas:
-        <% if(props.mfaTypes.includes('SMS Text Message') ||
-        props.autoVerifiedAttributes.includes('phone_number') ||
-        props.requiredAttributes.includes('phone_number')) {%> 
+        <% if(configureSMS) {%> 
         - SMS_MFA
         <% } %>
         <% if(props.mfaTypes.includes('TOTP')) {%>
         - SOFTWARE_TOKEN_MFA
         <% } %>
       <% } %>  
-      <% if(!props.useEnabledMfas || 
-      (props.mfaConfiguration != 'OFF' && props.mfaTypes.includes('SMS Text Message')) || 
-      props.autoVerifiedAttributes.includes('phone_number') ||
-      props.requiredAttributes.includes('phone_number')) {%> 
+      <% if(!props.useEnabledMfas || configureSMS) {%> 
       SmsVerificationMessage: !Ref smsVerificationMessage
       SmsAuthenticationMessage: !Ref smsAuthenticationMessage
       SmsConfiguration:
         SnsCallerArn: !GetAtt SNSRole.Arn
         ExternalId: <%=`${props.resourceNameTruncated}_role_external_id`%>
       <% } %>
-    <%if (props.mfaConfiguration != 'OFF') { %>
+    <%if (configureSMS) { %>
     DependsOn: SNSRole
     <% } %>
   <%if (!props.breakCircularDependency && props.triggers && props.dependsOn) { %>
@@ -1224,7 +1222,7 @@ Outputs :
   AppClientSecret:
     Value: !GetAtt UserPoolClientInputs.appSecret
     Condition: ShouldOutputAppClientSecrets
-  <%if (props.mfaConfiguration != 'OFF') { %>
+  <%if (!props.useEnabledMfas || configureSMS) { %>
   CreatedSNSRole:
     Value: !GetAtt SNSRole.Arn
     Description: role arn

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
@@ -27,6 +27,7 @@ export interface ServiceQuestionsBaseResult {
   userpoolClientReadAttributes: string[];
   userpoolClientWriteAttributes: string[];
   usernameCaseSensitive?: boolean;
+  useEnabledMfas?: boolean;
   authTriggerConnections?: string;
 }
 

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -29,6 +29,9 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
   if (FeatureFlags.getBoolean('auth.enableCaseInsensitivity')) {
     result.usernameCaseSensitive = false;
   }
+  // If the feature flag is enabled the MFA TOTP can only be enabled
+
+  result.useEnabledMfas = FeatureFlags.getBoolean('auth.useEnabledMfas');
 
   /* merge actual answers object into props object,
    * ensuring that manual entries override defaults */

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -581,6 +581,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
       },
+      {
+        name: 'useEnabledMfas',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: true,
+      },
     ]);
 
     this.registerFlag('codegen', [
@@ -642,8 +648,8 @@ export class FeatureFlags {
         name: 'enableDartNullSafety',
         type: 'boolean',
         defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: true
-      }
+        defaultValueForNewProjects: true,
+      },
     ]);
 
     this.registerFlag('appSync', [

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -116,6 +116,11 @@ export const getUserPool = async (userpoolId, region) => {
   return res;
 };
 
+export const getMFAConfiguration = async (userPoolId, region): Promise<CognitoIdentityServiceProvider.GetUserPoolMfaConfigResponse> => {
+  config.update({ region });
+  return await new CognitoIdentityServiceProvider().getUserPoolMfaConfig({ UserPoolId: userPoolId }).promise();
+};
+
 export const getLambdaFunction = async (functionName: string, region: string) => {
   const lambda = new Lambda({ region });
   try {

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -116,7 +116,10 @@ export const getUserPool = async (userpoolId, region) => {
   return res;
 };
 
-export const getMFAConfiguration = async (userPoolId, region): Promise<CognitoIdentityServiceProvider.GetUserPoolMfaConfigResponse> => {
+export const getMFAConfiguration = async (
+  userPoolId: string,
+  region: string,
+): Promise<CognitoIdentityServiceProvider.GetUserPoolMfaConfigResponse> => {
   config.update({ region });
   return await new CognitoIdentityServiceProvider().getUserPoolMfaConfig({ UserPoolId: userPoolId }).promise();
 };

--- a/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
@@ -9,10 +9,11 @@ import {
   headlessAuthImport,
 } from 'amplify-e2e-core';
 import { addAuthWithDefault, getBackendAmplifyMeta } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool, getMFAConfiguration } from 'amplify-e2e-core';
 import {
   AddAuthRequest,
   CognitoUserPoolSigninMethod,
+  CognitoPasswordRecoveryConfiguration,
   CognitoUserProperty,
   ImportAuthRequest,
   UpdateAuthRequest,
@@ -63,6 +64,105 @@ describe('headless auth', () => {
     const meta = getProjectMeta(projRoot);
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
+    expect(userPool.UserPool).toBeDefined();
+  });
+  it('adds auth resource with TOTP only', async () => {
+    const addAuthRequest: AddAuthRequest = {
+      version: 1,
+      resourceName: 'myAuthResource',
+      serviceConfiguration: {
+        serviceName: 'Cognito',
+        includeIdentityPool: false,
+        userPoolConfiguration: {
+          requiredSignupAttributes: [CognitoUserProperty.EMAIL],
+          signinMethod: CognitoUserPoolSigninMethod.PHONE_NUMBER,
+          mfa: {
+            mode: 'OPTIONAL',
+            mfaTypes: ['TOTP'],
+            smsMessage: 'The verification code is',
+          },
+        },
+      },
+    };
+
+    await initJSProjectWithProfile(projRoot, defaultsSettings);
+    await addHeadlessAuth(projRoot, addAuthRequest);
+    await amplifyPushAuth(projRoot);
+    const meta = getProjectMeta(projRoot);
+    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+    const region = meta.providers.awscloudformation.Region;
+    const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
+    const mfaconfig = await getMFAConfiguration(id, region);
+    expect(mfaconfig.SoftwareTokenMfaConfiguration.Enabled).toBeTruthy();
+    expect(mfaconfig.SmsMfaConfiguration).toBeUndefined();
+    expect(userPool.UserPool).toBeDefined();
+  });
+
+  it('adds auth resource with TOTP only but enable SMS through signUp Attributes', async () => {
+    const addAuthRequest: AddAuthRequest = {
+      version: 1,
+      resourceName: 'myAuthResource',
+      serviceConfiguration: {
+        serviceName: 'Cognito',
+        includeIdentityPool: false,
+        userPoolConfiguration: {
+          requiredSignupAttributes: [CognitoUserProperty.EMAIL, CognitoUserProperty.PHONE_NUMBER],
+          signinMethod: CognitoUserPoolSigninMethod.PHONE_NUMBER,
+          mfa: {
+            mode: 'OPTIONAL',
+            mfaTypes: ['TOTP'],
+            smsMessage: 'The verification code is {####}',
+          },
+        },
+      },
+    };
+
+    await initJSProjectWithProfile(projRoot, defaultsSettings);
+    await addHeadlessAuth(projRoot, addAuthRequest);
+    await amplifyPushAuth(projRoot);
+    const meta = getProjectMeta(projRoot);
+    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+    const region = meta.providers.awscloudformation.Region;
+    const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
+    const mfaconfig = await getMFAConfiguration(id, region);
+    expect(mfaconfig.SoftwareTokenMfaConfiguration.Enabled).toBeTruthy();
+    expect(mfaconfig.SmsMfaConfiguration.SmsConfiguration).toBeDefined();
+    expect(userPool.UserPool).toBeDefined();
+  });
+
+  it('adds auth resource with TOTP only but enables SMS through password recovery', async () => {
+    const addAuthRequest: AddAuthRequest = {
+      version: 1,
+      resourceName: 'myAuthResource',
+      serviceConfiguration: {
+        serviceName: 'Cognito',
+        includeIdentityPool: false,
+        userPoolConfiguration: {
+          requiredSignupAttributes: [CognitoUserProperty.EMAIL],
+          passwordRecovery: {
+            deliveryMethod: 'SMS',
+            smsMessage: 'The verification code is {####}',
+          },
+          signinMethod: CognitoUserPoolSigninMethod.PHONE_NUMBER,
+          mfa: {
+            mode: 'OPTIONAL',
+            mfaTypes: ['TOTP'],
+            smsMessage: 'The verification code is {####}',
+          },
+        },
+      },
+    };
+
+    await initJSProjectWithProfile(projRoot, defaultsSettings);
+    await addHeadlessAuth(projRoot, addAuthRequest);
+    await amplifyPushAuth(projRoot);
+    const meta = getProjectMeta(projRoot);
+    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+    const region = meta.providers.awscloudformation.Region;
+    const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
+    const mfaconfig = await getMFAConfiguration(id, region);
+    expect(mfaconfig.SoftwareTokenMfaConfiguration.Enabled).toBeTruthy();
+    expect(mfaconfig.SmsMfaConfiguration.SmsConfiguration).toBeDefined();
     expect(userPool.UserPool).toBeDefined();
   });
 
@@ -117,7 +217,7 @@ describe('headless auth', () => {
   });
 
   describe(' import', () => {
-    let ogProjectSettings: {name: string};
+    let ogProjectSettings: { name: string };
     let ogProjectRoot: string;
 
     beforeEach(async () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Added a way to only configure only TOTP. Configuring the user pool with any other attribute with 'phone_number' turn on SMS MFA


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

`yarn e2e src/__tests__/auth_*`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.