### PR TITLE
fix(amplify-category-auth): fixed walkthrough prompt after choosing same web & native app clients

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/import/index.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/import/index.ts
@@ -415,7 +415,7 @@ const selectAppClients = async (
   answers: ImportAnswers,
 ): Promise<void> => {
   let autoSelected = 0;
-  let changeAppClientSelction = false;
+  let changeAppClientSelection = false;
   do {
     // Select web application clients
     if (questionParameters.webClients!.length === 1) {
@@ -480,12 +480,13 @@ const selectAppClients = async (
       answers.appClientNative = questionParameters.nativeClients!.find(c => c.ClientId! === appClientNativeId);
       answers.appClientNativeId = undefined; // Only to be used by enquirer
 
-      if (answers.appClientNative === answers.appClientWeb) {
-        changeAppClientSelction = await context.prompt.confirm(importMessages.ConfirmUseDifferentAppClient);
-      }
+      changeAppClientSelection =
+        answers.appClientNative === answers.appClientWeb
+          ? await context.prompt.confirm(importMessages.ConfirmUseDifferentAppClient)
+          : false;
     }
     questionParameters.bothAppClientsWereAutoSelected = autoSelected === 2;
-  } while (changeAppClientSelction);
+  } while (changeAppClientSelection);
 };
 
 const appClientsOAuthPropertiesMatching = async (


### PR DESCRIPTION
#### Description of changes
- made sure that the prompt loop has a way to terminate

#### Issue #7949  

#### Description of how you validated changes
- reproduced the issue with production version
- manually tested the changes and confirmed the issue is fixed

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.