### PR TITLE
feat: make cognito userpool id optional for headless mode

### DIFF
--- a/packages/amplify-headless-interface/schemas/api/1/AddApiRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/api/1/AddApiRequest.schema.json
@@ -139,7 +139,6 @@
                 }
             },
             "required": [
-                "cognitoUserPoolId",
                 "mode"
             ]
         },

--- a/packages/amplify-headless-interface/schemas/api/1/UpdateApiRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/api/1/UpdateApiRequest.schema.json
@@ -142,7 +142,7 @@
                 }
             },
             "required": [
-                "cognitoUserPoolId"
+                "mode"
             ]
         },
         "AppSyncOpenIDConnectAuthType": {

--- a/packages/amplify-headless-interface/schemas/api/1/UpdateApiRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/api/1/UpdateApiRequest.schema.json
@@ -142,8 +142,7 @@
                 }
             },
             "required": [
-                "cognitoUserPoolId",
-                "mode"
+                "cognitoUserPoolId"
             ]
         },
         "AppSyncOpenIDConnectAuthType": {

--- a/packages/amplify-headless-interface/src/interface/api/add.ts
+++ b/packages/amplify-headless-interface/src/interface/api/add.ts
@@ -148,7 +148,7 @@ export interface AppSyncCognitoUserPoolsAuthType {
   /**
    * The user pool that will be used to authenticate requests.
    */
-  cognitoUserPoolId: string;
+  cognitoUserPoolId?: string;
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Makes the Cognito Userpool Id optional for headless API commands. Enables you to setup both Auth and API both from the CI/CD pipelines.

If no Auth has been added to the project yet it will kick back with a proper error by default.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- Ran `yarn test`
- Ran a CI/CD pipeline w/ and w/o Auth added


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.