### PR TITLE
feat: graphql auth v2 add schemaChanges, iam policy generation, and query/read resolvers

### DIFF
--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -30,7 +30,10 @@
     "@aws-amplify/graphql-transformer-core": "0.8.1",
     "@aws-amplify/graphql-transformer-interfaces": "1.8.1",
     "@aws-amplify/graphql-model-transformer": "0.5.1",
+    "@aws-cdk/aws-appsync": "~1.72.0",
+    "@aws-cdk/aws-dynamodb": "~1.72.0",
     "@aws-cdk/core": "~1.72.0",
+    "@aws-cdk/aws-iam": "~1.72.0",
     "constructs": "^3.0.12",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.18.2",
@@ -39,6 +42,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
+    "@aws-cdk/assert": "~1.72.0",
     "@types/node": "^12.12.6"
   },
   "jest": {

--- a/packages/amplify-graphql-auth-transformer/src/accesscontrol/acm.ts
+++ b/packages/amplify-graphql-auth-transformer/src/accesscontrol/acm.ts
@@ -63,7 +63,11 @@ export class AccessControlMatrix {
     return this.roles.includes(role);
   }
 
-  public getResources(): Array<string> {
+  public getRoles(): Array<string> {
+    return this.roles;
+  }
+
+  public getResources(): Readonly<Array<string>> {
     return this.resources;
   }
 
@@ -81,6 +85,33 @@ export class AccessControlMatrix {
     for (let i = 0; i < this.roles.length; i++) {
       this.matrix[i][resourceIndex] = new Array(this.operations.length).fill(false);
     }
+  }
+
+  /**
+   * Given an operation returns the roles which have access to at least one resource
+   * If fullAccess is true then it returns roles which have operation access on all resources
+   * @param operation string
+   * @param fullAccess boolean
+   * @returns array of roles
+   */
+  public getRolesPerOperation(operation: string, fullAccess: boolean = false): Array<string> {
+    this.validate({ operations: [operation] });
+    const operationIndex = this.operations.indexOf(operation);
+    const roles = new Array<string>();
+    for (let x = 0; x < this.roles.length; x++) {
+      let hasOperation: boolean = false;
+      if (fullAccess) {
+        hasOperation = this.resources.every((resource, idx) => {
+          return this.matrix[x][idx][operationIndex];
+        });
+      } else {
+        hasOperation = this.resources.some((resource, idx) => {
+          return this.matrix[x][idx][operationIndex];
+        });
+      }
+      if (hasOperation) roles.push(this.roles[x]);
+    }
+    return roles;
   }
 
   /**

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -3,12 +3,13 @@ import {
   TransformerContractError,
   TransformerAuthBase,
   InvalidDirectiveError,
+  MappingTemplate,
 } from '@aws-amplify/graphql-transformer-core';
 import {
+  QueryFieldType,
   TransformerContextProvider,
   TransformerResolverProvider,
   TransformerSchemaVisitStepContextProvider,
-  TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   AuthRule,
@@ -27,10 +28,37 @@ import {
   getModelConfig,
   validateFieldRules,
   validateRules,
+  AuthProvider,
+  AUTH_PROVIDER_DIRECTIVE_MAP,
+  extendTypeWithDirectives,
+  RoleDefinition,
+  addDirectivesToOperation,
+  createPolicyDocumentForManagedPolicy,
+  IAM_AUTH_ROLE_PARAMETER,
+  IAM_UNAUTH_ROLE_PARAMETER,
 } from './utils';
-import { DirectiveNode, FieldDefinitionNode, ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode, Kind } from 'graphql';
-import { ModelDirectiveConfiguration } from '@aws-amplify/graphql-model-transformer';
+import { generateAuthExpressionForField, generateAuthExpressionForQueries, generateFieldAuthResponse } from './resolvers';
+import {
+  DirectiveNode,
+  FieldDefinitionNode,
+  ObjectTypeDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  Kind,
+  TypeDefinitionNode,
+} from 'graphql';
+import { SubscriptionLevel, ModelDirectiveConfiguration } from '@aws-amplify/graphql-model-transformer';
 import { AccessControlMatrix } from './accesscontrol';
+import {
+  getBaseType,
+  makeDirective,
+  makeField,
+  makeInputValueDefinition,
+  makeNamedType,
+  ResourceConstants,
+  toCamelCase,
+} from 'graphql-transformer-common';
+import * as iam from '@aws-cdk/aws-iam';
+import * as cdk from '@aws-cdk/core';
 
 // @ auth
 // changing the schema
@@ -46,10 +74,11 @@ import { AccessControlMatrix } from './accesscontrol';
 export class AuthTransformer extends TransformerAuthBase {
   private config: AuthTransformerConfig;
   private configuredAuthProviders: ConfiguredAuthProviders;
-  private modelConfig: Map<string, ModelDirectiveConfiguration>;
+  private roleMap: Map<string, RoleDefinition>;
   private authModelConfig: Map<string, AccessControlMatrix>;
-  private roleMap: Map<string, any>;
-  private authNonModelTypes: Map<string, AccessControlMatrix>;
+  private authNonModelConfig: Map<string, AccessControlMatrix>;
+  private modelDirectiveConfig: Map<string, ModelDirectiveConfiguration>;
+  private seenNonModelTypes: Map<string, Set<string>>;
   private generateIAMPolicyforUnauthRole: boolean;
   private generateIAMPolicyforAuthRole: boolean;
   private authPolicyResources = new Set<string>();
@@ -59,12 +88,13 @@ export class AuthTransformer extends TransformerAuthBase {
     super('amplify-auth-transformer', authDirectiveDefinition);
     this.config = config;
     this.configuredAuthProviders = getConfiguredAuthProviders(this.config.authConfig);
-    this.modelConfig = new Map();
+    this.modelDirectiveConfig = new Map();
+    this.seenNonModelTypes = new Map();
     this.authModelConfig = new Map();
     this.roleMap = new Map();
     this.generateIAMPolicyforUnauthRole = false;
     this.generateIAMPolicyforAuthRole = false;
-    this.authNonModelTypes = new Map();
+    this.authNonModelConfig = new Map();
   }
 
   object = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerSchemaVisitStepContextProvider): void => {
@@ -74,7 +104,9 @@ export class AuthTransformer extends TransformerAuthBase {
     }
     const typeName = def.name.value;
     const authDir = new DirectiveWrapper(directive);
-    const rules: AuthRule[] = this.extendAuthRulesForAdminUI(authDir.getArguments<AuthRule[]>([]));
+    const rules: AuthRule[] = this.extendAuthRulesForAdminUI(
+      authDir.getArguments<{ rules: Array<AuthRule> }>({ rules: [] }).rules,
+    );
     ensureAuthRuleDefaults(rules);
     // validate rules
     validateRules(rules, this.configuredAuthProviders);
@@ -90,7 +122,7 @@ export class AuthTransformer extends TransformerAuthBase {
     this.addTypeToResourceReferences(def.name.value, rules);
     // turn rules into roles and add into acm and roleMap
     this.convertModelRulesToRoles(acm, rules);
-    this.modelConfig.set(typeName, getModelConfig(modelDirective, typeName));
+    this.modelDirectiveConfig.set(typeName, getModelConfig(modelDirective, typeName));
     this.authModelConfig.set(typeName, acm);
   };
 
@@ -135,8 +167,8 @@ Static group authorization should perform as expected.`,
       // auth on models
       let acm: AccessControlMatrix;
       // check if the parent is already in the model config if not add it
-      if (!(typeName in this.modelConfig)) {
-        this.modelConfig.set(typeName, getModelConfig(modelDirective, typeName));
+      if (!(typeName in this.modelDirectiveConfig)) {
+        this.modelDirectiveConfig.set(typeName, getModelConfig(modelDirective, typeName));
         acm = new AccessControlMatrix({
           operations: MODEL_OPERATIONS,
           resources: collectFieldNames(parent),
@@ -156,119 +188,181 @@ Static group authorization should perform as expected.`,
         resources: [typeFieldName],
       });
       this.convertNonModelRulesToRoles(acm, staticGroupRules, typeFieldName);
-      this.authNonModelTypes.set(typeFieldName, acm);
+      this.authNonModelConfig.set(typeFieldName, acm);
     }
   };
 
-  transformSchema = (ctx: TransformerTransformSchemaStepContextProvider): void => {
-    // generate schema changes & IAM Policy Changes
+  transformSchema = (ctx: TransformerContextProvider): void => {
+    // generate schema changes
+    for (let [modelName, acm] of this.authModelConfig) {
+      const modelDirectiveConfig = this.modelDirectiveConfig.get(modelName)!;
+      // collect ownerFields
+      // add the owner fields for the model
+      this.addOwnerFieldsToObject(ctx, modelName, this.getOwnerFields(acm));
+      // Get the directives we need to add to the GraphQL nodes
+      let providers = this.getAuthProvidersPerModel(modelName);
+      let directives = this.getServiceDirectives(providers, providers.length === 0 ? this.shouldAddDefaultServiceDirective() : false);
+      if (directives.length > 0) {
+        extendTypeWithDirectives(ctx, modelName, directives);
+      }
+      this.protectSchemaOperations(ctx, acm, providers, modelDirectiveConfig);
+      this.propagateAuthDirectivesToNestedTypes(ctx, ctx.output.getObject(modelName)!, providers);
+    }
   };
 
   generateResolvers = (ctx: TransformerContextProvider): void => {
+    // generate iam policies
+    this.generateIAMPolicies(ctx);
     // generate auth resolver code
+    for (let [modelName, acm] of this.authModelConfig) {
+      const def = ctx.output.getObject(modelName)!;
+      // queries
+      const queryFields = this.getQueryFieldNames(ctx, def!);
+      const readRoles = acm.getRolesPerOperation('read');
+      for (let query of queryFields.values()) {
+        switch (query.type) {
+          case QueryFieldType.GET:
+            this.protectGetResolver(ctx, def, query.typeName, query.fieldName, acm);
+            break;
+          case QueryFieldType.LIST:
+            this.protectListResolver(ctx, def, query.typeName, query.fieldName, acm);
+            break;
+          default:
+            throw new Error('Unkown query field type');
+        }
+      }
+      // get fields specified in the schema
+      // if there is a role that does not have read access on the field then we create a field resolver
+      const modelFields = def.fields?.filter(f => acm.getResources().includes(f.name.value)) ?? [];
+      for (let field of modelFields) {
+        const allowedRoles = readRoles.filter(r => acm.isAllowed(r, field.name.value, 'read'));
+        if (allowedRoles.length < readRoles.length) {
+          if (field.type.kind === Kind.NON_NULL_TYPE) {
+            throw new InvalidDirectiveError(`\nPer-field auth on the required field ${field.name.value} is not supported with subscriptions.
+  Either make the field optional, set auth on the object and not the field, or disable subscriptions for the object (setting level to off or public)\n`);
+          }
+          this.protectFieldResolver(ctx, modelName, field.name.value, allowedRoles);
+        }
+      }
+    }
   };
 
-  // Mutations
-  protectCreateResolver = <AuthRule, ModelConfiguration>(
+  protectSchemaOperations = (
     ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
+    acm: AccessControlMatrix,
+    providers: Array<AuthProvider>,
+    modelConfig: ModelDirectiveConfiguration,
+  ): void => {
+    const addServiceDirective = (operation: ModelOperation, operationName: string | null = null) => {
+      if (operationName) {
+        let includeDefault = this.doesTypeHaveRulesForOperation(acm, operation);
+        let operationDirectives = this.getServiceDirectives(providers, includeDefault);
+        if (operationDirectives.length > 0) {
+          addDirectivesToOperation(ctx, ctx.output.getQueryTypeName()!, operationName, operationDirectives);
+        }
+        this.addOperationToResourceReferences(ctx.output.getQueryTypeName()!, operationName, acm.getRoles());
+      }
+    };
+    addServiceDirective('read', modelConfig?.queries?.get);
+    addServiceDirective('read', modelConfig?.queries?.list);
+    addServiceDirective('create', modelConfig?.mutations?.create);
+    addServiceDirective('update', modelConfig?.mutations?.update);
+    addServiceDirective('delete', modelConfig?.mutations?.delete);
+    // TODO: protect sync queries once supported
+
+    // subscriptions
+    const subscriptions = modelConfig?.subscriptions;
+    if (subscriptions && subscriptions.level === SubscriptionLevel.on) {
+      const ownerFields = this.getOwnerFields(acm) ?? [];
+      for (let onCreateSub of subscriptions.onCreate ?? []) {
+        addServiceDirective('read', onCreateSub);
+        this.addSubscriptionOwnerArguments(ctx, onCreateSub, ownerFields);
+      }
+      for (let onUpdateSub of subscriptions.onUpdate ?? []) {
+        addServiceDirective('read', onUpdateSub);
+        this.addSubscriptionOwnerArguments(ctx, onUpdateSub, ownerFields);
+      }
+      for (let onDeleteSub of subscriptions.onDelete ?? []) {
+        addServiceDirective('read', onDeleteSub);
+        this.addSubscriptionOwnerArguments(ctx, onDeleteSub, ownerFields);
+      }
+    }
   };
-  protectUpdateResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  protectDeleteResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  // Subscriptions
-  protectOnCreateResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  protectOnUpdateResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  protectOnDeleteResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
+
   // Queries
-  protectGetResolver = <AuthRule, ModelConfiguration>(
+  protectGetResolver = (
     ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  protectListResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  protectSyncResolver = <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: AuthRule[],
-    modelConfiguration: ModelConfiguration,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
-  };
-  protectFieldResolver = (
-    ctx: TransformerContextProvider,
-    field: FieldDefinitionNode,
+    def: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
-  ): TransformerResolverProvider => {
-    const resolver = ctx.resolvers.getResolver('typeName', 'fieldName') as TransformerResolverProvider;
-    return resolver;
+    acm: AccessControlMatrix,
+  ): void => {
+    const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
+    const roleDefinitions = acm.getRolesPerOperation('read').map(r => this.roleMap.get(r)!);
+    const authExpression = generateAuthExpressionForQueries(roleDefinitions, def.fields ?? []);
+    resolver.addToSlot(
+      'auth',
+      MappingTemplate.s3MappingTemplateFromString(authExpression, `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`),
+    );
+  };
+  protectListResolver = (
+    ctx: TransformerContextProvider,
+    def: ObjectTypeDefinitionNode,
+    typeName: string,
+    fieldName: string,
+    acm: AccessControlMatrix,
+  ): void => {
+    const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
+    const roleDefinitions = acm.getRolesPerOperation('read').map(r => this.roleMap.get(r)!);
+    const authExpression = generateAuthExpressionForQueries(roleDefinitions, def.fields ?? []);
+    resolver.addToSlot(
+      'auth',
+      MappingTemplate.s3MappingTemplateFromString(authExpression, `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`),
+    );
+  };
+  protectFieldResolver = (ctx: TransformerContextProvider, typeName: string, fieldName: string, roles: Array<string>): void => {
+    const roleDefinitions = roles.map(r => this.roleMap.get(r)!);
+    const fieldAuthExpression = generateAuthExpressionForField(roleDefinitions);
+    const subsEnabled = this.modelDirectiveConfig.get(typeName)!.subscriptions.level === 'on';
+    const fieldResponse = generateFieldAuthResponse(ctx.output.getMutationTypeName()!, fieldName, subsEnabled);
+    // TODO: check if a function resolver is created here
+    ctx.api.host.addResolver(
+      typeName,
+      fieldName,
+      MappingTemplate.s3MappingTemplateFromString(fieldAuthExpression, `${typeName}.${fieldName}.req.vtl`),
+      MappingTemplate.s3MappingTemplateFromString(fieldResponse, `${typeName}.${fieldName}.req.vtl`),
+    );
+  };
+
+  getQueryFieldNames = (
+    ctx: TransformerContextProvider,
+    type: ObjectTypeDefinitionNode,
+  ): Set<{ fieldName: string; typeName: string; type: QueryFieldType }> => {
+    const typeName = type.name.value;
+    const fields: Set<{ fieldName: string; typeName: string; type: QueryFieldType }> = new Set();
+    const modelDirectiveConfig = this.modelDirectiveConfig.get(type.name.value);
+    if (modelDirectiveConfig?.queries?.get) {
+      fields.add({
+        typeName: 'Query',
+        fieldName: modelDirectiveConfig.queries.get || toCamelCase(['get', typeName]),
+        type: QueryFieldType.GET,
+      });
+    }
+
+    if (modelDirectiveConfig?.queries?.list) {
+      fields.add({
+        typeName: 'Query',
+        fieldName: modelDirectiveConfig.queries.list || toCamelCase(['list', typeName]),
+        type: QueryFieldType.LIST,
+      });
+    }
+    // check if this API is sync enabled and then if the model is sync enabled
+    // fields.add({
+    //   typeName: 'Query',
+    //   fieldName: camelCase(`sync ${typeName}`),
+    //   type: QueryFieldType.SYNC,
+    // });
+    return fields;
   };
 
   private convertNonModelRulesToRoles(acm: AccessControlMatrix, authRules: AuthRule[], field?: string) {
@@ -277,9 +371,11 @@ Static group authorization should perform as expected.`,
         let roleName = `${rule.provider}:staticGroup:${group}`;
         if (!(roleName in this.roleMap)) {
           this.roleMap.set(roleName, {
-            provider: rule.provider,
+            provider: rule.provider!,
+            strategy: rule.allow,
+            static: true,
             claim: rule.groupClaim || DEFAULT_GROUP_CLAIM,
-            value: group,
+            entity: group,
           });
         }
         acm.setRole({ role: roleName, resource: field, operations: ['read'] });
@@ -290,30 +386,34 @@ Static group authorization should perform as expected.`,
   private convertModelRulesToRoles(acm: AccessControlMatrix, authRules: AuthRule[], field?: string) {
     for (let rule of authRules) {
       let operations: ModelOperation[] = rule.operations || MODEL_OPERATIONS;
-      if (rule.groups) {
+      if (rule.groups && !rule.groupsField) {
         rule.groups.forEach(group => {
           let roleName = `${rule.provider}:staticGroup:${group}`;
           if (!(roleName in this.roleMap)) {
             this.roleMap.set(roleName, {
-              provider: rule.provider,
+              provider: rule.provider!,
+              strategy: rule.allow,
+              static: true,
               claim: rule.groupClaim || DEFAULT_GROUP_CLAIM,
-              value: group,
+              entity: group,
             });
           }
           acm.setRole({ role: roleName, resource: field, operations });
         });
       } else {
         let roleName: string;
-        let roleDefinition: any;
+        let roleDefinition: RoleDefinition;
         switch (rule.provider) {
           case 'apiKey':
             roleName = 'apiKey:public';
-            roleDefinition = { provider: rule.provider };
+            roleDefinition = { provider: rule.provider, strategy: rule.allow, static: true };
             break;
           case 'iam':
             roleName = `iam:${rule.allow}`;
             roleDefinition = {
               provider: rule.provider,
+              strategy: rule.allow,
+              static: true,
               claim: rule.allow === 'private' ? 'authenticated' : 'unauthenticated',
             };
             break;
@@ -324,39 +424,247 @@ Static group authorization should perform as expected.`,
               roleName = `${rule.provider}:dynamicGroup:${groupsField}`;
               roleDefinition = {
                 provider: rule.provider,
+                strategy: rule.allow,
+                static: false,
                 claim: rule.groupClaim || DEFAULT_GROUP_CLAIM,
-                value: groupsField,
+                entity: groupsField,
               };
-            }
-            if (rule.allow === 'owner') {
+            } else if (rule.allow === 'owner') {
               let ownerField = rule.ownerField || DEFAULT_OWNER_FIELD;
               roleName = `${rule.provider}:owner:${ownerField}`;
               roleDefinition = {
                 provider: rule.provider,
+                strategy: rule.allow,
+                static: false,
                 claim: rule.identityClaim || DEFAULT_IDENTITY_CLAIM,
-                value: ownerField,
+                entity: ownerField,
               };
             } else {
-              throw new TransformerContractError(`Could not create a role from ${rule}`);
+              throw new TransformerContractError(`Could not create a role from ${JSON.stringify(rule)}`);
             }
             break;
           default:
-            throw new TransformerContractError(`Could not create a role from ${rule}`);
+            throw new TransformerContractError(`Could not create a role from ${JSON.stringify(rule)}`);
+        }
+        if (!(roleName in this.roleMap)) {
+          this.roleMap.set(roleName, roleDefinition);
         }
         acm.setRole({ role: roleName, resource: field, operations });
-        this.roleMap.set(roleName, roleDefinition);
       }
     }
   }
+  /*
+  Role Helpers
+  */
+  private doesTypeHaveRulesForOperation(acm: AccessControlMatrix, operation: ModelOperation) {
+    const rolesHasDefaultProvider = (roles: Array<string>) => {
+      return roles.some(r => this.roleMap.get(r)!.provider! === this.configuredAuthProviders.default);
+    };
+    const roles = acm.getRolesPerOperation(operation, operation === 'delete');
+    return rolesHasDefaultProvider(roles) || (roles.length === 0 && this.shouldAddDefaultServiceDirective());
+  }
+  private getAuthProvidersPerModel(typeName: string): Array<AuthProvider> {
+    const providers: Set<AuthProvider> = new Set();
+    // get the roles created for type
+    const roles = this.authModelConfig.get(typeName)!.getRoles();
+    for (let role of roles) {
+      providers.add(this.roleMap.get(role)!.provider);
+    }
+    return Array.from(providers);
+  }
+  private getOwnerFields(acm: AccessControlMatrix): Array<string> {
+    return acm.getRoles().reduce((prev: string[], role: string) => {
+      if (this.roleMap.get(role)!.strategy === 'owner') prev.push(this.roleMap.get(role)!.entity!);
+      return prev;
+    }, []);
+  }
+  /*
+  Schema Generation Helpers
+  */
+  private addOwnerFieldsToObject(ctx: TransformerContextProvider, modelName: string, ownerFields: Array<string>) {
+    const modelObject = ctx.output.getObject(modelName)!;
+    const existingFields = collectFieldNames(modelObject);
+    const ownerFieldsToAdd = ownerFields.filter(field => !existingFields.includes(field));
+    for (let ownerField of ownerFieldsToAdd) {
+      (modelObject as any).fields.push(makeField(ownerField, [], makeNamedType('String')));
+    }
+    ctx.output.putType(modelObject);
+  }
+  private addSubscriptionOwnerArguments(ctx: TransformerContextProvider, operationName: string, ownerFields: Array<string>) {
+    let subscription = ctx.output.getSubscription()!;
+    let createField: FieldDefinitionNode = subscription!.fields!.find(field => field.name.value === operationName) as FieldDefinitionNode;
+    const ownerArgumentList = ownerFields.map(role => {
+      return makeInputValueDefinition(role, makeNamedType('String'));
+    });
+    createField = {
+      ...createField,
+      arguments: ownerArgumentList,
+    };
+    subscription = {
+      ...subscription,
+      fields: subscription!.fields!.map(field => (field.name.value === operationName ? createField : field)),
+    };
+    ctx.output.putType(subscription);
+  }
+  private propagateAuthDirectivesToNestedTypes(
+    ctx: TransformerContextProvider,
+    type: ObjectTypeDefinitionNode,
+    providers: Array<AuthProvider>,
+  ) {
+    const getDirectivesToAdd = (nonModelName: string): { current: DirectiveNode[]; old?: Set<string> } => {
+      const directives = this.getServiceDirectives(providers, true);
+      if (this.seenNonModelTypes.has(nonModelName)) {
+        const nonModelDirectives: Set<string> = this.seenNonModelTypes.get(nonModelName)!;
+        return { current: directives.filter(directive => !nonModelDirectives.has(directive.name.value)), old: nonModelDirectives };
+      }
+      return { current: directives };
+    };
+
+    const nonModelTypePredicate = (fieldType: TypeDefinitionNode): TypeDefinitionNode | undefined => {
+      if (fieldType) {
+        if (fieldType.kind !== 'ObjectTypeDefinition') {
+          return undefined;
+        }
+        const typeModel = fieldType.directives!.find(dir => dir.name.value === 'model');
+        return typeModel !== undefined ? undefined : fieldType;
+      }
+      return fieldType;
+    };
+    const nonModelFieldTypes = type
+      .fields!.map(f => ctx.output.getType(getBaseType(f.type)) as TypeDefinitionNode)
+      .filter(nonModelTypePredicate);
+    for (const nonModelFieldType of nonModelFieldTypes) {
+      const directives = getDirectivesToAdd(nonModelFieldType.name.value);
+      if (directives.current.length > 0) {
+        // merge back the newly added auth directives with what already exists in the set
+        const totalDirectives = new Set<string>([
+          ...directives.current.map(dir => dir.name.value),
+          ...(directives.old ? directives.old : []),
+        ]);
+        this.seenNonModelTypes.set(nonModelFieldType.name.value, totalDirectives);
+        extendTypeWithDirectives(ctx, nonModelFieldType.name.value, directives.current);
+        const hasIAM =
+          directives.current.filter(directive => directive.name.value === 'aws_iam') || this.configuredAuthProviders.default === 'iam';
+        if (hasIAM) {
+          this.unauthPolicyResources.add(`${nonModelFieldType.name.value}/null`);
+          this.authPolicyResources.add(`${nonModelFieldType.name.value}/null`);
+        }
+        this.propagateAuthDirectivesToNestedTypes(ctx, <ObjectTypeDefinitionNode>nonModelFieldType, providers);
+      }
+    }
+  }
+
+  private getServiceDirectives(providers: Readonly<Array<AuthProvider>>, addDefaultIfNeeded: boolean = true): Array<DirectiveNode> {
+    if (providers.length === 0) {
+      return [];
+    }
+    const directives: Array<DirectiveNode> = new Array();
+    /*
+      We only add a service directive if it's not the default or
+      it's the default but there are other rules under different providers.
+      For fields we don't we don't add the default since it would open up access.
+    */
+    const addDirectiveIfNeeded = (provider: AuthProvider, directiveName: string): void => {
+      if (
+        (this.configuredAuthProviders.default !== provider && providers.some(p => p === provider)) ||
+        (this.configuredAuthProviders.default === provider && providers.some(p => p !== provider && addDefaultIfNeeded === true))
+      ) {
+        directives.push(makeDirective(directiveName, []));
+      }
+    };
+
+    for (let [authProvider, directiveName] of AUTH_PROVIDER_DIRECTIVE_MAP) {
+      addDirectiveIfNeeded(authProvider, directiveName);
+    }
+    /*
+      If we have any rules for the default provider AND those with other providers,
+      we add the default provider directive, regardless of the addDefaultDirective value
+
+      For example if we have this rule and the default is API_KEY
+      @auth(rules: [{ allow: owner }, { allow: public, operations: [read] }])
+
+      Then we need to add @aws_api_key on the queries along with @aws_cognito_user_pools, but we
+      cannot add @aws_api_key to other operations since their is no rule granted access to it
+    */
+    if (
+      Boolean(providers.find(p => p === this.configuredAuthProviders.default)) &&
+      Boolean(
+        providers.find(p => p !== this.configuredAuthProviders.default) &&
+          !Boolean(directives.find(d => d.name.value === AUTH_PROVIDER_DIRECTIVE_MAP.get(this.configuredAuthProviders.default))),
+      )
+    ) {
+      directives.push(makeDirective(AUTH_PROVIDER_DIRECTIVE_MAP.get(this.configuredAuthProviders.default) as string, []));
+    }
+    return directives;
+  }
+  /*
+  Admin UI Helpers
+  */
   private isAdminUIEnabled(): boolean {
     return this.configuredAuthProviders.hasIAM && this.config.addAwsIamAuthInOutputSchema;
   }
-  private extendAuthRulesForAdminUI(rules: Readonly<AuthRule[]>): AuthRule[] {
+  private extendAuthRulesForAdminUI(rules: AuthRule[]): AuthRule[] {
     // Check for Amplify Admin
     if (this.isAdminUIEnabled()) {
       return [...rules, { allow: 'private', provider: 'iam', generateIAMPolicy: false }];
     }
-    return [...rules];
+    return rules;
+  }
+  /**
+   * When AdminUI is enabled, all the types and operations get IAM auth. If the default auth mode is
+   * not IAM all the fields will need to have the default auth mode directive to ensure both IAM and deault
+   * auth modes are allowed to access
+   *  default auth provider needs to be added if AdminUI is enabled and default auth type is not IAM
+   * @returns boolean
+   */
+  private shouldAddDefaultServiceDirective(): boolean {
+    return this.isAdminUIEnabled() && this.config.authConfig.defaultAuthentication.authenticationType !== 'AWS_IAM';
+  }
+  /*
+  IAM Helpers
+   */
+  private generateIAMPolicies(ctx: TransformerContextProvider) {
+    // iam
+    if (this.generateIAMPolicyforAuthRole) {
+      // Sanity check to make sure we're not generating invalid policies, where no resources are defined.
+      if (this.authPolicyResources.size === 0) {
+        // When AdminUI is enabled, IAM auth is added but it does not need any policies to be generated
+        if (!this.isAdminUIEnabled()) {
+          throw new TransformerContractError('AuthRole policies should be generated, but no resources were added.');
+        }
+      } else {
+        const authRoleParameter = ctx.stackManager.addParameter(IAM_AUTH_ROLE_PARAMETER, { type: 'String' });
+        const role = iam.Role.fromRoleArn(ctx.stackManager.rootStack, 'auth-role-name', authRoleParameter.valueAsString);
+        const authPolicyDocuments = createPolicyDocumentForManagedPolicy(this.authPolicyResources);
+        for (let i = 0; i < authPolicyDocuments.length; i++) {
+          const paddedIndex = `${i + 1}`.padStart(2, '0');
+          const resourceName = `${ResourceConstants.RESOURCES.AuthRolePolicy}${paddedIndex}`;
+          role.addManagedPolicy(
+            new iam.ManagedPolicy(ctx.stackManager.rootStack, resourceName, {
+              document: iam.PolicyDocument.fromJson(authPolicyDocuments[i]),
+            }),
+          );
+        }
+      }
+    }
+    if (this.generateIAMPolicyforUnauthRole) {
+      // Sanity check to make sure we're not generating invalid policies, where no resources are defined.
+      if (this.unauthPolicyResources.size === 0) {
+        throw new TransformerContractError('UnauthRole policies should be generated, but no resources were added');
+      }
+      const unauthParameter = ctx.stackManager.addParameter(IAM_UNAUTH_ROLE_PARAMETER, { type: 'String' });
+      const role = iam.Role.fromRoleArn(ctx.stackManager.rootStack, 'unauth-role-name', unauthParameter.valueAsString);
+      const unauthPolicyDocuments = createPolicyDocumentForManagedPolicy(this.unauthPolicyResources);
+      for (let i = 0; i < unauthPolicyDocuments.length; i++) {
+        const paddedIndex = `${i + 1}`.padStart(2, '0');
+        const resourceName = `${ResourceConstants.RESOURCES.UnauthRolePolicy}${paddedIndex}`;
+        role.addManagedPolicy(
+          new iam.ManagedPolicy(ctx.stackManager.rootStack, resourceName, {
+            document: iam.PolicyDocument.fromJson(unauthPolicyDocuments[i]),
+          }),
+        );
+      }
+    }
   }
   private setAuthPolicyFlag(rules: AuthRule[]): void {
     if (rules.length === 0 || this.generateIAMPolicyforAuthRole === true) {
@@ -382,28 +690,45 @@ Static group authorization should perform as expected.`,
     }
   }
 
-  private addTypeToResourceReferences(typeName: string, rules: AuthRule[]): void {
-    const iamPublicRules = rules.filter(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
-    const iamPrivateRules = rules.filter(r => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
+  private addOperationToResourceReferences(operationName: string, fieldName: string, roles: Array<string>) {
+    const iamPublicRolesExist = roles.some(r => this.roleMap.get(r)!.provider === 'iam' && this.roleMap.get(r)!.strategy === 'public');
+    const iamPrivateRolesExist = roles.some(r => this.roleMap.get(r)!.provider === 'iam' && this.roleMap.get(r)!.strategy === 'private');
 
-    if (iamPublicRules.length > 0) {
+    if (iamPublicRolesExist) {
+      this.unauthPolicyResources.add(`${operationName}/${fieldName}`);
+      this.authPolicyResources.add(`${operationName}/${fieldName}`);
+    }
+    if (iamPrivateRolesExist) {
+      this.authPolicyResources.add(`${operationName}/${fieldName}`);
+    }
+  }
+
+  /**
+   * TODO: Change Resource Ref Object/Field Functions to work with roles
+   * Currently we need FieldToResourceRef to have deny by default behavior for IAM Policy
+   */
+  private addTypeToResourceReferences(typeName: string, rules: AuthRule[]): void {
+    const iamPublicRulesExist = rules.some(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPrivateRulesExist = rules.some(r => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
+
+    if (iamPublicRulesExist) {
       this.unauthPolicyResources.add(`${typeName}/null`);
       this.authPolicyResources.add(`${typeName}/null`);
     }
-    if (iamPrivateRules.length > 0) {
+    if (iamPrivateRulesExist) {
       this.authPolicyResources.add(`${typeName}/null`);
     }
   }
 
   private addFieldToResourceReferences(typeName: string, fieldName: string, rules: AuthRule[]): void {
-    const iamPublicRules = rules.filter(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
-    const iamPrivateRules = rules.filter(r => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPublicRulesExist = rules.some(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPrivateRulesExist = rules.some(r => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
 
-    if (iamPublicRules.length > 0) {
+    if (iamPublicRulesExist) {
       this.unauthPolicyResources.add(`${typeName}/${fieldName}`);
       this.authPolicyResources.add(`${typeName}/${fieldName}`);
     }
-    if (iamPrivateRules.length > 0) {
+    if (iamPrivateRulesExist) {
       this.authPolicyResources.add(`${typeName}/${fieldName}`);
     }
   }

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/index.ts
@@ -1,0 +1,1 @@
+export * from './query';

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -1,0 +1,298 @@
+import { FieldDefinitionNode } from 'graphql';
+import {
+  compoundExpression,
+  iff,
+  raw,
+  set,
+  ref,
+  forEach,
+  bool,
+  Expression,
+  not,
+  ObjectNode,
+  obj,
+  list,
+  qref,
+  equals,
+  str,
+  and,
+  methodCall,
+  toJson,
+  printBlock,
+  print,
+  block,
+  ifElse,
+  nul,
+} from 'graphql-mapping-template';
+import { isListType, NONE_VALUE } from 'graphql-transformer-common';
+import {
+  COGNITO_AUTH_TYPE,
+  OIDC_AUTH_TYPE,
+  DEFAULT_COGNITO_IDENTITY_CLAIM,
+  API_KEY_AUTH_TYPE,
+  RoleDefinition,
+  RolesByProvider,
+} from '../utils';
+
+// Generic Auth VTL Functions
+const getIdentityClaimExp = (value: Expression, defaultValueExp: Expression) => {
+  return methodCall(ref('util.defaultIfNull'), methodCall(ref('ctx.identity.claims.get'), value), defaultValueExp);
+};
+
+export const splitRoles = (roles: Array<RoleDefinition>): RolesByProvider => {
+  return {
+    cognitoStaticGroupRoles: roles.filter(r => r.static && r.provider === 'userPools'),
+    cognitoDynamicRoles: roles.filter(r => !r.static && r.provider === 'userPools'),
+    oidcStaticGroupRoles: roles.filter(r => r.static && r.provider === 'oidc'),
+    oidcDynamicRoles: roles.filter(r => !r.static && r.provider === 'oidc'),
+    apiKeyRoles: roles.filter(r => r.provider === 'apiKey'),
+  };
+};
+
+export const staticRuleExpression = (roles: Array<RoleDefinition>): Array<Expression> => {
+  return [
+    set(ref('staticGroupRoles'), raw(JSON.stringify(roles.map(r => ({ claim: r.claim, entity: r.entity }))))),
+    forEach(/** for */ ref('groupRole'), /** in */ ref('staticGroupRoles'), [
+      set(ref('groupsInToken'), getIdentityClaimExp(ref('groupRole.claim'), list([]))),
+      iff(
+        methodCall(ref('groupsInToken.contains'), ref('groupRole.entity')),
+        compoundExpression([
+          set(ref('isStaticAuthorized'), bool(true)),
+          qref(methodCall(ref('ctx.stash.remove'), str('authFilter'))),
+          raw(`#break`),
+        ]),
+      ),
+    ]),
+  ];
+};
+
+/**
+ * Behavior of auth v1
+ * Order of how the owner value is retrieved from the jwt
+ * if claim is username
+ * 1. username
+ * 2. cognito:username
+ * 3. none value
+ *
+ * if claim is custom
+ * 1. custom
+ * 2. none value
+ */
+export const getOwnerExpression = (ownerClaim: string): Expression => {
+  if (ownerClaim === 'username') {
+    return getIdentityClaimExp(str(ownerClaim), getIdentityClaimExp(str(DEFAULT_COGNITO_IDENTITY_CLAIM), str(NONE_VALUE)));
+  }
+  return getIdentityClaimExp(str(ownerClaim), str(NONE_VALUE));
+};
+
+export const fieldIsList = (fields: ReadonlyArray<FieldDefinitionNode>, fieldName: string) => {
+  const field = fields.find(field => field.name.value === fieldName);
+  if (field) {
+    return isListType(field.type);
+  }
+  return false;
+};
+
+// Query VTL Functions
+export const generateAuthFilter = (roles: Array<RoleDefinition>, fields: ReadonlyArray<FieldDefinitionNode>): Expression => {
+  const authFilter = new Array<ObjectNode>();
+  /**
+   * if ownerField is string
+   * ownerField: { eq: "cognito:owner" }
+   * if ownerField is a List
+   * ownerField: { contains: "cognito:owner"}
+   *
+   * if groupsField is a string
+   * groupsField: { in: "cognito:groups" }
+   * if groupsField is a list
+   * groupsField: { contains: "cognito:groups" }
+   *  */
+  for (let role of roles) {
+    const entityIsList = fieldIsList(fields, role.entity!);
+    if (role.strategy === 'owner') {
+      const ownerCondition = entityIsList ? 'contains' : 'eq';
+      authFilter.push(obj({ [role.entity!]: obj({ [ownerCondition]: getOwnerExpression(role.claim!) }) }));
+    }
+    if (role.strategy === 'groups') {
+      const groupsCondition = entityIsList ? 'contains' : 'in';
+      authFilter.push(obj({ [role.entity!]: obj({ [groupsCondition]: getIdentityClaimExp(str(role.claim!), list([str(NONE_VALUE)])) }) }));
+    }
+  }
+  return qref(methodCall(ref('ctx.stash.put'), str('authFilter'), obj({ or: list(authFilter) })));
+};
+
+export const jwtQueryAuthExpression = (
+  provider: string,
+  fields: ReadonlyArray<FieldDefinitionNode>,
+  staticRoles: Array<RoleDefinition>,
+  dynamicRoles: Array<RoleDefinition>,
+): Expression | null => {
+  const authExpressions = new Array<Expression>();
+  if (dynamicRoles.length > 0) {
+    authExpressions.push(generateAuthFilter(dynamicRoles, fields));
+  }
+  if (staticRoles.length > 0) {
+    authExpressions.push(...staticRuleExpression(staticRoles));
+  }
+  if (authExpressions.length > 0) {
+    authExpressions.push(
+      iff(
+        and([not(ref('isStaticAuthorized')), methodCall(ref('util.isNullOrEmpty'), methodCall(ref('ctx.stash.get'), str('authFilter')))]),
+        ref('util.unauthorized()'),
+      ),
+    );
+    return iff(equals(ref('util.authType()'), str(provider)), compoundExpression(authExpressions));
+  }
+  return null;
+};
+
+export const generateAuthExpressionForQueries = (roles: Array<RoleDefinition>, fields: ReadonlyArray<FieldDefinitionNode>): string => {
+  const { cognitoStaticGroupRoles, cognitoDynamicRoles, oidcStaticGroupRoles, oidcDynamicRoles } = splitRoles(roles);
+  const totalAuthExpressions = Array<Expression>();
+  const cognitoAuthExpression = jwtQueryAuthExpression(COGNITO_AUTH_TYPE, fields, cognitoStaticGroupRoles, cognitoDynamicRoles);
+  const oidcAuthExpression = jwtQueryAuthExpression(OIDC_AUTH_TYPE, fields, oidcStaticGroupRoles, oidcDynamicRoles);
+  if (cognitoAuthExpression) totalAuthExpressions.push(cognitoAuthExpression);
+  if (oidcAuthExpression) totalAuthExpressions.push(oidcAuthExpression);
+  return printBlock('Authorization Steps')(compoundExpression([...totalAuthExpressions, toJson(obj({}))]));
+};
+
+// Field Read VTL Functions
+export const generateDynamicAuthReadExpression = (roles: Array<RoleDefinition>) => {
+  const ownerExpression = new Array<ObjectNode>();
+  const dynamicGroupExpression = new Array<ObjectNode>();
+  const ownerRuleLoop = [
+    iff(
+      not(ref('isFieldAuthorized')),
+      forEach(ref('ownerRole'), ref('dynamicRoles.owner'), [
+        set(ref('ownerEntity'), ref('ownerRole.entity')),
+        set(ref('ownerClaim'), ref('ownerRole.claim')),
+        iff(
+          methodCall(ref('util.isList'), ref('ownerEntity')),
+          forEach(ref('allowedOwner'), ref('ownerEntity'), [
+            iff(
+              equals(ref('allowedOwner'), ref('ownerClaim')),
+              compoundExpression([
+                set(ref('isFieldAuthorized'), bool(true)),
+                // break from inner loop
+                str('#break'),
+              ]),
+            ),
+          ]),
+        ),
+        iff(
+          methodCall(ref('util.isString'), ref('ownerEntity')),
+          iff(equals(ref('ownerEntity'), ref('ownerClaim')), set(ref('isFieldAuthorized'), bool(true))),
+        ),
+        iff(ref('isFieldAuthorized'), str('#break')),
+      ]),
+    ),
+  ];
+  const dynamicGroupLoop = [
+    iff(
+      not(ref('isFieldAuthorized')),
+      forEach(ref('dynamicGroupRole'), ref('dynamicRoles.dynamicGroups'), [
+        set(ref('dynamicGroupEntity'), ref('dynamicGroupRole.entity')),
+        set(ref('dynamicGroupClaim'), ref('dynamicGroupRole.claim')),
+        forEach(ref('userGroup'), ref('dynamicGroupClaim'), [
+          iff(
+            methodCall(ref('util.isList'), ref('dynamicGroupEntity')),
+            iff(
+              methodCall(ref('dynamicGroupEntity.contains'), ref('userGroup')),
+              compoundExpression([
+                set(ref('isFieldAuthorized'), bool(true)),
+                // break from inner loop
+                str('#break'),
+              ]),
+            ),
+          ),
+          iff(
+            methodCall(ref('util.isString'), ref('dynamicGroupEntity')),
+            iff(equals(ref('dynamicGroupEntity'), ref('userGroup')), set(ref('isFieldAuthorized'), bool(true))),
+          ),
+        ]),
+        iff(ref('isFieldAuthorized'), str('#break')),
+      ]),
+    ),
+  ];
+
+  for (let role of roles) {
+    if (role.strategy === 'owner') {
+      ownerExpression.push(
+        obj({
+          entity: methodCall(ref('util.defaultIfNull'), ref(`ctx.source.${role.entity}`), list([])),
+          claim: getOwnerExpression(role.claim!),
+        }),
+      );
+    }
+    if (role.strategy === 'groups') {
+      dynamicGroupExpression.push(
+        obj({
+          entity: methodCall(ref('util.defaultIfNull'), ref(`ctx.source.${role.entity}`), list([])),
+          claim: getIdentityClaimExp(str(role.claim!), list([])),
+        }),
+      );
+    }
+  }
+  return compoundExpression([
+    set(ref('dynamicRoles'), obj({ owner: list(ownerExpression), dynamicGroups: list(dynamicGroupExpression) })),
+    ...(ownerExpression.length > 0 ? ownerRuleLoop : []),
+    ...(dynamicGroupExpression.length > 0 ? dynamicGroupLoop : []),
+  ]);
+};
+
+/**
+ * if the apiKey and iam providers are not listed for those operations/field then they are denied
+ * @param allowed can be used for query/field resolvers
+ * @returns
+ */
+export const apiKeyReadExpression = (allowed: boolean = false): Expression => {
+  return iff(equals(ref('util.authType()'), str(API_KEY_AUTH_TYPE)), set(ref('isStaticGroupAuthorized'), bool(allowed)));
+};
+
+export const jwtFieldAuthExpression = (
+  provider: string,
+  staticRoles: Array<RoleDefinition>,
+  dynamicRoles: Array<RoleDefinition>,
+): Expression | null => {
+  const authExpressions = new Array<Expression>();
+  if (staticRoles.length > 0) {
+    authExpressions.push(...staticRuleExpression(staticRoles));
+  }
+  if (dynamicRoles.length > 0) {
+    authExpressions.push(iff(not(ref('isFieldAuthorized')), generateDynamicAuthReadExpression(dynamicRoles)));
+  }
+  if (authExpressions.length > 0) {
+    authExpressions.push(iff(not(ref('isFieldAuthorized')), ref('util.unauthorized()')));
+    return iff(equals(ref('util.authType()'), str(provider)), compoundExpression(authExpressions));
+  }
+  return null;
+};
+
+export const generateAuthExpressionForField = (roles: Array<RoleDefinition>): string => {
+  const { cognitoStaticGroupRoles, cognitoDynamicRoles, oidcStaticGroupRoles, oidcDynamicRoles, apiKeyRoles } = splitRoles(roles);
+  const totalAuthExpressions = Array<Expression>();
+  const canApiRead = apiKeyRoles.length > 0 ? true : false;
+  totalAuthExpressions.push(apiKeyReadExpression(canApiRead));
+  const cognitoAuthExpression = jwtFieldAuthExpression(COGNITO_AUTH_TYPE, cognitoStaticGroupRoles, cognitoDynamicRoles);
+  const oidcAuthExpression = jwtFieldAuthExpression(OIDC_AUTH_TYPE, oidcStaticGroupRoles, oidcDynamicRoles);
+  if (cognitoAuthExpression) totalAuthExpressions.push(cognitoAuthExpression);
+  if (oidcAuthExpression) totalAuthExpressions.push(oidcAuthExpression);
+  return printBlock('Field Authorization Steps')(compoundExpression([...totalAuthExpressions, toJson(obj({}))]));
+};
+
+/**
+ * This is the response resolver for fields to protect subscriptions
+ * @param subscriptionsEnabled
+ * @returns
+ */
+export const generateFieldAuthResponse = (operation: string, fieldName: string, subscriptionsEnabled: boolean): string => {
+  if (subscriptionsEnabled) {
+    return printBlock('Checking for allowed operations which can return this field')(
+      compoundExpression([
+        set(ref('operation'), methodCall(ref('util.defaultIfNull'), ref('context.source.operation'), nul())),
+        ifElse(equals(ref('operation'), str(operation)), toJson(nul()), toJson(ref(`context.source.${fieldName}`))),
+      ]),
+    );
+  }
+  return print(toJson(ref(`context.source.${fieldName}`)));
+};

