### PR TITLE
fix(amplify-category-geo): modify the pricing plan walkthrough

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1202,7 +1202,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/s3-sse.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
   pull-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1210,7 +1210,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/pull.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
   migration-node-function-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1218,7 +1218,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
   layer-2-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1226,7 +1226,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/layer-2.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
   iam-permissions-boundary-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1234,7 +1234,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
   function_7-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1242,7 +1242,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_7.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
   function_6-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1250,7 +1250,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_6.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
   function_5-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1258,7 +1258,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
   frontend_config_drift-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1266,7 +1266,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
   configure-project-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1274,7 +1274,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/configure-project.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
   api_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1282,7 +1282,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -1971,7 +1971,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/pull.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_6
   migration-node-function-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1981,7 +1981,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_6
   layer-2-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1991,7 +1991,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/layer-2.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
     steps: *ref_6
   iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2001,7 +2001,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: us-west-2
     steps: *ref_6
   function_7-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2011,7 +2011,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_7.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: eu-west-2
     steps: *ref_6
   function_6-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2021,7 +2021,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_6.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: eu-central-1
     steps: *ref_6
   function_5-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2031,7 +2031,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: ap-northeast-1
     steps: *ref_6
   frontend_config_drift-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2041,7 +2041,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: ap-southeast-1
     steps: *ref_6
   configure-project-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2051,7 +2051,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/configure-project.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-southeast-2
     steps: *ref_6
   api_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2061,7 +2061,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_4.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
     steps: *ref_6
 workflows:
   version: 2
