### PR TITLE
feat(amplify-util-mock): support pseudo parameters in environment variables when running `amplify mock function`

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/intrinsic-functions.ts
+++ b/packages/amplify-util-mock/src/CFNParser/intrinsic-functions.ts
@@ -99,8 +99,6 @@ export function cfnRef(valNode, { params, resources }: CloudFormationParseContex
   }
 
   if (params.hasOwnProperty(key)) {
-    // Substitute any pseudo parameters with their mock value
-    if (params.hasOwnProperty(params[key])) params[key] = params[params[key]];
     return params[key];
   }
 
@@ -137,10 +135,11 @@ export function cfnIf(valNode, { params, conditions, resources, exports }: Cloud
     throw new Error(`FN::If expects an array with  3 elements instead got ${JSON.stringify(valNode)}`);
   }
   const condition = conditions[valNode[0]];
-  if (condition) {
-    return processValue(valNode[1], { params, condition, resources, exports });
+  const result = condition ? valNode[1] : valNode[2];
+  if (result.Ref && result.Ref === 'AWS::NoValue') {
+    return undefined;
   }
-  return processValue(valNode[2], { params, condition, resources, exports });
+  return processValue(result, { params, condition, resources, exports });
 }
 
 export function cfnEquals(valNode, { params, conditions, resources, exports }: CloudFormationParseContext, processValue) {

--- a/packages/amplify-util-mock/src/CFNParser/intrinsic-functions.ts
+++ b/packages/amplify-util-mock/src/CFNParser/intrinsic-functions.ts
@@ -98,7 +98,9 @@ export function cfnRef(valNode, { params, resources }: CloudFormationParseContex
     throw new Error(`Ref expects a string or an array with 1 item. Instead got ${JSON.stringify(valNode)}`);
   }
 
-  if (Object.keys(params).includes(key)) {
+  if (params.hasOwnProperty(key)) {
+    // Substitute any pseudo parameters with their mock value
+    if (params.hasOwnProperty(params[key])) params[key] = params[params[key]];
     return params[key];
   }
 

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/intrinsic-functions.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/intrinsic-functions.test.ts
@@ -227,6 +227,10 @@ describe('intrinsic-functions', () => {
       const node = ['bar', 'foo value', 'bar value'];
       expect(cfnIf(node, cfnContext, parseValue)).toEqual('bar value');
     });
+    it('should return `undefined` when the returned value section is a `AWS::NoValue` Ref', () => {
+      const node = ['foo', { Ref: 'AWS::NoValue' }, 'bar value'];
+      expect(cfnIf(node, cfnContext, parseValue)).toBeUndefined();
+    });
   });
 
   describe('cfnEquals', () => {

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/nested-aws-no-value.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/nested-aws-no-value.test.ts
@@ -1,0 +1,57 @@
+import { CloudFormationTemplate } from '../../CFNParser/stack/types';
+import { CloudFormationParseContext } from '../../CFNParser/types';
+import { parseValue } from '../../CFNParser/field-parser';
+
+describe('cloudformation templates', () => {
+  const nestedNoValue: CloudFormationTemplate = {
+    Conditions: {
+      AlwaysTrue: {
+        'Fn::Equals': ['true', 'true'],
+      },
+    },
+    Resources: {
+      DummyResource: {
+        Type: 'Resource::Dummy',
+        Properties: {
+          ConditionalValue: {
+            'Fn::If': ['AlwaysTrue', 'ConditionIsTrue', { Ref: 'AWS::NoValue' }],
+          },
+          ConditionalRef: {
+            'Fn::If': ['AlwaysTrue', { Ref: 'SomeRef' }, { Ref: 'AWS::NoValue' }],
+          },
+          ConditionalNoValue: {
+            'Fn::If': ['AlwaysTrue', { Ref: 'AWS::NoValue' }, { Ref: 'SomeRef' }],
+          },
+        },
+      },
+    },
+  };
+  const cfnContext: CloudFormationParseContext = {
+    params: {},
+    conditions: {
+      AlwaysTrue: true,
+    },
+    resources: {
+      SomeRef: {
+        Type: 'String',
+        result: { ref: 'resolvedRefValue' },
+      },
+    },
+    exports: {},
+  };
+
+  it('should resolve nested `Fn::If`', () => {
+    const value = parseValue(nestedNoValue.Resources.DummyResource.Properties.ConditionalValue, cfnContext);
+    expect(value).toEqual('ConditionIsTrue');
+  });
+
+  it('should resolve nested `Fn::If` and evaluate a resulting Ref', () => {
+    const value = parseValue(nestedNoValue.Resources.DummyResource.Properties.ConditionalRef, cfnContext);
+    expect(value).toEqual('resolvedRefValue');
+  });
+
+  it('should resolve nested `Fn::If` and evaluate a resulting `AWS::NoValue` Ref', () => {
+    const value = parseValue(nestedNoValue.Resources.DummyResource.Properties.ConditionalNoValue, cfnContext);
+    expect(value).toBeUndefined();
+  });
+});

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/nested-aws-no-value.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/nested-aws-no-value.test.ts
@@ -8,6 +8,9 @@ describe('cloudformation templates', () => {
       AlwaysTrue: {
         'Fn::Equals': ['true', 'true'],
       },
+      AlwaysFalse: {
+        'Fn::Equals': ['false', 'true'],
+      },
     },
     Resources: {
       DummyResource: {
@@ -17,7 +20,7 @@ describe('cloudformation templates', () => {
             'Fn::If': ['AlwaysTrue', 'ConditionIsTrue', { Ref: 'AWS::NoValue' }],
           },
           ConditionalRef: {
-            'Fn::If': ['AlwaysTrue', { Ref: 'SomeRef' }, { Ref: 'AWS::NoValue' }],
+            'Fn::If': ['AlwaysFalse', { Ref: 'AWS::NoValue' }, { Ref: 'SomeRef' }],
           },
           ConditionalNoValue: {
             'Fn::If': ['AlwaysTrue', { Ref: 'AWS::NoValue' }, { Ref: 'SomeRef' }],
@@ -30,6 +33,7 @@ describe('cloudformation templates', () => {
     params: {},
     conditions: {
       AlwaysTrue: true,
+      AlwaysFalse: false,
     },
     resources: {
       SomeRef: {

--- a/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
@@ -33,7 +33,6 @@ const getCfnPseudoParams = (): Record<string, string> => {
     'AWS::StackId': stackId,
     'AWS::StackName': stackName,
     'AWS::URLSuffix': 'amazonaws.com',
-    'AWS::NoValue': undefined,
   };
 };
 

--- a/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
@@ -33,6 +33,7 @@ const getCfnPseudoParams = (): Record<string, string> => {
     'AWS::StackId': stackId,
     'AWS::StackName': stackName,
     'AWS::URLSuffix': 'amazonaws.com',
+    'AWS::NoValue': undefined,
   };
 };
 


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Environment variables can have now pseudo parameter values (i.e. AWS::NoValue) that will be substituted appropriately when running `amplify mock function`.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

close #6122

#### Description of how you validated changes

- Manually tested with `amplify-dev`
  - Created lambda function in test app
  - Added environment variables with pseudo parameters like `AWS::NoValue` and `AWS::Region`
  - Configure lambda function to return the values of these environment variables
  - run `amplify-dev mock function`
- `yarn test`
- `yarn lint`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.