--- a/packages/amplify-graphql-auth-transformer/src/utils/constants.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/constants.ts
@@ -1,10 +1,26 @@
-import { ModelOperation } from './definitions';
+import { AuthProvider, ModelOperation } from './definitions';
 export const DEFAULT_OWNER_FIELD = 'owner';
 export const DEFAULT_GROUPS_FIELD = 'groups';
-export const DEFAULT_IDENTITY_CLAIM = 'cognito:username';
+export const DEFAULT_IDENTITY_CLAIM = 'username';
+export const DEFAULT_COGNITO_IDENTITY_CLAIM = 'cognito:username';
 export const DEFAULT_GROUP_CLAIM = 'cognito:groups';
+export const NONE_VALUE = '';
 export const ON_CREATE_FIELD = 'onCreate';
 export const ON_UPDATE_FIELD = 'onUpdate';
 export const ON_DELETE_FIELD = 'onDelete';
 export const AUTH_NON_MODEL_TYPES = 'authNonModelTypes';
 export const MODEL_OPERATIONS: ModelOperation[] = ['create', 'read', 'update', 'delete'];
+export const AUTH_PROVIDER_DIRECTIVE_MAP = new Map<AuthProvider, string>([
+  ['apiKey', 'aws_api_key'],
+  ['iam', 'aws_iam'],
+  ['oidc', 'aws_oidc'],
+  ['userPools', 'aws_cognito_user_pools'],
+]);
+// values for $util.authType() https://docs.aws.amazon.com/appsync/latest/devguide/resolver-util-reference.html
+export const COGNITO_AUTH_TYPE = 'User Pool Authorization';
+export const OIDC_AUTH_TYPE = 'Open ID Connect Authorization';
+export const IAM_AUTH_TYPE = 'IAM Authorization';
+export const API_KEY_AUTH_TYPE = 'API Key Authorization';
+// iam parameter names
+export const IAM_AUTH_ROLE_PARAMETER = 'authRoleName';
+export const IAM_UNAUTH_ROLE_PARAMETER = 'unauthRoleName';

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -1,9 +1,18 @@
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-core';
 export type AuthStrategy = 'owner' | 'groups' | 'public' | 'private';
