### PR TITLE
Revert "feat(amplify-category-auth): use EnabledMFAs to only configure TOTP"

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -1,5 +1,4 @@
 <% var autoVerifiedAttributes = props.autoVerifiedAttributes ? props.autoVerifiedAttributes.concat(props.aliasAttributes).filter((attr, i, aliasAttributeArray) => ['email', 'phone_number'].includes(attr) && aliasAttributeArray.indexOf(attr) === i) : [] %>
-<% var configureSMS = ((props.autoVerifiedAttributes && props.autoVerifiedAttributes.includes('phone_number')) || (props.mfaConfiguration != 'OFF' && props.mfaTypes && props.mfaTypes.includes('SMS Text Message')) || (props.requiredAttributes && props.requiredAttributes.includes('phone_number'))) %> 
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
@@ -79,7 +78,6 @@ Resources:
             MaxAge: 3000
   <% } %>
   <%if (props.authSelections !== 'identityPoolOnly') { %>
-  <% if(!props.useEnabledMfas || configureSMS) { %>
   # BEGIN SNS ROLE RESOURCE
   SNSRole:
   # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
@@ -109,7 +107,6 @@ Resources:
                 Action:
                   - "sns:Publish"
                 Resource: "*"
-  <% } %> 
   # BEGIN USER POOL RESOURCES
   UserPool:
   # Created upon user selection
@@ -185,23 +182,12 @@ Resources:
       AliasAttributes: !Ref aliasAttributes
       <% } %>
       MfaConfiguration: !Ref mfaConfiguration
