### PR TITLE
chore: add deprecated tag to context.print

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/print.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/print.ts
@@ -139,6 +139,9 @@ const CLI_TABLE_MARKDOWN = {
   middle: '|',
 };
 
+/**
+ * @deprecated Use printer from amplify-prompts instead
+ */
 export const print = {
   info,
   warning,

--- a/packages/amplify-prompts/src/demo/demo.ts
+++ b/packages/amplify-prompts/src/demo/demo.ts
@@ -10,12 +10,6 @@ const printTypeofResult = (result: any) => console.log(`Response type was [${typ
  * Run `yarn demo` to see it in action
  */
 const demo = async () => {
-  printResult(await prompter.input('this is a prompt', { initial: 'that has an initial value' }));
-  printResult(await prompter.pick('these options have a default selected', ['opt1', 'opt2', 'opt3'], { initial: 1 }));
-  printResult(
-    await prompter.pick<'many'>('this is a multiselect with a default', ['opt1', 'opt2', 'opt3'], { initial: [1, 2], returnSize: 'many' }),
-  );
-  printResult(await prompter.pick('theres only one option here', ['opt1']));
   // confirmContinue
   printer.info(
     'confirmContine is intended to be used anywhere the CLI is doing a potentially dangerous or destructive action and we want the customer to confirm their understanding.',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Mark `context.print` deprecated in favor of `amplify-prompts`
Also removed some lines from the prompts demo file that were there just for testing

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.