### PR TITLE
fix(amplify-category-function): 'filter' of undefined when removing layers

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -245,7 +245,7 @@ export function getLambdaFunctionsDependentOnLayerFromMeta(layerName: string, me
   return Object.entries(meta[categoryName]).filter(
     ([_, lambdaFunction]: [string, $TSObject]) =>
       lambdaFunction.service === ServiceName.LambdaFunction &&
-      lambdaFunction?.dependsOn.filter(dependency => dependency.resourceName === layerName).length > 0,
+      lambdaFunction?.dependsOn?.filter(dependency => dependency.resourceName === layerName).length > 0,
   );
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When metadata for function doesn't have dependsOn property, then amplify function remove a layer would throw an error 'Cannot read property 'filter' of undefined' ... on layerHelpers.ts:248:33

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.