### PR TITLE
fix(amplify-graphql-types-generator):Changed path-format to match sna…

### DIFF
--- a/packages/amplify-graphql-types-generator/src/flow-modern/codeGeneration.ts
+++ b/packages/amplify-graphql-types-generator/src/flow-modern/codeGeneration.ts
@@ -64,7 +64,7 @@ export function generateSource(context: CompilerContext) {
 
     const output = generator.printer.printAndClear();
 
-    const outputFilePath = path.join(path.dirname(operation.filePath), '__generated__', `${operation.operationName}.js`);
+    const outputFilePath = path.posix.join(path.dirname(operation.filePath), '__generated__', `${operation.operationName}.js`);
 
     generatedFiles[outputFilePath] = new FlowGeneratedFile(output);
   });
@@ -76,7 +76,7 @@ export function generateSource(context: CompilerContext) {
 
     const output = generator.printer.printAndClear();
 
-    const outputFilePath = path.join(path.dirname(fragment.filePath), '__generated__', `${fragment.fragmentName}.js`);
+    const outputFilePath = path.posix.join(path.dirname(fragment.filePath), '__generated__', `${fragment.fragmentName}.js`);
 
     generatedFiles[outputFilePath] = new FlowGeneratedFile(output);
   });


### PR DESCRIPTION
#### Description of changes
Changed path-format to match / instead of \\\\ , to solve windows compatibility error, using path module.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#7799 


#### Description of how you validated changes
1. cd packages/amplify-graphql-types-generator
2. yarn test
![Screenshot 2021-07-26 123703](https://user-images.githubusercontent.com/43947328/126948371-8c087522-c831-4252-83cb-791659ab206b.png)



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.