### PR TITLE
fix(amplify-category-function): fixed issue for removing function env variable

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
@@ -248,7 +248,7 @@ const deleteEnvironmentVariable = (resourceName: string, targetedKey: string): v
     return item.cloudFormationParameterName !== cameledKey && item.environmentVariableName !== targetedKey;
   });
   _.unset(newReferences, targetedKey);
-  _.unset(newParameters, targetedKey);
+  _.unset(newParameters, cameledKey);
   _.unset(newKeyValue, cameledKey);
 
   setStoredList(resourceName, newList);


### PR DESCRIPTION
#### Description of changes
{functionResource}-cloudformation-template.json file has the env variable in camel case format, so env variable
deletion should look for camel case version of the variable name

#### Issue #7777 

#### Description of how you validated changes
- created a project following the reproduction steps and confirmed that push succeeds

1. `amplify add function`, add sample env var, the `env_var_should_have_underscores` for the issue to occur
2. `amplify update function`, remove sample env var
3. `amplify push`
4. Observe error shown in this issue

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.