### PR TITLE
fix(container-hosting): e2e test fix

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/container-hosting.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/container-hosting.test.ts
@@ -3,10 +3,10 @@ import {
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
-  enableContainerHosting,
   getBackendAmplifyMeta,
   initJSProjectWithProfile,
   removeHosting,
+  amplifyConfigureProject,
 } from 'amplify-e2e-core';
 
 import * as fs from 'fs-extra';
@@ -18,7 +18,10 @@ describe('amplify add hosting - container', () => {
   beforeAll(async () => {
     projRoot = await createNewProjectDir('container-hosting');
     await initJSProjectWithProfile(projRoot, {});
-    await enableContainerHosting(projRoot);
+    await amplifyConfigureProject({
+      cwd: projRoot,
+      enableContainers: true
+    });
     await addDevContainerHosting(projRoot);
   });
 


### PR DESCRIPTION
Fix e2e test for container hosting

#### Description of changes
This PR makes use of existing ConfigureProject method to enable container based hosting.

#### Description of how you validated changes
Ran e2e test in local.


#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.