### PR TITLE
fix(graphql-model-transformer): added @model name reserved words validation

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModelTransformer:  should not add default primary key when ID is defined 1`] = `
+"## [Start] Create Request template. **
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": false
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": false
+  }
+}))
+#end
+## End - key condition **
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## set the typename **
+$util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
+#set( $PutObject = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"attributeValues\\":   $util.dynamodb.toMapValues($mergedValues),
+  \\"condition\\": $condition
+} )
+#if( $context.args.condition )
+  $util.qr($ctx.stash.conditions.add($context.args.condition))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": false
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": false
+  }
+}))
+#end
+## End - key condition **
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($PutObject.put(\\"condition\\", $Conditions))
+#end
+#if( $ctx.stash.metadata.modelObjectKey )
+  $util.qr($PutObject.put(\\"key\\", $ctx.stash.metadata.modelObjectKey))
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($mergedValues.id)
+} )
+  $util.qr($PutObject.put(\\"key\\", $Key))
+#end
+$util.toJson($PutObject)
+## [End] Create Request template. **"
+`;

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1,9 +1,9 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
-import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { InputObjectTypeDefinitionNode, InputValueDefinitionNode, NamedTypeNode, parse } from 'graphql';
 import { getBaseType } from 'graphql-transformer-common';
 import {
+  doNotExpectFields,
   expectFields,
   expectFieldsOnInputType,
   getFieldOnInputType,
@@ -14,12 +14,7 @@ import {
 } from './test-utils/helpers';
 
 const featureFlags = {
-  getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-    if (name === 'validateTypeNameReservedWords') {
-      return false;
-    }
-    return;
-  }),
+  getBoolean: jest.fn(),
   getNumber: jest.fn(),
   getObject: jest.fn(),
   getString: jest.fn(),
@@ -42,6 +37,7 @@ describe('ModelTransformer: ', () => {
     expect(out).toBeDefined();
 
     validateModelSchema(parse(out.schema));
+    parse(out.schema);
   });
 
   it('should support custom query overrides', () => {
@@ -275,6 +271,7 @@ describe('ModelTransformer: ', () => {
     expect(definition).toBeDefined();
     const parsed = parse(definition);
     validateModelSchema(parsed);
+
     const createPostInput = getInputType(parsed, 'CreatePostInput');
     expectFieldsOnInputType(createPostInput!, ['different']);
     const updatePostInput = getInputType(parsed, 'UpdatePostInput');
@@ -331,6 +328,7 @@ describe('ModelTransformer: ', () => {
     expect(out).toBeDefined();
     const parsed = parse(out.schema);
     validateModelSchema(parsed);
+
     const subscriptionType = getObjectType(parsed, 'Subscription');
     expect(subscriptionType).toBeDefined();
     expectFields(subscriptionType!, ['onCreatePost', 'onUpdatePost', 'onDeletePost']);
@@ -367,5 +365,50 @@ describe('ModelTransformer: ', () => {
     const commentObjectIDField = getFieldOnObjectType(commentObject!, 'id');
     const commentInputIDField = getFieldOnInputType(commentInputObject!, 'id');
     verifyMatchingTypes(commentObjectIDField.type, commentInputIDField.type);
+    const subscriptionType = getObjectType(parsed, 'Subscription');
+    expect(subscriptionType).toBeDefined();
+  });
+
+  it('should throw for reserved type name usage', () => {
+    const invalidSchema = `
+      type Subscription @model{
+        id: Int
+        str: String
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+    });
+    expect(() => transformer.transform(invalidSchema)).toThrowError(
+      "Subscription' is a reserved type name and currently in use within the default schema element.",
+    );
+  });
+
+  it('should not add default primary key when ID is defined', () => {
+    const validSchema = `
+      type Post @model{
+        id: Int
+        str: String
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+      featureFlags,
+    });
+    const result = transformer.transform(validSchema);
+    expect(result).toBeDefined();
+    expect(result.schema).toBeDefined();
+    const schema = parse(result.schema);
+    validateModelSchema(schema);
+
+    const createPostInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+      d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreatePostInput',
+    )! as InputObjectTypeDefinitionNode;
+    expect(createPostInput).toBeDefined();
+    const defaultIdField: InputValueDefinitionNode = createPostInput.fields!.find(f => f.name.value === 'id')!;
+    expect(defaultIdField).toBeDefined();
+    expect(getBaseType(defaultIdField.type)).toEqual('Int');
+    // It should not add default value for ctx.arg.id as id is of type Int
+    expect(result.pipelineFunctions['Mutation.createPost.req.vtl']).toMatchSnapshot();
   });
 });

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -380,7 +380,7 @@ describe('ModelTransformer: ', () => {
       transformers: [new ModelTransformer()],
     });
     expect(() => transformer.transform(invalidSchema)).toThrowError(
-      "Subscription' is a reserved type name and currently in use within the default schema element.",
+      "'Subscription' is a reserved type name and currently in use within the default schema element.",
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9892,14 +9892,6 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 change-case@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"


### PR DESCRIPTION
#### Description of changes
Added name validation for @model type name against the reserved words. Changes are made on top of #7857

#### Description of how you validated changes
- ran yarn test
- migrated unit test from graphql-dynamodb-transformer
- manual debugging and testing
- CircleCI [build_test_deploy](https://app.circleci.com/pipelines/github/lazpavel/amplify-cli/139/workflows/0d8aa736-701a-4f73-81b3-3cb15fac5fe5) job

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.