### PR TITLE
fix: prevent creating duplicate user in test

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
@@ -223,7 +223,7 @@ beforeAll(async () => {
 
     await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
     await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
-    await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+    await signupUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD);
     await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
     await createGroup(USER_POOL_ID, PARTICIPANT_GROUP_NAME);
     await createGroup(USER_POOL_ID, WATCHER_GROUP_NAME);


### PR DESCRIPTION
#### Description of changes
Instead of creating username2 twice, update the test setup to create username2 and username3.

#### Issue #, if available

#### Description of how you validated changes
Ran one of the failing e2e tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.