### PR TITLE
chore(amplify-provider-awscloudformation): reduce log level

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -538,7 +538,7 @@ function validateCfnTemplates(context: $TSContext, resourcesToBeUpdated: $TSAny[
       try {
         validateFile(filePath);
       } catch (err) {
-        context.print.error(`Invalid CloudFormation template: ${filePath}${EOL}${err.message}`);
+        context.print.warning(`Invalid CloudFormation template: ${filePath}${EOL}${err.message}`);
       }
     }
   }


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

since cfn-lint is deprecated, it does not always proper validate cloudformation. we've made validation errors non-blocking already in [#7132](https://github.com/aws-amplify/amplify-cli/issues/7132). This commit also addresses the log level so as not to confuse customers with a red error message.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix
 https://github.com/aws-amplify/amplify-cli/issues/7831

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.