-export type AuthProvider = 'apiKey' | 'iam' | 'oidc' | 'userPools' | null;
+export type AuthProvider = 'apiKey' | 'iam' | 'oidc' | 'userPools';
 export type ModelQuery = 'get' | 'list';
 export type ModelMutation = 'create' | 'update' | 'delete';
 export type ModelOperation = 'create' | 'update' | 'delete' | 'read';
+
+export interface RolesByProvider {
+  cognitoStaticGroupRoles: Array<RoleDefinition>;
+  cognitoDynamicRoles: Array<RoleDefinition>;
+  oidcStaticGroupRoles: Array<RoleDefinition>;
+  oidcDynamicRoles: Array<RoleDefinition>;
+  iamRoles?: Array<RoleDefinition>;
+  apiKeyRoles: Array<RoleDefinition>;
+}
 
 export interface AuthRule {
   allow: AuthStrategy;
@@ -16,6 +25,14 @@ export interface AuthRule {
   operations?: ModelOperation[];
   // Used only for IAM provider to decide if an IAM policy needs to be generated. IAM auth with AdminUI does not need IAM policies
   generateIAMPolicy?: boolean;
+}
+
+export interface RoleDefinition {
+  provider: AuthProvider;
+  strategy: AuthStrategy;
+  static: boolean;
+  claim?: string;
+  entity?: string;
 }
 
 export interface AuthDirective {

--- a/packages/amplify-graphql-auth-transformer/src/utils/iam.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/iam.ts
@@ -1,0 +1,70 @@
+import * as cdk from '@aws-cdk/core';
+interface PolicyDocument {
+  [key: string]: any;
+}
+
+export const createPolicyDocumentForManagedPolicy = (resources: Set<string>) => {
+  const policyDocuments = new Array<PolicyDocument>();
+  let policyDocumentResources = new Array<string>();
+  let resourceSize = 0;
+
+  // 6144 bytes is the maximum policy payload size, but there is structural overhead, hence the 6000 bytes
+  const MAX_BUILT_SIZE_BYTES = 6000;
+  // The overhead is the amount of static policy arn contents like region, accountid, etc.
+  // arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:apis/${apiId}/types/${typeName}/fields/${fieldName}
+  // 16              15             13                5    27       6     X+1         7      Y
+  // 89 + 11 extra = 100
+  const RESOURCE_OVERHEAD = 100;
+
+  const createPolicyDocument = (newPolicyDocumentResources: Array<string>): PolicyDocument => {
+    return {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: ['appsync:GraphQL'],
+          Resource: newPolicyDocumentResources,
+        },
+      ],
+    };
+  };
+
+  for (const resource of resources) {
+    // We always have 2 parts, no need to check
+    const [typeName, fieldName] = resource.split('/');
+
+    if (fieldName !== 'null') {
+      policyDocumentResources.push(
+        cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:apis/${apiId}/types/${typeName}/fields/${fieldName}', {
+          apiId: cdk.Fn.getAtt('GraphQLAPI', 'ApiId').toString(),
+          typeName,
+          fieldName,
+        }).toString(),
+      );
+      resourceSize += RESOURCE_OVERHEAD + typeName.length + fieldName.length;
+    } else {
+      policyDocumentResources.push(
+        cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:apis/${apiId}/types/${typeName}/*', {
+          apiId: cdk.Fn.getAtt('GraphQLAPI', 'ApiId').toString(),
+          typeName,
+        }).toString(),
+      );
+      resourceSize = RESOURCE_OVERHEAD + typeName.length;
+    }
+    //
+    // Check size of resource and if needed create a new one and clear the resources and
+    // reset accumulated size
+    //
+    if (resourceSize > MAX_BUILT_SIZE_BYTES) {
+      const policyDocument = createPolicyDocument(policyDocumentResources.slice(0, policyDocumentResources.length - 1));
+      policyDocuments.push(policyDocument);
+      // Remove all but the last item
+      policyDocumentResources = policyDocumentResources.slice(-1);
+      resourceSize = 0;
+    }
+  }
+  if (policyDocumentResources.length > 0) {
+    policyDocuments.push(createPolicyDocument(policyDocumentResources));
+  }
+  return policyDocuments;
+};

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -1,0 +1,61 @@
+import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode, NamedTypeNode } from 'graphql';
+import { blankObjectExtension, extendFieldWithDirectives, extensionWithDirectives } from 'graphql-transformer-common';
+
+export const collectFieldNames = (object: ObjectTypeDefinitionNode): Array<string> => {
+  return object.fields!.map((field: FieldDefinitionNode) => field.name.value);
+};
+
+export const extendTypeWithDirectives = (ctx: TransformerContextProvider, typeName: string, directives: Array<DirectiveNode>): void => {
+  let objectTypeExtension = blankObjectExtension(typeName);
+  objectTypeExtension = extensionWithDirectives(objectTypeExtension, directives);
+  ctx.output.addObjectExtension(objectTypeExtension);
+};
+
+export const addDirectivesToField = (
+  ctx: TransformerContextProvider,
+  typeName: string,
+  fieldName: string,
+  directives: Array<DirectiveNode>,
+) => {
+  const type = ctx.output.getType(typeName) as ObjectTypeDefinitionNode;
+  if (type) {
+    const field = type.fields?.find(f => f.name.value === fieldName);
+    if (field) {
+      const newFields = [...type.fields!.filter(f => f.name.value !== field.name.value), extendFieldWithDirectives(field, directives)];
+
+      const newType = {
+        ...type,
+        fields: newFields,
+      };
+
+      ctx.output.putType(newType);
+    }
+  }
+};
+
+export const addDirectivesToOperation = (
+  ctx: TransformerContextProvider,
+  typeName: string,
+  operationName: string,
+  directives: Array<DirectiveNode>,
+) => {
+  // add directives to the given operation
+  addDirectivesToField(ctx, typeName, operationName, directives);
+
+  // add the directives to the result type of the operation
+  const type = ctx.output.getType(typeName) as ObjectTypeDefinitionNode;
+  if (type) {
+    const field = type.fields!.find(f => f.name.value === operationName);
+
+    if (field) {
+      const returnFieldType = field.type as NamedTypeNode;
+
+      if (returnFieldType.name) {
+        const returnTypeName = returnFieldType.name.value;
+
+        extendTypeWithDirectives(ctx, returnTypeName, directives);
+      }
+    }
+  }
+};

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -383,25 +383,44 @@ $util.toJson($UpdateItem)
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listByEmailKindDate.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -535,8 +554,20 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -1031,25 +1062,44 @@ $util.toJson($UpdateItem)
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listByEmailKindDate.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -1183,8 +1233,20 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -1601,25 +1663,44 @@ $util.toJson($UpdateItem)
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listByEmailKindDate.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -1753,8 +1834,20 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -2481,25 +2574,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listByEmailKindDate.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -2695,8 +2807,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -4423,25 +4547,44 @@ $util.toJson($ctx.result)",
   "Query.getBlog.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getBlog.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getBlog.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.getItem.postAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"orderId\\": $util.dynamodb.toDynamoDB($ctx.args.orderId),
@@ -4452,25 +4595,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getItem.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getItem.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getItem.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -4481,47 +4643,85 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.getTodo.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTodo.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTodo.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.itemsByCreatedAt.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -4687,8 +4887,20 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -5101,8 +5313,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -5204,8 +5428,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -372,25 +372,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -508,8 +527,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -901,25 +932,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -991,8 +1041,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -1380,25 +1442,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -1427,8 +1508,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -1820,25 +1913,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.status) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'status'.\\", \\"InvalidArgumentsError\\")
@@ -1910,8 +2022,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -2648,25 +2772,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -2695,8 +2838,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -2737,25 +2892,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.testGet.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.testGet.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.testGet.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.testList.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -2827,8 +3001,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -3562,25 +3748,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getTest.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -3609,8 +3814,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))
@@ -3651,25 +3868,44 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   "Query.testGet.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.testGet.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.testGet.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.testList.postAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -3741,8 +3977,20 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -293,7 +293,7 @@ function setQuerySnippet(config: PrimaryKeyDirectiveConfiguration, ctx: Transfor
 
   expressions.push(
     set(ref(ResourceConstants.SNIPPETS.ModelQueryExpression), obj({})),
-    applyKeyExpressionForCompositeKey(keyNames, keyTypes, ResourceConstants.SNIPPETS.ModelQueryExpression),
+    applyKeyExpressionForCompositeKey(keyNames, keyTypes, ResourceConstants.SNIPPETS.ModelQueryExpression)!,
   );
 
   return block(`Set query expression for key`, expressions);

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -59,7 +59,7 @@ import {
   generateUpdateInitSlotTemplate,
   generateUpdateRequestTemplate,
 } from './resolvers';
-import { generateGetRequestTemplate, generateListRequestTemplate } from './resolvers/query';
+import { generateGetRequestTemplate, generateGetResponseTemplate, generateListRequestTemplate } from './resolvers/query';
 import {
   DirectiveWrapper,
   FieldWrapper,
@@ -89,7 +89,7 @@ export type ModelDirectiveConfiguration = {
     onCreate: OptionalAndNullable<string>[];
     onUpdate: OptionalAndNullable<string>[];
     onDelete: OptionalAndNullable<string>[];
-    level: Partial<SubscriptionLevel>;
+    level: SubscriptionLevel;
   }>;
   timestamps: OptionalAndNullable<{
     createdAt: OptionalAndNullable<string>;
@@ -389,7 +389,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
         fieldName,
         dataSource,
         MappingTemplate.s3MappingTemplateFromString(generateGetRequestTemplate(), `${typeName}.${fieldName}.req.vtl`),
-        MappingTemplate.s3MappingTemplateFromString(generateDefaultResponseMappingTemplate(), `${typeName}.${fieldName}.res.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(generateGetResponseTemplate(), `${typeName}.${fieldName}.res.vtl`),
       );
     }
     return this.resolverMap[resolverKey];

--- a/packages/amplify-graphql-model-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/query.ts
@@ -16,24 +16,60 @@ import {
   equals,
   bool,
   and,
+  isNullOrEmpty,
+  list,
+  forEach,
+  nul,
 } from 'graphql-mapping-template';
+
+const authFilter = methodCall(ref('ctx.stash.get'), str('authFilter'));
 
 /**
  * Generate get query resolver template
  */
 export const generateGetRequestTemplate = (): string => {
   const statements: Expression[] = [
-    set(ref('GetRequest'), obj({ version: str('2018-05-29'), operation: str('GetItem') })),
+    set(ref('GetRequest'), obj({ version: str('2018-05-29'), operation: str('Query') })),
     ifElse(
       ref('ctx.stash.metadata.modelObjectKey'),
-      set(ref('key'), ref('ctx.stash.metadata.modelObjectKey')),
-      compoundExpression([set(ref('key'), obj({ id: methodCall(ref('util.dynamodb.toDynamoDB'), ref('ctx.args.id')) }))]),
+      compoundExpression([
+        set(ref('expression'), str('')),
+        set(ref('expressionValues'), obj({})),
+        forEach(ref('item'), ref('ctx.stash.metadata.modelObjectKey.entrySet()'), [
+          set(ref('expression'), str('$expression$item.key = :$item.key AND ')),
+          qref(methodCall(ref('expressionValues.put'), str(':$item.key'), ref('item.value'))),
+        ]),
+        set(ref('expression'), methodCall(ref('expression.replaceAll'), str('AND $'), str(''))),
+        set(ref('query'), obj({ expression: ref('expression'), expressionValues: ref('expressionValues') })),
+      ]),
+      set(
+        ref('query'),
+        obj({
+          expression: str('id = :id'),
+          expressionValues: obj({ ':id': methodCall(ref('util.dynamodb.toDynamoDBJson'), ref('ctx.args.id')) }),
+        }),
+      ),
     ),
-    qref(methodCall(ref('GetRequest.put'), str('key'), ref('key'))),
+    qref(methodCall(ref('GetRequest.put'), str('query'), ref('query'))),
+    iff(not(isNullOrEmpty(authFilter)), qref(methodCall(ref('GetRequest.put'), str('filter'), authFilter))),
     toJson(ref('GetRequest')),
   ];
 
   return printBlock('Get Request template')(compoundExpression(statements));
+};
+
+export const generateGetResponseTemplate = (): string => {
+  const statements: Expression[] = [
+    ifElse(
+      and([not(ref('ctx.result.items.isEmpty()')), equals(ref('ctx.result.scannedCount'), int(1))]),
+      toJson(ref('ctx.result.items[0]')),
+      compoundExpression([
+        iff(and([ref('ctx.result.items.isEmpty()'), equals(ref('ctx.result.scannedCount'), int(1))]), ref('util.unauthorized()')),
+        toJson(nul()),
+      ]),
+    ),
+  ];
+  return printBlock('Get Response template')(compoundExpression(statements));
 };
 
 export const generateListRequestTemplate = (): string => {
@@ -50,12 +86,23 @@ export const generateListRequestTemplate = (): string => {
       }),
     ),
     iff(ref('context.args.nextToken'), set(ref(`${requestVariable}.nextToken`), ref('context.args.nextToken'))),
+    ifElse(
+      not(isNullOrEmpty(authFilter)),
+      compoundExpression([
+        set(ref('filter'), authFilter),
+        iff(
+          not(isNullOrEmpty(ref('ctx.args.filter'))),
+          set(ref('filter'), list([obj({ and: list([ref('filter'), ref('ctx.args.filter')]) })])),
+        ),
+      ]),
+      iff(not(isNullOrEmpty(ref('ctx.args.filter'))), set(ref('filter'), ref('ctx.args.filter'))),
+    ),
     iff(
-      ref('context.args.filter'),
+      not(isNullOrEmpty(ref('filter'))),
       compoundExpression([
         set(
           ref(`filterExpression`),
-          methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('ctx.args.filter'))),
+          methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('filter'))),
         ),
         iff(
           not(methodCall(ref('util.isNullOrBlank'), ref('filterExpression.expression'))),

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -899,25 +899,44 @@ $util.toJson($UpdateItem)
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"GetItem\\"
+  \\"operation\\": \\"Query\\"
 } )
 #if( $ctx.stash.metadata.modelObjectKey )
