### PR TITLE
test: improve schema validation in tests

### DIFF
--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer.test.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer.test.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { anything, countResources, expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
-import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
 import { PredictionsTransformer } from '..';
 
@@ -14,6 +14,7 @@ test('does not generate any resources if @predictions is unused', () => {
   });
 
   const out = transformer.transform(schema);
+  validateModelSchema(parse(out.schema));
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   expect(out.stacks.PredictionsDirectiveStack).toEqual(undefined);
@@ -31,7 +32,7 @@ test('lambda function is added to pipeline when lambda dependent action is added
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
-  parse(out.schema);
+  validateModelSchema(parse(out.schema));
   expect(out.schema).toMatchSnapshot();
   const stack = out.stacks.PredictionsDirectiveStack;
   expect(stack).toBeDefined();
@@ -157,7 +158,7 @@ test('return type is a list based on the action', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
-  parse(out.schema);
+  validateModelSchema(parse(out.schema));
   expect(out.schema).toMatchSnapshot();
   const stack = out.stacks.PredictionsDirectiveStack;
   expect(stack).toBeDefined();
@@ -186,7 +187,7 @@ test('can use actions individually and in supported sequences', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
-  parse(out.schema);
+  validateModelSchema(parse(out.schema));
   expect(out.schema).toMatchSnapshot();
   const stack = out.stacks.PredictionsDirectiveStack;
   expect(stack).toBeDefined();

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -14,6 +14,7 @@ export {
   UserPoolConfig,
 } from './transformation';
 export { DeploymentResources } from './transformation/types';
+export { validateModelSchema } from './transformation/validation';
 export {
   ConflictDetectionType,
   ConflictHandlerType,


### PR DESCRIPTION
#### Description of changes
This commit exposes the `validateModelSchema()` function from the GraphQL Transformer core. This function is very helpful for validating the Transformer output schema's correctness. This commit also applies the validation to the `@predictions` v2 test suite.

cc: @lazpavel 

#### Issue #, if available

#### Description of how you validated changes
Test suite changes in this PR.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.