### PR TITLE
fix: resource key should be 'category', not 'categoryName'

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSContext, FeatureFlags, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, FeatureFlags, pathManager, stateManager } from 'amplify-cli-core';
 import { FunctionDependency, FunctionParameters } from 'amplify-function-plugin-interface';
 import * as TransformPackage from 'graphql-transformer-core';
 import inquirer, { CheckboxQuestion, DistinctChoice } from 'inquirer';
@@ -258,7 +258,7 @@ export async function getResourcesForCfn(context, resourceName, resourcePolicy, 
   return { permissionPolicies, cfnResources };
 }
 
-export async function generateEnvVariablesForCfn(context, resources, currentEnvMap) {
+export async function generateEnvVariablesForCfn(context: $TSContext, resources: $TSAny[], currentEnvMap: $TSAny) {
   const environmentMap = {};
   const envVars = new Set<string>();
   const dependsOn: FunctionDependency[] = [];

--- a/packages/amplify-category-storage/src/index.ts
+++ b/packages/amplify-category-storage/src/index.ts
@@ -80,7 +80,7 @@ export async function getPermissionPolicies(context: $TSContext, resourceOpsMapp
         } else {
           permissionPolicies.push(policy);
         }
-        resourceAttributes.push({ resourceName, attributes, categoryName });
+        resourceAttributes.push({ resourceName, attributes, category: categoryName });
       } else {
         printer.error(`Provider not configured for ${categoryName}: ${resourceName}`);
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- fix an accidental change to the resource object's key
- add missing function signature types

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/2164/workflows/4ce6dfe6-570f-4c4f-99e3-14d3d9298f55/jobs/23400


#### Description of how you validated changes
yarn test
yarn e2e __tests__/import_dynamodb_1.test.ts -t "imported dynamodb table with function and crud on storage should push"


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.