### PR TITLE
fix: remove side effect from getConfigForEnv

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/configuration-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/configuration-manager.test.ts
@@ -1,0 +1,44 @@
+import { $TSContext, pathManager, JSONUtilities } from 'amplify-cli-core';
+import _ from 'lodash';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { loadConfigurationForEnv } from '../configuration-manager';
+import { mocked } from 'ts-jest/utils';
+
+jest.mock('amplify-cli-core');
+jest.mock('fs-extra');
+jest.mock('../system-config-manager');
+
+const pathManager_mock = mocked(pathManager);
+const JSONUtilities_mock = mocked(JSONUtilities);
+const fs_mock = mocked(fs);
+
+const testPath = path.join('test', 'path');
+pathManager_mock.getDotConfigDirPath.mockReturnValue(testPath);
+fs_mock.existsSync.mockReturnValue(true);
+JSONUtilities_mock.readJson.mockReturnValue({
+  oldenv: {
+    configLevel: 'project',
+    useProfile: true,
+    profileName: 'oldprofile',
+  },
+});
+
+describe('load configuration for env', () => {
+  it('does not overwrite awsConfigInfo in context object', async () => {
+    const context_stub = {
+      exeInfo: {
+        awsConfigInfo: {
+          configLevel: 'project',
+          config: {
+            profileName: 'newprofile',
+            useProfile: true,
+          },
+        },
+      },
+    } as $TSContext;
+    const context_clone = _.cloneDeep(context_stub);
+    await loadConfigurationForEnv(context_clone, 'oldenv');
+    expect(context_clone).toStrictEqual(context_stub);
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -531,7 +531,7 @@ function getCurrentConfig(context: $TSContext) {
 }
 
 function getConfigForEnv(context: $TSContext, envName: string) {
-  const projectConfigInfo: ProjectConfig = context?.exeInfo?.awsConfigInfo || {
+  const projectConfigInfo: ProjectConfig = _.cloneDeep(context?.exeInfo?.awsConfigInfo) || {
     configLevel: 'general',
     config: {},
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The previous logic of `getConfigForEnv` had the side effect of modifying `context.exeInfo.awsConfigInfo`. In the case of creating a new environment, this caused the previous environments' config to overwrite the new environment config.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fixes https://github.com/aws-amplify/amplify-cli/issues/7977


#### Description of how you validated changes
Manually tested and added a unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.