### PR TITLE
fix: e2e tests by passing categoryName for the resource

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
@@ -13,7 +13,7 @@ import { zipPackage } from './zipResource';
  * Packages lambda source code and artifacts into a lambda-compatible .zip file
  */
 export const packageFunction: Packager = async (context, resource) => {
-  const resourcePath = pathManager.getResourceDirectoryPath(undefined, categoryName, resource.resourceName);
+  const resourcePath = pathManager.getResourceDirectoryPath(undefined, resource.category, resource.resourceName);
   const runtimeManager = await getRuntimeManager(context, resource.resourceName);
   const distDirPath = path.join(resourcePath, 'dist');
   fs.ensureDirSync(distDirPath);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
fix e2e test for interactions
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/1781/workflows/3745b435-ce9e-4d77-bc46-ea07c8a4307e/jobs/19114/steps

<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Tested Manually and failed e2e test passed

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.