### PR TITLE
fix: added await to init invocation

### DIFF
--- a/packages/amplify-cli/src/commands/env/add.ts
+++ b/packages/amplify-cli/src/commands/env/add.ts
@@ -1,5 +1,6 @@
+import { $TSContext } from 'amplify-cli-core';
 import { run as init } from '../init';
 
-export const run = async context => {
+export const run = async (context: $TSContext) => {
   await init(context);
 };

--- a/packages/amplify-cli/src/commands/env/add.ts
+++ b/packages/amplify-cli/src/commands/env/add.ts
@@ -1,5 +1,5 @@
 import { run as init } from '../init';
 
 export const run = async context => {
-  init(context);
+  await init(context);
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Added await to the async function init invocation.
Before this, the post execution events were being called before the axtual completion of the add env command. 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.