### PR TITLE
fix: #7696 - support production package install for function category

### DIFF
--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -200,9 +200,12 @@ export async function getInvoker(
 }
 
 export function getBuilder(context: $TSContext, resourceName: string, buildType: BuildType): () => Promise<void> {
-  const lastBuildTimestamp = _.get(stateManager.getMeta(), [categoryName, resourceName, buildTypeKeyMap[buildType]]);
+  const meta = stateManager.getMeta();
+  const lastBuildTimestamp = _.get(meta, [categoryName, resourceName, buildTypeKeyMap[buildType]]);
+  const lastBuildType = _.get(meta, [categoryName, resourceName, 'lastBuildType']);
+
   return async () => {
-    await buildFunction(context, { resourceName, buildType, lastBuildTimestamp });
+    await buildFunction(context, { resourceName, buildType, lastBuildTimestamp, lastBuildType });
   };
 }
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildFunction.ts
@@ -5,7 +5,7 @@ import { categoryName } from '../../../constants';
 
 export const buildFunction = async (
   context: $TSContext,
-  { resourceName, lastBuildTimestamp, buildType = BuildType.PROD }: BuildRequestMeta,
+  { resourceName, lastBuildTimestamp, lastBuildType, buildType = BuildType.PROD }: BuildRequestMeta,
 ) => {
   const resourcePath = path.join(pathManager.getBackendDirPath(), categoryName, resourceName);
   const breadcrumbs = context.amplify.readBreadcrumbs(categoryName, resourceName);
@@ -35,9 +35,10 @@ export const buildFunction = async (
       runtime: breadcrumbs.functionRuntime,
       legacyBuildHookParams: {
         projectRoot: pathManager.findProjectRoot(),
-        resourceName: resourceName,
+        resourceName,
       },
       lastBuildTimeStamp: prevBuildTime,
+      lastBuildType,
     };
     rebuilt = (await runtimePlugin.build(buildRequest)).rebuilt;
   }
