### PR TITLE
fix(amplify-graphql-types-generator): invalid filepath format on Windows

### DIFF
--- a/packages/amplify-graphql-types-generator/src/loading.ts
+++ b/packages/amplify-graphql-types-generator/src/loading.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 
 import { buildClientSchema, Source, concatAST, parse, DocumentNode, GraphQLSchema, buildASTSchema } from 'graphql';
 
@@ -67,7 +68,7 @@ export function loadAndMergeQueryDocuments(inputPaths: string[], tagName: string
       return parse(source);
     } catch (err) {
       const relativePathToInput = relative(process.cwd(), source.name);
-      throw new ToolError(`Could not parse graphql operations in ${relativePathToInput}\n  Failed on : ${source.body}`);
+      throw new ToolError(`Could not parse graphql operations in ${relativePathToInput.replace(/\\/g, '/')}${os.EOL}  Failed on : ${source.body}`);
     }
   });
   return concatAST(parsedSources);


### PR DESCRIPTION
#### Description of changes
Fixed file path format to be specific to each operating system, to prevent failing of test cases
Changed '/' to '\\' for windows


#### Issue #, if available
#7900 

#### Description of how you validated changes
1. cd packages/amplify-graphql-types-generator
2. yarn test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.