-      <% if(props.useEnabledMfas && props.mfaConfiguration != 'OFF') {%>
-      EnabledMfas:
-        <% if(configureSMS) {%> 
-        - SMS_MFA
-        <% } %>
-        <% if(props.mfaTypes.includes('TOTP')) {%>
-        - SOFTWARE_TOKEN_MFA
-        <% } %>
-      <% } %>  
-      <% if(!props.useEnabledMfas || configureSMS) {%> 
       SmsVerificationMessage: !Ref smsVerificationMessage
       SmsAuthenticationMessage: !Ref smsAuthenticationMessage
       SmsConfiguration:
         SnsCallerArn: !GetAtt SNSRole.Arn
         ExternalId: <%=`${props.resourceNameTruncated}_role_external_id`%>
-      <% } %>
-    <%if (configureSMS) { %>
+    <%if (props.mfaConfiguration != 'OFF') { %>
     DependsOn: SNSRole
     <% } %>
   <%if (!props.breakCircularDependency && props.triggers && props.dependsOn) { %>
@@ -832,7 +818,7 @@ Resources:
     DependsOn: OAuthCustomResourceLogPolicy
   <% } %>
 
-  <%if (!props.useEnabledMfas && props.mfaConfiguration != 'OFF') { %>
+  <%if (props.mfaConfiguration != 'OFF') { %>
   # BEGIN MFA LAMBDA RESOURCES
   MFALambdaRole:
   # Created to execute Lambda which sets MFA config values
@@ -1222,7 +1208,7 @@ Outputs :
   AppClientSecret:
     Value: !GetAtt UserPoolClientInputs.appSecret
     Condition: ShouldOutputAppClientSecrets
-  <%if (!props.useEnabledMfas || configureSMS) { %>
+  <%if (props.mfaConfiguration != 'OFF') { %>
   CreatedSNSRole:
     Value: !GetAtt SNSRole.Arn
     Description: role arn

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types.ts
@@ -27,7 +27,6 @@ export interface ServiceQuestionsBaseResult {
   userpoolClientReadAttributes: string[];
   userpoolClientWriteAttributes: string[];
   usernameCaseSensitive?: boolean;
-  useEnabledMfas?: boolean;
   authTriggerConnections?: string;
 }
 

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-defaults-appliers.ts
@@ -29,9 +29,6 @@ export const getAddAuthDefaultsApplier = (context: any, defaultValuesFilename: s
   if (FeatureFlags.getBoolean('auth.enableCaseInsensitivity')) {
     result.usernameCaseSensitive = false;
   }
-  // If the feature flag is enabled the MFA TOTP can only be enabled
-
-  result.useEnabledMfas = FeatureFlags.getBoolean('auth.useEnabledMfas');
 
   /* merge actual answers object into props object,
    * ensuring that manual entries override defaults */

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -581,12 +581,6 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
       },
-      {
-        name: 'useEnabledMfas',
-        type: 'boolean',
-        defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: true,
-      },
     ]);
 
     this.registerFlag('codegen', [
@@ -648,8 +642,8 @@ export class FeatureFlags {
         name: 'enableDartNullSafety',
         type: 'boolean',
         defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: true,
-      },
+        defaultValueForNewProjects: true
+      }
     ]);
 
     this.registerFlag('appSync', [

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -116,14 +116,6 @@ export const getUserPool = async (userpoolId, region) => {
   return res;
 };
 
-export const getMFAConfiguration = async (
-  userPoolId: string,
-  region: string,
-): Promise<CognitoIdentityServiceProvider.GetUserPoolMfaConfigResponse> => {
-  config.update({ region });
-  return await new CognitoIdentityServiceProvider().getUserPoolMfaConfig({ UserPoolId: userPoolId }).promise();
-};
-
 export const getLambdaFunction = async (functionName: string, region: string) => {
   const lambda = new Lambda({ region });
   try {

--- a/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
@@ -9,11 +9,10 @@ import {
   headlessAuthImport,
 } from 'amplify-e2e-core';
 import { addAuthWithDefault, getBackendAmplifyMeta } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool, getMFAConfiguration } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool } from 'amplify-e2e-core';
 import {
   AddAuthRequest,
   CognitoUserPoolSigninMethod,
-  CognitoPasswordRecoveryConfiguration,
   CognitoUserProperty,
   ImportAuthRequest,
   UpdateAuthRequest,
@@ -64,105 +63,6 @@ describe('headless auth', () => {
     const meta = getProjectMeta(projRoot);
     const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    expect(userPool.UserPool).toBeDefined();
-  });
-  it('adds auth resource with TOTP only', async () => {
-    const addAuthRequest: AddAuthRequest = {
-      version: 1,
-      resourceName: 'myAuthResource',
-      serviceConfiguration: {
-        serviceName: 'Cognito',
-        includeIdentityPool: false,
-        userPoolConfiguration: {
-          requiredSignupAttributes: [CognitoUserProperty.EMAIL],
-          signinMethod: CognitoUserPoolSigninMethod.PHONE_NUMBER,
-          mfa: {
-            mode: 'OPTIONAL',
-            mfaTypes: ['TOTP'],
-            smsMessage: 'The verification code is',
-          },
-        },
-      },
-    };
-
-    await initJSProjectWithProfile(projRoot, defaultsSettings);
-    await addHeadlessAuth(projRoot, addAuthRequest);
-    await amplifyPushAuth(projRoot);
-    const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
-    const region = meta.providers.awscloudformation.Region;
-    const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const mfaconfig = await getMFAConfiguration(id, region);
-    expect(mfaconfig.SoftwareTokenMfaConfiguration.Enabled).toBeTruthy();
-    expect(mfaconfig.SmsMfaConfiguration).toBeUndefined();
-    expect(userPool.UserPool).toBeDefined();
-  });
-
-  it('adds auth resource with TOTP only but enable SMS through signUp Attributes', async () => {
-    const addAuthRequest: AddAuthRequest = {
-      version: 1,
-      resourceName: 'myAuthResource',
-      serviceConfiguration: {
-        serviceName: 'Cognito',
-        includeIdentityPool: false,
-        userPoolConfiguration: {
-          requiredSignupAttributes: [CognitoUserProperty.EMAIL, CognitoUserProperty.PHONE_NUMBER],
-          signinMethod: CognitoUserPoolSigninMethod.PHONE_NUMBER,
-          mfa: {
-            mode: 'OPTIONAL',
-            mfaTypes: ['TOTP'],
-            smsMessage: 'The verification code is {####}',
-          },
-        },
-      },
-    };
-
-    await initJSProjectWithProfile(projRoot, defaultsSettings);
-    await addHeadlessAuth(projRoot, addAuthRequest);
-    await amplifyPushAuth(projRoot);
-    const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
-    const region = meta.providers.awscloudformation.Region;
-    const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const mfaconfig = await getMFAConfiguration(id, region);
-    expect(mfaconfig.SoftwareTokenMfaConfiguration.Enabled).toBeTruthy();
-    expect(mfaconfig.SmsMfaConfiguration.SmsConfiguration).toBeDefined();
-    expect(userPool.UserPool).toBeDefined();
-  });
-
-  it('adds auth resource with TOTP only but enables SMS through password recovery', async () => {
-    const addAuthRequest: AddAuthRequest = {
-      version: 1,
-      resourceName: 'myAuthResource',
-      serviceConfiguration: {
-        serviceName: 'Cognito',
-        includeIdentityPool: false,
-        userPoolConfiguration: {
-          requiredSignupAttributes: [CognitoUserProperty.EMAIL],
-          passwordRecovery: {
-            deliveryMethod: 'SMS',
-            smsMessage: 'The verification code is {####}',
-          },
-          signinMethod: CognitoUserPoolSigninMethod.PHONE_NUMBER,
-          mfa: {
-            mode: 'OPTIONAL',
-            mfaTypes: ['TOTP'],
-            smsMessage: 'The verification code is {####}',
-          },
-        },
-      },
-    };
-
-    await initJSProjectWithProfile(projRoot, defaultsSettings);
-    await addHeadlessAuth(projRoot, addAuthRequest);
-    await amplifyPushAuth(projRoot);
-    const meta = getProjectMeta(projRoot);
-    const id = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
-    const region = meta.providers.awscloudformation.Region;
-    const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
-    const mfaconfig = await getMFAConfiguration(id, region);
-    expect(mfaconfig.SoftwareTokenMfaConfiguration.Enabled).toBeTruthy();
-    expect(mfaconfig.SmsMfaConfiguration.SmsConfiguration).toBeDefined();
     expect(userPool.UserPool).toBeDefined();
   });
 
@@ -217,7 +117,7 @@ describe('headless auth', () => {
   });
 
   describe(' import', () => {
-    let ogProjectSettings: { name: string };
+    let ogProjectSettings: {name: string};
     let ogProjectRoot: string;
 
     beforeEach(async () => {


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#7779

Reverting PR to not break the downstream changes will push it when the policy is accounted for 