@@ -2165,18 +2165,18 @@ workflows:
                 - /run-e2e\/*./
       - done_with_node_e2e_tests:
           requires:
-            - containers-api-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - datastore-modelgen-amplify_e2e_tests
-            - iam-permissions-boundary-amplify_e2e_tests
+            - layer-2-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
             - schema-iterative-update-2-amplify_e2e_tests
             - schema-data-access-patterns-amplify_e2e_tests
             - init-special-case-amplify_e2e_tests
-            - function_7-amplify_e2e_tests
+            - iam-permissions-boundary-amplify_e2e_tests
             - feature-flags-amplify_e2e_tests
             - schema-versioned-amplify_e2e_tests
             - plugin-amplify_e2e_tests
-            - function_6-amplify_e2e_tests
+            - function_7-amplify_e2e_tests
             - analytics-amplify_e2e_tests
             - notifications-amplify_e2e_tests
             - schema-iterative-update-locking-amplify_e2e_tests
@@ -2193,32 +2193,20 @@ workflows:
             - amplify-configure-amplify_e2e_tests
             - migration-node-function-amplify_e2e_tests
             - configure-project-amplify_e2e_tests
-            - interactions-amplify_e2e_tests
-            - datastore-modelgen-amplify_e2e_tests
-            - layer-2-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
-            - schema-iterative-update-2-amplify_e2e_tests
-            - schema-data-access-patterns-amplify_e2e_tests
-            - init-special-case-amplify_e2e_tests
-            - iam-permissions-boundary-amplify_e2e_tests
-            - feature-flags-amplify_e2e_tests
-            - schema-versioned-amplify_e2e_tests
-            - plugin-amplify_e2e_tests
-            - function_7-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           requires:
-            - containers-api-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
             - datastore-modelgen-amplify_e2e_tests_pkg_linux
-            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
+            - layer-2-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
             - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
             - init-special-case-amplify_e2e_tests_pkg_linux
-            - function_7-amplify_e2e_tests_pkg_linux
+            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
             - feature-flags-amplify_e2e_tests_pkg_linux
             - schema-versioned-amplify_e2e_tests_pkg_linux
             - plugin-amplify_e2e_tests_pkg_linux
-            - function_6-amplify_e2e_tests_pkg_linux
+            - function_7-amplify_e2e_tests_pkg_linux
             - analytics-amplify_e2e_tests_pkg_linux
             - notifications-amplify_e2e_tests_pkg_linux
             - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
@@ -2235,18 +2223,6 @@ workflows:
             - amplify-configure-amplify_e2e_tests_pkg_linux
             - migration-node-function-amplify_e2e_tests_pkg_linux
             - configure-project-amplify_e2e_tests_pkg_linux
-            - interactions-amplify_e2e_tests_pkg_linux
-            - datastore-modelgen-amplify_e2e_tests_pkg_linux
-            - layer-2-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
-            - schema-iterative-update-2-amplify_e2e_tests_pkg_linux
-            - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
-            - init-special-case-amplify_e2e_tests_pkg_linux
-            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
-            - feature-flags-amplify_e2e_tests_pkg_linux
-            - schema-versioned-amplify_e2e_tests_pkg_linux
-            - plugin-amplify_e2e_tests_pkg_linux
-            - function_7-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           context:
             - amplify-ecr-image-pull
@@ -2462,12 +2438,18 @@ workflows:
           filters: *ref_10
           requires:
             - function_2-amplify_e2e_tests
-      - function_6-amplify_e2e_tests:
+      - layer-2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-key-amplify_e2e_tests
+      - api_4-amplify_e2e_tests:
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
+          requires:
+            - containers-api-amplify_e2e_tests
       - api_2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -2528,7 +2510,7 @@ workflows:
           filters: *ref_10
           requires:
             - delete-amplify_e2e_tests
-      - function_5-amplify_e2e_tests:
+      - iam-permissions-boundary-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2588,13 +2570,13 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests
-      - pull-amplify_e2e_tests:
+      - plugin-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-auth-3-amplify_e2e_tests
-      - frontend_config_drift-amplify_e2e_tests:
+      - function_7-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2654,13 +2636,13 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests
-      - migration-node-function-amplify_e2e_tests:
+      - schema-iterative-update-locking-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-iterative-update-1-amplify_e2e_tests
-      - configure-project-amplify_e2e_tests:
+      - function_6-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2720,18 +2702,18 @@ workflows:
           filters: *ref_10
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
-      - layer-2-amplify_e2e_tests:
+      - s3-sse-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - function_3-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - function_5-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - containers-api-amplify_e2e_tests
+            - geo-add-amplify_e2e_tests
       - schema-auth-2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -2786,13 +2768,13 @@ workflows:
           filters: *ref_10
           requires:
             - layer-amplify_e2e_tests
-      - iam-permissions-boundary-amplify_e2e_tests:
+      - pull-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - auth_5-amplify_e2e_tests
-      - configure-project-amplify_e2e_tests:
+      - frontend_config_drift-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2852,13 +2834,13 @@ workflows:
           filters: *ref_10
           requires:
             - auth_3-amplify_e2e_tests
-      - function_7-amplify_e2e_tests:
+      - migration-node-function-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - auth_1-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - configure-project-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2938,12 +2920,18 @@ workflows:
           filters: *ref_13
           requires:
             - function_2-amplify_e2e_tests_pkg_linux
-      - function_6-amplify_e2e_tests_pkg_linux:
+      - layer-2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-key-amplify_e2e_tests_pkg_linux
+      - api_4-amplify_e2e_tests_pkg_linux:
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
+          requires:
+            - containers-api-amplify_e2e_tests_pkg_linux
       - api_2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
@@ -3008,7 +2996,7 @@ workflows:
           filters: *ref_13
           requires:
             - delete-amplify_e2e_tests_pkg_linux
-      - function_5-amplify_e2e_tests_pkg_linux:
+      - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3072,13 +3060,13 @@ workflows:
           filters: *ref_13
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
-      - pull-amplify_e2e_tests_pkg_linux:
+      - plugin-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-auth-3-amplify_e2e_tests_pkg_linux
-      - frontend_config_drift-amplify_e2e_tests_pkg_linux:
+      - function_7-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3142,13 +3130,13 @@ workflows:
           filters: *ref_13
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - migration-node-function-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-iterative-update-1-amplify_e2e_tests_pkg_linux
-      - configure-project-amplify_e2e_tests_pkg_linux:
+      - function_6-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3212,18 +3200,18 @@ workflows:
           filters: *ref_13
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
-      - layer-2-amplify_e2e_tests_pkg_linux:
+      - s3-sse-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - function_3-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - function_5-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - containers-api-amplify_e2e_tests_pkg_linux
+            - geo-add-amplify_e2e_tests_pkg_linux
       - schema-auth-2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
@@ -3282,13 +3270,13 @@ workflows:
           filters: *ref_13
           requires:
             - layer-amplify_e2e_tests_pkg_linux
-      - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
+      - pull-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - auth_5-amplify_e2e_tests_pkg_linux
-      - configure-project-amplify_e2e_tests_pkg_linux:
+      - frontend_config_drift-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3352,13 +3340,13 @@ workflows:
           filters: *ref_13
           requires:
             - auth_3-amplify_e2e_tests_pkg_linux
-      - function_7-amplify_e2e_tests_pkg_linux:
+      - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - auth_1-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - configure-project-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13

--- a/packages/amplify-category-geo/package.json
+++ b/packages/amplify-category-geo/package.json
@@ -22,7 +22,7 @@
     "aws"
   ],
   "dependencies": {
-    "amplify-cli-core": "1.24.0",
+    "amplify-cli-core": "1.24.1",
     "enquirer": "^2.3.6",
     "folder-hash": "^3.3.2",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
@@ -3,7 +3,6 @@ import { EsriMapStyleType, getGeoMapStyle, MapParameters, MapStyle } from '../..
 import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
-import { YesOrNo } from '../../service-walkthroughs/resourceWalkthrough';
 
 jest.mock('amplify-cli-core');
 
@@ -87,7 +86,7 @@ describe('Map walkthrough works as expected', () => {
                     mockUserInput['mapStyle'] = getGeoMapStyle(mockMapParameters.dataProvider, mockMapParameters.mapStyleType);
                 }
                 else if(questions[0].name === 'pricingPlanBusinessType') {
-                    mockUserInput['pricingPlanBusinessType'] = YesOrNo.Yes;
+                    mockUserInput['pricingPlanBusinessType'] = true;
                 }
                 else if(questions[0].name === 'resourceName') {
                     mockUserInput['resourceName'] = mockMapParameters.name;

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
@@ -3,6 +3,7 @@ import { EsriMapStyleType, getGeoMapStyle, MapParameters, MapStyle } from '../..
 import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
+import { YesOrNo } from '../../service-walkthroughs/resourceWalkthrough';
 
 jest.mock('amplify-cli-core');
 
@@ -25,7 +26,8 @@ describe('Map walkthrough works as expected', () => {
     };
     const mockPlaceIndexResource = {
         resourceName: 'placeIndex12345',
-        service: 'PlaceIndex'
+        service: ServiceName.PlaceIndex,
+        pricingPlan: PricingPlan.MobileAssetTracking
     };
 
     const mockMapParameters: MapParameters = {
@@ -37,7 +39,7 @@ describe('Map walkthrough works as expected', () => {
         name: mockMapName,
         mapStyleType: EsriMapStyleType.Streets,
         dataProvider: DataProvider.Esri,
-        pricingPlan: PricingPlan.RequestBasedUsage,
+        pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedUsers,
         isDefault: false
     };
@@ -84,8 +86,8 @@ describe('Map walkthrough works as expected', () => {
                 else if(questions[0].name === 'mapStyle') {
                     mockUserInput['mapStyle'] = getGeoMapStyle(mockMapParameters.dataProvider, mockMapParameters.mapStyleType);
                 }
-                else if(questions[0].name === 'pricingPlan') {
-                    mockUserInput['pricingPlan'] = mockMapParameters.pricingPlan;
+                else if(questions[0].name === 'pricingPlanBusinessType') {
+                    mockUserInput['pricingPlanBusinessType'] = YesOrNo.Yes;
                 }
                 else if(questions[0].name === 'resourceName') {
                     mockUserInput['resourceName'] = mockMapParameters.name;
@@ -161,7 +163,7 @@ describe('Map walkthrough works as expected', () => {
         expect(mockContext.print.error).toBeCalledWith('No Map resource to update. Use "amplify add geo" to create a new Map.');
     });
 
-    it('sets parameters based on user input for add map walkthrough', async() => {
+    it('sets parameters based on user input for adding subsequent map walkthrough', async() => {
         let mapParams: Partial<MapParameters> = {
             providerContext: mockMapParameters.providerContext
         };
@@ -183,7 +185,7 @@ describe('Map walkthrough works as expected', () => {
 
         expect({ ...mockMapParameters, isDefault: true }).toMatchObject(mapParams);
         // map default setting question is skipped
-        expect(mockContext.amplify.confirmPrompt).toBeCalledTimes(1);
+        expect(mockContext.amplify.confirmPrompt).toBeCalledTimes(2);
         expect(mockContext.amplify.confirmPrompt).toBeCalledWith('Do you want to configure advanced settings?', false);
     });
 

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
@@ -3,6 +3,7 @@ import { DataSourceIntendedUse, PlaceIndexParameters } from '../../service-utils
 import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
+import { YesOrNo } from '../../service-walkthroughs/resourceWalkthrough';
 
 jest.mock('amplify-cli-core');
 
@@ -14,7 +15,8 @@ describe('Search walkthrough works as expected', () => {
     const secondaryPlaceIndexName = 'secondaryindex12345';
     const mockMapResource = {
         resourceName: 'map12345',
-        service: ServiceName.Map
+        service: ServiceName.Map,
+        pricingPlan: PricingPlan.MobileAssetTracking
     };
     const mockPlaceIndexResource = {
         resourceName: mockPlaceIndexName,
@@ -33,7 +35,7 @@ describe('Search walkthrough works as expected', () => {
         name: mockPlaceIndexName,
         dataProvider: DataProvider.Esri,
         dataSourceIntendedUse: DataSourceIntendedUse.SingleUse,
-        pricingPlan: PricingPlan.RequestBasedUsage,
+        pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedUsers,
         isDefault: false
     };
@@ -83,8 +85,8 @@ describe('Search walkthrough works as expected', () => {
                 else if(questions[0].name === 'dataSourceIntendedUse') {
                     mockUserInput['dataSourceIntendedUse'] = mockPlaceIndexParameters.dataSourceIntendedUse;
                 }
-                else if(questions[0].name === 'pricingPlan') {
-                    mockUserInput['pricingPlan'] = mockPlaceIndexParameters.pricingPlan;
+                else if(questions[0].name === 'pricingPlanBusinessType') {
+                    mockUserInput['pricingPlanBusinessType'] = YesOrNo.Yes;
                 }
                 else if(questions[0].name === 'resourceName') {
                     mockUserInput['resourceName'] = mockPlaceIndexParameters.name;
@@ -160,7 +162,7 @@ describe('Search walkthrough works as expected', () => {
         expect(mockContext.print.error).toBeCalledWith('No search index resource to update. Use "amplify add geo" to create a new search index.');
     });
 
-    it('sets parameters based on user input for add place index walkthrough', async() => {
+    it('sets parameters based on user input for adding subsequent place index walkthrough', async() => {
         let indexParams: Partial<PlaceIndexParameters> = {
             providerContext: mockPlaceIndexParameters.providerContext
         };
@@ -182,7 +184,7 @@ describe('Search walkthrough works as expected', () => {
 
         expect({ ...mockPlaceIndexParameters, isDefault: true }).toMatchObject(indexParams);
         // place index default setting question is skipped
-        expect(mockContext.amplify.confirmPrompt).toBeCalledTimes(1);
+        expect(mockContext.amplify.confirmPrompt).toBeCalledTimes(2);
         expect(mockContext.amplify.confirmPrompt).toBeCalledWith('Do you want to configure advanced settings?', false);
     });
 

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
@@ -3,7 +3,6 @@ import { DataSourceIntendedUse, PlaceIndexParameters } from '../../service-utils
 import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
-import { YesOrNo } from '../../service-walkthroughs/resourceWalkthrough';
 
 jest.mock('amplify-cli-core');
 
@@ -86,7 +85,7 @@ describe('Search walkthrough works as expected', () => {
                     mockUserInput['dataSourceIntendedUse'] = mockPlaceIndexParameters.dataSourceIntendedUse;
                 }
                 else if(questions[0].name === 'pricingPlanBusinessType') {
-                    mockUserInput['pricingPlanBusinessType'] = YesOrNo.Yes;
+                    mockUserInput['pricingPlanBusinessType'] = true;
                 }
                 else if(questions[0].name === 'resourceName') {
                     mockUserInput['resourceName'] = mockPlaceIndexParameters.name;

--- a/packages/amplify-category-geo/src/service-utils/constants.ts
+++ b/packages/amplify-category-geo/src/service-utils/constants.ts
@@ -1,7 +1,14 @@
+export const apiDocs = {
+  mapStyles: "https://docs.aws.amazon.com/location-maps/latest/APIReference/API_MapConfiguration.html",
+  pricingPlan: "https://aws.amazon.com/location/pricing/",
+  dataSourceUsage: "https://docs.aws.amazon.com/location-places/latest/APIReference/API_DataSourceConfiguration.html"
+}
+
 export const previewBanner = 'Amplify Geo category is in developer preview and not intended for production use at this time.';
 export const chooseServiceMessageAdd = 'Select which capability you want to add:';
 export const chooseServiceMessageUpdate = 'Select which capability you want to update:';
 export const chooseServiceMessageRemove = 'Select which capability you want to remove:';
+export const choosePricingPlan = `The following choices determine the pricing plan for Geo resources. Learn more at ${apiDocs.pricingPlan}`;
 export const parametersFileName = 'parameters.json';
 export const provider = 'awscloudformation';
 
@@ -11,10 +18,3 @@ export const enum ServiceName {
   GeofenceCollection = "GeofenceCollection",
   Tracker = "Tracker"
 }
-
-export const apiDocs = {
-  mapStyles: "https://docs.aws.amazon.com/location-maps/latest/APIReference/API_MapConfiguration.html",
-  pricingPlan: "https://aws.amazon.com/location/pricing/",
-  dataSourceUsage: "https://docs.aws.amazon.com/location-places/latest/APIReference/API_DataSourceConfiguration.html"
-}
-

--- a/packages/amplify-category-geo/src/service-utils/mapUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapUtils.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { parametersFileName, provider, ServiceName } from './constants';
 import { category } from '../constants';
 import { MapStack } from '../service-stacks/mapStack';
-import { updateParametersFile, getGeoServiceMeta, generateTemplateFile, updateDefaultResource, readResourceMetaParameters } from './resourceUtils';
+import { updateParametersFile, getGeoServiceMeta, generateTemplateFile, updateDefaultResource, readResourceMetaParameters, updateGeoPricingPlan } from './resourceUtils';
 import { App } from '@aws-cdk/core';
 
 export const createMapResource = async (context: $TSContext, parameters: MapParameters) => {
@@ -20,6 +20,9 @@ export const createMapResource = async (context: $TSContext, parameters: MapPara
     // remove the previous default map
     await updateDefaultResource(context, ServiceName.Map);
   }
+
+  // update the pricing plan
+  await updateGeoPricingPlan(context, parameters.pricingPlan);
 
   context.amplify.updateamplifyMetaAfterResourceAdd(
     category,

--- a/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { parametersFileName, provider, ServiceName } from './constants';
 import { category } from '../constants';
 import { PlaceIndexStack } from '../service-stacks/placeIndexStack';
-import { updateParametersFile, generateTemplateFile, updateDefaultResource, readResourceMetaParameters } from './resourceUtils';
+import { updateParametersFile, generateTemplateFile, updateDefaultResource, readResourceMetaParameters, updateGeoPricingPlan } from './resourceUtils';
 import { App } from '@aws-cdk/core';
 
 export const createPlaceIndexResource = async (context: $TSContext, parameters: PlaceIndexParameters) => {
@@ -20,6 +20,9 @@ export const createPlaceIndexResource = async (context: $TSContext, parameters: 
     // remove the previous default place index
     await updateDefaultResource(context, ServiceName.PlaceIndex);
   }
+
+  // update the pricing plan
+  await updateGeoPricingPlan(context, parameters.pricingPlan);
 
   context.amplify.updateamplifyMetaAfterResourceAdd(
     category,

--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -3,7 +3,8 @@ import { category } from '../constants';
 import path from 'path';
 import _ from 'lodash';
 import { BaseStack } from '../service-stacks/baseStack';
-import { ServiceName } from './constants';
+import { parametersFileName, ServiceName } from './constants';
+import { PricingPlan } from './resourceParams';
 
 
 // Merges other with existing in a non-destructive way.
@@ -85,3 +86,50 @@ export const updateDefaultResource = async (
     );
   });
 };
+
+/**
+ * Check if any resource of given type exists
+ */
+export const geoServiceExists = async (service: ServiceName): Promise<boolean> => {
+  const serviceMeta = await getGeoServiceMeta(service);
+  return serviceMeta && Object.keys(serviceMeta).length > 0;
+}
+
+/**
+ * Get the pricing plan for Geo resources
+ */
+export const getGeoPricingPlan = async (): Promise<PricingPlan> => {
+  // search Map resources
+  const mapServiceMeta = await getGeoServiceMeta(ServiceName.Map);
+  const placeIndexServiceMeta = await getGeoServiceMeta(ServiceName.PlaceIndex);
+  if (mapServiceMeta && Object.keys(mapServiceMeta).length > 0) {
+    return mapServiceMeta[Object.keys(mapServiceMeta)[0]].pricingPlan;
+  }
+  else if (placeIndexServiceMeta && Object.keys(placeIndexServiceMeta).length > 0) {
+    return placeIndexServiceMeta[Object.keys(placeIndexServiceMeta)[0]].pricingPlan;
+  }
+  return PricingPlan.RequestBasedUsage; // default
+}
+
+/**
+ * Update Geo pricing plan
+ */
+export const updateGeoPricingPlan = async (context: $TSContext, pricingPlan: PricingPlan) => {
+  const geoMeta = stateManager.getMeta()?.[category]
+  Object.keys(geoMeta).forEach(resource => {
+    // update pricing plan in meta for all Geo resources
+    context.amplify.updateamplifyMetaAfterResourceUpdate(
+      category,
+      resource,
+      'pricingPlan',
+      pricingPlan
+    );
+
+    // update CFN parameters for all Geo resources
+    updateParametersFile(
+      { pricingPlan: pricingPlan },
+      resource,
+      parametersFileName
+    );
+  });
+}

