### PR TITLE
fix(amplify-category-geo): enable unauth access for identity pool

### DIFF
--- a/packages/amplify-category-geo/src/service-utils/mapUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapUtils.ts
@@ -4,10 +4,13 @@ import _ from 'lodash';
 import { parametersFileName, provider, ServiceName } from './constants';
 import { category } from '../constants';
 import { MapStack } from '../service-stacks/mapStack';
-import { updateParametersFile, getGeoServiceMeta, generateTemplateFile, updateDefaultResource, readResourceMetaParameters } from './resourceUtils';
+import { updateParametersFile, getGeoServiceMeta, generateTemplateFile, updateDefaultResource, readResourceMetaParameters, checkAuthConfig } from './resourceUtils';
 import { App } from '@aws-cdk/core';
 
 export const createMapResource = async (context: $TSContext, parameters: MapParameters) => {
+  // allow unauth access for identity pool if guest access is enabled
+  await checkAuthConfig(context, parameters, ServiceName.Map);
+
   // generate CFN files
   const mapStack = new MapStack(new App(), 'MapStack', parameters);
   generateTemplateFile(mapStack, parameters.name);
@@ -35,6 +38,9 @@ export const modifyMapResource = async (
   context: $TSContext,
   parameters: Pick<MapParameters, 'accessType' | 'name' | 'isDefault'>
   ) => {
+  // allow unauth access for identity pool if guest access is enabled
+  await checkAuthConfig(context, parameters, ServiceName.Map);
+
   // generate CFN files
   const mapStack = new MapStack(new App(), 'MapStack', parameters);
   generateTemplateFile(mapStack, parameters.name);

--- a/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
@@ -4,10 +4,13 @@ import _ from 'lodash';
 import { parametersFileName, provider, ServiceName } from './constants';
 import { category } from '../constants';
 import { PlaceIndexStack } from '../service-stacks/placeIndexStack';
-import { updateParametersFile, generateTemplateFile, updateDefaultResource, readResourceMetaParameters } from './resourceUtils';
+import { updateParametersFile, generateTemplateFile, updateDefaultResource, readResourceMetaParameters, checkAuthConfig } from './resourceUtils';
 import { App } from '@aws-cdk/core';
 
 export const createPlaceIndexResource = async (context: $TSContext, parameters: PlaceIndexParameters) => {
+  // allow unauth access for identity pool if guest access is enabled
+  await checkAuthConfig(context, parameters, ServiceName.PlaceIndex);
+
   // generate CFN files
   const placeIndexStack = new PlaceIndexStack(new App(), 'PlaceIndexStack', parameters);
   generateTemplateFile(placeIndexStack, parameters.name);
@@ -35,6 +38,9 @@ export const modifyPlaceIndexResource = async (
   context: $TSContext,
   parameters: Pick<PlaceIndexParameters, 'accessType' | 'name' | 'isDefault'>
   ) => {
+  // allow unauth access for identity pool if guest access is enabled
+  await checkAuthConfig(context, parameters, ServiceName.PlaceIndex);
+
   // generate CFN files
   const placeIndexStack = new PlaceIndexStack(new App(), 'PlaceIndexStack', parameters);
   generateTemplateFile(placeIndexStack, parameters.name);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
These changes fix a bug where the unauth access is not enabled on an identity pool when the Developer chooses to add guest access to Geo resources. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
tested with a JS sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.