### PR TITLE
fix: use improved pluralization in graphql transformer v2

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
@@ -592,3 +592,23 @@ test('key with complex fields updates the input objects', () => {
   expect(deleteInput.fields.find((f: any) => f.name.value === 'email' && f.type.kind === Kind.NON_NULL_TYPE)).toBeDefined();
   expect(deleteInput.fields.find((f: any) => f.name.value === 'nonNullListInputOfNonNullStrings')).toBeUndefined();
 });
+
+test('list queries use correct pluralization', () => {
+  const inputSchema = `
+    type Boss @model {
+      id: ID! @primaryKey
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+  });
+  const out = transformer.transform(inputSchema);
+  const schema = parse(out.schema);
+  const query: any = schema.definitions.find((d: any) => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === 'Query');
+  expect(query).toBeDefined();
+
+  const listQuery = query.fields.find((f: any) => f.name.value === 'listBosses');
+  expect(listQuery).toBeDefined();
+
+  expect(out.pipelineFunctions['Query.listBosses.req.vtl']).toBeDefined();
+  expect(out.pipelineFunctions['Query.listBosses.res.vtl']).toBeDefined();
+});

--- a/packages/amplify-graphql-index-transformer/src/utils.ts
+++ b/packages/amplify-graphql-index-transformer/src/utils.ts
@@ -1,4 +1,5 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { plurality } from 'graphql-transformer-common';
 import { PrimaryKeyDirectiveConfiguration } from './types';
 
 export function lookupResolverName(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider, op: string): string | null {
@@ -26,7 +27,11 @@ export function lookupResolverName(config: PrimaryKeyDirectiveConfiguration, ctx
   }
 
   if (!resolverName) {
-    resolverName = `${op}${object.name.value}${op === 'list' ? 's' : ''}`;
+    if (op === 'list') {
+      resolverName = `${op}${plurality(object.name.value, true)}`;
+    } else {
+      resolverName = `${op}${object.name.value}`;
+    }
   }
 
   return resolverName;

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -25,6 +25,7 @@ import {
   makeNamedType,
   makeNonNullType,
   makeValueNode,
+  plurality,
   ResourceConstants,
   toCamelCase,
   toPascalCase,
@@ -141,7 +142,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const options = directiveWrapped.getArguments({
       queries: {
         get: toCamelCase(['get', typeName]),
-        list: toCamelCase(['list', `${typeName}s`]), // Existing implementation suffixes `s` at the end
+        list: toCamelCase(['list', plurality(typeName, true)]),
       },
       mutations: {
         create: toCamelCase(['create', typeName]),

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -160,7 +160,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
     }
     const fieldName = searchFieldNameOverride
       ? searchFieldNameOverride
-      : graphqlName(`search${plurality(toUpper(definition.name.value), ctx.featureFlags.getBoolean('improvePluralization', true))}`);
+      : graphqlName(`search${plurality(toUpper(definition.name.value), true)}`);
     this.searchableObjectTypeDefinitions.push({
       node: definition,
       fieldName,


### PR DESCRIPTION
#### Description of changes
This commit updates GraphQL Transformer v2 to use the newly improved pluralization rules by default.

#### Description of how you validated changes
Manual and unit testing.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.