### PR TITLE
fix(amplify-category-auth): add handling for undefined autoVerifiedAttributes

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -1,4 +1,4 @@
-<% var autoVerifiedAttributes = props.autoVerifiedAttributes.concat(props.aliasAttributes).filter((attr, i, aliasAttributeArray) => ['email', 'phone_number'].includes(attr) && aliasAttributeArray.indexOf(attr) === i) %>
+<% var autoVerifiedAttributes = props.autoVerifiedAttributes ? props.autoVerifiedAttributes.concat(props.aliasAttributes).filter((attr, i, aliasAttributeArray) => ['email', 'phone_number'].includes(attr) && aliasAttributeArray.indexOf(attr) === i) : [] %>
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
@@ -164,7 +164,7 @@ Resources:
         - <%= autoVerifiedAttributes[x] %>
       <% } %>
       <% } %>
-      <%if (autoVerifiedAttributes.includes('email')) { %>
+      <%if (autoVerifiedAttributes && autoVerifiedAttributes.includes('email')) { %>
       EmailVerificationMessage: !Ref emailVerificationMessage
       EmailVerificationSubject: !Ref emailVerificationSubject
       <% } %>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This commit fixes a bug where if `autoVerifiedAttributes` is undefined, the ejs template breaks.

#### Description of how you validated changes

- existing e2e test failure now passes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.