### PR TITLE
fix: move storage check in @predictions v2

### DIFF
--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import { DirectiveWrapper, InvalidDirectiveError, MappingTemplate, TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
 import {
-  TransformerBeforeStepContextProvider,
   TransformerContextProvider,
   TransformerSchemaVisitStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
@@ -71,18 +70,16 @@ export class PredictionsTransformer extends TransformerPluginBase {
     this.bucketName = predictionsConfig?.bucketName ?? '';
   }
 
-  before = (context: TransformerBeforeStepContextProvider): void => {
-    if (!this.bucketName) {
-      throw new InvalidDirectiveError('Please configure storage in your project in order to use the @predictions directive');
-    }
-  };
-
   field = (
     parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
     definition: FieldDefinitionNode,
     directive: DirectiveNode,
     context: TransformerSchemaVisitStepContextProvider,
   ): void => {
+    if (!this.bucketName) {
+      throw new InvalidDirectiveError('Please configure storage in your project in order to use the @predictions directive');
+    }
+
     if (parent.name.value !== context.output.getQueryTypeName()) {
       throw new InvalidDirectiveError('@predictions directive only works under Query operations.');
     }


### PR DESCRIPTION
#### Description of changes
`@predictions` requires that storage is configured. This commit moves the check out of the `before()` phase, as that is invoked even if `@predictions` is not used in the schema, leading to unnecessary errors.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.