### PR TITLE
fix(graphql-model-transformer): fixed input type field generation for enum types

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -368,4 +368,31 @@ describe('ModelTransformer: ', () => {
     const commentInputIDField = getFieldOnInputType(commentInputObject!, 'id');
     verifyMatchingTypes(commentObjectIDField.type, commentInputIDField.type);
   });
+
+  it('should support enum as a field', () => {
+    const validSchema = `
+      enum Status { DELIVERED IN_TRANSIT PENDING UNKNOWN }
+      type Test @model {
+        status: Status!
+        lastStatus: Status!
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+      featureFlags,
+    });
+
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    const definition = out.schema;
+    expect(definition).toBeDefined();
+    const parsed = parse(definition);
+    validateModelSchema(parsed);
+
+    const createTestInput = getInputType(parsed, 'CreateTestInput');
+    expectFieldsOnInputType(createTestInput!, ['status', 'lastStatus']);
+
+    const updateTestInput = getInputType(parsed, 'CreateTestInput');
+    expectFieldsOnInputType(updateTestInput!, ['status', 'lastStatus']);
+  });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
@@ -1,5 +1,5 @@
 import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { ObjectTypeDefinitionNode, InputObjectTypeDefinitionNode } from 'graphql';
+import { ObjectTypeDefinitionNode, InputObjectTypeDefinitionNode, DocumentNode } from 'graphql';
 import { ModelResourceIDs, toPascalCase } from 'graphql-transformer-common';
 import { ModelDirectiveConfiguration } from '../graphql-model-transformer';
 import { ObjectDefinitionWrapper, InputObjectDefinitionWrapper, InputFieldWrapper } from '../wrappers/object-definition-wrapper';
@@ -15,6 +15,7 @@ export const makeUpdateInputField = (
   obj: ObjectTypeDefinitionNode,
   modelDirectiveConfig: ModelDirectiveConfiguration,
   knownModelTypes: Set<string>,
+  document: DocumentNode,
 ): InputObjectTypeDefinitionNode => {
   // sync related things
   const objectWrapped = new ObjectDefinitionWrapper(obj);
@@ -32,10 +33,12 @@ export const makeUpdateInputField = (
       return field.getTypeName();
     });
 
-  const input = InputObjectDefinitionWrapper.fromObject(name, {
+  const objectTypeDefinition: ObjectTypeDefinitionNode = {
     ...obj,
     fields: obj.fields?.filter(f => !fieldsToRemove.includes(f.name.value)),
-  });
+  };
+
+  const input = InputObjectDefinitionWrapper.fromObject(name, objectTypeDefinition, document);
 
   // make all the fields optional
   input.fields.forEach(f => f.makeNullable());
@@ -84,6 +87,7 @@ export const makeCreateInputField = (
   obj: ObjectTypeDefinitionNode,
   modelDirectiveConfig: ModelDirectiveConfiguration,
   knownModelTypes: Set<string>,
+  document: DocumentNode,
 ): InputObjectTypeDefinitionNode => {
   // sync related things
   const objectWrapped = new ObjectDefinitionWrapper(obj);
@@ -102,10 +106,12 @@ export const makeCreateInputField = (
       return field.getTypeName();
     });
 
-  const input = InputObjectDefinitionWrapper.fromObject(name, {
+  const objectTypeDefinition: ObjectTypeDefinitionNode = {
     ...obj,
     fields: obj.fields?.filter(f => !fieldsToRemove.includes(f.name.value)),
-  });
+  };
+
+  const input = InputObjectDefinitionWrapper.fromObject(name, objectTypeDefinition, document);
 
   // Add id field and make it optional
   if (!hasIdField) {

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -268,7 +268,7 @@ input CreateEmployeeInput {
   id: ID
   firstName: String!
   lastName: String!
-  type: EmploymentTypeInput!
+  type: EmploymentType!
 }
 
 type Mutation {
@@ -281,7 +281,7 @@ input UpdateEmployeeInput {
   id: ID!
   firstName: String
   lastName: String
-  type: EmploymentTypeInput
+  type: EmploymentType
 }
 
 input DeleteEmployeeInput {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9892,14 +9892,6 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 change-case@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"


### PR DESCRIPTION
#### Description of changes
Fixed the input field type for enum types

#### Description of how you validated changes
- manual debug
- unit test added
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.