### PR TITLE
fix: include hooks' Readme.md in pkg CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
     "pkg-install": "cd pkg && cp ../yarn.lock ./ && yarn --production",
-    "pkg-prune": "cd pkg && rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md",
+    "pkg-prune": "cd pkg && rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md packages/*/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md",
     "pkg-transpile": "cd pkg && babel node_modules --extensions '.js,.jsx,.es6,.es,.ts' --copy-files --include-dotfiles -d ../build/node_modules",
     "pkg-build": "cp pkg/package.json build/node_modules/package.json && pkg -t node12-macos-x64,node12-linux-x64,node12-win-x64 build/node_modules --out-path out",
     "pkg-all": "yarn pkg-install && yarn pkg-prune && yarn pkg-transpile && yarn pkg-build",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Reduce the scope of exlcuded `Readme.md` files in the `pkg-prune` script


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.