### PR TITLE
fix(amplify-graphql-types-generator): added functionality for Windows snapshot testing

### DIFF
--- a/packages/amplify-graphql-types-generator/src/loading.ts
+++ b/packages/amplify-graphql-types-generator/src/loading.ts
@@ -48,7 +48,7 @@ function extractDocumentFromJavascript(content: string, tagName: string = 'gql')
 }
 
 export function loadAndMergeQueryDocuments(inputPaths: string[], tagName: string = 'gql'): DocumentNode {
-  var sources = inputPaths
+  let sources = inputPaths
     .map(inputPath => {
       const body = fs.readFileSync(inputPath, 'utf8');
       if (!body) {

--- a/packages/amplify-graphql-types-generator/src/loading.ts
+++ b/packages/amplify-graphql-types-generator/src/loading.ts
@@ -5,7 +5,6 @@ import { buildClientSchema, Source, concatAST, parse, DocumentNode, GraphQLSchem
 import { ToolError } from './errors';
 import { extname, join, normalize, relative } from 'path';
 
-
 export function loadSchema(schemaPath: string): GraphQLSchema {
   if (extname(schemaPath) === '.json') {
     return loadIntrospectionSchema(schemaPath);

--- a/packages/amplify-graphql-types-generator/src/loading.ts
+++ b/packages/amplify-graphql-types-generator/src/loading.ts
@@ -63,7 +63,7 @@ export function loadAndMergeQueryDocuments(inputPaths: string[], tagName: string
     })
     .filter((source): source is Source => Boolean(source));
 
-    if (originalPlatform === 'win32') {
+    if (process.platform === 'win32') {
       sources = sources.map(source => {
         source.body = source.body.replace(/\r\n/g, '\n');
         return new Source(source.body, source.name);

--- a/packages/amplify-graphql-types-generator/src/loading.ts
+++ b/packages/amplify-graphql-types-generator/src/loading.ts
@@ -5,7 +5,6 @@ import { buildClientSchema, Source, concatAST, parse, DocumentNode, GraphQLSchem
 import { ToolError } from './errors';
 import { extname, join, normalize, relative } from 'path';
 
-const originalPlatform = process.platform;
 
 export function loadSchema(schemaPath: string): GraphQLSchema {
   if (extname(schemaPath) === '.json') {


### PR DESCRIPTION
#### Description of changes
![Screenshot 2021-08-05 214742](https://user-images.githubusercontent.com/43947328/128402540-9138c780-808f-4ff7-9425-73cac2b260c9.png)
 \n is a line feed, \r is a carriage return
Different operating systems use different combinations of these characters to represent the end of a line of text
The snapshot test cases have been failing only in Windows, since windows used \\r and \\n together to depict new line escape sequence in this case, which is different from the normal usage of just \n in most other operating systems

Therefore, added a new functionality to replace \\r\\n with \n when being tested on a windows platform

#### Issue #, if available
#7901 

#### Description of how you validated changes
1. cd packages/amplify-graphql-types-generator
2. yarn test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.