-  #set( $key = $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression$item.key = :$item.key AND \\" )
+    $util.qr($expressionValues.put(\\":$item.key\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionValues\\": $expressionValues
+} )
 #else
-  #set( $key = {
-  \\"id\\":   $util.dynamodb.toDynamoDB($ctx.args.id)
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+  }
 } )
 #end
-$util.qr($GetRequest.put(\\"key\\", $key))
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
-  "Query.getPost.res.vtl": "## [Start] Get ResponseTemplate. **
-#if( $ctx.error )
-  $util.error($ctx.error.message, $ctx.error.type)
+  "Query.getPost.res.vtl": "## [Start] Get Response template. **
+#if( !$$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
 #else
-  $util.toJson($ctx.result)
+  #if( $$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized
+  #end
+  $util.toJson(null)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] Get Response template. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -927,8 +946,20 @@ $util.toJson($GetRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( $context.args.filter )
-  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.args.filter)) )
+#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
+  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterEpression.expressionValues.size() == 0 )
       $util.qr($filterEpression.remove(\\"expressionValues\\"))

--- a/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts
@@ -19,7 +19,6 @@ import {
   DocumentNode,
   Kind,
   ObjectTypeDefinitionNode,
-  FieldDefinitionNode,
   parse,
   InputValueDefinitionNode,
 } from 'graphql';
