### PR TITLE
fix(amplify-category-function): specify UTC tz when selecting start time

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cronHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cronHelper.ts
@@ -43,25 +43,13 @@ export async function timeHelper(exp: CronBuilder) {
   const timeQuestion = {
     type: 'datetime',
     name: 'dt',
-    message: 'Select the start time (use arrow keys):',
+    message: 'Select the start time in UTC (use arrow keys):',
     format: ['hh', ':', 'mm', ' ', 'A'],
   };
 
   const timeAnswer = await inquirer.prompt([timeQuestion]);
-  exp.set(
-    'minute',
-    (<dtType>timeAnswer.dt)
-      .getMinutes()
-      .toString()
-      .split(),
-  );
-  exp.set(
-    'hour',
-    (<dtType>timeAnswer.dt)
-      .getHours()
-      .toString()
-      .split(),
-  );
+  exp.set('minute', (<dtType>timeAnswer.dt).getMinutes().toString().split());
+  exp.set('hour', (<dtType>timeAnswer.dt).getHours().toString().split());
   return exp;
 }
 
@@ -98,13 +86,7 @@ export async function monthHelper(exp, context) {
     const suffix = (<dtType>dateAnswer.dt).getDate() === 31 ? 'st' : 'th';
     context.print.warning(`Function won't be invoked on months without the ${(<dtType>dateAnswer.dt).getDate()}${suffix} day`);
   }
-  exp.set(
-    'dayOfTheMonth',
-    (<dtType>dateAnswer.dt)
-      .getDate()
-      .toString()
-      .split(),
-  );
+  exp.set('dayOfTheMonth', (<dtType>dateAnswer.dt).getDate().toString().split());
   return exp;
 }
 
@@ -120,19 +102,7 @@ export async function yearHelper(exp, context) {
     const suffix = (<dtType>dateAnswer.dt).getDate() === 31 ? 'st' : 'th';
     context.print.warning(`Function won't be invoked on months without the ${(<dtType>dateAnswer.dt).getDate()}${suffix} day`);
   }
-  exp.set(
-    'dayOfTheMonth',
-    (<dtType>dateAnswer.dt)
-      .getDate()
-      .toString()
-      .split(),
-  );
-  exp.set(
-    'month',
-    (<dtType>dateAnswer.dt)
-      .getMonth()
-      .toString()
-      .split(),
-  );
+  exp.set('dayOfTheMonth', (<dtType>dateAnswer.dt).getDate().toString().split());
+  exp.set('month', (<dtType>dateAnswer.dt).getMonth().toString().split());
   return exp;
 }

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -176,7 +176,7 @@ const coreFunction = (
       }
     } else {
       if (settings.layerOptions && settings.layerOptions.layerAndFunctionExist) {
-        chain.wait('Select which capability you want to update:').sendCarriageReturn() // lambda function
+        chain.wait('Select which capability you want to update:').sendCarriageReturn(); // lambda function
       }
       chain.wait('Select the Lambda function you want to update').sendCarriageReturn(); // assumes only one function configured in the project
     }
@@ -494,7 +494,7 @@ const addWeekly = (chain: ExecutionContext) => {
   chain
     .wait('Select the day to invoke the function:')
     .sendCarriageReturn()
-    .wait('Select the start time (use arrow keys):')
+    .wait('Select the start time in UTC (use arrow keys):')
     .sendCarriageReturn();
   return chain;
 };
@@ -520,7 +520,7 @@ const addCron = (chain: ExecutionContext, settings: any) => {
       addhourly(moveDown(chain, 1).sendCarriageReturn());
       break;
     case 'Daily':
-      moveDown(chain, 2).sendCarriageReturn().wait('Select the start time (use arrow keys):').sendCarriageReturn();
+      moveDown(chain, 2).sendCarriageReturn().wait('Select the start time in UTC (use arrow keys):').sendCarriageReturn();
       break;
     case 'Weekly':
       addWeekly(moveDown(chain, 3).sendCarriageReturn());


### PR DESCRIPTION

#### Description of changes
Adds `'in UTC'` when selecting a function start time or scheduled recurring time.


#### Issue #, if available
Fixes: https://github.com/aws-amplify/amplify-cli/issues/8027


#### Description of how you validated changes
Locally built the cli and tested by adding and updating a function.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.