### PR TITLE
fix(amplify-category-function): check for new function when adding permissions

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/__snapshots__/execPermissionsWalkthrough.test.ts.snap
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/__snapshots__/execPermissionsWalkthrough.test.ts.snap
@@ -1,5 +1,129 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`askExecRolePermissionsQuestions returns permissions for exists function 1`] = `
+Object {
+  "categoryPolicies": Array [
+    Object {
+      "Action": Array [
+        "lambda:Get*",
+        "lambda:List*",
+        "lambda:Invoke*",
+      ],
+      "Effect": "Allow",
+      "Resource": Array [
+        Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:aws:lambda:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":function:",
+              Object {
+                "Ref": "functionlambda2Name",
+              },
+            ],
+          ],
+        },
+      ],
+    },
+  ],
+  "dependsOn": Array [
+    Object {
+      "attributes": Array [
+        "Name",
+      ],
+      "category": "function",
+      "resourceName": "lambda2",
+    },
+  ],
+  "environmentMap": Object {
+    "FUNCTION_LAMBDA2_NAME": Object {
+      "Ref": "functionlambda2Name",
+    },
+  },
+  "mutableParametersState": Object {
+    "permissions": Object {
+      "function": Object {
+        "lambda2": Array [
+          "read",
+        ],
+      },
+    },
+  },
+  "topLevelComment": "/* Amplify Params - DO NOT EDIT
+	FUNCTION_LAMBDA2_NAME
+Amplify Params - DO NOT EDIT */",
+}
+`;
+
+exports[`askExecRolePermissionsQuestions returns permissions for function that be about to add right 1`] = `
+Object {
+  "categoryPolicies": Array [
+    Object {
+      "Action": Array [
+        "lambda:Get*",
+        "lambda:List*",
+        "lambda:Invoke*",
+      ],
+      "Effect": "Allow",
+      "Resource": Array [
+        Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:aws:lambda:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":function:",
+              Object {
+                "Ref": "functionlambda2Name",
+              },
+            ],
+          ],
+        },
+      ],
+    },
+  ],
+  "dependsOn": Array [
+    Object {
+      "attributes": Array [
+        "Name",
+      ],
+      "category": "function",
+      "resourceName": "lambda2",
+    },
+  ],
+  "environmentMap": Object {
+    "FUNCTION_LAMBDA2_NAME": Object {
+      "Ref": "functionlambda2Name",
+    },
+  },
+  "mutableParametersState": Object {
+    "permissions": Object {
+      "function": Object {
+        "lambda2": Array [
+          "read",
+        ],
+      },
+    },
+  },
+  "topLevelComment": "/* Amplify Params - DO NOT EDIT
+	FUNCTION_LAMBDA2_NAME
+Amplify Params - DO NOT EDIT */",
+}
+`;
+
 exports[`check CFN resources 1`] = `
 Object {
   "cfnResources": Array [

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.test.ts
@@ -1,13 +1,38 @@
+import { $TSContext } from 'amplify-cli-core';
 import {
   getResourcesForCfn,
   generateEnvVariablesForCfn,
+  askExecRolePermissionsQuestions,
 } from '../../../../provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough';
 import {
   constructCFModelTableNameComponent,
   constructCFModelTableArnComponent,
 } from '../../../../provider-utils/awscloudformation/utils/cloudformationHelpers';
+import { stateManager } from 'amplify-cli-core';
+import { CRUDOperation } from '../../../../constants';
+import inquirer from 'inquirer';
+
+const backendDirPathStub = 'backendDirPath';
 
 jest.mock('../../../../provider-utils/awscloudformation/utils/cloudformationHelpers');
+
+jest.mock('amplify-cli-core', () => ({
+  stateManager: {
+    getMeta: jest.fn(),
+  },
+  FeatureFlags: {
+    getBoolean: jest.fn().mockReturnValue(false),
+  },
+  pathManager: {
+    getBackendDirPath: jest.fn(() => backendDirPathStub),
+  },
+}));
+
+jest.mock('inquirer', () => {
+  return {
+    prompt: jest.fn(),
+  };
+});
 
 export const appsyncTableSuffix = '@model(appsync)';
 
@@ -102,4 +127,128 @@ test('env resources for CFN for auth and storage for api', async () => {
     },
   ];
   expect(await generateEnvVariablesForCfn(contextStub, resources, {})).toMatchSnapshot();
+});
+
+describe('askExecRolePermissionsQuestions', () => {
+  beforeEach(() => {
+    const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
+    stateManagerMock.getMeta.mockReturnValue({
+      providers: {
+        awscloudformation: {},
+      },
+      function: {
+        lambda1: {
+          service: 'Lambda',
+          providerPlugin: 'awscloudformation',
+        },
+        lambda2: {
+          service: 'Lambda',
+          providerPlugin: 'awscloudformation',
+          lastPushTimeStamp: '2021-07-12T00:41:17.966Z',
+        },
+      },
+      auth: {
+        authResourceName: {
+          service: 'Cognito',
+          serviceType: 'imported',
+          providerPlugin: 'awscloudformation',
+        },
+      },
+      storage: {
+        s3Bucket: {
+          service: 'S3',
+          serviceType: 'imported',
+          providerPlugin: 'awscloudformation',
+        },
+      },
+    });
+  });
+
+  it('returns permissions for function that be about to add right', async () => {
+    const inquirerMock = inquirer as jest.Mocked<typeof inquirer>;
+
+    inquirerMock.prompt.mockResolvedValueOnce({ categories: ['function'] });
+    inquirerMock.prompt.mockResolvedValueOnce({ resources: ['lambda2'] });
+    inquirerMock.prompt.mockResolvedValueOnce({ options: [CRUDOperation.READ] });
+
+    const resourceAttributes = [
+      {
+        attributes: ['Name'],
+        category: 'function',
+        resourceName: 'lambda2',
+      },
+    ];
+    const permissionPolicies = [
+      {
+        Action: ['lambda:Get*', 'lambda:List*', 'lambda:Invoke*'],
+        Effect: 'Allow',
+        Resource: [
+          {
+            'Fn::Join': [
+              '',
+              ['arn:aws:lambda:', { Ref: 'AWS::Region' }, ':', { Ref: 'AWS::AccountId' }, ':function:', { Ref: 'functionlambda2Name' }],
+            ],
+          },
+        ],
+      },
+    ];
+    const contextStub = {
+      print: {
+        warning: jest.fn(),
+        info: jest.fn(),
+      },
+      usageData: {
+        emitError: jest.fn(),
+      },
+      amplify: {
+        invokePluginMethod: jest.fn().mockResolvedValueOnce({ permissionPolicies, resourceAttributes }),
+      },
+    };
+    const answers = await askExecRolePermissionsQuestions((contextStub as unknown) as $TSContext, 'lambda3', undefined);
+    expect(answers).toMatchSnapshot();
+  });
+
+  it('returns permissions for exists function', async () => {
+    const inquirerMock = inquirer as jest.Mocked<typeof inquirer>;
+
+    inquirerMock.prompt.mockResolvedValueOnce({ categories: ['function'] });
+    //inquirerMock.prompt.mockResolvedValueOnce({ resources: ['lambda2'] });
+    inquirerMock.prompt.mockResolvedValueOnce({ options: [CRUDOperation.READ] });
+
+    const resourceAttributes = [
+      {
+        attributes: ['Name'],
+        category: 'function',
+        resourceName: 'lambda2',
+      },
+    ];
+    const permissionPolicies = [
+      {
+        Action: ['lambda:Get*', 'lambda:List*', 'lambda:Invoke*'],
+        Effect: 'Allow',
+        Resource: [
+          {
+            'Fn::Join': [
+              '',
+              ['arn:aws:lambda:', { Ref: 'AWS::Region' }, ':', { Ref: 'AWS::AccountId' }, ':function:', { Ref: 'functionlambda2Name' }],
+            ],
+          },
+        ],
+      },
+    ];
+    const contextStub = {
+      print: {
+        warning: jest.fn(),
+        info: jest.fn(),
+      },
+      usageData: {
+        emitError: jest.fn(),
+      },
+      amplify: {
+        invokePluginMethod: jest.fn().mockResolvedValueOnce({ permissionPolicies, resourceAttributes }),
+      },
+    };
+    const answers = await askExecRolePermissionsQuestions((contextStub as unknown) as $TSContext, 'lambda1', undefined);
+    expect(answers).toMatchSnapshot();
+  });
 });

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.test.ts
@@ -204,7 +204,7 @@ describe('askExecRolePermissionsQuestions', () => {
         invokePluginMethod: jest.fn().mockResolvedValueOnce({ permissionPolicies, resourceAttributes }),
       },
     };
-    const answers = await askExecRolePermissionsQuestions((contextStub as unknown) as $TSContext, 'lambda3', undefined);
+    const answers = await askExecRolePermissionsQuestions(contextStub as unknown as $TSContext, 'lambda3', undefined);
     expect(answers).toMatchSnapshot();
   });
 
@@ -212,7 +212,6 @@ describe('askExecRolePermissionsQuestions', () => {
     const inquirerMock = inquirer as jest.Mocked<typeof inquirer>;
 
     inquirerMock.prompt.mockResolvedValueOnce({ categories: ['function'] });
-    //inquirerMock.prompt.mockResolvedValueOnce({ resources: ['lambda2'] });
     inquirerMock.prompt.mockResolvedValueOnce({ options: [CRUDOperation.READ] });
 
     const resourceAttributes = [
@@ -248,7 +247,7 @@ describe('askExecRolePermissionsQuestions', () => {
         invokePluginMethod: jest.fn().mockResolvedValueOnce({ permissionPolicies, resourceAttributes }),
       },
     };
-    const answers = await askExecRolePermissionsQuestions((contextStub as unknown) as $TSContext, 'lambda1', undefined);
+    const answers = await askExecRolePermissionsQuestions(contextStub as unknown as $TSContext, 'lambda1', undefined);
     expect(answers).toMatchSnapshot();
   });
 });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -80,12 +80,14 @@ export const askExecRolePermissionsQuestions = async (
       // A Lambda function cannot depend on itself
       // Lambda layer dependencies are handled seperately, also apply the filter if the selected resource is within the function category
       // but serviceName argument was no passed in
-      const selectedResource = _.get(amplifyMeta, [categoryName, resourceNameToUpdate]);
-
       if (serviceName === ServiceName.LambdaFunction || selectedCategory === categoryName) {
+        const selectedResource = _.get(amplifyMeta, [categoryName, resourceNameToUpdate]);
+        // A new function resource is not exsits in amplifyMeta yet
+        const isNewFunctionResource = !selectedResource;
         resourcesList = resourcesList.filter(
           resourceName =>
-            resourceName !== resourceNameToUpdate && amplifyMeta[selectedCategory][resourceName].service === selectedResource.service,
+            resourceName !== resourceNameToUpdate &&
+            (isNewFunctionResource || amplifyMeta[selectedCategory][resourceName].service === selectedResource.service),
         );
       } else {
         resourcesList = resourcesList.filter(

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -82,7 +82,7 @@ export const askExecRolePermissionsQuestions = async (
       // but serviceName argument was no passed in
       if (serviceName === ServiceName.LambdaFunction || selectedCategory === categoryName) {
         const selectedResource = _.get(amplifyMeta, [categoryName, resourceNameToUpdate]);
-        // A new function resource is not exsits in amplifyMeta yet
+        // A new function resource does not exist in amplifyMeta yet
         const isNewFunctionResource = !selectedResource;
         resourcesList = resourcesList.filter(
           resourceName =>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

A function attempting to add permissions is handled as new function when is not found in amplify meta.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

fix #7970

#### Description of how you validated changes

- Unit Testing `yarn lerna --scope amplify-category-function run test`
- Manual Testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.