### PR TITLE
fix: verification-link variable with small typo

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/verification-link.js
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CustomMessage/verification-link.js
@@ -18,7 +18,7 @@ exports.handler = async event => {
       'sa-east-1',
     ];
 
-    const seperator = hyphenRegions.includes(region) ? '-' : '.';
+    const separator = hyphenRegions.includes(region) ? '-' : '.';
 
     const payload = Buffer.from(
       JSON.stringify({
@@ -28,7 +28,7 @@ exports.handler = async event => {
         clientId,
       }),
     ).toString('base64');
-    const bucketUrl = `http://${resourcePrefix}verificationbucket-${process.env.ENV}.s3-website${seperator}${region}.amazonaws.com`;
+    const bucketUrl = `http://${resourcePrefix}verificationbucket-${process.env.ENV}.s3-website${separator}${region}.amazonaws.com`;
     const url = `${bucketUrl}/?data=${payload}&code=${codeParameter}`;
     const message = `${process.env.EMAILMESSAGE}. \n ${url}`;
     event.response.smsMessage = message;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Very simple typo fix, a variable called "seperator" was changed to separator, not affecting code logic itself, just an aesthetic fix.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.