@@ -183,73 +182,4 @@ export abstract class TransformerAuthBase extends TransformerPluginBase implemen
   constructor(name: string, doc: DocumentNode | string, type: TransformerPluginType = TransformerPluginType.AUTH) {
     super(name, doc, type);
   }
-  abstract protectGetResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectListResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectCreateResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectUpdateResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectDeleteResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectOnCreateResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectOnUpdateResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectOnDeleteResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectSyncResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  abstract protectFieldResolver?: (
-    ctx: TransformerContextProvider,
-    field: FieldDefinitionNode,
-    typeName: string,
-    fieldName: string,
-  ) => TransformerResolverProvider;
 }

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
@@ -1,6 +1,7 @@
 import { CfnParameter, CfnParameterProps, Stack } from '@aws-cdk/core';
 
 export interface StackManagerProvider {
+  readonly rootStack: Stack;
   getStack: (stackName: string) => Stack;
   createStack: (stackName: string) => Stack;
   getStackFor: (resourceId: string, defaultStackName?: string) => Stack;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-model-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-model-provider.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveDefinitionNode, InputValueDefinitionNode } from 'graphql';
+import { ObjectTypeDefinitionNode, DirectiveDefinitionNode, InputValueDefinitionNode } from 'graphql';
 import { TransformerPluginProvider } from './transformer-plugin-provider';
 import { TransformerResolverProvider, TransformerContextProvider, AppSyncDataSourceType, DataSourceInstance } from './transformer-context';
 
