### PR TITLE
fix(amplify-category-function): allow user to update function without length validation

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -202,7 +202,6 @@ const selectCategories = (choices: DistinctChoice<any>[], currentPermissionMap: 
   name: 'categories',
   message: 'Select the categories you want this function to have access to.',
   choices,
-  validate: answers => (_.isEmpty(answers) ? 'You must select at least one category' : true),
   default: fetchPermissionCategories(currentPermissionMap),
 });
 

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -42,6 +42,11 @@ const appSyncOptions = ['Query', 'Mutation', 'Subscription'];
 
 const additionalPermissions = (cwd: string, chain: ExecutionContext, settings: any) => {
   multiSelect(chain.wait('Select the categories you want this function to have access to'), settings.permissions, settings.choices);
+
+  if (!settings.resources) {
+    return;
+  }
+
   if (settings.resourceChoices === undefined) {
     settings.resourceChoices = settings.resources;
   }


### PR DESCRIPTION
#### Description of changes
When updating a function, removes to category length validation so that a user can remove all category access.


#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-cli/issues/8010


#### Description of how you validated changes
I tested this locally by duplicating the Issue steps, and it works as requested now. 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes