### PR TITLE
feat(amplify-category-function):function names are made to match package.json's format (All Lowercase)

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
@@ -19,8 +19,8 @@ function generalQuestions(context: any): object[] {
       message: 'Provide an AWS Lambda function name:',
       validate: context.amplify.inputValidation({
         operator: 'regex',
-        value: '^[a-zA-Z0-9]+$',
-        onErrorMsg: 'You can use the following characters: a-z A-Z 0-9',
+        value: '^[a-z0-9]+$',
+        onErrorMsg: 'You can use the following characters: a-z 0-9',
         required: true,
       }),
       default: () => {


### PR DESCRIPTION
#### Description of changes
Made inputted lambda function name's characters to match either character of only a-z and 0-9
package.json's name requires to follow the format : https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields
(To prevent any warning messages)


#### Issue #, if available
#7905 



#### Description of how you validated changes
Tested lambda function names restriction by creating a test-app and then running amplify add function command


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.