@@ -129,76 +129,6 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
   ) => ObjectTypeDefinitionNode;
 }
 
-export interface TransformerAuthProvider extends TransformerPluginProvider {
-  protectGetResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectListResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectCreateResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectUpdateResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectDeleteResolver: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectOnCreateResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectOnUpdateResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectOnDeleteResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectSyncResolver?: <AuthRule, ModelConfiguration>(
-    ctx: TransformerContextProvider,
-    resolverResourceID: string,
-    type: ObjectTypeDefinitionNode,
-    authRules: Array<AuthRule>,
-    modelConfiguration: ModelConfiguration,
-  ) => TransformerResolverProvider;
-  protectFieldResolver?: (
-    ctx: TransformerContextProvider,
-    field: FieldDefinitionNode,
-    typeName: string,
-    fieldName: string,
-  ) => TransformerResolverProvider;
-}
+export interface TransformerAuthProvider extends TransformerPluginProvider {}
 
 export interface TransformerModelEnhancementProvider extends Partial<TransformerModelProvider> {}

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -24,6 +24,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
+    "@aws-amplify/graphql-auth-transformer": "0.1.0",
     "@aws-amplify/graphql-function-transformer": "0.4.1",
     "@aws-amplify/graphql-http-transformer": "0.5.1",
     "@aws-amplify/graphql-index-transformer": "0.2.1",

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -11,6 +11,7 @@ import {
   TransformerProjectConfig,
 } from '@aws-amplify/graphql-transformer-core';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
 import { FunctionTransformer } from '@aws-amplify/graphql-function-transformer';
 import { HttpTransformer } from '@aws-amplify/graphql-http-transformer';
 import { PredictionsTransformer } from '@aws-amplify/graphql-predictions-transformer';
