### PR TITLE
fix(amplify-cli-core): extend js-yaml.JSON_SCHEMA to inherit json type conversions when parsing .yml cfn templates

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
@@ -73,6 +73,42 @@ describe('readCFNTemplate', () => {
       }
     `);
   });
+
+  it('casts yaml boolean values to corresponding JavaScript boolean', async () => {
+    const yamlContent = `
+      someKey: true
+      someOtherKey: false
+      someStringKey: "true"
+    `;
+
+    ((fs_mock.readFile as unknown) as jest.MockedFunction<TwoArgReadFile>).mockResolvedValueOnce(yamlContent);
+
+    const result = await readCFNTemplate(testPath);
+
+    expect(result.cfnTemplate).toEqual({
+      someKey: true,
+      someOtherKey: false,
+      someStringKey: 'true',
+    });
+  });
+
+  it('casts yaml integer and float values to corresponding JavaScript number', async () => {
+    const yamlContent = `
+      someKey: 1
+      someOtherKey: 1.234
+      someStringKey: "1.234"
+    `;
+
+    ((fs_mock.readFile as unknown) as jest.MockedFunction<TwoArgReadFile>).mockResolvedValueOnce(yamlContent);
+
+    const result = await readCFNTemplate(testPath);
+
+    expect(result.cfnTemplate).toEqual({
+      someKey: 1,
+      someOtherKey: 1.234,
+      someStringKey: '1.234',
+    });
+  });
 });
 
 describe('writeCFNTemplate', () => {

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -66,7 +66,7 @@ export async function writeCFNTemplate(template: object, filePath: string, optio
 
 // Register custom tags for yaml parser
 // Order and definition based on docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
-const CF_SCHEMA = new yaml.Schema([
+const CF_SCHEMA = yaml.JSON_SCHEMA.extend([
   new yaml.Type('!Base64', {
     kind: 'scalar',
     construct: function (data) {


### PR DESCRIPTION





<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Instead of creating a js-yaml schema that only contains conversions for cloudformation intrinsic
functions, we extend the built-in JSON-SCHEMA to inherit type conversions for bools, ints,
floats, etc.

See https://github.com/nodeca/js-yaml#load-string---options-

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->


fix #7819

#### Description of how you validated changes

- Parsed yaml cloudformation templates with boolean, number, and float values, and observed correct types in the returned object
- `yarn test`
- `yarn lint`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.