--- a/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
@@ -36,7 +36,10 @@ export const createMapWalkthrough = async (
   // ask if the map should be set as a default. Default to true if it's the only map
   const currentMapResources = await getGeoServiceMeta(ServiceName.Map);
   if (currentMapResources && Object.keys(currentMapResources).length > 0) {
-    parameters.isDefault = await context.amplify.confirmPrompt('Do you want to set this map as default?', true)
+    parameters.isDefault = await context.amplify.confirmPrompt(
+        'Do you want to set this map as default? It will be used in Amplify Map API calls if no explicit reference is provided.',
+        true
+    );
   }
   else {
       parameters.isDefault = true;
@@ -65,7 +68,8 @@ export const mapNameWalkthrough = async (context: any): Promise<Partial<MapParam
 };
 
 export const mapAdvancedWalkthrough = async (context: $TSContext, parameters: Partial<MapParameters>): Promise<Partial<MapParameters>> => {
-    const includePricingPlan = await geoServiceExists(ServiceName.Map) || await geoServiceExists(ServiceName.PlaceIndex);
+    // const includePricingPlan = await geoServiceExists(ServiceName.Map) || await geoServiceExists(ServiceName.PlaceIndex);
+    const includePricingPlan = false;
     const currentPricingPlan = parameters.pricingPlan ? parameters.pricingPlan : await getGeoPricingPlan();
     context.print.info('Available advanced settings:');
     context.print.info('- Map style & Map data provider (default: Streets provided by Esri)');
@@ -81,6 +85,9 @@ export const mapAdvancedWalkthrough = async (context: $TSContext, parameters: Pa
         if (includePricingPlan) {
             // get the pricing plan
             parameters = merge(parameters, await pricingPlanWalkthrough(context, parameters));
+        }
+        else {
+            parameters.pricingPlan = currentPricingPlan;
         }
     }
     else {

--- a/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
@@ -36,7 +36,10 @@ export const createPlaceIndexWalkthrough = async (
   // ask if the place index should be set as a default. Default to true if it's the only place index
   const currentPlaceIndexResources = await getGeoServiceMeta(ServiceName.PlaceIndex);
   if (currentPlaceIndexResources && Object.keys(currentPlaceIndexResources).length > 0) {
-    parameters.isDefault = await context.amplify.confirmPrompt('Do you want to set this search index as default?', true)
+    parameters.isDefault = await context.amplify.confirmPrompt(
+        'Do you want to set this search index as default? It will be used in Amplify Search API calls if no explicit reference is provided.',
+        true
+    );
   }
   else {
       parameters.isDefault = true;
@@ -65,7 +68,8 @@ export const placeIndexNameWalkthrough = async (context: any): Promise<Partial<P
 };
 
 export const placeIndexAdvancedWalkthrough = async (context: $TSContext, parameters: Partial<PlaceIndexParameters>): Promise<Partial<PlaceIndexParameters>> => {
-    const includePricingPlan = await geoServiceExists(ServiceName.Map) || await geoServiceExists(ServiceName.PlaceIndex);
+    // const includePricingPlan = await geoServiceExists(ServiceName.Map) || await geoServiceExists(ServiceName.PlaceIndex);
+    const includePricingPlan = false;
     const currentPricingPlan = parameters.pricingPlan ? parameters.pricingPlan : await getGeoPricingPlan();
     context.print.info('Available advanced settings:');
     context.print.info('- Search data provider (default: Esri)');
@@ -82,6 +86,9 @@ export const placeIndexAdvancedWalkthrough = async (context: $TSContext, paramet
         if (includePricingPlan) {
             // get the pricing plan
             parameters = merge(parameters, await pricingPlanWalkthrough(context, parameters));
+        }
+        else {
+            parameters.pricingPlan = currentPricingPlan;
         }
 
         // get the place index data storage option if the pricing plan is RequestBasedUsage

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -1,7 +1,8 @@
 import { AccessType, DataProvider, ResourceParameters } from "../service-utils/resourceParams";
 import inquirer from "inquirer";
-import { apiDocs, ServiceName } from "../service-utils/constants";
+import { ServiceName, choosePricingPlan } from "../service-utils/constants";
 import { PricingPlan } from "../service-utils/resourceParams";
+import { $TSContext } from "amplify-cli-core";
 
 export async function resourceAccessWalkthrough<T extends ResourceParameters>(
     parameters: Partial<T>,
@@ -18,17 +19,40 @@ export async function resourceAccessWalkthrough<T extends ResourceParameters>(
 };
 
 export async function pricingPlanWalkthrough<T extends ResourceParameters>(
-    parameters: Partial<T>,
-    service: ServiceName
+    context: $TSContext,
+    parameters: Partial<T>
 ): Promise<Partial<T>> {
-    const pricingPlanPrompt = {
+    let pricingPlan: PricingPlan = parameters.pricingPlan ? parameters.pricingPlan : PricingPlan.RequestBasedUsage;
+
+    context.print.info(choosePricingPlan);
+
+    const pricingPlanBusinessTypeChoices = [
+        { name: 'No, I only need to track consumers personal mobile devices', value: YesOrNo.No },
+        { name: 'Yes, I track commercial assets (For example, any mobile object that is tracked by a company in support of its business)', value: YesOrNo.Yes }
+    ];
+    const pricingPlanBusinessTypePrompt = {
         type: 'list',
-        name: 'pricingPlan',
-        message: `Specify the pricing plan for this ${getServiceFriendlyName(service)}. Refer ${apiDocs.pricingPlan}:`,
-        choices: Object.values(PricingPlan),
-        default: parameters.pricingPlan ? parameters.pricingPlan : 'RequestBasedUsage'
+        name: 'pricingPlanBusinessType',
+        message: 'Are you tracking commercial assets for your business?',
+        choices: pricingPlanBusinessTypeChoices,
+        default: pricingPlan === PricingPlan.RequestBasedUsage ? YesOrNo.No : YesOrNo.Yes
     };
-    return await inquirer.prompt([pricingPlanPrompt]);
+
+    const pricingPlanBusinessTypeChoice = ((await inquirer.prompt([pricingPlanBusinessTypePrompt])).pricingPlanBusinessType as YesOrNo);
+    if (pricingPlanBusinessTypeChoice === YesOrNo.No) {
+        pricingPlan = PricingPlan.RequestBasedUsage;
+    }
+    else {
+        const pricingPlanRoutingChoice = await context.amplify.confirmPrompt(
+            'Does your app provide routing or route optimization for commercial assets?',
+            pricingPlan === PricingPlan.MobileAssetManagement ? true : false
+        );
+        pricingPlan = pricingPlanRoutingChoice ? PricingPlan.MobileAssetManagement : PricingPlan.MobileAssetTracking;
+    }
+    parameters.pricingPlan = pricingPlan;
+
+    context.print.info(`Successfully set ${pricingPlan} pricing plan for your Geo resources.`);
+    return parameters;
 };
 
 export async function dataProviderWalkthrough<T extends ResourceParameters>(
@@ -53,3 +77,8 @@ const getServiceFriendlyName = (service: ServiceName): string => {
             return service;
     }
 };
+
+export const enum YesOrNo {
+    Yes = 'Yes',
+    No = 'No'
+}

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -32,19 +32,19 @@ export async function pricingPlanWalkthrough<T extends ResourceParameters>(
     context.print.info(choosePricingPlan);
 
     const pricingPlanBusinessTypeChoices = [
-        { name: 'No, I only need to track consumers personal mobile devices', value: YesOrNo.No },
-        { name: 'Yes, I track commercial assets (For example, any mobile object that is tracked by a company in support of its business)', value: YesOrNo.Yes }
+        { name: 'No, I only need to track consumers personal mobile devices', value: false },
+        { name: 'Yes, I track commercial assets (For example, any mobile object that is tracked by a company in support of its business)', value: true }
     ];
     const pricingPlanBusinessTypePrompt = {
         type: 'list',
         name: 'pricingPlanBusinessType',
         message: 'Are you tracking commercial assets for your business in your app?',
         choices: pricingPlanBusinessTypeChoices,
-        default: pricingPlan === PricingPlan.RequestBasedUsage ? YesOrNo.No : YesOrNo.Yes
+        default: pricingPlan === PricingPlan.RequestBasedUsage ? false : true
     };
 
-    const pricingPlanBusinessTypeChoice = ((await inquirer.prompt([pricingPlanBusinessTypePrompt])).pricingPlanBusinessType as YesOrNo);
-    if (pricingPlanBusinessTypeChoice === YesOrNo.No) {
+    const pricingPlanBusinessTypeChoice = ((await inquirer.prompt([pricingPlanBusinessTypePrompt])).pricingPlanBusinessType as boolean);
+    if (pricingPlanBusinessTypeChoice === false) {
         pricingPlan = PricingPlan.RequestBasedUsage;
     }
     else {
@@ -82,8 +82,3 @@ const getServiceFriendlyName = (service: ServiceName): string => {
             return service;
     }
 };
-
-export const enum YesOrNo {
-    Yes = 'Yes',
-    No = 'No'
-}

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -8,14 +8,19 @@ export async function resourceAccessWalkthrough<T extends ResourceParameters>(
     parameters: Partial<T>,
     service: ServiceName
 ): Promise<Partial<T>> {
-    const indexAccessPrompt = {
+    const accessChoices = [
+        { name: 'Authorized users only', value: AccessType.AuthorizedUsers },
+        { name: 'Authorized and Guest users', value: AccessType.AuthorizedAndGuestUsers }
+    ];
+
+    const accessPrompt = {
         type: 'list',
         name: 'accessType',
         message: `Who can access this ${getServiceFriendlyName(service)}?`,
-        choices: Object.keys(AccessType),
-        default: parameters.accessType ? parameters.accessType : 'AuthorizedUsers'
+        choices: accessChoices,
+        default: parameters.accessType ? parameters.accessType : AccessType.AuthorizedUsers
     };
-    return await inquirer.prompt([indexAccessPrompt]);
+    return await inquirer.prompt([accessPrompt]);
 };
 
 export async function pricingPlanWalkthrough<T extends ResourceParameters>(
@@ -33,7 +38,7 @@ export async function pricingPlanWalkthrough<T extends ResourceParameters>(
     const pricingPlanBusinessTypePrompt = {
         type: 'list',
         name: 'pricingPlanBusinessType',
-        message: 'Are you tracking commercial assets for your business?',
+        message: 'Are you tracking commercial assets for your business in your app?',
         choices: pricingPlanBusinessTypeChoices,
         default: pricingPlan === PricingPlan.RequestBasedUsage ? YesOrNo.No : YesOrNo.Yes
     };

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -190,13 +190,15 @@ function getAWSExportsObject(resources) {
     Object.assign(configOutput, { predictions: predictionsConfig });
   }
 
-  // add geo config if predictions resources exist
+  // add geo config if geo resources exist
   if (Object.entries(geoConfig).length > 0) {
     geoConfig.region = projectRegion;
     Object.assign(
       configOutput,
       {
-        geo: geoConfig
+        geo: {
+          amazon_location_services: geoConfig
+        }
       }
     );
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Modifications to pricing plan walkthrough. The latest behavior is:
- All Geo resources will have the same pricing plan
- When creating the first Map or Place Index resource, a questionnaire is provided to help the developer set the pricing plan
- For subsequent Maps or Place Indices, the developer can change the pricing plan if his use-case has evolved. We provide this option through advanced configuration walkthrough. 

The Amazon Location Service does not currently support updating the Geo Resource properties through CFN. Hence, the pricing plan is set only when the first Geo resource is added and cannot be modified later. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.