@@ -24,7 +25,8 @@ import { loadProject } from 'graphql-transformer-core';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-core';
 import { Template } from '@aws-amplify/graphql-transformer-core/lib/config/project-config';
 import { AmplifyCLIFeatureFlagAdapter } from '../utils/amplify-cli-feature-flag-adapter';
-import { JSONUtilities } from 'amplify-cli-core';
+import { isAmplifyAdminApp } from '../utils/admin-helpers';
+import { JSONUtilities, stateManager, $TSContext } from 'amplify-cli-core';
 
 const API_CATEGORY = 'api';
 const STORAGE_CATEGORY = 'storage';
@@ -46,7 +48,10 @@ function warnOnAuth(context, map) {
   }
 }
 
-function getTransformerFactory(context, resourceDir) {
+function getTransformerFactory(
+  context: $TSContext,
+  resourceDir: string,
+): (options: TransformerFactoryArgs) => Promise<TransformerPluginProvider[]> {
   return async (options?: TransformerFactoryArgs) => {
     const transformerList: TransformerPluginProvider[] = [
       new ModelTransformer(),
@@ -131,7 +136,17 @@ function getTransformerFactory(context, resourceDir) {
 
     // TODO: Build dependency mechanism into transformers. Auth runs last
     // so any resolvers that need to be protected will already be created.
-    // transformerList.push(new ModelAuthTransformer({ authConfig }));
+
+    let amplifyAdminEnabled: boolean = false;
+    try {
+      const amplifyMeta = stateManager.getMeta();
+      const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
+      const res = await isAmplifyAdminApp(appId);
+      amplifyAdminEnabled = res.isAdminApp;
+    } catch (err) {
+      console.info('App not deployed yet.');
+    }
+    transformerList.push(new AuthTransformer({ authConfig: options?.authConfig, addAwsIamAuthInOutputSchema: false }));
 
     return transformerList;
   };
@@ -208,7 +223,7 @@ export async function transformGraphQLSchema(context, options) {
     }
   }
 
-  let { authConfig } = options;
+  let { authConfig }: { authConfig: AppSyncAuthConfiguration } = options;
 
   //
   // If we don't have an authConfig from the caller, use it from the
@@ -277,7 +292,7 @@ export async function transformGraphQLSchema(context, options) {
     buildParameters,
     projectDirectory: resourceDir,
     transformersFactory: transformerListFactory,
-    transformersFactoryArgs: { addSearchableTransformer: searchableTransformerFlag, storageConfig },
+    transformersFactoryArgs: { addSearchableTransformer: searchableTransformerFlag, storageConfig, authConfig },
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
     minify: options.minify,
@@ -319,8 +334,8 @@ async function getPreviousDeploymentRootKey(previouslyDeployedBackendDir) {
   }
 }
 
-export async function getDirectiveDefinitions(context, resourceDir) {
-  const transformList = await getTransformerFactory(context, resourceDir)({ addSearchableTransformer: true });
+export async function getDirectiveDefinitions(context: $TSContext, resourceDir: string) {
+  const transformList = await getTransformerFactory(context, resourceDir)({ addSearchableTransformer: true, authConfig: {} });
   const appSynDirectives = getAppSyncServiceExtraDirectives();
   const transformDirectives = transformList
     .map(transformPluginInst => [transformPluginInst.directive, ...transformPluginInst.typeDefinitions].map(node => print(node)).join('\n'))
@@ -367,6 +382,7 @@ function getBucketName(context, s3ResourceName, backEndDir) {
 
 type TransformerFactoryArgs = {
   addSearchableTransformer: boolean;
+  authConfig: any;
   storageConfig?: any;
 };
 export type ProjectOptions<T> = {
@@ -375,7 +391,7 @@ export type ProjectOptions<T> = {
     S3DeploymentRootKey: string;
   };
   projectDirectory?: string;
-  transformersFactory: (options: T) => TransformerPluginProvider[];
+  transformersFactory: (options: T) => Promise<TransformerPluginProvider[]>;
   transformersFactoryArgs: T;
   rootStackFileName: 'cloudformation-template.json';
   currentCloudBackendDirectory: string;


### PR DESCRIPTION
#### Description of changes
- Updated Get Resolver Logic in order to maintain to maintain auth vtl logic pre query.
  - updated snapshot tests to account for new get resolver logic
- Added Transform Schema logic
  -  Adding Owner Arguments on Subscription Operations
  - Adding AppSync Service Directives on Operations
  - Adding ownerfield in model type
- Resolver Logic for Reads
  - Get Resolver 
  - List Resolver
  - Field Resolver (if there is at least one role that is not allowed generate field resolver)
- IAM Policy Generation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.