### PR TITLE
fix(amplify-category-function): include files starting with a period on packaging

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/zipResource.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/zipResource.ts
@@ -19,6 +19,7 @@ export const zipPackage = (zipEntries: ZipEntry[], packageFileName: string): Pro
           zip.glob('**/*', {
             cwd: entry.sourceFolder,
             ignore: entry.ignoreFiles,
+            dot: true,
           });
         }
         if (entry.packageFolder) {


### PR DESCRIPTION
#### Description of changes

I use [prisma](https://www.prisma.io/) with lambda function and it creates node_modules/.prisma folder to add query-engines. When packaging process, Amplify does not include this folder into build.zip . Adding `dot: true` option to archiver will solve this issue. But it will copy the unwanted files which is starting with period like `.env` . So I am not sure this is the best solution. I hope you will find this useful.

#### Description of how you validated changes

Manual

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.