### PR TITLE
test(amplify-e2e-tests): assume function and layer lambdas are not being tested simultaneously

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-layer.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-layer.ts
@@ -251,9 +251,6 @@ export function updateLayer(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const chain: ExecutionContext = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'function'], { cwd, stripColors: true })
-      .wait('Select which capability you want to update:')
-      .sendKeyDown()
-      .sendCarriageReturn(); // Layer
     if (settings.numLayers > 1) {
       chain.wait('Select the Lambda layer to update:').sendCarriageReturn();
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

this commit updates the lambda layer e2e helper so that it no longer expects a prompt to choose layer vs function, which is no longer needed since automatic detection was added in https://github.com/aws-amplify/amplify-cli/pull/7755


#### Description of how you validated changes

- failing test `yarn e2e src/__tests__/layer.test.ts` now passes
- failing test `yarn e2e src/__tests__/layer-2.test.ts` now passes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.