### PR TITLE
fix: specify default auth role name on import auth

### DIFF
--- a/packages/amplify-e2e-tests/schemas/model_with_iam_auth.graphql
+++ b/packages/amplify-e2e-tests/schemas/model_with_iam_auth.graphql
@@ -1,0 +1,9 @@
+type Todo
+  @model
+  @auth(rules: [{ allow: private, provider: iam }])
+  @key(name: "todosByOwnerId", fields: ["owner_id"], queryField: "todosByOwnerId") {
+  id: ID!
+  owner_id: String!
+  task: String!
+  description: String
+}

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
@@ -19,6 +19,8 @@ import {
   getTeamProviderInfo,
   initJSProjectWithProfile,
   initProjectWithAccessKey,
+  addApi,
+  updateApiSchema,
 } from 'amplify-e2e-core';
 import {
   AppClientSettings,
@@ -230,6 +232,17 @@ describe('auth import userpool only', () => {
     await expect(addS3WithAuthConfigurationMismatchErrorExit(projectRoot, {})).rejects.toThrowError(
       'Process exited with non zero exit code 1',
     );
+  });
+
+  it('imported user pool only should allow iam auth in graphql api', async () => {
+    await initJSProjectWithProfile(projectRoot, projectSettings);
+    await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
+    await addApi(projectRoot, {
+      IAM: {},
+    });
+    await updateApiSchema(projectRoot, projectPrefix, 'model_with_iam_auth.graphql');
+    await amplifyPush(projectRoot);
+    // successful push indicates iam auth works when only importing user pool
   });
 
   it('imported auth, push, pull to empty directory, files should match', async () => {

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1046,7 +1046,7 @@ async function formNestedStack(
           }
 
           if (parameters.authRoleName) {
-            parameters.authRoleName = authRoleName;
+            parameters.authRoleName = authRoleName || { Ref: 'AuthRoleName' }; // if only a user pool is imported, we ref the root stack AuthRoleName because the child stacks still need this parameter
           }
 
           if (parameters.unauthRoleArn) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
If imported authRoleName is undefined (which is the case when only importing a user pool), then ref the root stack AuthRoleName by default

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-cli/issues/7920


#### Description of how you validated changes
manually pushed project


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.