### PR TITLE
fix(amplify-category-auth): fixed no parameter when hostedui is not p…

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -132,6 +132,10 @@ async function serviceWalkthrough(context, defaultValuesFilename, stringMapsFile
         if (answer.useDefault === 'defaultSocial') {
           coreAnswers.hostedUI = true;
         }
+
+        if (answer.useDefault === 'default') {
+          coreAnswers.hostedUI = false;
+        }
         delete answer.updateFlow;
       }
       coreAnswers = { ...coreAnswers, ...answer };

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -368,6 +368,23 @@ export function updateAuthSignInSignOutUrl(cwd: string, settings: any): Promise<
   });
 }
 
+export function updateAuthToRemoveFederation(cwd: string, settings: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['update', 'auth'], { cwd, stripColors: true })
+      .wait('What do you want to do?')
+      .sendCarriageReturn()
+      .wait('"amplify publish" will build all your local backend and frontend resources')
+      .sendEof()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
 export function updateAuthWithoutCustomTrigger(cwd: string, settings: any): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['update', 'auth'], { cwd, stripColors: true })

--- a/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
@@ -16,6 +16,7 @@ import {
   getUserPoolClients,
   isDeploymentSecretForEnvExists,
   getLambdaFunction,
+  removeAuthWithDefault,
 } from 'amplify-e2e-core';
 
 const defaultsSettings = {
@@ -52,6 +53,14 @@ describe('amplify add auth...', () => {
     expect(clients[0].UserPoolClient.CallbackURLs[0]).toEqual('https://www.google.com/');
     expect(clients[0].UserPoolClient.LogoutURLs[0]).toEqual('https://www.nytimes.com/');
     expect(clients[0].UserPoolClient.SupportedIdentityProviders).toHaveLength(5);
+  });
+
+  it('...should init a project and add auth with defaultSocial and then remove federation', async () => {
+    await initJSProjectWithProfile(projRoot, defaultsSettings);
+    await addAuthWithDefaultSocial(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    await removeAuthWithDefault(projRoot);
+    await amplifyPushAuth(projRoot);
   });
 
   it('...should init a project and add auth a PostConfirmation: add-to-group trigger', async () => {


### PR DESCRIPTION
…resent

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Set hostedUI to false when federation is removed in update flow

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
yarn e2e src/__tests__/auth*


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.