### PR TITLE
chore: add lock file use to packaged cli build for consistent builds

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -1,7 +1,7 @@
-  #!/bin/bash
+#!/bin/bash
 
 custom_registry_url=http://localhost:4873
-default_verdaccio_package=verdaccio@4.5.1
+default_verdaccio_package=verdaccio@5.1.2
 
 function startLocalRegistry {
   # Start local registry

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "setup-dev-win": "yarn dev-build && yarn link-win && yarn link-aa-win",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
-    "pkg-install": "cd pkg && yarn install --production",
+    "pkg-install": "cd pkg && cp ../yarn.lock ./ && yarn --production",
     "pkg-prune": "cd pkg && rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md",
     "pkg-transpile": "cd pkg && babel node_modules --extensions '.js,.jsx,.es6,.es,.ts' --copy-files --include-dotfiles -d ../build/node_modules",
     "pkg-build": "cp pkg/package.json build/node_modules/package.json && pkg -t node12-macos-x64,node12-linux-x64,node12-win-x64 build/node_modules --out-path out",


### PR DESCRIPTION
#### Description of changes

Change packaged CLI script to use the CLI's `yarn.lock` file as a baseline, so packaged CLI will have the same dependencies packaged that the NPM version, it was not consistent before.

Note: frozen lockfile cannot be used because packaged CLI is getting Amplify CLI from a local verdaccio instance that updated the CLI package urls to a local verdaccio one, that file is thrown away after build, not commited back.

#### Checklist

- [X] PR description included
- [X] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.