### PR TITLE
fix: update GQL E2E test to use unique names

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
@@ -30,9 +30,9 @@ const featureFlags = {
 };
 
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
-const STACK_NAME = `TestSearchableModelTransformer-${BUILD_TIMESTAMP}`;
-const BUCKET_NAME = `testsearchablemodeltransformer-${BUILD_TIMESTAMP}`;
-const LOCAL_FS_BUILD_DIR = '/tmp/model_searchable_transform_tests/';
+const STACK_NAME = `TestSearchableAggregates-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `testsearchableaggregates-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = '/tmp/model_searchable_aggregates_tests/';
 const S3_ROOT_DIR_KEY = 'deployments';
 
 const fragments = [`fragment FullPost on Post { id author title ups downs percentageUp isPublished createdAt }`];


### PR DESCRIPTION
#### Description of changes
This commit updates the `@searchable` v2 aggregates test to use a unique stack and bucket name to avoid race conditions with other tests.

#### Issue #, if available

#### Description of how you validated changes
Ran the E2E test.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.