@@ -52,6 +53,7 @@ export const buildFunction = async (
 export interface BuildRequestMeta {
   resourceName: string;
   lastBuildTimestamp?: string;
+  lastBuildType?: BuildType;
   buildType?: BuildType;
 }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
@@ -207,6 +207,7 @@ export async function updateamplifyMetaAfterPush(resources: $TSObject[]) {
 export function updateamplifyMetaAfterBuild({ category, resourceName }: ResourceTuple, buildType: BuildType = BuildType.PROD) {
   const amplifyMeta = stateManager.getMeta();
   _.set(amplifyMeta, [category, resourceName, buildTypeKeyMap[buildType]], new Date());
+  _.set(amplifyMeta, [category, resourceName, 'lastBuildType'], buildType);
   stateManager.setMeta(undefined, amplifyMeta);
 }
 

--- a/packages/amplify-e2e-core/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-core/src/init/deleteProject.ts
@@ -1,7 +1,9 @@
-import { nspawn as spawn, retry, getCLIPath, describeCloudFormationStack, getProjectMeta } from '..';
+import { nspawn as spawn, retry, getCLIPath, describeCloudFormationStack } from '..';
+import { getBackendAmplifyMeta } from '../utils';
 
 export const deleteProject = async (cwd: string, profileConfig?: any): Promise<void> => {
-  const { StackName: stackName, Region: region } = getProjectMeta(cwd).providers.awscloudformation;
+  // Read the meta from backend otherwise it could fail on non-pushed, just initialized projects
+  const { StackName: stackName, Region: region } = getBackendAmplifyMeta(cwd).providers.awscloudformation;
   await retry(
     () => describeCloudFormationStack(stackName, region, profileConfig),
     stack => stack.StackStatus.endsWith('_COMPLETE'),
@@ -10,7 +12,7 @@ export const deleteProject = async (cwd: string, profileConfig?: any): Promise<v
     const noOutputTimeout = 1000 * 60 * 20; // 20 minutes;
     spawn(getCLIPath(), ['delete'], { cwd, stripColors: true, noOutputTimeout })
       .wait('Are you sure you want to continue?')
-      .sendLine('y')
+      .sendConfirmYes()
       .wait('Project deleted locally.')
       .run((err: Error) => {
         if (!err) {

--- a/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3.test.ts
@@ -1,6 +1,7 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth } from 'amplify-e2e-core';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, getBackendAmplifyMeta } from 'amplify-e2e-core';
 import { addFunction, functionMockAssert, functionCloudInvoke } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import _ from 'lodash';
 
 describe('go function tests', () => {
   const helloWorldSuccessOutput = 'Hello Amplify!';
@@ -150,5 +151,82 @@ describe('dotnet function tests', () => {
     await amplifyPushAuth(projRoot);
     const response = await functionCloudInvoke(projRoot, { funcName, payload });
     expect(JSON.parse(response.Payload.toString())).toEqual(helloWorldSuccessObj);
+  });
+});
+
+describe('nodejs function tests', () => {
+  const helloWorldSuccessString = 'Hello from Lambda!';
+  const helloWorldSuccessObj = {
+    statusCode: 200,
+    body: '"Hello from Lambda!"',
+  };
+
+  let projRoot: string;
+  let funcName: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('nodejs-functions');
+    await initJSProjectWithProfile(projRoot, {});
+
+    const random = Math.floor(Math.random() * 10000);
+    funcName = `nodejstestfn${random}`;
+
+    await addFunction(
+      projRoot,
+      {
+        name: funcName,
+        functionTemplate: 'Hello World',
+      },
+      'nodejs',
+    );
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('add nodejs hello world function and mock locally', async () => {
+    await functionMockAssert(projRoot, {
+      funcName,
+      successString: helloWorldSuccessString,
+      eventFile: 'src/event.json',
+    }); // will throw if successString is not in output
+  });
+
+  it('add nodejs hello world function and invoke in the cloud', async () => {
+    const payload = '{"key1":"value1","key2":"value2","key3":"value3"}';
+
+    await amplifyPushAuth(projRoot);
+
+    const response = await functionCloudInvoke(projRoot, { funcName, payload });
+
+    expect(JSON.parse(response.Payload.toString())).toEqual(helloWorldSuccessObj);
+  });
+
+  it('add nodejs hello world function and mock locally, check buildType, push, check buildType', async () => {
+    await functionMockAssert(projRoot, {
+      funcName,
+      successString: helloWorldSuccessString,
+      eventFile: 'src/event.json',
+    }); // will throw if successString is not in output
+
+    let meta = getBackendAmplifyMeta(projRoot);
+    let functionResource = _.get(meta, ['function', funcName]);
+
+    const lastDevBuildTimeStampBeforePush = functionResource.lastDevBuildTimeStamp;
+
+    // Mock should trigger a DEV build of the function
+    expect(functionResource).toBeDefined();
+    expect(functionResource.lastBuildType).toEqual('DEV');
+
+    await amplifyPushAuth(projRoot);
+
+    meta = getBackendAmplifyMeta(projRoot);
+    functionResource = _.get(meta, ['function', funcName]);
+
+    // Push should trigger a PROD build of the function
+    expect(functionResource.lastBuildType).toEqual('PROD');
+    expect(functionResource.lastDevBuildTimeStamp).toEqual(lastDevBuildTimeStampBeforePush);
   });
 });

--- a/packages/amplify-function-plugin-interface/src/index.ts
+++ b/packages/amplify-function-plugin-interface/src/index.ts
@@ -70,6 +70,7 @@ export type BuildRequest = {
     resourceName: string;
   };
   lastBuildTimeStamp?: Date;
+  lastBuildType?: BuildType;
   service?: string;
 };
 

--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/legacyBuild.test.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/legacyBuild.test.ts
@@ -30,10 +30,25 @@ describe('legacy build resource', () => {
       srcRoot: 'resourceDir',
       runtime: 'other',
       buildType: BuildType.PROD,
+      lastBuildType: BuildType.PROD,
     });
 
     expect(result.rebuilt).toEqual(false);
     expect(glob_mock.sync.mock.calls.length).toBe(1);
     expect(fs_mock.statSync.mock.calls.length).toBe(5);
+  });
+
+  it('checks lastBuildType difference triggers rebuild', async () => {
+    glob_mock.sync.mockImplementationOnce(() => Array.from(stubFileTimestamps.keys()));
+    fs_mock.statSync.mockImplementation(file => ({ mtime: new Date(stubFileTimestamps.get(file.toString())!) } as any));
+
+    const result = await buildResource({
+      lastBuildTimeStamp: new Date(timestamp),
+      srcRoot: 'resourceDir',
+      runtime: 'other',
+      buildType: BuildType.PROD,
+    });
+
+    expect(result.rebuilt).toEqual(true);
   });
 });


### PR DESCRIPTION
#### Description of changes

This PR enables `npm install --production` automatically, depending on the build type for functions. For `mock`, `devDependencies` will also be installed, for `push` only `dependencies` are installed, thus reducing the uploaded package size. `lastBuildType` is now persisted in the meta file for the given resources.

- Missing and new `nodejs` E2E tests were added.
- Project delete fixed in E2E to check project meta, not current meta for root stack information.

#### Issue #, if available

fixes: #7696 

#### Description of how you validated changes

New unit and E2E tests.

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.