### PR TITLE
Revert "fix: function names are made to match package.json's format (#7988)

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
@@ -19,8 +19,8 @@ function generalQuestions(context: any): object[] {
       message: 'Provide an AWS Lambda function name:',
       validate: context.amplify.inputValidation({
         operator: 'regex',
-        value: '^[a-z0-9]+$',
-        onErrorMsg: 'You can use the following characters: a-z 0-9',
+        value: '^[a-zA-Z0-9]+$',
+        onErrorMsg: 'You can use the following characters: a-z A-Z 0-9',
         required: true,
       }),
       default: () => {


### PR DESCRIPTION
#### Description of changes
This reverts commit 25689ddd099895d3d2ea2f4cb70f69f3c7801661.

Reverting as this breaks an E2E test, and if released, this could
break customers' automated workflows. I'm also not sure that this needs to be enforced for anything but Node.js functions.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.