### PR TITLE
fix: handle case where there is no appId

### DIFF
--- a/packages/amplify-cli/src/utils/check-hosting.ts
+++ b/packages/amplify-cli/src/utils/check-hosting.ts
@@ -2,6 +2,11 @@ import { getPluginInstance } from '../extensions/amplify-helpers/get-plugin-inst
 
 export async function hasCdBranches(context) {
   const appId = context.exeInfo.amplifyMeta.providers.awscloudformation.AmplifyAppId;
+
+  if (!appId) {
+    return false;
+  }
+
   const awsCloudPlugin = getPluginInstance(context, 'awscloudformation');
   const amplifyClient = await awsCloudPlugin.getConfiguredAmplifyClient(context, {});
   const result = await amplifyClient.listBranches({ appId }).promise();


### PR DESCRIPTION
#### Description of changes
This was causing E2E test failures.

Refs: https://github.com/aws-amplify/amplify-cli/pull/7874

#### Issue #, if available

#### Description of how you validated changes
Ran the failing E2E test locally.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.