### PR TITLE
test(amplify-e2e-tests): add layerAndFunctionExist param to trigger capability selection

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -175,6 +175,9 @@ const coreFunction = (
         selectTemplate(chain, settings.functionTemplate, runtime);
       }
     } else {
+      if (settings.layerOptions && settings.layerOptions.layerAndFunctionExist) {
+        chain.wait('Select which capability you want to update:').sendCarriageReturn() // lambda function
+      }
       chain.wait('Select the Lambda function you want to update').sendCarriageReturn(); // assumes only one function configured in the project
     }
 
@@ -358,6 +361,7 @@ export const removeFunction = (cwd: string, funcName: string) =>
 
 export interface LayerOptions {
   select?: string[]; // list options to select
+  layerAndFunctionExist?: boolean; // whether this test involves both a function and a layer
   expectedListOptions?: string[]; // the expected list of all layers
   versions?: Record<string, { version: number; expectedVersionOptions: number[] }>; // map with keys for each element of select that determines the verison and expected version for each layer
   customArns?: string[]; // external ARNs to enter

--- a/packages/amplify-e2e-tests/src/__tests__/layer-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer-2.test.ts
@@ -254,6 +254,7 @@ describe('amplify add lambda layer with changes', () => {
         expectedListOptions: [fullLayerName],
         versions: { [fullLayerName]: { version: 1, expectedVersionOptions: [1] } },
         skipLayerAssignment: true,
+        layerAndFunctionExist: true,
       },
     };
 
@@ -277,6 +278,7 @@ describe('amplify add lambda layer with changes', () => {
       layerName,
       projName,
       layerOptions: {
+        layerAndFunctionExist: true,
         layerWalkthrough: (chain: ExecutionContext): void => {
           chain
             .wait('Provide existing layers')

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts
@@ -172,6 +172,7 @@ describe('test lambda layer migration flow introduced in v5.0.0', () => {
       layerOptions: {
         select: [],
         expectedListOptions: [layerName],
+        layerAndFunctionExist: true,
       },
     };
 

--- a/packages/amplify-migration-tests/src/__tests__/update_tests/function_migration_update.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/update_tests/function_migration_update.test.ts
@@ -117,6 +117,7 @@ describe('amplify function migration', () => {
         layerOptions: {
           select: [projName + layerName],
           expectedListOptions: [projName + layerName],
+          layerAndFunctionExist: true,
         },
         name: function1,
         testingWithLatestCodebase: true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This commit adds a flag, `settings.layerOptions.layerAndFunctionExist` to e2e tests where the test should expect that the capability will need to be prompted on update.


#### Description of how you validated changes

- ran e2e migration and layer tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.