### PR TITLE
fix(amplify-cli-core):new-line escape sequence made os-specific

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
@@ -208,7 +208,7 @@ describe('feature flags', () => {
       await expect(async () => {
         await FeatureFlags.initialize(envProvider, undefined, getTestFlags());
       }).rejects.toThrowError(
-        `Found '}' where a key name was expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at line 1,0 >>> Not a json {\n ...`,
+        `Found '}' where a key name was expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at line 1,0 >>> Not a json {${os.EOL} ...`,
       );
     });
 


### PR DESCRIPTION
#### Description of changes
Fixed issue of non-matching substrings in amplify-cli-core package 
(Error was being thrown due \n not being recognized as a valid newline escape sequence character in Windows)
Fixed the issue by making \n os-specific in nature


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#7813 

#### Description of how you validated changes
1. cd packages/amplify-cli-core
2. yarn test
(Successful completion of tests)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.