### PR TITLE
feat(graphql-relay-transformer): Support Relay Modern in GraphQL API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1163,86 +1163,6 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-southeast-2
-  schema-iterative-update-locking-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: us-east-2
-  s3-sse-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/s3-sse.test.ts
-      CLI_REGION: us-west-2
-  pull-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/pull.test.ts
-      CLI_REGION: eu-west-2
-  migration-node-function-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: eu-central-1
-  layer-2-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/layer-2.test.ts
-      CLI_REGION: ap-northeast-1
-  iam-permissions-boundary-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
-      CLI_REGION: ap-southeast-1
-  hooks-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/hooks.test.ts
-      CLI_REGION: ap-southeast-2
-  function_7-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/function_7.test.ts
-      CLI_REGION: us-east-2
-  function_6-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/function_6.test.ts
-      CLI_REGION: us-west-2
-  function_5-amplify_e2e_tests:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    steps: *ref_5
-    environment:
-      TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: eu-west-2
   frontend_config_drift-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1250,7 +1170,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: us-east-2
   container-hosting-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1258,7 +1178,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/container-hosting.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-west-2
   configure-project-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1266,7 +1186,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/configure-project.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-west-2
   auth_6-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1274,7 +1194,47 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/auth_6.test.ts
+      CLI_REGION: eu-central-1
+  schema-iterative-update-locking-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
+      CLI_REGION: ap-northeast-1
+  hooks-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/hooks.test.ts
+      CLI_REGION: ap-southeast-1
+  function_7-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/function_7.test.ts
       CLI_REGION: ap-southeast-2
+  function_6-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/function_6.test.ts
+      CLI_REGION: us-east-2
+  migration-node-function-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/migration/node.function.test.ts
+      CLI_REGION: us-west-2
   api_4-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1282,6 +1242,46 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
+      CLI_REGION: eu-west-2
+  function_5-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/function_5.test.ts
+      CLI_REGION: eu-central-1
+  pull-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/pull.test.ts
+      CLI_REGION: ap-northeast-1
+  s3-sse-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/s3-sse.test.ts
+      CLI_REGION: ap-southeast-1
+  layer-2-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/layer-2.test.ts
+      CLI_REGION: ap-southeast-2
+  iam-permissions-boundary-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    steps: *ref_5
+    environment:
+      TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
       CLI_REGION: us-east-2
   schema-iterative-update-4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1913,106 +1913,6 @@ jobs:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-southeast-2
     steps: *ref_6
-  schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
-      CLI_REGION: us-east-2
-    steps: *ref_6
-  s3-sse-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/s3-sse.test.ts
-      CLI_REGION: us-west-2
-    steps: *ref_6
-  pull-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/pull.test.ts
-      CLI_REGION: eu-west-2
-    steps: *ref_6
-  migration-node-function-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/migration/node.function.test.ts
-      CLI_REGION: eu-central-1
-    steps: *ref_6
-  layer-2-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/layer-2.test.ts
-      CLI_REGION: ap-northeast-1
-    steps: *ref_6
-  iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
-      CLI_REGION: ap-southeast-1
-    steps: *ref_6
-  hooks-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/hooks.test.ts
-      CLI_REGION: ap-southeast-2
-    steps: *ref_6
-  function_7-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/function_7.test.ts
-      CLI_REGION: us-east-2
-    steps: *ref_6
-  function_6-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/function_6.test.ts
-      CLI_REGION: us-west-2
-    steps: *ref_6
-  function_5-amplify_e2e_tests_pkg_linux:
-    working_directory: ~/repo
-    docker: *ref_1
-    resource_class: large
-    environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-      TEST_SUITE: src/__tests__/function_5.test.ts
-      CLI_REGION: eu-west-2
-    steps: *ref_6
   frontend_config_drift-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
     docker: *ref_1
@@ -2021,7 +1921,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: us-east-2
     steps: *ref_6
   container-hosting-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2031,7 +1931,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/container-hosting.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-west-2
     steps: *ref_6
   configure-project-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2041,7 +1941,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/configure-project.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-west-2
     steps: *ref_6
   auth_6-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2051,7 +1951,57 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/auth_6.test.ts
+      CLI_REGION: eu-central-1
+    steps: *ref_6
+  schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
+      CLI_REGION: ap-northeast-1
+    steps: *ref_6
+  hooks-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/hooks.test.ts
+      CLI_REGION: ap-southeast-1
+    steps: *ref_6
+  function_7-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/function_7.test.ts
       CLI_REGION: ap-southeast-2
+    steps: *ref_6
+  function_6-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/function_6.test.ts
+      CLI_REGION: us-east-2
+    steps: *ref_6
+  migration-node-function-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/migration/node.function.test.ts
+      CLI_REGION: us-west-2
     steps: *ref_6
   api_4-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2061,6 +2011,56 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/api_4.test.ts
+      CLI_REGION: eu-west-2
+    steps: *ref_6
+  function_5-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/function_5.test.ts
+      CLI_REGION: eu-central-1
+    steps: *ref_6
+  pull-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/pull.test.ts
+      CLI_REGION: ap-northeast-1
+    steps: *ref_6
+  s3-sse-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/s3-sse.test.ts
+      CLI_REGION: ap-southeast-1
+    steps: *ref_6
+  layer-2-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/layer-2.test.ts
+      CLI_REGION: ap-southeast-2
+    steps: *ref_6
+  iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
+    working_directory: ~/repo
+    docker: *ref_1
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+      TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
       CLI_REGION: us-east-2
     steps: *ref_6
 workflows:
@@ -2166,63 +2166,63 @@ workflows:
       - done_with_node_e2e_tests:
           requires:
             - notifications-amplify_e2e_tests
-            - schema-iterative-update-locking-amplify_e2e_tests
-            - function_7-amplify_e2e_tests
-            - api_4-amplify_e2e_tests
+            - frontend_config_drift-amplify_e2e_tests
+            - function_6-amplify_e2e_tests
+            - iam-permissions-boundary-amplify_e2e_tests
             - hosting-amplify_e2e_tests
             - tags-amplify_e2e_tests
-            - s3-sse-amplify_e2e_tests
-            - function_6-amplify_e2e_tests
+            - container-hosting-amplify_e2e_tests
+            - migration-node-function-amplify_e2e_tests
             - amplify-app-amplify_e2e_tests
             - init-amplify_e2e_tests
-            - pull-amplify_e2e_tests
-            - function_5-amplify_e2e_tests
+            - configure-project-amplify_e2e_tests
+            - api_4-amplify_e2e_tests
             - schema-predictions-amplify_e2e_tests
             - amplify-configure-amplify_e2e_tests
-            - migration-node-function-amplify_e2e_tests
-            - frontend_config_drift-amplify_e2e_tests
+            - auth_6-amplify_e2e_tests
+            - function_5-amplify_e2e_tests
             - interactions-amplify_e2e_tests
             - datastore-modelgen-amplify_e2e_tests
-            - layer-2-amplify_e2e_tests
-            - container-hosting-amplify_e2e_tests
+            - schema-iterative-update-locking-amplify_e2e_tests
+            - pull-amplify_e2e_tests
             - schema-data-access-patterns-amplify_e2e_tests
             - init-special-case-amplify_e2e_tests
-            - iam-permissions-boundary-amplify_e2e_tests
-            - configure-project-amplify_e2e_tests
+            - hooks-amplify_e2e_tests
+            - s3-sse-amplify_e2e_tests
             - schema-versioned-amplify_e2e_tests
             - plugin-amplify_e2e_tests
-            - hooks-amplify_e2e_tests
-            - auth_6-amplify_e2e_tests
+            - function_7-amplify_e2e_tests
+            - layer-2-amplify_e2e_tests
       - done_with_pkg_linux_e2e_tests:
           requires:
             - notifications-amplify_e2e_tests_pkg_linux
-            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
-            - function_7-amplify_e2e_tests_pkg_linux
-            - api_4-amplify_e2e_tests_pkg_linux
+            - frontend_config_drift-amplify_e2e_tests_pkg_linux
+            - function_6-amplify_e2e_tests_pkg_linux
+            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
             - hosting-amplify_e2e_tests_pkg_linux
             - tags-amplify_e2e_tests_pkg_linux
-            - s3-sse-amplify_e2e_tests_pkg_linux
-            - function_6-amplify_e2e_tests_pkg_linux
+            - container-hosting-amplify_e2e_tests_pkg_linux
+            - migration-node-function-amplify_e2e_tests_pkg_linux
             - amplify-app-amplify_e2e_tests_pkg_linux
             - init-amplify_e2e_tests_pkg_linux
-            - pull-amplify_e2e_tests_pkg_linux
-            - function_5-amplify_e2e_tests_pkg_linux
+            - configure-project-amplify_e2e_tests_pkg_linux
+            - api_4-amplify_e2e_tests_pkg_linux
             - schema-predictions-amplify_e2e_tests_pkg_linux
             - amplify-configure-amplify_e2e_tests_pkg_linux
-            - migration-node-function-amplify_e2e_tests_pkg_linux
-            - frontend_config_drift-amplify_e2e_tests_pkg_linux
+            - auth_6-amplify_e2e_tests_pkg_linux
+            - function_5-amplify_e2e_tests_pkg_linux
             - interactions-amplify_e2e_tests_pkg_linux
             - datastore-modelgen-amplify_e2e_tests_pkg_linux
-            - layer-2-amplify_e2e_tests_pkg_linux
-            - container-hosting-amplify_e2e_tests_pkg_linux
+            - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux
+            - pull-amplify_e2e_tests_pkg_linux
             - schema-data-access-patterns-amplify_e2e_tests_pkg_linux
             - init-special-case-amplify_e2e_tests_pkg_linux
-            - iam-permissions-boundary-amplify_e2e_tests_pkg_linux
-            - configure-project-amplify_e2e_tests_pkg_linux
+            - hooks-amplify_e2e_tests_pkg_linux
+            - s3-sse-amplify_e2e_tests_pkg_linux
             - schema-versioned-amplify_e2e_tests_pkg_linux
             - plugin-amplify_e2e_tests_pkg_linux
-            - hooks-amplify_e2e_tests_pkg_linux
-            - auth_6-amplify_e2e_tests_pkg_linux
+            - function_7-amplify_e2e_tests_pkg_linux
+            - layer-2-amplify_e2e_tests_pkg_linux
       - amplify_migration_tests_latest:
           context:
             - amplify-ecr-image-pull
@@ -2432,19 +2432,19 @@ workflows:
           filters: *ref_10
           requires:
             - schema-searchable-amplify_e2e_tests
-      - schema-iterative-update-locking-amplify_e2e_tests:
+      - frontend_config_drift-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - function_2-amplify_e2e_tests
-      - function_7-amplify_e2e_tests:
+      - function_6-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-key-amplify_e2e_tests
-      - api_4-amplify_e2e_tests:
+      - iam-permissions-boundary-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2504,13 +2504,13 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-8-amplify_e2e_tests
-      - s3-sse-amplify_e2e_tests:
+      - container-hosting-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - delete-amplify_e2e_tests
-      - function_6-amplify_e2e_tests:
+      - migration-node-function-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2570,13 +2570,13 @@ workflows:
           filters: *ref_10
           requires:
             - schema-auth-7-amplify_e2e_tests
-      - pull-amplify_e2e_tests:
+      - configure-project-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-auth-3-amplify_e2e_tests
-      - function_5-amplify_e2e_tests:
+      - api_4-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2636,13 +2636,13 @@ workflows:
           filters: *ref_10
           requires:
             - auth_4-amplify_e2e_tests
-      - migration-node-function-amplify_e2e_tests:
+      - auth_6-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - schema-iterative-update-1-amplify_e2e_tests
-      - frontend_config_drift-amplify_e2e_tests:
+      - function_5-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2702,13 +2702,13 @@ workflows:
           filters: *ref_10
           requires:
             - migration-api-key-migration1-amplify_e2e_tests
-      - layer-2-amplify_e2e_tests:
+      - schema-iterative-update-locking-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - function_3-amplify_e2e_tests
-      - container-hosting-amplify_e2e_tests:
+      - pull-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2768,13 +2768,13 @@ workflows:
           filters: *ref_10
           requires:
             - layer-amplify_e2e_tests
-      - iam-permissions-boundary-amplify_e2e_tests:
+      - hooks-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - auth_5-amplify_e2e_tests
-      - configure-project-amplify_e2e_tests:
+      - s3-sse-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2834,13 +2834,13 @@ workflows:
           filters: *ref_10
           requires:
             - auth_3-amplify_e2e_tests
-      - hooks-amplify_e2e_tests:
+      - function_7-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - auth_1-amplify_e2e_tests
-      - auth_6-amplify_e2e_tests:
+      - layer-2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2914,19 +2914,19 @@ workflows:
           filters: *ref_13
           requires:
             - schema-searchable-amplify_e2e_tests_pkg_linux
-      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
+      - frontend_config_drift-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - function_2-amplify_e2e_tests_pkg_linux
-      - function_7-amplify_e2e_tests_pkg_linux:
+      - function_6-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-key-amplify_e2e_tests_pkg_linux
-      - api_4-amplify_e2e_tests_pkg_linux:
+      - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -2990,13 +2990,13 @@ workflows:
           filters: *ref_13
           requires:
             - schema-auth-8-amplify_e2e_tests_pkg_linux
-      - s3-sse-amplify_e2e_tests_pkg_linux:
+      - container-hosting-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - delete-amplify_e2e_tests_pkg_linux
-      - function_6-amplify_e2e_tests_pkg_linux:
+      - migration-node-function-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3060,13 +3060,13 @@ workflows:
           filters: *ref_13
           requires:
             - schema-auth-7-amplify_e2e_tests_pkg_linux
-      - pull-amplify_e2e_tests_pkg_linux:
+      - configure-project-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-auth-3-amplify_e2e_tests_pkg_linux
-      - function_5-amplify_e2e_tests_pkg_linux:
+      - api_4-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3130,13 +3130,13 @@ workflows:
           filters: *ref_13
           requires:
             - auth_4-amplify_e2e_tests_pkg_linux
-      - migration-node-function-amplify_e2e_tests_pkg_linux:
+      - auth_6-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - schema-iterative-update-1-amplify_e2e_tests_pkg_linux
-      - frontend_config_drift-amplify_e2e_tests_pkg_linux:
+      - function_5-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3200,13 +3200,13 @@ workflows:
           filters: *ref_13
           requires:
             - migration-api-key-migration1-amplify_e2e_tests_pkg_linux
-      - layer-2-amplify_e2e_tests_pkg_linux:
+      - schema-iterative-update-locking-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - function_3-amplify_e2e_tests_pkg_linux
-      - container-hosting-amplify_e2e_tests_pkg_linux:
+      - pull-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3270,13 +3270,13 @@ workflows:
           filters: *ref_13
           requires:
             - layer-amplify_e2e_tests_pkg_linux
-      - iam-permissions-boundary-amplify_e2e_tests_pkg_linux:
+      - hooks-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - auth_5-amplify_e2e_tests_pkg_linux
-      - configure-project-amplify_e2e_tests_pkg_linux:
+      - s3-sse-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3340,13 +3340,13 @@ workflows:
           filters: *ref_13
           requires:
             - auth_3-amplify_e2e_tests_pkg_linux
-      - hooks-amplify_e2e_tests_pkg_linux:
+      - function_7-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - auth_1-amplify_e2e_tests_pkg_linux
-      - auth_6-amplify_e2e_tests_pkg_linux:
+      - layer-2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13

--- a/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
@@ -5,6 +5,7 @@ import inquirer from 'inquirer';
 import importGlobal from 'import-global';
 import importFrom from 'import-from';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
+import { DynamoDBRelayModelTransformer, ModelRelayConnectionTransformer } from 'graphql-relay-transformer';
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { ModelConnectionTransformer } from 'graphql-connection-transformer';
 import { SearchableModelTransformer } from 'graphql-elasticsearch-transformer';
@@ -62,11 +63,13 @@ function getTransformerFactory(context, resourceDir, authConfig?) {
     const transformerList: ITransformer[] = [
       // TODO: Removing until further discussion. `getTransformerOptions(project, '@model')`
       new DynamoDBModelTransformer(),
+      new DynamoDBRelayModelTransformer(),
       new VersionedModelTransformer(),
       new FunctionTransformer(),
       new HttpTransformer(),
       new KeyTransformer(),
       new ModelConnectionTransformer(),
+      new ModelRelayConnectionTransformer(),
       new PredictionsTransformer(storageConfig),
     ];
 
@@ -75,9 +78,8 @@ function getTransformerFactory(context, resourceDir, authConfig?) {
     }
 
     const customTransformersConfig: TransformConfig = await readTransformerConfiguration(resourceDir);
-    const customTransformers = (customTransformersConfig && customTransformersConfig.transformers
-      ? customTransformersConfig.transformers
-      : []
+    const customTransformers = (
+      customTransformersConfig && customTransformersConfig.transformers ? customTransformersConfig.transformers : []
     )
       .map(transformer => {
         const fileUrlMatch = /^file:\/\/(.*)\s*$/m.exec(transformer);

--- a/packages/graphql-relay-transformer/.npmignore
+++ b/packages/graphql-relay-transformer/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/graphql-relay-transformer/CHANGELOG.md
+++ b/packages/graphql-relay-transformer/CHANGELOG.md
@@ -1,0 +1,1026 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [4.21.18](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.17...graphql-connection-transformer@4.21.18) (2021-08-24)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.17](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.16...graphql-connection-transformer@4.21.17) (2021-08-06)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.16](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.15...graphql-connection-transformer@4.21.16) (2021-07-30)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.15](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.14...graphql-connection-transformer@4.21.15) (2021-07-27)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.14](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.13...graphql-connection-transformer@4.21.14) (2021-07-16)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.13](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.12...graphql-connection-transformer@4.21.13) (2021-06-30)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.12](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.11...graphql-connection-transformer@4.21.12) (2021-06-24)
+
+
+### Bug Fixes
+
+* **graphql-transformer-common:** improve generated graphql pluralization ([#7258](https://github.com/aws-amplify/amplify-cli/issues/7258)) ([fc3ad0d](https://github.com/aws-amplify/amplify-cli/commit/fc3ad0dd5a12a7912c59ae12024f593b4cdf7f2d)), closes [#4224](https://github.com/aws-amplify/amplify-cli/issues/4224)
+
+
+
+
+
+## [4.21.11](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.10...graphql-connection-transformer@4.21.11) (2021-06-15)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.10](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.9...graphql-connection-transformer@4.21.10) (2021-05-29)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.9](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.8...graphql-connection-transformer@4.21.9) (2021-05-26)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.8](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.7...graphql-connection-transformer@4.21.8) (2021-05-18)
+
+
+### Bug Fixes
+
+* **graphql-dynamodb-transformer:** make primary key non null on del ([#6337](https://github.com/aws-amplify/amplify-cli/issues/6337)) ([4a5c679](https://github.com/aws-amplify/amplify-cli/commit/4a5c6795680b6b88efb19b923ee234253ca30c35)), closes [#2564](https://github.com/aws-amplify/amplify-cli/issues/2564)
+
+
+
+
+
+## [4.21.7](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.6...graphql-connection-transformer@4.21.7) (2021-05-14)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.4...graphql-connection-transformer@4.21.6) (2021-05-03)
+
+
+
+## 4.50.1 (2021-05-03)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.4...graphql-connection-transformer@4.21.5) (2021-05-03)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.3...graphql-connection-transformer@4.21.4) (2021-04-27)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.2...graphql-connection-transformer@4.21.3) (2021-04-19)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.21.1...graphql-connection-transformer@4.21.2) (2021-04-14)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.21.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.7...graphql-connection-transformer@4.21.1) (2021-04-09)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.7](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.6...graphql-connection-transformer@4.20.7) (2021-03-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.5...graphql-connection-transformer@4.20.6) (2021-03-11)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.4...graphql-connection-transformer@4.20.5) (2021-03-05)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.3...graphql-connection-transformer@4.20.4) (2021-02-26)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.2...graphql-connection-transformer@4.20.3) (2021-02-24)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.1...graphql-connection-transformer@4.20.2) (2021-02-17)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.20.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.20.0...graphql-connection-transformer@4.20.1) (2021-02-11)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+# [4.20.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.19.4...graphql-connection-transformer@4.20.0) (2021-02-10)
+
+
+### Features
+
+* **graphql-connection-transformer:** allow null key-based connections ([#5153](https://github.com/aws-amplify/amplify-cli/issues/5153)) ([e9c8276](https://github.com/aws-amplify/amplify-cli/commit/e9c82768df42144291c70bc719db9f1ab546c39a))
+
+
+
+
+
+## [4.19.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.19.3...graphql-connection-transformer@4.19.4) (2020-12-16)
+
+
+### Bug Fixes
+
+* **graphql-key-transformer:** prevent non-scalar key fields ([#5319](https://github.com/aws-amplify/amplify-cli/issues/5319)) ([4a5b305](https://github.com/aws-amplify/amplify-cli/commit/4a5b305dd695e61fcbc4ce0ca659b6f5a1c7e467)), closes [#5300](https://github.com/aws-amplify/amplify-cli/issues/5300)
+* [#6108](https://github.com/aws-amplify/amplify-cli/issues/6108) - add proper AWSJSON mapping in generated filter input types ([#6112](https://github.com/aws-amplify/amplify-cli/issues/6112)) ([743e84a](https://github.com/aws-amplify/amplify-cli/commit/743e84a9d968aab4648a12d3a19aa5ea14c4d755))
+
+
+### Reverts
+
+* Revert "Revert "Revert "fix: #6108 - add proper AWSJSON mapping in generated filter input types (#6112)" (#6158)" (#6160)" (#6183) ([a0ca94e](https://github.com/aws-amplify/amplify-cli/commit/a0ca94e5a1a848404ef3977743f19d26300a636a)), closes [#6108](https://github.com/aws-amplify/amplify-cli/issues/6108) [#6112](https://github.com/aws-amplify/amplify-cli/issues/6112) [#6158](https://github.com/aws-amplify/amplify-cli/issues/6158) [#6160](https://github.com/aws-amplify/amplify-cli/issues/6160) [#6183](https://github.com/aws-amplify/amplify-cli/issues/6183)
+* Revert "fix(graphql-key-transformer): prevent non-scalar key fields (#5319)" (#6181) ([c61268d](https://github.com/aws-amplify/amplify-cli/commit/c61268d093571c906c13e7033552503b9fd83a98)), closes [#5319](https://github.com/aws-amplify/amplify-cli/issues/5319) [#6181](https://github.com/aws-amplify/amplify-cli/issues/6181)
+* Revert "Revert "fix: #6108 - add proper AWSJSON mapping in generated filter input types (#6112)" (#6158)" (#6160) ([f425924](https://github.com/aws-amplify/amplify-cli/commit/f42592420dcb49640c680c5001b3026ae0129090)), closes [#6108](https://github.com/aws-amplify/amplify-cli/issues/6108) [#6112](https://github.com/aws-amplify/amplify-cli/issues/6112) [#6158](https://github.com/aws-amplify/amplify-cli/issues/6158) [#6160](https://github.com/aws-amplify/amplify-cli/issues/6160)
+* Revert "fix: #6108 - add proper AWSJSON mapping in generated filter input types (#6112)" (#6158) ([9e57e4d](https://github.com/aws-amplify/amplify-cli/commit/9e57e4d8c887be8ee4119c87383c7379cec40c37)), closes [#6108](https://github.com/aws-amplify/amplify-cli/issues/6108) [#6112](https://github.com/aws-amplify/amplify-cli/issues/6112) [#6158](https://github.com/aws-amplify/amplify-cli/issues/6158)
+
+
+
+
+
+## [4.19.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.19.2...graphql-connection-transformer@4.19.3) (2020-12-07)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.19.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.19.1...graphql-connection-transformer@4.19.2) (2020-11-30)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.19.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.18...graphql-connection-transformer@4.19.1) (2020-11-22)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+# [4.19.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@4.19.0) (2020-11-22)
+
+
+### Bug Fixes
+
+* **graphql-connection-transformer:** error if field not in relatedType ([#4481](https://github.com/aws-amplify/amplify-cli/issues/4481)) ([48e4a5e](https://github.com/aws-amplify/amplify-cli/commit/48e4a5ed8656f963d7cde49d465e4436b313e23e)), closes [#4236](https://github.com/aws-amplify/amplify-cli/issues/4236)
+* add custom enum filter to connection filter ([#4269](https://github.com/aws-amplify/amplify-cli/issues/4269)) ([f559df0](https://github.com/aws-amplify/amplify-cli/commit/f559df077015c1c8d8462a92968093efdc5b9452))
+* **graphql-connection-transformer:** limit was not respected ([#4021](https://github.com/aws-amplify/amplify-cli/issues/4021)) ([480d0a0](https://github.com/aws-amplify/amplify-cli/commit/480d0a02a5744225d8375f447ab8dc642e285eaa))
+* [#3438](https://github.com/aws-amplify/amplify-cli/issues/3438), many-to-many with conflict resolution generated wrong schema ([#4171](https://github.com/aws-amplify/amplify-cli/issues/4171)) ([9e8606c](https://github.com/aws-amplify/amplify-cli/commit/9e8606c4a300b5690839ec0869f7384aff189b1f))
+* add AttributeTypeEnum for connections on models with no codegen ([#4102](https://github.com/aws-amplify/amplify-cli/issues/4102)) ([4e92402](https://github.com/aws-amplify/amplify-cli/commit/4e92402e0b0fae30501972f3ad16203fc19ba287))
+* **graphql-connection-transformer:** support non string type in sort key ([#3492](https://github.com/aws-amplify/amplify-cli/issues/3492)) ([bc4a1d9](https://github.com/aws-amplify/amplify-cli/commit/bc4a1d9bd707c62ea2c4ec685401f34dfeca0bd0)), closes [#3403](https://github.com/aws-amplify/amplify-cli/issues/3403)
+* **graphql-connection-transformer:** valiate composite sortkey ([#3419](https://github.com/aws-amplify/amplify-cli/issues/3419)) ([e9d0e95](https://github.com/aws-amplify/amplify-cli/commit/e9d0e95616075d9f152191bc5eb0ee612f8f65c0))
+* [#2296](https://github.com/aws-amplify/amplify-cli/issues/2296) [#2304](https://github.com/aws-amplify/amplify-cli/issues/2304) [#2100](https://github.com/aws-amplify/amplify-cli/issues/2100) ([#2439](https://github.com/aws-amplify/amplify-cli/issues/2439)) ([82762d6](https://github.com/aws-amplify/amplify-cli/commit/82762d6187eb2102ebd134b181622188c5632d1d))
+* [#2347](https://github.com/aws-amplify/amplify-cli/issues/2347) - enum validation for key directive ([#2363](https://github.com/aws-amplify/amplify-cli/issues/2363)) ([1facade](https://github.com/aws-amplify/amplify-cli/commit/1facaded3095eaff5a015e76ca4d718b7bc3c938))
+* [#2389](https://github.com/aws-amplify/amplify-cli/issues/2389) ([#2538](https://github.com/aws-amplify/amplify-cli/issues/2538)) ([fb92a9d](https://github.com/aws-amplify/amplify-cli/commit/fb92a9d7c6a1f807e49b7f899531de90cc1f4ee3))
+* build break, chore: typescript, lerna update ([#2640](https://github.com/aws-amplify/amplify-cli/issues/2640)) ([29fae36](https://github.com/aws-amplify/amplify-cli/commit/29fae366f4cab054feefa58c7dc733002d19570c))
+* export Typescript definitions and fix resulting type errors ([#2452](https://github.com/aws-amplify/amplify-cli/issues/2452)) ([7de3845](https://github.com/aws-amplify/amplify-cli/commit/7de384594d3b9cbf22cdaa85107fc8df26c141ec)), closes [#2451](https://github.com/aws-amplify/amplify-cli/issues/2451)
+* sanitize input in transformer resolver([#3316](https://github.com/aws-amplify/amplify-cli/issues/3316)) ([a3bc0a5](https://github.com/aws-amplify/amplify-cli/commit/a3bc0a5e5d3faa7946d16d0f6595ce8c2f3c11dc))
+* upgrade to node10 as min version for CLI ([#3128](https://github.com/aws-amplify/amplify-cli/issues/3128)) ([a0b18e0](https://github.com/aws-amplify/amplify-cli/commit/a0b18e0187a26b4ab0e6e986b0277f347e829444))
+* **graphql-connection-transformer:** fix self connection bug ([#1944](https://github.com/aws-amplify/amplify-cli/issues/1944)) ([1a6affc](https://github.com/aws-amplify/amplify-cli/commit/1a6affc7cc5ba0d59c908b6f6a58852013d22343)), closes [#1799](https://github.com/aws-amplify/amplify-cli/issues/1799)
+
+
+### Features
+
+* **amplify-category-api:** change default graphql query limit to 100 ([#4124](https://github.com/aws-amplify/amplify-cli/issues/4124)) ([1a68c4d](https://github.com/aws-amplify/amplify-cli/commit/1a68c4d589e2101357dec4e980719fc547964e23))
+* **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+* **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+* **graphql-connection-transformer:** limit ([#1953](https://github.com/aws-amplify/amplify-cli/issues/1953)) ([dcaf844](https://github.com/aws-amplify/amplify-cli/commit/dcaf84480974e7a697d1ea29782a4f5032a77942))
+* **graphql-dynamodb-transformer:** expose createdAt and updatedAt on model ([#4149](https://github.com/aws-amplify/amplify-cli/issues/4149)) ([8e0662e](https://github.com/aws-amplify/amplify-cli/commit/8e0662eac8c88da9393f32c33457a597acf591ed)), closes [#401](https://github.com/aws-amplify/amplify-cli/issues/401)
+* **graphql-key-transformer:** add query automatically for named keys ([#4458](https://github.com/aws-amplify/amplify-cli/issues/4458)) ([375282d](https://github.com/aws-amplify/amplify-cli/commit/375282d648cf9d096d13c7b958a0dfb7bd6d60b0))
+* adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c1927da10f8c54f38a523021187361131c))
+* conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+* updated version of [#2118](https://github.com/aws-amplify/amplify-cli/issues/2118) with addressed review comments ([#2230](https://github.com/aws-amplify/amplify-cli/issues/2230)) ([be3c499](https://github.com/aws-amplify/amplify-cli/commit/be3c499edcc6bec63b38e9241c5af7b83c930022))
+
+
+### Reverts
+
+* add query automatically for named keys ([#4513](https://github.com/aws-amplify/amplify-cli/issues/4513)) ([50c1120](https://github.com/aws-amplify/amplify-cli/commit/50c112050645b8fd5011a1e6863d30f58e0c55cb))
+
+
+
+
+
+## [4.18.21](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.18...graphql-connection-transformer@4.18.21) (2020-11-20)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.20](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.18...graphql-connection-transformer@4.18.20) (2020-11-20)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.19](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.18...graphql-connection-transformer@4.18.19) (2020-11-19)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.18](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.17...graphql-connection-transformer@4.18.18) (2020-11-08)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.17](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.16...graphql-connection-transformer@4.18.17) (2020-10-30)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.16](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.15...graphql-connection-transformer@4.18.16) (2020-10-27)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.15](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.14...graphql-connection-transformer@4.18.15) (2020-10-22)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.14](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.13...graphql-connection-transformer@4.18.14) (2020-10-17)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.13](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.12...graphql-connection-transformer@4.18.13) (2020-10-01)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.12](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.11...graphql-connection-transformer@4.18.12) (2020-09-16)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.11](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.10...graphql-connection-transformer@4.18.11) (2020-09-02)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.10](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.9...graphql-connection-transformer@4.18.10) (2020-08-31)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.9](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.8...graphql-connection-transformer@4.18.9) (2020-08-14)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.8](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.7...graphql-connection-transformer@4.18.8) (2020-08-11)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.7](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.5...graphql-connection-transformer@4.18.7) (2020-07-29)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.5...graphql-connection-transformer@4.18.6) (2020-07-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.4...graphql-connection-transformer@4.18.5) (2020-07-18)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.18.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.3...graphql-connection-transformer@4.18.4) (2020-07-15)
+
+
+### Bug Fixes
+
+* **graphql-connection-transformer:** error if field not in relatedType ([#4481](https://github.com/aws-amplify/amplify-cli/issues/4481)) ([0a6a7ea](https://github.com/aws-amplify/amplify-cli/commit/0a6a7eabbe726d7add52b8a8811c54f7257d176f)), closes [#4236](https://github.com/aws-amplify/amplify-cli/issues/4236)
+
+
+
+
+
+## [4.18.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.2...graphql-connection-transformer@4.18.3) (2020-06-25)
+
+
+### Reverts
+
+* Revert "fix: change scope of hashed files for AppSync (#4602)" ([73aaab1](https://github.com/aws-amplify/amplify-cli/commit/73aaab1a7b1f8b2de5fa22fa1ef9aeea7de35cb4)), closes [#4602](https://github.com/aws-amplify/amplify-cli/issues/4602)
+
+
+
+
+
+## [4.18.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.1...graphql-connection-transformer@4.18.2) (2020-06-18)
+
+
+### Bug Fixes
+
+* change scope of hashed files for AppSync ([#4602](https://github.com/aws-amplify/amplify-cli/issues/4602)) ([10fa9da](https://github.com/aws-amplify/amplify-cli/commit/10fa9da646f4de755e2dc92cd4bb2a6319425d72)), closes [#4458](https://github.com/aws-amplify/amplify-cli/issues/4458)
+
+
+
+
+
+## [4.18.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.18.0...graphql-connection-transformer@4.18.1) (2020-06-11)
+
+
+### Reverts
+
+* add query automatically for named keys ([#4513](https://github.com/aws-amplify/amplify-cli/issues/4513)) ([6d3123b](https://github.com/aws-amplify/amplify-cli/commit/6d3123bfe3ba412d3b1af076e550e6733c988c8f))
+
+
+
+
+
+# [4.18.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.17.2...graphql-connection-transformer@4.18.0) (2020-06-10)
+
+
+### Features
+
+* **graphql-key-transformer:** add query automatically for named keys ([#4458](https://github.com/aws-amplify/amplify-cli/issues/4458)) ([3d194f8](https://github.com/aws-amplify/amplify-cli/commit/3d194f805dcbd6325ddf78155c4327dbca3e7f4a))
+
+
+
+
+
+## [4.17.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.17.1...graphql-connection-transformer@4.17.2) (2020-06-02)
+
+
+### Bug Fixes
+
+* add custom enum filter to connection filter ([#4269](https://github.com/aws-amplify/amplify-cli/issues/4269)) ([a29d427](https://github.com/aws-amplify/amplify-cli/commit/a29d427dc23f82f04d4e7b79402dd9642591e759))
+
+
+
+
+
+## [4.17.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.17.0...graphql-connection-transformer@4.17.1) (2020-05-26)
+
+
+### Bug Fixes
+
+* **graphql-connection-transformer:** limit was not respected ([#4021](https://github.com/aws-amplify/amplify-cli/issues/4021)) ([9800384](https://github.com/aws-amplify/amplify-cli/commit/9800384efff53a57973105508482cad945523727))
+
+
+
+
+
+# [4.17.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.16.0...graphql-connection-transformer@4.17.0) (2020-05-15)
+
+
+### Features
+
+* **graphql-dynamodb-transformer:** expose createdAt and updatedAt on model ([#4149](https://github.com/aws-amplify/amplify-cli/issues/4149)) ([8e0662e](https://github.com/aws-amplify/amplify-cli/commit/8e0662eac8c88da9393f32c33457a597acf591ed)), closes [#401](https://github.com/aws-amplify/amplify-cli/issues/401)
+
+
+
+
+
+# [4.16.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.15.3...graphql-connection-transformer@4.16.0) (2020-05-08)
+
+
+### Bug Fixes
+
+* [#3438](https://github.com/aws-amplify/amplify-cli/issues/3438), many-to-many with conflict resolution generated wrong schema ([#4171](https://github.com/aws-amplify/amplify-cli/issues/4171)) ([9e8606c](https://github.com/aws-amplify/amplify-cli/commit/9e8606c4a300b5690839ec0869f7384aff189b1f))
+* add AttributeTypeEnum for connections on models with no codegen ([#4102](https://github.com/aws-amplify/amplify-cli/issues/4102)) ([4e92402](https://github.com/aws-amplify/amplify-cli/commit/4e92402e0b0fae30501972f3ad16203fc19ba287))
+
+
+### Features
+
+* **amplify-category-api:** change default graphql query limit to 100 ([#4124](https://github.com/aws-amplify/amplify-cli/issues/4124)) ([1a68c4d](https://github.com/aws-amplify/amplify-cli/commit/1a68c4d589e2101357dec4e980719fc547964e23))
+
+
+
+
+
+## [4.15.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.15.2...graphql-connection-transformer@4.15.3) (2020-04-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.15.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.15.1...graphql-connection-transformer@4.15.2) (2020-03-22)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.15.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.13.4...graphql-connection-transformer@4.15.1) (2020-03-07)
+
+
+### Bug Fixes
+
+* **graphql-connection-transformer:** support non string type in sort key ([#3492](https://github.com/aws-amplify/amplify-cli/issues/3492)) ([bc4a1d9](https://github.com/aws-amplify/amplify-cli/commit/bc4a1d9bd707c62ea2c4ec685401f34dfeca0bd0)), closes [#3403](https://github.com/aws-amplify/amplify-cli/issues/3403)
+* **graphql-connection-transformer:** valiate composite sortkey ([#3419](https://github.com/aws-amplify/amplify-cli/issues/3419)) ([e9d0e95](https://github.com/aws-amplify/amplify-cli/commit/e9d0e95616075d9f152191bc5eb0ee612f8f65c0))
+
+
+
+
+
+## [4.14.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.13.6-beta.0...graphql-connection-transformer@4.14.1) (2020-03-05)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.13.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.13.3...graphql-connection-transformer@4.13.4) (2020-02-18)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.13.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.13.2...graphql-connection-transformer@4.13.3) (2020-02-13)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+## [4.13.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.13.1...graphql-connection-transformer@4.13.2) (2020-02-07)
+
+
+### Bug Fixes
+
+* sanitize input in transformer resolver([#3316](https://github.com/aws-amplify/amplify-cli/issues/3316)) ([a3bc0a5](https://github.com/aws-amplify/amplify-cli/commit/a3bc0a5e5d3faa7946d16d0f6595ce8c2f3c11dc))
+
+
+
+
+
+## [4.13.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@4.13.0...graphql-connection-transformer@4.13.1) (2020-01-24)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+
+
+
+
+# [4.13.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.13.0) (2020-01-23)
+
+### Bug Fixes
+
+- upgrade to node10 as min version for CLI ([#3128](https://github.com/aws-amplify/amplify-cli/issues/3128)) ([a0b18e0](https://github.com/aws-amplify/amplify-cli/commit/a0b18e0187a26b4ab0e6e986b0277f347e829444))
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.12.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.12.0) (2020-01-09)
+
+### Bug Fixes
+
+- upgrade to node10 as min version for CLI ([#3128](https://github.com/aws-amplify/amplify-cli/issues/3128)) ([a0b18e0](https://github.com/aws-amplify/amplify-cli/commit/a0b18e0187a26b4ab0e6e986b0277f347e829444))
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.11.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.11.0) (2019-12-31)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.10.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.10.0) (2019-12-28)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.9.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.9.0) (2019-12-26)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.8.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.8.0) (2019-12-25)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.7.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.7.0) (2019-12-20)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.6.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.6.0) (2019-12-10)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.4.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.4.0) (2019-12-03)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.3.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.3.0) (2019-12-01)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.2.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.2.0) (2019-11-27)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [4.1.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.29.0...graphql-connection-transformer@4.1.0) (2019-11-27)
+
+### Features
+
+- conditions update ([#2789](https://github.com/aws-amplify/amplify-cli/issues/2789)) ([3fae391](https://github.com/aws-amplify/amplify-cli/commit/3fae391340d5fd151e1c43286c90142b5ab0eab0))
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [3.11.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@3.11.0) (2019-08-30)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** fix self connection bug ([#1944](https://github.com/aws-amplify/amplify-cli/issues/1944)) ([1a6affc](https://github.com/aws-amplify/amplify-cli/commit/1a6affc)), closes [#1799](https://github.com/aws-amplify/amplify-cli/issues/1799)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+# [3.10.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@3.10.0) (2019-08-28)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** fix self connection bug ([#1944](https://github.com/aws-amplify/amplify-cli/issues/1944)) ([1a6affc](https://github.com/aws-amplify/amplify-cli/commit/1a6affc)), closes [#1799](https://github.com/aws-amplify/amplify-cli/issues/1799)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+# [3.9.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@3.9.0) (2019-08-13)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** fix self connection bug ([#1944](https://github.com/aws-amplify/amplify-cli/issues/1944)) ([1a6affc](https://github.com/aws-amplify/amplify-cli/commit/1a6affc)), closes [#1799](https://github.com/aws-amplify/amplify-cli/issues/1799)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+# [3.8.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@3.8.0) (2019-08-07)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+# [3.7.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@3.7.0) (2019-08-02)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+# [3.6.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.5...graphql-connection-transformer@3.6.0) (2019-07-31)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+## [3.5.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.4...graphql-connection-transformer@3.5.5) (2019-07-24)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.5.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.2...graphql-connection-transformer@3.5.4) (2019-06-30)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.5.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.1...graphql-connection-transformer@3.5.2) (2019-06-26)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.5.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.5.0...graphql-connection-transformer@3.5.1) (2019-06-12)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+# [3.5.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.4.6...graphql-connection-transformer@3.5.0) (2019-05-29)
+
+### Features
+
+- feature/[@key](https://github.com/key) ([#1463](https://github.com/aws-amplify/amplify-cli/issues/1463)) ([00ed819](https://github.com/aws-amplify/amplify-cli/commit/00ed819))
+
+## [3.4.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.4.5...graphql-connection-transformer@3.4.6) (2019-05-21)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.4.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.4.4...graphql-connection-transformer@3.4.5) (2019-05-17)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.4.4](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.4.2...graphql-connection-transformer@3.4.4) (2019-05-07)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.4.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.4.2...graphql-connection-transformer@3.4.3) (2019-05-06)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.4.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.4.1...graphql-connection-transformer@3.4.2) (2019-04-16)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.4.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.3.1...graphql-connection-transformer@3.4.1) (2019-04-09)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.3.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.9...graphql-connection-transformer@3.3.1) (2019-04-03)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.0.9](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.8...graphql-connection-transformer@3.0.9) (2019-03-22)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.0.8](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.7...graphql-connection-transformer@3.0.8) (2019-03-05)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.0.7](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.6...graphql-connection-transformer@3.0.7) (2019-02-20)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.0.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.5...graphql-connection-transformer@3.0.6) (2019-02-12)
+
+### Bug Fixes
+
+- cloudform/type versions ([ec6f99f](https://github.com/aws-amplify/amplify-cli/commit/ec6f99f))
+
+## [3.0.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.3-beta.0...graphql-connection-transformer@3.0.5) (2019-02-11)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.0.3](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.3-beta.0...graphql-connection-transformer@3.0.3) (2019-02-11)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+## [3.0.3-beta.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@3.0.2...graphql-connection-transformer@3.0.3-beta.0) (2019-02-11)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="2.0.0-multienv.2"></a>
+
+# [2.0.0-multienv.2](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.34-multienv.1...graphql-connection-transformer@2.0.0-multienv.2) (2018-12-31)
+
+### Bug Fixes
+
+- update grahql transformer package versions for multienv ([8b4b2bd](https://github.com/aws-amplify/amplify-cli/commit/8b4b2bd))
+
+<a name="1.0.34-multienv.1"></a>
+
+## [1.0.34-multienv.1](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.34-multienv.0...graphql-connection-transformer@1.0.34-multienv.1) (2018-12-19)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.34-multienv.0"></a>
+
+## [1.0.34-multienv.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.33...graphql-connection-transformer@1.0.34-multienv.0) (2018-11-16)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.33"></a>
+
+## [1.0.33](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.33-beta.0...graphql-connection-transformer@1.0.33) (2018-11-09)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.33-beta.0"></a>
+
+## [1.0.33-beta.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.12...graphql-connection-transformer@1.0.33-beta.0) (2018-11-09)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** Remove unused types ([87c3e0a](https://github.com/aws-amplify/amplify-cli/commit/87c3e0a))
+
+<a name="1.0.32"></a>
+
+## [1.0.32](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.32-beta.0...graphql-connection-transformer@1.0.32) (2018-11-05)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.32-beta.0"></a>
+
+## [1.0.32-beta.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.12...graphql-connection-transformer@1.0.32-beta.0) (2018-11-05)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** Remove unused types ([87c3e0a](https://github.com/aws-amplify/amplify-cli/commit/87c3e0a))
+
+<a name="1.0.31"></a>
+
+## [1.0.31](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.12...graphql-connection-transformer@1.0.31) (2018-11-02)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** Remove unused types ([87c3e0a](https://github.com/aws-amplify/amplify-cli/commit/87c3e0a))
+
+<a name="1.0.30"></a>
+
+## [1.0.30](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.30-beta.0...graphql-connection-transformer@1.0.30) (2018-11-02)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.30-beta.0"></a>
+
+## [1.0.30-beta.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.12...graphql-connection-transformer@1.0.30-beta.0) (2018-11-02)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** Remove unused types ([87c3e0a](https://github.com/aws-amplify/amplify-cli/commit/87c3e0a))
+
+<a name="1.0.29"></a>
+
+## [1.0.29](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.29-beta.0...graphql-connection-transformer@1.0.29) (2018-10-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.29-beta.0"></a>
+
+## [1.0.29-beta.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.12...graphql-connection-transformer@1.0.29-beta.0) (2018-10-23)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** Remove unused types ([87c3e0a](https://github.com/aws-amplify/amplify-cli/commit/87c3e0a))
+
+<a name="1.0.28"></a>
+
+## [1.0.28](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.28-beta.0...graphql-connection-transformer@1.0.28) (2018-10-18)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.28-beta.0"></a>
+
+## [1.0.28-beta.0](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.12...graphql-connection-transformer@1.0.28-beta.0) (2018-10-12)
+
+### Bug Fixes
+
+- **graphql-connection-transformer:** Remove unused types ([87c3e0a](https://github.com/aws-amplify/amplify-cli/commit/87c3e0a))
+
+<a name="1.0.12"></a>
+
+## [1.0.12](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.11...graphql-connection-transformer@1.0.12) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.11"></a>
+
+## [1.0.11](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.10...graphql-connection-transformer@1.0.11) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.10"></a>
+
+## [1.0.10](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.9...graphql-connection-transformer@1.0.10) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.9"></a>
+
+## [1.0.9](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.8...graphql-connection-transformer@1.0.9) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.8"></a>
+
+## [1.0.8](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.7...graphql-connection-transformer@1.0.8) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.7"></a>
+
+## [1.0.7](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.6...graphql-connection-transformer@1.0.7) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.6"></a>
+
+## [1.0.6](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.5...graphql-connection-transformer@1.0.6) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.5"></a>
+
+## [1.0.5](https://github.com/aws-amplify/amplify-cli/compare/graphql-connection-transformer@1.0.4...graphql-connection-transformer@1.0.5) (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.4"></a>
+
+## 1.0.4 (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.3"></a>
+
+## 1.0.3 (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.2"></a>
+
+## 1.0.2 (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer
+
+<a name="1.0.1"></a>
+
+## 1.0.1 (2018-08-23)
+
+**Note:** Version bump only for package graphql-connection-transformer

--- a/packages/graphql-relay-transformer/package.json
+++ b/packages/graphql-relay-transformer/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "graphql-relay-transformer",
+  "version": "1.0.0",
+  "description": "An AppSync model transform for connecting objects using Relay Modern.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-cli.git",
+    "directory": "packages/graphql-relay-transformer"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "keywords": [
+    "graphql",
+    "appsync",
+    "aws"
+  ],
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "clean": "rimraf ./lib"
+  },
+  "dependencies": {
+    "cloudform-types": "^4.2.0",
+    "graphql": "^14.5.8",
+    "graphql-dynamodb-transformer": "6.22.18",
+    "graphql-key-transformer": "2.23.18",
+    "graphql-mapping-template": "4.18.3",
+    "graphql-transformer-common": "4.19.8",
+    "graphql-transformer-core": "6.29.3"
+  },
+  "devDependencies": {
+    "@types/node": "^12.12.6"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testURL": "http://localhost/",
+    "testRegex": "(src/__tests__/.*.test.(t|j)s)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true
+  }
+}

--- a/packages/graphql-relay-transformer/package.json
+++ b/packages/graphql-relay-transformer/package.json
@@ -24,11 +24,11 @@
   "dependencies": {
     "cloudform-types": "^4.2.0",
     "graphql": "^14.5.8",
-    "graphql-dynamodb-transformer": "6.22.18",
-    "graphql-key-transformer": "2.23.18",
+    "graphql-dynamodb-transformer": "6.22.19",
+    "graphql-key-transformer": "2.23.19",
     "graphql-mapping-template": "4.18.3",
-    "graphql-transformer-common": "4.19.8",
-    "graphql-transformer-core": "6.29.3"
+    "graphql-transformer-common": "4.19.9",
+    "graphql-transformer-core": "6.29.4"
   },
   "devDependencies": {
     "@types/node": "^12.12.6"

--- a/packages/graphql-relay-transformer/src/__tests__/DynamoDBRelayModelTransformer.test.ts
+++ b/packages/graphql-relay-transformer/src/__tests__/DynamoDBRelayModelTransformer.test.ts
@@ -1,0 +1,826 @@
+import {
+  ObjectTypeDefinitionNode,
+  parse,
+  FieldDefinitionNode,
+  DocumentNode,
+  DefinitionNode,
+  Kind,
+  InputObjectTypeDefinitionNode,
+  ListValueNode,
+  InputValueDefinitionNode,
+  TypeNode,
+  NamedTypeNode,
+} from 'graphql';
+import { FeatureFlagProvider, GraphQLTransform, TRANSFORM_BASE_VERSION, TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
+import { DynamoDBRelayModelTransformer } from '../model/DynamoDBRelayModelTransformer';
+import { getBaseType } from 'graphql-transformer-common';
+const featureFlags = {
+  getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+    if (name === 'improvePluralization') {
+      return true;
+    }
+    if (name === 'validateTypeNameReservedWords') {
+      return false;
+    }
+    return;
+  }),
+  getNumber: jest.fn(),
+  getObject: jest.fn(),
+  getString: jest.fn(),
+};
+
+test('Test DynamoDBRelayModelTransformer validation happy case', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+});
+
+test('Test DynamoDBRelayModelTransformer with query overrides', () => {
+  const validSchema = `type Post @relayModel(queries: { get: "customGetPost", list: "customListPost" }) {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const createPostInput = getInputType(parsed, 'CreatePostInput');
+  expectFieldsOnInputType(createPostInput, ['id', 'title', 'createdAt', 'updatedAt']);
+  // This id should always be optional.
+  // aka a named type node aka name.value would not be set if it were a non null node
+  const idField = createPostInput.fields.find(f => f.name.value === 'id');
+  expect((idField.type as NamedTypeNode).name.value).toEqual('ID');
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  expectFields(queryType, ['customGetPost']);
+  expectFields(queryType, ['customListPost']);
+  const subscriptionType = getObjectType(parsed, 'Subscription');
+  expect(subscriptionType).toBeDefined();
+  expectFields(subscriptionType, ['onCreatePost', 'onUpdatePost', 'onDeletePost']);
+  const subField = subscriptionType.fields.find(f => f.name.value === 'onCreatePost');
+  expect(subField.directives.length).toEqual(1);
+  expect(subField.directives[0].name.value).toEqual('aws_subscribe');
+});
+
+test('Test DynamoDBRelayModelTransformer with mutation overrides', () => {
+  const validSchema = `type Post @relayModel(mutations: { create: "customCreatePost", update: "customUpdatePost", delete: "customDeletePost" }) {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  expectFields(mutationType, ['customCreatePost', 'customUpdatePost', 'customDeletePost']);
+});
+
+test('Test DynamoDBRelayModelTransformer with only create mutations', () => {
+  const validSchema = `type Post @relayModel(mutations: { create: "customCreatePost" }) {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  expectFields(mutationType, ['customCreatePost']);
+  doNotExpectFields(mutationType, ['updatePost']);
+});
+
+test('Test DynamoDBRelayModelTransformer with multiple model directives', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+
+    type User @relayModel {
+        id: ID!
+        name: String!
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  expectFields(queryType, ['listPosts']);
+  expectFields(queryType, ['listUsers']);
+
+  const stringInputType = getInputType(parsed, 'ModelStringFilterInput');
+  expect(stringInputType).toBeDefined();
+  const booleanInputType = getInputType(parsed, 'ModelBooleanFilterInput');
+  expect(booleanInputType).toBeDefined();
+  const intInputType = getInputType(parsed, 'ModelIntFilterInput');
+  expect(intInputType).toBeDefined();
+  const floatInputType = getInputType(parsed, 'ModelFloatFilterInput');
+  expect(floatInputType).toBeDefined();
+  const idInputType = getInputType(parsed, 'ModelIDFilterInput');
+  expect(idInputType).toBeDefined();
+  const postInputType = getInputType(parsed, 'ModelPostFilterInput');
+  expect(postInputType).toBeDefined();
+  const userInputType = getInputType(parsed, 'ModelUserFilterInput');
+  expect(userInputType).toBeDefined();
+
+  expect(verifyInputCount(parsed, 'ModelStringFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelBooleanFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelIntFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelUserFilterInput', 1)).toBeTruthy();
+});
+
+test('Test DynamoDBRelayModelTransformer with filter', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  expectFields(queryType, ['listPosts']);
+
+  const connectionType = getObjectType(parsed, 'ModelPostConnection');
+  expect(connectionType).toBeDefined();
+
+  expect(verifyInputCount(parsed, 'ModelStringFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelBooleanFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelIntFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelFloatFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelIDFilterInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'ModelPostFilterInput', 1)).toBeTruthy();
+});
+
+test('Test DynamoDBRelayModelTransformer with mutations set to null', () => {
+  const validSchema = `type Post @relayModel(mutations: null) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).not.toBeDefined();
+});
+test('Test DynamoDBRelayModelTransformer with queries set to null', () => {
+  const validSchema = `type Post @relayModel(queries: null) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).not.toBeDefined();
+});
+test('Test DynamoDBRelayModelTransformer with subscriptions set to null', () => {
+  const validSchema = `type Post @relayModel(subscriptions: null) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).toBeDefined();
+  const subscriptionType = getObjectType(parsed, 'Subscription');
+  expect(subscriptionType).not.toBeDefined();
+});
+test('Test DynamoDBRelayModelTransformer with queries and mutations set to null', () => {
+  const validSchema = `type Post @relayModel(queries: null, mutations: null, subscriptions: null) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).not.toBeDefined();
+  const queryType = getObjectType(parsed, 'Query');
+  expect(queryType).not.toBeDefined();
+  const subscriptionType = getObjectType(parsed, 'Subscription');
+  expect(subscriptionType).not.toBeDefined();
+});
+test('Test DynamoDBRelayModelTransformer with advanced subscriptions', () => {
+  const validSchema = `type Post @relayModel(subscriptions: {
+            onCreate: ["onFeedUpdated", "onCreatePost"],
+            onUpdate: ["onFeedUpdated"],
+            onDelete: ["onFeedUpdated"]
+        }) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const subscriptionType = getObjectType(parsed, 'Subscription');
+  expect(subscriptionType).toBeDefined();
+  expectFields(subscriptionType, ['onFeedUpdated', 'onCreatePost']);
+  const subField = subscriptionType.fields.find(f => f.name.value === 'onFeedUpdated');
+  expect(subField.directives.length).toEqual(1);
+  expect(subField.directives[0].name.value).toEqual('aws_subscribe');
+  const mutationsList = subField.directives[0].arguments.find(a => a.name.value === 'mutations').value as ListValueNode;
+  const mutList = mutationsList.values.map((v: any) => v.value);
+  expect(mutList.length).toEqual(3);
+  expect(mutList).toContain('createPost');
+  expect(mutList).toContain('updatePost');
+  expect(mutList).toContain('deletePost');
+});
+
+test('Test DynamoDBRelayModelTransformer with non-model types and enums', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+        metadata: [PostMetadata!]!
+        appearsIn: [Episode]!
+    }
+    type PostMetadata {
+        tags: Tag
+    }
+    type Tag {
+        published: Boolean
+        metadata: PostMetadata
+    }
+    enum Episode {
+        NEWHOPE
+        EMPIRE
+        JEDI
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+
+  const postMetaDataInputType = getInputType(parsed, 'PostMetadataInput');
+  expect(postMetaDataInputType).toBeDefined();
+  const tagInputType = getInputType(parsed, 'TagInput');
+  expect(tagInputType).toBeDefined();
+  expectFieldsOnInputType(tagInputType, ['metadata']);
+  const createPostInputType = getInputType(parsed, 'CreatePostInput');
+  expectFieldsOnInputType(createPostInputType, ['metadata', 'appearsIn']);
+  const updatePostInputType = getInputType(parsed, 'UpdatePostInput');
+  expectFieldsOnInputType(updatePostInputType, ['metadata', 'appearsIn']);
+
+  const postModelObject = getObjectType(parsed, 'Post');
+  const postMetaDataInputField = getFieldOnInputType(createPostInputType, 'metadata');
+  const postMetaDataField = getFieldOnObjectType(postModelObject, 'metadata');
+  // this checks that the non-model type was properly "unwrapped", renamed, and "rewrapped"
+  // in the generated CreatePostInput type - its types should be the same as in the Post @relayModel type
+  verifyMatchingTypes(postMetaDataInputField.type, postMetaDataField.type);
+
+  expect(verifyInputCount(parsed, 'PostMetadataInput', 1)).toBeTruthy();
+  expect(verifyInputCount(parsed, 'TagInput', 1)).toBeTruthy();
+});
+
+test('Test DynamoDBRelayModelTransformer with mutation input overrides when mutations are disabled', () => {
+  const validSchema = `type Post @relayModel(mutations: null) {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    input CreatePostInput {
+        different: String
+    }
+    input UpdatePostInput {
+        different2: String
+    }
+    input DeletePostInput {
+        different3: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const createPostInput = getInputType(parsed, 'CreatePostInput');
+  expectFieldsOnInputType(createPostInput, ['different']);
+  const updatePostInput = getInputType(parsed, 'UpdatePostInput');
+  expectFieldsOnInputType(updatePostInput, ['different2']);
+  const deletePostInput = getInputType(parsed, 'DeletePostInput');
+  expectFieldsOnInputType(deletePostInput, ['different3']);
+});
+
+test('Test DynamoDBRelayModelTransformer with mutation input overrides when mutations are enabled', () => {
+  const validSchema = `type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }
+    # User defined types always take precedence.
+    input CreatePostInput {
+        different: String
+    }
+    input UpdatePostInput {
+        different2: String
+    }
+    input DeletePostInput {
+        different3: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const createPostInput = getInputType(parsed, 'CreatePostInput');
+  expectFieldsOnInputType(createPostInput, ['different']);
+  const updatePostInput = getInputType(parsed, 'UpdatePostInput');
+  expectFieldsOnInputType(updatePostInput, ['different2']);
+  const deletePostInput = getInputType(parsed, 'DeletePostInput');
+  expectFieldsOnInputType(deletePostInput, ['different3']);
+});
+
+test('Test non model objects contain id as a type for fields', () => {
+  const validSchema = `
+    type Post @relayModel {
+      id: ID!
+      comments: [Comment]
+    }
+    type Comment {
+      id: String!
+      text: String!
+    }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+  const parsed = parse(definition);
+  const commentInput = getInputType(parsed, 'CommentInput');
+  expectFieldsOnInputType(commentInput, ['id', 'text']);
+  const commentObject = getObjectType(parsed, 'Comment');
+  const commentInputObject = getInputType(parsed, 'CommentInput');
+  const commentObjectIDField = getFieldOnObjectType(commentObject, 'id');
+  const commentInputIDField = getFieldOnInputType(commentInputObject, 'id');
+  verifyMatchingTypes(commentObjectIDField.type, commentInputIDField.type);
+});
+
+test('Test schema includes attribute enum when only queries specified', () => {
+  const validSchema = `
+    type Entity @relayModel(mutations: null, subscriptions: null) {
+      id: ID!
+      str: String
+    }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: 5,
+    },
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+});
+
+test('Test only get does not generate superfluous input and filter types', () => {
+  const validSchema = `
+  type Entity @relayModel(mutations: null, subscriptions: null, queries: {get: "getEntity"}) {
+    id: ID!
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: 5,
+    },
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+});
+
+test('Test timestamp parameters when generating resolvers and output schema', () => {
+  const validSchema = `
+  type Post @relayModel(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn"}) {
+    id: ID!
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+
+  expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+  expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+});
+
+test('Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime', () => {
+  const validSchema = `
+  type Post @relayModel {
+    id: ID!
+    str: String
+    createdAt: AWSTimestamp
+    updatedAt: AWSTimestamp
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+
+  expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+  expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+});
+
+test('Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable', () => {
+  const validSchema = `
+  type Post @relayModel {
+    id: ID!
+    str: String
+    createdAt: AWSDateTime!
+    updatedAt: AWSDateTime!
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+
+  expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+  expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+});
+
+test('Test not to include createdAt and updatedAt field when timestamps is set to null', () => {
+  const validSchema = `
+  type Post @relayModel(timestamps: null) {
+    id: ID!
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toMatchSnapshot();
+
+  expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+  expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+});
+
+test(`V${TRANSFORM_BASE_VERSION} transformer snapshot test`, () => {
+  const schema = transformerVersionSnapshot(TRANSFORM_BASE_VERSION);
+  expect(schema).toMatchSnapshot();
+});
+
+test(`V5 transformer snapshot test`, () => {
+  const schema = transformerVersionSnapshot(5);
+  expect(schema).toMatchSnapshot();
+});
+
+test(`Current version transformer snapshot test`, () => {
+  const schema = transformerVersionSnapshot(TRANSFORM_CURRENT_VERSION);
+  expect(schema).toMatchSnapshot();
+});
+
+test('DynamoDB transformer should add default primary key when not defined', () => {
+  const validSchema = `
+  type Post @relayModel{
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toBeDefined();
+  const schema = parse(result.schema);
+
+  const createPostInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+    d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreatePostInput',
+  ) as InputObjectTypeDefinitionNode | undefined;
+  expect(createPostInput).toBeDefined();
+  const defaultIdField: InputValueDefinitionNode = createPostInput.fields.find(f => f.name.value === 'id');
+  expect(defaultIdField).toBeDefined();
+  expect(getBaseType(defaultIdField.type)).toEqual('ID');
+});
+
+test('DynamoDB transformer should not add default primary key when ID is defined', () => {
+  const validSchema = `
+  type Post @relayModel{
+    id: Int
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const result = transformer.transform(validSchema);
+  expect(result).toBeDefined();
+  expect(result.schema).toBeDefined();
+  expect(result.schema).toBeDefined();
+  const schema = parse(result.schema);
+
+  const createPostInput: InputObjectTypeDefinitionNode = schema.definitions.find(
+    d => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'CreatePostInput',
+  ) as InputObjectTypeDefinitionNode | undefined;
+  expect(createPostInput).toBeDefined();
+  const defaultIdField: InputValueDefinitionNode = createPostInput.fields.find(f => f.name.value === 'id');
+  expect(defaultIdField).toBeDefined();
+  expect(getBaseType(defaultIdField.type)).toEqual('Int');
+  // It should not add default value for ctx.arg.id as id is of type Int
+  expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+});
+
+test('DynamoDB transformer should throw for reserved type name usage', () => {
+  const invalidSchema = `
+  type Subscription @relayModel{
+    id: Int
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+  });
+  expect(() => transformer.transform(invalidSchema)).toThrowError(
+    "Subscription' is a reserved type name and currently in use within the default schema element.",
+  );
+});
+
+test('Schema should compile successfully when subscription is missing from schema', () => {
+  const validSchema = `
+  type Post @relayModel {
+    id: Int
+    str: String
+  }
+
+  type Query {
+    Custom: String
+  }
+
+  schema {
+    query: Query
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const parsed = parse(out.schema);
+  const subscriptionType = getObjectType(parsed, 'Subscription');
+  expect(subscriptionType).toBeDefined();
+  expectFields(subscriptionType, ['onCreatePost', 'onUpdatePost', 'onDeletePost']);
+  const mutationType = getObjectType(parsed, 'Mutation');
+  expect(mutationType).toBeDefined();
+  expectFields(mutationType, ['createPost', 'updatePost', 'deletePost']);
+});
+
+test('Should not validate reserved type names when validateTypeNameReservedWords is off', () => {
+  const schema = `
+  type Subscription @relayModel{
+    id: Int
+    str: String
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags: {
+      getBoolean: jest.fn().mockImplementation(name => (name === 'validateTypeNameReservedWords' ? false : undefined)),
+    } as unknown as FeatureFlagProvider,
+  });
+  const out = transformer.transform(schema);
+  expect(out).toBeDefined();
+  const parsed = parse(out.schema);
+  const subscriptionType = getObjectType(parsed, 'Subscription');
+  expect(subscriptionType).toBeDefined();
+});
+
+function transformerVersionSnapshot(version: number): string {
+  const validSchema = `
+        type Post @relayModel
+        {
+          id: ID!
+          content: String
+        }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: version,
+    },
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  return out.schema;
+}
+
+function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeDefined();
+  }
+}
+
+function expectFieldsOnInputType(type: InputObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: InputValueDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeDefined();
+  }
+}
+
+function getFieldOnInputType(type: InputObjectTypeDefinitionNode, field: string): InputValueDefinitionNode {
+  return type.fields.find((f: InputValueDefinitionNode) => f.name.value === field);
+}
+
+function getFieldOnObjectType(type: ObjectTypeDefinitionNode, field: string): FieldDefinitionNode {
+  return type.fields.find((f: FieldDefinitionNode) => f.name.value === field);
+}
+
+function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    expect(type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)).toBeUndefined();
+  }
+}
+
+function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | ObjectTypeDefinitionNode
+    | undefined;
+}
+
+function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | InputObjectTypeDefinitionNode
+    | undefined;
+}
+
+function verifyInputCount(doc: DocumentNode, type: string, count: number): boolean {
+  return doc.definitions.filter(def => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type).length == count;
+}
+
+function verifyMatchingTypes(t1: TypeNode, t2: TypeNode): boolean {
+  if (t1.kind !== t2.kind) {
+    return false;
+  }
+
+  if (t1.kind !== Kind.NAMED_TYPE && t2.kind !== Kind.NAMED_TYPE) {
+    verifyMatchingTypes(t1.type, t2.type);
+  } else {
+    return false;
+  }
+}

--- a/packages/graphql-relay-transformer/src/__tests__/ModelRelayConnectionTransformer.test.ts
+++ b/packages/graphql-relay-transformer/src/__tests__/ModelRelayConnectionTransformer.test.ts
@@ -1,0 +1,778 @@
+import {
+  ObjectTypeDefinitionNode,
+  parse,
+  FieldDefinitionNode,
+  DocumentNode,
+  DefinitionNode,
+  Kind,
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+} from 'graphql';
+import { GraphQLTransform, TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
+import { ResolverResourceIDs, ModelResourceIDs, ResourceConstants } from 'graphql-transformer-common';
+import { DynamoDBRelayModelTransformer } from '../model/DynamoDBRelayModelTransformer';
+import { ModelRelayConnectionTransformer } from '../connection/ModelRelayConnectionTransformer';
+const featureFlags = {
+  getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+    if (name === 'improvePluralization') {
+      return true;
+    }
+    return;
+  }),
+  getNumber: jest.fn(),
+  getObject: jest.fn(),
+  getString: jest.fn(),
+};
+
+test('Test ModelRelayConnectionTransformer simple one to many happy case', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  // Post.comments field
+  const postType = getObjectType(schemaDoc, 'Post');
+  expectFields(postType, ['comments']);
+  const commentField = postType.fields.find(f => f.name.value === 'comments');
+  expect(commentField.arguments.length).toEqual(4);
+  expectArguments(commentField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(commentField.type.kind).toEqual(Kind.NAMED_TYPE);
+  expect((commentField.type as any).name.value).toEqual('ModelCommentConnection');
+
+  // Check the Comment.commentPostId
+  // Check the Comment.commentPostId inputs
+  const commentCreateInput = getInputType(schemaDoc, ModelResourceIDs.ModelCreateInputObjectName('Comment'));
+  const connectionId = commentCreateInput.fields.find(f => f.name.value === 'postCommentsId');
+  expect(connectionId).toBeTruthy();
+
+  const commentUpdateInput = getInputType(schemaDoc, ModelResourceIDs.ModelUpdateInputObjectName('Comment'));
+  const connectionUpdateId = commentUpdateInput.fields.find(f => f.name.value === 'postCommentsId');
+  expect(connectionUpdateId).toBeTruthy();
+});
+
+test('Test ModelRelayConnectionTransformer simple one to many happy case with custom keyField', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(keyField: "postId")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  // Post.comments field
+  const postType = getObjectType(schemaDoc, 'Post');
+  expectFields(postType, ['comments']);
+  const commentField = postType.fields.find(f => f.name.value === 'comments');
+  expect(commentField.arguments.length).toEqual(4);
+  expectArguments(commentField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(commentField.type.kind).toEqual(Kind.NAMED_TYPE);
+  expect((commentField.type as any).name.value).toEqual('ModelCommentConnection');
+
+  // Check the Comment.commentPostId
+  // Check the Comment.commentPostId inputs
+  const commentCreateInput = getInputType(schemaDoc, ModelResourceIDs.ModelCreateInputObjectName('Comment'));
+  const connectionId = commentCreateInput.fields.find(f => f.name.value === 'postId');
+  expect(connectionId).toBeTruthy();
+
+  const commentUpdateInput = getInputType(schemaDoc, ModelResourceIDs.ModelUpdateInputObjectName('Comment'));
+  const connectionUpdateId = commentUpdateInput.fields.find(f => f.name.value === 'postId');
+  expect(connectionUpdateId).toBeTruthy();
+});
+
+test('Test that ModelRelayConnection Transformer throws error when the field in connection is not found in the related Type', () => {
+  const invalidSchema = `
+  type Post @relayModel {
+    name: String!
+    teamID: ID!
+    team: Team @relayConnection(fields: ["teamID"])
+  }
+
+  type Team @relayModel {
+    name: [String!]!
+  }
+  `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  try {
+    transformer.transform(invalidSchema);
+    expect(true).toEqual(false);
+  } catch (e) {
+    console.log(e);
+    expect(e).toBeTruthy();
+    expect(e.name).toEqual('InvalidDirectiveError');
+  }
+});
+
+test('Test ModelRelayConnectionTransformer simple one to many happy case with custom keyField', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+        comments: [Comment] @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String!
+        post: Post! @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  // Post.comments field
+  const postType = getObjectType(schemaDoc, 'Post');
+  expectFields(postType, ['comments']);
+  const commentField = postType.fields.find(f => f.name.value === 'comments');
+  expect(commentField.arguments.length).toEqual(4);
+  expectArguments(commentField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(commentField.type.kind).toEqual(Kind.NAMED_TYPE);
+  expect((commentField.type as any).name.value).toEqual('ModelCommentConnection');
+
+  // Check the Comment.commentPostId
+  // Check the Comment.commentPostId inputs
+  const commentCreateInput = getInputType(schemaDoc, ModelResourceIDs.ModelCreateInputObjectName('Comment'));
+  const connectionId = commentCreateInput.fields.find(f => f.name.value === 'postId');
+  expect(connectionId).toBeTruthy();
+  expect(connectionId.type.kind).toEqual(Kind.NON_NULL_TYPE);
+
+  const commentUpdateInput = getInputType(schemaDoc, ModelResourceIDs.ModelUpdateInputObjectName('Comment'));
+  const connectionUpdateId = commentUpdateInput.fields.find(f => f.name.value === 'postId');
+  expect(connectionUpdateId).toBeTruthy();
+  expect(connectionUpdateId.type.kind).toEqual(Kind.NAMED_TYPE);
+});
+
+test('Test ModelRelayConnectionTransformer complex one to many happy case', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "PostComments")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+        post: Post @relayConnection(name: "PostComments")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Comment', 'post')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+  const postType = getObjectType(schemaDoc, 'Post');
+  const commentType = getObjectType(schemaDoc, 'Comment');
+
+  // Check Post.comments field
+  expectFields(postType, ['comments']);
+  const commentField = postType.fields.find(f => f.name.value === 'comments');
+  expect(commentField.arguments.length).toEqual(4);
+  expectArguments(commentField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(commentField.type.kind).toEqual(Kind.NAMED_TYPE);
+  expect((commentField.type as any).name.value).toEqual('ModelCommentConnection');
+
+  // Check the Comment.commentPostId inputs
+  const commentCreateInput = getInputType(schemaDoc, ModelResourceIDs.ModelCreateInputObjectName('Comment'));
+  const connectionId = commentCreateInput.fields.find(f => f.name.value === 'commentPostId');
+  expect(connectionId).toBeTruthy();
+
+  const commentUpdateInput = getInputType(schemaDoc, ModelResourceIDs.ModelUpdateInputObjectName('Comment'));
+  const connectionUpdateId = commentUpdateInput.fields.find(f => f.name.value === 'commentPostId');
+  expect(connectionUpdateId).toBeTruthy();
+
+  // Check Comment.post field
+  const postField = commentType.fields.find(f => f.name.value === 'post');
+  expect(postField.arguments.length).toEqual(0);
+  expect(postField.type.kind).toEqual(Kind.NAMED_TYPE);
+  expect((postField.type as any).name.value).toEqual('Post');
+});
+
+test('Test ModelRelayConnectionTransformer many to many should fail', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "ManyToMany")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+        posts: [Post] @relayConnection(name: "ManyToMany")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  try {
+    transformer.transform(validSchema);
+    expect(true).toEqual(false);
+  } catch (e) {
+    // Should throw bc we don't let support many to many
+    expect(e).toBeTruthy();
+    expect(e.name).toEqual('InvalidDirectiveError');
+  }
+});
+
+test('Test ModelRelayConnectionTransformer many to many should fail due to missing other "name"', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "ManyToMany")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # This is meant to be the other half of "ManyToMany" but I forgot.
+        posts: [Post] @relayConnection
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  try {
+    transformer.transform(validSchema);
+    expect(true).toEqual(false);
+  } catch (e) {
+    // Should throw bc we check both halves when name is given
+    expect(e).toBeTruthy();
+    expect(e.name).toEqual('InvalidDirectiveError');
+  }
+});
+
+test('Test ModelRelayConnectionTransformer many to many should fail due to missing other "name"', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        things: [Thing!] @relayConnection
+    }
+
+    type Thing @relayModel(queries: null, mutations: null) {
+        id: ID!
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'things')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+  const postType = getObjectType(schemaDoc, 'Post');
+  const postConnection = getObjectType(schemaDoc, 'ModelPostConnection');
+  const thingConnection = getObjectType(schemaDoc, 'ModelThingConnection');
+  const thingEdge = getObjectType(schemaDoc, 'ModelThingEdge');
+  const thingFilterInput = getInputType(schemaDoc, 'ModelThingFilterInput');
+  expect(thingFilterInput).toBeDefined();
+  expect(postType).toBeDefined();
+  expect(thingConnection).toBeDefined();
+  expect(thingEdge).toBeDefined();
+  expect(postConnection).toBeDefined();
+});
+
+test('Test ModelRelayConnectionTransformer with non null @relayConnections', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+        comments: [Comment] @relayConnection(name: "PostComments", keyField: "postId")
+
+        # A non null on the one in a 1-M does enforce a non-null
+        # on the CreatePostInput
+        singleComment: Comment! @relayConnection
+
+        # A non null on the many in a 1-M does not enforce a non-null
+        # in the CommentCreateInput because it is not explicitly implied.
+        manyComments: [Comment]! @relayConnection
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String!
+
+        # A non-null on the one in 1-M again enforces a non null.
+        post: Post! @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  // Post.comments field
+  const postType = getObjectType(schemaDoc, 'Post');
+  expectFields(postType, ['comments']);
+  const commentField = postType.fields.find(f => f.name.value === 'comments');
+  expect(commentField.arguments.length).toEqual(4);
+  expectArguments(commentField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(commentField.type.kind).toEqual(Kind.NAMED_TYPE);
+  expect((commentField.type as any).name.value).toEqual('ModelCommentConnection');
+
+  // Check the Comment.commentPostId
+  // Check the Comment.commentPostId inputs
+  const commentCreateInput = getInputType(schemaDoc, ModelResourceIDs.ModelCreateInputObjectName('Comment'));
+  const connectionId = commentCreateInput.fields.find(f => f.name.value === 'postId');
+  expect(connectionId).toBeTruthy();
+  expect(connectionId.type.kind).toEqual(Kind.NON_NULL_TYPE);
+
+  const manyCommentId = commentCreateInput.fields.find(f => f.name.value === 'postManyCommentsId');
+  expect(manyCommentId).toBeTruthy();
+  expect(manyCommentId.type.kind).toEqual(Kind.NAMED_TYPE);
+
+  const commentUpdateInput = getInputType(schemaDoc, ModelResourceIDs.ModelUpdateInputObjectName('Comment'));
+  const connectionUpdateId = commentUpdateInput.fields.find(f => f.name.value === 'postId');
+  expect(connectionUpdateId).toBeTruthy();
+  expect(connectionUpdateId.type.kind).toEqual(Kind.NAMED_TYPE);
+
+  // Check the post create type
+  const postCreateInput = getInputType(schemaDoc, ModelResourceIDs.ModelCreateInputObjectName('Post'));
+  const postConnectionId = postCreateInput.fields.find(f => f.name.value === 'postSingleCommentId');
+  expect(postConnectionId).toBeTruthy();
+  expect(postConnectionId.type.kind).toEqual(Kind.NON_NULL_TYPE);
+});
+
+test('Test ModelRelayConnectionTransformer with sortField fails if not specified in associated type', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "PostComments", sortField: "createdAt")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+        post: Post @relayConnection(name: "PostComments")
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  expect(() => {
+    transformer.transform(validSchema);
+  }).toThrowError();
+});
+
+test('Test ModelRelayConnectionTransformer with sortField creates a connection resolver with a sort key condition.', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "PostComments", sortField: "createdAt")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+        post: Post @relayConnection(name: "PostComments", sortField: "createdAt")
+        createdAt: AWSDateTime
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  // Post.comments field
+  const postType = getObjectType(schemaDoc, 'Post');
+  expectFields(postType, ['comments']);
+  const commentField = postType.fields.find(f => f.name.value === 'comments');
+  expect(commentField.arguments.length).toEqual(5);
+  expectArguments(commentField, ['createdAt', 'filter', 'first', 'after', 'sortDirection']);
+});
+
+test('Test ModelRelayConnectionTransformer throws with invalid key fields', () => {
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const invalidSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(keyField: "postId")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # Key fields must be String or ID.
+        postId: [String]
+    }
+    `;
+  expect(() => transformer.transform(invalidSchema)).toThrow();
+
+  const invalidSchema2 = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # Key fields must be String or ID.
+        postId: [String]
+
+        post: Post @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    `;
+  expect(() => transformer.transform(invalidSchema2)).toThrow();
+
+  const invalidSchema3 = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # Key fields must be String or ID.
+        postId: [String]
+
+        post: Post @relayConnection(keyField: "postId")
+    }
+    `;
+  expect(() => transformer.transform(invalidSchema3)).toThrow();
+});
+
+test('Test ModelRelayConnectionTransformer does not throw with valid key fields', () => {
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(keyField: "postId")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # Key fields must be String or ID.
+        postId: String
+    }
+    `;
+  expect(() => transformer.transform(validSchema)).toBeTruthy();
+
+  const validSchema2 = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # Key fields must be String or ID.
+        postId: ID
+
+        post: Post @relayConnection(name: "PostComments", keyField: "postId")
+    }
+    `;
+  expect(() => transformer.transform(validSchema2)).toBeTruthy();
+
+  const validSchema3 = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+
+        # Key fields must be String or ID.
+        postId: String
+
+        post: Post @relayConnection(keyField: "postId")
+    }
+    `;
+  expect(() => transformer.transform(validSchema3)).toBeTruthy();
+});
+
+test('Test ModelRelayConnectionTransformer sortField with missing @key should fail', () => {
+  const validSchema = `
+    type Model1 @relayModel(subscriptions: null)
+    {
+        id: ID!
+        sort: Int!
+        name: String!
+    }
+    type Model2 @relayModel(subscriptions: null)
+    {
+        id: ID!
+        connection: Model1 @relayConnection(sortField: "modelOneSort")
+        modelOneSort: Int!
+    }
+        `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  try {
+    transformer.transform(validSchema);
+    expect(true).toEqual(false);
+  } catch (e) {
+    expect(e).toBeTruthy();
+    expect(e.name).toEqual('InvalidDirectiveError');
+  }
+});
+
+test('Test ModelRelayConnectionTransformer overrides the default limit', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(limit: 50)
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+
+  // Post.comments field
+  expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 50) )');
+});
+
+test('Test ModelRelayConnectionTransformer uses the default limit', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+
+  // Post.comments field
+  expect(out.resolvers['Post.comments.req.vtl']).toContain(
+    `#set( $limit = $util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT}) )`,
+  );
+});
+
+test('Test ModelRelayConnectionTransformer with keyField overrides the default limit', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(limit: 50, fields: ["id"])
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+
+  // Post.comments field
+  expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 50) )');
+});
+
+test('Test ModelRelayConnectionTransformer with keyField uses the default limit', () => {
+  const validSchema = `
+    type Post @relayModel {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection(fields: ["id"])
+    }
+    type Comment @relayModel {
+        id: ID!
+        content: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'comments')]).toBeTruthy();
+
+  // Post.comments field
+  expect(out.resolvers['Post.comments.req.vtl']).toContain(
+    `#set( $limit = $util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT}) )`,
+  );
+});
+
+test('Connection on models with no codegen includes AttributeTypeEnum', () => {
+  const validSchema = `
+    type Post @relayModel(queries: null, mutations: null, subscriptions: null) {
+        id: ID!
+        title: String!
+        comments: [Comment] @relayConnection
+    }
+    type Comment @relayModel(queries: null, mutations: null, subscriptions: null) {
+        id: ID!
+        content: String
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: TRANSFORM_CURRENT_VERSION,
+    },
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  expect(out.schema).toMatchSnapshot();
+});
+
+test('Connection on models with no codegen includes custom enum filters', () => {
+  const validSchema = `
+    type Cart @relayModel(queries: null, mutations: null, subscriptions: null) {
+      id: ID!,
+      cartItems: [CartItem] @relayConnection(name: "CartCartItem")
+    }
+
+    type CartItem @relayModel(queries: null, mutations: null, subscriptions: null) {
+      id: ID!
+      productType: PRODUCT_TYPE!
+      cart: Cart @relayConnection(name: "CartCartItem")
+    }
+
+    enum PRODUCT_TYPE {
+      UNIT
+      PACKAGE
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: TRANSFORM_CURRENT_VERSION,
+    },
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toMatchSnapshot();
+});
+
+function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeDefined();
+  }
+}
+
+function expectArguments(field: FieldDefinitionNode, args: string[]) {
+  for (const argName of args) {
+    const foundArg = field.arguments.find((a: InputValueDefinitionNode) => a.name.value === argName);
+    expect(foundArg).toBeDefined();
+  }
+}
+
+function doNotExpectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    expect(type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName)).toBeUndefined();
+  }
+}
+
+function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | ObjectTypeDefinitionNode
+    | undefined;
+}
+
+function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | InputObjectTypeDefinitionNode
+    | undefined;
+}
+
+function verifyInputCount(doc: DocumentNode, type: string, count: number): boolean {
+  return doc.definitions.filter(def => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type).length === count;
+}

--- a/packages/graphql-relay-transformer/src/__tests__/NewRelayConnectionTransformer.test.ts
+++ b/packages/graphql-relay-transformer/src/__tests__/NewRelayConnectionTransformer.test.ts
@@ -1,0 +1,695 @@
+import {
+  ObjectTypeDefinitionNode,
+  parse,
+  FieldDefinitionNode,
+  DocumentNode,
+  DefinitionNode,
+  Kind,
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+} from 'graphql';
+import { GraphQLTransform, ConflictHandlerType, TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
+import { ResolverResourceIDs } from 'graphql-transformer-common';
+import { ModelRelayConnectionTransformer } from '../connection/ModelRelayConnectionTransformer';
+import { DynamoDBRelayModelTransformer } from '../model/DynamoDBRelayModelTransformer';
+import { KeyTransformer } from 'graphql-key-transformer';
+const featureFlags = {
+  getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+    if (name === 'improvePluralization') {
+      return true;
+    }
+    return;
+  }),
+  getNumber: jest.fn(),
+  getObject: jest.fn(),
+  getString: jest.fn(),
+};
+
+test('ModelConnectionTransformer should fail if connection was called on an object that is not a Model type.', () => {
+  const validSchema = `
+    type Test {
+        id: ID!
+        email: String!
+        testObj: Test1 @relayConnection(fields: ["email"])
+    }
+
+    type Test1 @relayModel {
+        id: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError(`@relayConnection must be on an @relayModel object type field.`);
+});
+
+test('ModelConnectionTransformer should fail if connection was with an object that is not a Model type.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: Test1 @relayConnection(fields: ["email"])
+    }
+
+    type Test1 {
+        id: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError(`Object type Test1 must be annotated with @relayModel.`);
+});
+
+test('ModelConnectionTransformer should fail if the field type where the directive is called is incorrect.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: Test2 @relayConnection(fields: ["email"])
+    }
+
+    type Test1 @relayModel {
+        id: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('Unknown type "Test2". Did you mean "Test" or "Test1"?');
+});
+
+test('ModelConnectionTransformer should fail if an empty list of fields is passed in.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String
+        testObj: Test1 @relayConnection(fields: [])
+    }
+
+    type Test1 @relayModel {
+        id: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('No fields passed in to @relayConnection directive.');
+});
+
+test('ModelConnectionTransformer should fail if any of the fields passed in are not in the Parent model.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String
+        testObj: [Test1] @relayConnection(fields: ["id", "name"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "name"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('name is not a field in Test');
+});
+
+test('ModelConnectionTransformer should fail if the query is not run on the default table when connection is trying to connect a single object.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String
+        testObj: Test1 @relayConnection(keyName: "notDefault", fields: ["id"])
+    }
+
+    type Test1
+        @relayModel
+        @key(name: "notDefault", fields: ["friendID"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError(
+    'Connection is to a single object but the keyName notDefault was provided which does not reference the default table.',
+  );
+});
+
+test('ModelConnectionTransformer should fail if keyName provided does not exist.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String
+        testObj: [Test1] @relayConnection(keyName: "notDefault", fields: ["id"])
+    }
+
+    type Test1 @relayModel {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('Key notDefault does not exist for model Test1');
+});
+
+test('ModelConnectionTransformer should fail if first field does not match PK of table. (When using default table)', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: Test1 @relayConnection(fields: ["email"])
+    }
+
+    type Test1 @relayModel {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('email field is not of type ID');
+});
+
+test('ModelConnectionTransformer should fail if sort key type passed in does not match default table sort key type.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: [Test1] @relayConnection(fields: ["id", "email"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "friendID"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('email field is not of type ID');
+});
+
+test('ModelConnectionTransformer should fail if partial sort key is passed in connection.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: [Test1] @relayConnection(keyName: "testIndex", fields: ["id", "email"])
+    }
+
+    type Test1
+        @relayModel
+        @key(name: "testIndex", fields: ["id", "friendID", "name"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError(
+    'Invalid @relayConnection directive  testObj. fields does not accept partial sort key',
+  );
+});
+
+test('ModelConnectionTransformer should accept connection without sort key', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: [Test1] @relayConnection(keyName: "testIndex", fields: ["id"])
+    }
+
+    type Test1
+        @relayModel
+        @key(name: "testIndex", fields: ["id", "friendID", "name"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).not.toThrowError();
+});
+
+test('ModelConnectionTransformer should fail if sort key type passed in does not match custom index sort key type.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: [Test1] @relayConnection(keyName: "testIndex", fields: ["id", "email"])
+    }
+
+    type Test1
+        @relayModel
+        @key(name: "testIndex", fields: ["id", "friendID"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('email field is not of type ID');
+});
+
+test('ModelConnectionTransformer should fail if partition key type passed in does not match custom index partition key type.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        testObj: [Test1] @relayConnection(keyName: "testIndex", fields: ["email", "id"])
+    }
+
+    type Test1
+        @relayModel
+        @key(name: "testIndex", fields: ["id", "friendID"])
+    {
+        id: ID!
+        friendID: ID!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  expect(() => transformer.transform(validSchema)).toThrowError('email field is not of type ID');
+});
+
+test('Test ModelConnectionTransformer for One-to-One getItem case.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        otherHalf: Test1 @relayConnection(fields: ["id", "email"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "email"])
+    {
+        id: ID!
+        friendID: ID!
+        email: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Test', 'otherHalf')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  const testObjType = getObjectType(schemaDoc, 'Test');
+  expectFields(testObjType, ['otherHalf']);
+  const relatedField = testObjType.fields.find(f => f.name.value === 'otherHalf');
+  expect(relatedField.type.kind).toEqual(Kind.NAMED_TYPE);
+});
+
+test('Test ModelConnectionTransformer for One-to-Many query case.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        otherParts: [Test1] @relayConnection(fields: ["id", "email"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "email"])
+    {
+        id: ID!
+        friendID: ID!
+        email: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Test', 'otherParts')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  const testObjType = getObjectType(schemaDoc, 'Test');
+  expectFields(testObjType, ['otherParts']);
+  const relatedField = testObjType.fields.find(f => f.name.value === 'otherParts');
+
+  expect(relatedField.arguments.length).toEqual(4);
+  expectArguments(relatedField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(relatedField.type.kind).toEqual(Kind.NAMED_TYPE);
+
+  expect((relatedField.type as any).name.value).toEqual('ModelTest1Connection');
+});
+
+test('Test ModelConnectionTransformer for bidirectional One-to-Many query case.', () => {
+  const validSchema = `
+    type Post
+        @relayModel
+        @key(name: "byOwner", fields: ["owner", "id"])
+    {
+        id: ID!
+        title: String!
+        author: User @relayConnection(fields: ["owner"])
+        owner: ID!
+    }
+    type User @relayModel {
+        id: ID!
+        posts: [Post] @relayConnection(keyName: "byOwner", fields: ["id"])
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Post', 'author')]).toBeTruthy();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('User', 'posts')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  const userType = getObjectType(schemaDoc, 'User');
+  expectFields(userType, ['posts']);
+  const postsField = userType.fields.find(f => f.name.value === 'posts');
+
+  expect(postsField.arguments.length).toEqual(5);
+  expectArguments(postsField, ['id', 'filter', 'first', 'after', 'sortDirection']);
+  expect(postsField.type.kind).toEqual(Kind.NAMED_TYPE);
+
+  expect((postsField.type as any).name.value).toEqual('ModelPostConnection');
+
+  const postType = getObjectType(schemaDoc, 'Post');
+  expectFields(postType, ['author']);
+  const userField = postType.fields.find(f => f.name.value === 'author');
+  expect(userField.type.kind).toEqual(Kind.NAMED_TYPE);
+});
+
+test('Test ModelConnectionTransformer for One-to-Many query with a composite sort key.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        name: String!
+        otherParts: [Test1] @relayConnection(fields: ["id", "email", "name"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "email", "name"])
+    {
+        id: ID!
+        friendID: ID!
+        email: String!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Test', 'otherParts')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  const testObjType = getObjectType(schemaDoc, 'Test');
+  expectFields(testObjType, ['otherParts']);
+  const relatedField = testObjType.fields.find(f => f.name.value === 'otherParts');
+
+  expect(relatedField.arguments.length).toEqual(4);
+  expectArguments(relatedField, ['filter', 'first', 'after', 'sortDirection']);
+  expect(relatedField.type.kind).toEqual(Kind.NAMED_TYPE);
+
+  expect((relatedField.type as any).name.value).toEqual('ModelTest1Connection');
+});
+test('Test ModelConnectionTransformer for One-to-Many query with a composite sort key passed in as an argument.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        name: String!
+        otherParts: [Test1] @relayConnection(fields: ["id"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "email", "name"])
+    {
+        id: ID!
+        friendID: ID!
+        email: String!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Test', 'otherParts')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  const testObjType = getObjectType(schemaDoc, 'Test');
+  expectFields(testObjType, ['otherParts']);
+  const relatedField = testObjType.fields.find(f => f.name.value === 'otherParts');
+
+  expect(relatedField.arguments.length).toEqual(5);
+  expectArguments(relatedField, ['emailName', 'filter', 'first', 'after', 'sortDirection']);
+  expect(relatedField.type.kind).toEqual(Kind.NAMED_TYPE);
+
+  expect((relatedField.type as any).name.value).toEqual('ModelTest1Connection');
+});
+
+test('Test ModelConnectionTransformer for One-to-One getItem with composite sort key.', () => {
+  const validSchema = `
+    type Test @relayModel {
+        id: ID!
+        email: String!
+        name: String!
+        otherHalf: Test1 @relayConnection(fields: ["id", "email", "name"])
+    }
+
+    type Test1
+        @relayModel
+        @key(fields: ["id", "email", "name"])
+    {
+        id: ID!
+        friendID: ID!
+        email: String!
+        name: String!
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks.RelayConnectionStack.Resources[ResolverResourceIDs.ResolverResourceID('Test', 'otherHalf')]).toBeTruthy();
+  const schemaDoc = parse(out.schema);
+
+  const testObjType = getObjectType(schemaDoc, 'Test');
+  expectFields(testObjType, ['otherHalf']);
+  const relatedField = testObjType.fields.find(f => f.name.value === 'otherHalf');
+  expect(relatedField.type.kind).toEqual(Kind.NAMED_TYPE);
+});
+
+test('Many-to-many without conflict resolution generates correct schema', () => {
+  const validSchema = `
+    type Post @relayModel {
+      id: ID!
+      title: String!
+      editors: [PostEditor] @relayConnection(keyName: "byPost", fields: ["id"])
+    }
+
+    # Create a join model and disable queries as you don't need them
+    # and can query through Post.editors and User.posts
+    type PostEditor
+      @relayModel(queries: null)
+      @key(name: "byPost", fields: ["postID", "editorID"])
+      @key(name: "byEditor", fields: ["editorID", "postID"]) {
+      id: ID!
+      postID: ID!
+      editorID: ID!
+      post: Post! @relayConnection(fields: ["postID"])
+      editor: User! @relayConnection(fields: ["editorID"])
+    }
+
+    type User @relayModel {
+      id: ID!
+      username: String!
+      posts: [PostEditor] @relayConnection(keyName: "byEditor", fields: ["id"])
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: TRANSFORM_CURRENT_VERSION,
+    },
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  expect(out.schema).toMatchSnapshot();
+});
+
+test('Many-to-many with conflict resolution generates correct schema', () => {
+  const validSchema = `
+    type Post @relayModel {
+      id: ID!
+      title: String!
+      editors: [PostEditor] @relayConnection(keyName: "byPost", fields: ["id"])
+    }
+
+    # Create a join model and disable queries as you don't need them
+    # and can query through Post.editors and User.posts
+    type PostEditor
+      @relayModel(queries: null)
+      @key(name: "byPost", fields: ["postID", "editorID"])
+      @key(name: "byEditor", fields: ["editorID", "postID"]) {
+      id: ID!
+      postID: ID!
+      editorID: ID!
+      post: Post! @relayConnection(fields: ["postID"])
+      editor: User! @relayConnection(fields: ["editorID"])
+    }
+
+    type User @relayModel {
+      id: ID!
+      username: String!
+      posts: [PostEditor] @relayConnection(keyName: "byEditor", fields: ["id"])
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBRelayModelTransformer(), new KeyTransformer(), new ModelRelayConnectionTransformer()],
+    featureFlags,
+    transformConfig: {
+      Version: TRANSFORM_CURRENT_VERSION,
+      ResolverConfig: {
+        project: {
+          ConflictHandler: ConflictHandlerType.AUTOMERGE,
+          ConflictDetection: 'VERSION',
+        },
+      },
+    },
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  expect(out.schema).toMatchSnapshot();
+});
+
+function getInputType(doc: DocumentNode, type: string): InputObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | InputObjectTypeDefinitionNode
+    | undefined;
+}
+
+// Taken from ModelConnectionTransformer.test.ts
+function getObjectType(doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined {
+  return doc.definitions.find((def: DefinitionNode) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | ObjectTypeDefinitionNode
+    | undefined;
+}
+
+function expectFields(type: ObjectTypeDefinitionNode, fields: string[]) {
+  for (const fieldName of fields) {
+    const foundField = type.fields.find((f: FieldDefinitionNode) => f.name.value === fieldName);
+    expect(foundField).toBeDefined();
+  }
+}
+
+function expectArguments(field: FieldDefinitionNode, args: string[]) {
+  for (const argName of args) {
+    const foundArg = field.arguments.find((a: InputValueDefinitionNode) => a.name.value === argName);
+    expect(foundArg).toBeDefined();
+  }
+}

--- a/packages/graphql-relay-transformer/src/__tests__/__snapshots__/DynamoDBRelayModelTransformer.test.ts.snap
+++ b/packages/graphql-relay-transformer/src/__tests__/__snapshots__/DynamoDBRelayModelTransformer.test.ts.snap
@@ -1,0 +1,1842 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Current version transformer snapshot test 1`] = `
+"type Post {
+  id: ID!
+  content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPostFilterInput {
+  id: ModelIDInput
+  content: ModelStringInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  content: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  content: String
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
+}
+
+input ModelPostConditionInput {
+  content: ModelStringInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`DynamoDB transformer should not add default primary key when ID is defined 1`] = `
+"## [Start] Set default values. **
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+#end
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 1`] = `
+"type Post {
+  id: ID!
+  str: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  createdAt: ModelStringFilterInput
+  updatedAt: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+  createdAt: AWSDateTime
+  updatedAt: AWSDateTime
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+  createdAt: AWSDateTime
+  updatedAt: AWSDateTime
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 2`] = `
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdAt\\", $util.defaultIfNull($ctx.args.input.createdAt, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $createdAt)))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+#end
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test create and update mutation input should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
+"#set( $optionalNonNullableFields = [\\"createdAt\\", \\"updatedAt\\"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedAt\\", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 1`] = `
+"type Post {
+  id: ID!
+  str: String
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 2`] = `
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+#end
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
+"#set( $optionalNonNullableFields = [] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test only get does not generate superfluous input and filter types 1`] = `
+"type Entity {
+  id: ID!
+  str: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type Query {
+  getEntity(id: ID!): Entity
+}
+"
+`;
+
+exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 1`] = `
+"type Post {
+  id: ID!
+  str: String
+  createdAt: AWSTimestamp
+  updatedAt: AWSTimestamp
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  createdAt: ModelIntFilterInput
+  updatedAt: ModelIntFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+  createdAt: AWSTimestamp
+  updatedAt: AWSTimestamp
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+  createdAt: AWSTimestamp
+  updatedAt: AWSTimestamp
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 2`] = `
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+#end
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test resolver template not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
+"#set( $optionalNonNullableFields = [] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`Test schema includes attribute enum when only queries specified 1`] = `
+"type Entity {
+  id: ID!
+  str: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelEntityConnection {
+  edges: [ModelEntityEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelEntityFilterInput {
+  id: ModelIDInput
+  str: ModelStringInput
+  and: [ModelEntityFilterInput]
+  or: [ModelEntityFilterInput]
+  not: ModelEntityFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  getEntity(id: ID!): Entity
+  listEntities(filter: ModelEntityFilterInput, first: Int, after: String): ModelEntityConnection
+}
+"
+`;
+
+exports[`Test timestamp parameters when generating resolvers and output schema 1`] = `
+"type Post {
+  id: ID!
+  str: String
+  createdOn: AWSDateTime!
+  updatedOn: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  str: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  str: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  str: String
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`Test timestamp parameters when generating resolvers and output schema 2`] = `
+"## [Start] Set default values. **
+$util.qr($context.args.input.put(\\"id\\", $util.defaultIfNull($ctx.args.input.id, $util.autoId())))
+#set( $createdAt = $util.time.nowISO8601() )
+## Automatically set the createdAt timestamp. **
+$util.qr($context.args.input.put(\\"createdOn\\", $util.defaultIfNull($ctx.args.input.createdOn, $createdAt)))
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $createdAt)))
+## [End] Set default values. **
+## [Start] Prepare DynamoDB PutItem Request. **
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+#if( $modelObjectKey )
+  #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    #if( $velocityCount == 1 )
+      $util.qr($condition.put(\\"expression\\", \\"attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #else
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_not_exists(#keyCondition$velocityCount)\\"))
+    #end
+    $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+#else
+  #set( $condition = {
+  \\"expression\\": \\"attribute_not_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+#end
+#if( $context.args.condition )
+  #set( $condition.expressionValues = {} )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\":   $util.dynamodb.toDynamoDBJson($ctx.args.input.id)
+} #end,
+  \\"attributeValues\\": $util.dynamodb.toMapValuesJson($context.args.input),
+  \\"condition\\": $util.toJson($condition)
+}
+## [End] Prepare DynamoDB PutItem Request. **"
+`;
+
+exports[`Test timestamp parameters when generating resolvers and output schema 3`] = `
+"#set( $optionalNonNullableFields = [] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
+$util.error(\\"An argument you marked as Non-Null is set to Null in the query or the body of your request.\\")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != \\"\\" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#id)\\"))
+    $util.qr($condition.expressionNames.put(\\"#id\\", \\"id\\"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  \\"expression\\": \\"\\",
+  \\"expressionNames\\": {},
+  \\"expressionValues\\": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put(\\"expression\\", \\"attribute_exists(#keyCondition$velocityCount)\\"))
+      #else
+        $util.qr($condition.put(\\"expression\\", \\"$condition.expression AND attribute_exists(#keyCondition$velocityCount)\\"))
+      #end
+      $util.qr($condition.expressionNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+    #end
+  #else
+    #set( $condition = {
+  \\"expression\\": \\"attribute_exists(#id)\\",
+  \\"expressionNames\\": {
+      \\"#id\\": \\"id\\"
+  },
+  \\"expressionValues\\": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put(\\"updatedOn\\", $util.defaultIfNull($ctx.args.input.updatedOn, $util.time.nowISO8601())))
+$util.qr($context.args.input.put(\\"__typename\\", \\"Post\\"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $versionedCondition.expression\\"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put(\\"expression\\", \\"($condition.expression) AND $conditionFilterExpressions.expression\\"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  \\"expression\\": $condition.expression,
+  \\"expressionNames\\": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  \\"id\\": {
+      \\"S\\": $util.toJson($context.args.input.id)
+  }
+} #end,
+  \\"update\\": $util.toJson($update),
+  \\"condition\\": $util.toJson($condition)
+}"
+`;
+
+exports[`V4 transformer snapshot test 1`] = `
+"type Post {
+  id: ID!
+  content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringFilterInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+}
+
+input ModelIDFilterInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+input ModelIntFilterInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelFloatFilterInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+}
+
+input ModelBooleanFilterInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelPostFilterInput {
+  id: ModelIDFilterInput
+  content: ModelStringFilterInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  content: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  content: String
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!): Post
+  updatePost(input: UpdatePostInput!): Post
+  deletePost(input: DeletePostInput!): Post
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;
+
+exports[`V5 transformer snapshot test 1`] = `
+"type Post {
+  id: ID!
+  content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPostFilterInput {
+  id: ModelIDInput
+  content: ModelStringInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+}
+
+input CreatePostInput {
+  id: ID
+  content: String
+}
+
+input UpdatePostInput {
+  id: ID!
+  content: String
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
+}
+
+input ModelPostConditionInput {
+  content: ModelStringInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+}
+"
+`;

--- a/packages/graphql-relay-transformer/src/__tests__/__snapshots__/ModelRelayConnectionTransformer.test.ts.snap
+++ b/packages/graphql-relay-transformer/src/__tests__/__snapshots__/ModelRelayConnectionTransformer.test.ts.snap
@@ -1,0 +1,265 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Connection on models with no codegen includes AttributeTypeEnum 1`] = `
+"type Post {
+  id: ID!
+  title: String!
+  comments(filter: ModelCommentFilterInput, sortDirection: RelayModelSortDirection, first: Int, after: String): ModelCommentConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type Comment {
+  id: ID!
+  content: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type ModelCommentConnection {
+  edges: [ModelCommentEdge]
+  pageInfo: PageInfo
+}
+
+type ModelCommentEdge {
+  node: Comment
+  cursor: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelCommentFilterInput {
+  id: ModelIDInput
+  content: ModelStringInput
+  and: [ModelCommentFilterInput]
+  or: [ModelCommentFilterInput]
+  not: ModelCommentFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+"
+`;
+
+exports[`Connection on models with no codegen includes custom enum filters 1`] = `
+"type Cart {
+  id: ID!
+  cartItems(filter: ModelCartItemFilterInput, sortDirection: RelayModelSortDirection, first: Int, after: String): ModelCartItemConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type CartItem {
+  id: ID!
+  productType: PRODUCT_TYPE!
+  cart: Cart
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum PRODUCT_TYPE {
+  UNIT
+  PACKAGE
+}
+
+type ModelCartItemConnection {
+  edges: [ModelCartItemEdge]
+  pageInfo: PageInfo
+}
+
+type ModelCartItemEdge {
+  node: CartItem
+  cursor: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPRODUCT_TYPEInput {
+  eq: PRODUCT_TYPE
+  ne: PRODUCT_TYPE
+}
+
+input ModelCartItemFilterInput {
+  id: ModelIDInput
+  productType: ModelPRODUCT_TYPEInput
+  and: [ModelCartItemFilterInput]
+  or: [ModelCartItemFilterInput]
+  not: ModelCartItemFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+"
+`;

--- a/packages/graphql-relay-transformer/src/__tests__/__snapshots__/NewRelayConnectionTransformer.test.ts.snap
+++ b/packages/graphql-relay-transformer/src/__tests__/__snapshots__/NewRelayConnectionTransformer.test.ts.snap
@@ -1,0 +1,574 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Many-to-many with conflict resolution generates correct schema 1`] = `
+"type Post {
+  id: ID!
+  title: String!
+  editors(editorID: ModelIDKeyConditionInput, filter: ModelPostEditorFilterInput, sortDirection: RelayModelSortDirection, first: Int, after: String): ModelPostEditorConnection
+  _version: Int!
+  _deleted: Boolean
+  _lastChangedAt: AWSTimestamp!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type PostEditor {
+  id: ID!
+  postID: ID!
+  editorID: ID!
+  post: Post!
+  editor: User!
+  _version: Int!
+  _deleted: Boolean
+  _lastChangedAt: AWSTimestamp!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type User {
+  id: ID!
+  username: String!
+  posts(postID: ModelIDKeyConditionInput, filter: ModelPostEditorFilterInput, sortDirection: RelayModelSortDirection, first: Int, after: String): ModelPostEditorConnection
+  _version: Int!
+  _deleted: Boolean
+  _lastChangedAt: AWSTimestamp!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+  startedAt: AWSTimestamp
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPostFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  syncPosts(filter: ModelPostFilterInput, first: Int, after: String, lastSync: AWSTimestamp): ModelPostConnection
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+  syncPostEditors(filter: ModelPostEditorFilterInput, first: Int, after: String, lastSync: AWSTimestamp): ModelPostEditorConnection
+  syncUsers(filter: ModelUserFilterInput, first: Int, after: String, lastSync: AWSTimestamp): ModelUserConnection
+  getUser(id: ID!): User
+  listUsers(filter: ModelUserFilterInput, first: Int, after: String): ModelUserConnection
+}
+
+input CreatePostInput {
+  id: ID
+  title: String!
+  _version: Int
+}
+
+input UpdatePostInput {
+  id: ID!
+  title: String
+  _version: Int
+}
+
+input DeletePostInput {
+  id: ID!
+  _version: Int
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
+  createPostEditor(input: CreatePostEditorInput!, condition: ModelPostEditorConditionInput): PostEditor
+  updatePostEditor(input: UpdatePostEditorInput!, condition: ModelPostEditorConditionInput): PostEditor
+  deletePostEditor(input: DeletePostEditorInput!, condition: ModelPostEditorConditionInput): PostEditor
+  createUser(input: CreateUserInput!, condition: ModelUserConditionInput): User
+  updateUser(input: UpdateUserInput!, condition: ModelUserConditionInput): User
+  deleteUser(input: DeleteUserInput!, condition: ModelUserConditionInput): User
+}
+
+input ModelPostConditionInput {
+  title: ModelStringInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePostEditor: PostEditor @aws_subscribe(mutations: [\\"createPostEditor\\"])
+  onUpdatePostEditor: PostEditor @aws_subscribe(mutations: [\\"updatePostEditor\\"])
+  onDeletePostEditor: PostEditor @aws_subscribe(mutations: [\\"deletePostEditor\\"])
+  onCreateUser: User @aws_subscribe(mutations: [\\"createUser\\"])
+  onUpdateUser: User @aws_subscribe(mutations: [\\"updateUser\\"])
+  onDeleteUser: User @aws_subscribe(mutations: [\\"deleteUser\\"])
+}
+
+type ModelPostEditorConnection {
+  edges: [ModelPostEditorEdge]
+  pageInfo: PageInfo
+  startedAt: AWSTimestamp
+}
+
+input ModelPostEditorFilterInput {
+  id: ModelIDInput
+  postID: ModelIDInput
+  editorID: ModelIDInput
+  and: [ModelPostEditorFilterInput]
+  or: [ModelPostEditorFilterInput]
+  not: ModelPostEditorFilterInput
+}
+
+input CreatePostEditorInput {
+  id: ID
+  postID: ID!
+  editorID: ID!
+  _version: Int
+}
+
+input UpdatePostEditorInput {
+  id: ID!
+  postID: ID
+  editorID: ID
+  _version: Int
+}
+
+input DeletePostEditorInput {
+  id: ID!
+  _version: Int
+}
+
+input ModelPostEditorConditionInput {
+  postID: ModelIDInput
+  editorID: ModelIDInput
+  and: [ModelPostEditorConditionInput]
+  or: [ModelPostEditorConditionInput]
+  not: ModelPostEditorConditionInput
+}
+
+type ModelUserConnection {
+  edges: [ModelUserEdge]
+  pageInfo: PageInfo
+  startedAt: AWSTimestamp
+}
+
+input ModelUserFilterInput {
+  id: ModelIDInput
+  username: ModelStringInput
+  and: [ModelUserFilterInput]
+  or: [ModelUserFilterInput]
+  not: ModelUserFilterInput
+}
+
+input CreateUserInput {
+  id: ID
+  username: String!
+  _version: Int
+}
+
+input UpdateUserInput {
+  id: ID!
+  username: String
+  _version: Int
+}
+
+input DeleteUserInput {
+  id: ID!
+  _version: Int
+}
+
+input ModelUserConditionInput {
+  username: ModelStringInput
+  and: [ModelUserConditionInput]
+  or: [ModelUserConditionInput]
+  not: ModelUserConditionInput
+}
+
+input ModelIDKeyConditionInput {
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+"
+`;
+
+exports[`Many-to-many without conflict resolution generates correct schema 1`] = `
+"type Post {
+  id: ID!
+  title: String!
+  editors(editorID: ModelIDKeyConditionInput, filter: ModelPostEditorFilterInput, sortDirection: RelayModelSortDirection, first: Int, after: String): ModelPostEditorConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type PostEditor {
+  id: ID!
+  postID: ID!
+  editorID: ID!
+  post: Post!
+  editor: User!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+type User {
+  id: ID!
+  username: String!
+  posts(postID: ModelIDKeyConditionInput, filter: ModelPostEditorFilterInput, sortDirection: RelayModelSortDirection, first: Int, after: String): ModelPostEditorConnection
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum RelayModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelPostConnection {
+  edges: [ModelPostEdge]
+  pageInfo: PageInfo
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelPostFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  and: [ModelPostFilterInput]
+  or: [ModelPostFilterInput]
+  not: ModelPostFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  getPost(id: ID!): Post
+  listPosts(filter: ModelPostFilterInput, first: Int, after: String): ModelPostConnection
+  getUser(id: ID!): User
+  listUsers(filter: ModelUserFilterInput, first: Int, after: String): ModelUserConnection
+}
+
+input CreatePostInput {
+  id: ID
+  title: String!
+}
+
+input UpdatePostInput {
+  id: ID!
+  title: String
+}
+
+input DeletePostInput {
+  id: ID!
+}
+
+type Mutation {
+  createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
+  updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post
+  deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
+  createPostEditor(input: CreatePostEditorInput!, condition: ModelPostEditorConditionInput): PostEditor
+  updatePostEditor(input: UpdatePostEditorInput!, condition: ModelPostEditorConditionInput): PostEditor
+  deletePostEditor(input: DeletePostEditorInput!, condition: ModelPostEditorConditionInput): PostEditor
+  createUser(input: CreateUserInput!, condition: ModelUserConditionInput): User
+  updateUser(input: UpdateUserInput!, condition: ModelUserConditionInput): User
+  deleteUser(input: DeleteUserInput!, condition: ModelUserConditionInput): User
+}
+
+input ModelPostConditionInput {
+  title: ModelStringInput
+  and: [ModelPostConditionInput]
+  or: [ModelPostConditionInput]
+  not: ModelPostConditionInput
+}
+
+type Subscription {
+  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePostEditor: PostEditor @aws_subscribe(mutations: [\\"createPostEditor\\"])
+  onUpdatePostEditor: PostEditor @aws_subscribe(mutations: [\\"updatePostEditor\\"])
+  onDeletePostEditor: PostEditor @aws_subscribe(mutations: [\\"deletePostEditor\\"])
+  onCreateUser: User @aws_subscribe(mutations: [\\"createUser\\"])
+  onUpdateUser: User @aws_subscribe(mutations: [\\"updateUser\\"])
+  onDeleteUser: User @aws_subscribe(mutations: [\\"deleteUser\\"])
+}
+
+input CreatePostEditorInput {
+  id: ID
+  postID: ID!
+  editorID: ID!
+}
+
+input UpdatePostEditorInput {
+  id: ID!
+  postID: ID
+  editorID: ID
+}
+
+input DeletePostEditorInput {
+  id: ID!
+}
+
+input ModelPostEditorConditionInput {
+  postID: ModelIDInput
+  editorID: ModelIDInput
+  and: [ModelPostEditorConditionInput]
+  or: [ModelPostEditorConditionInput]
+  not: ModelPostEditorConditionInput
+}
+
+type ModelUserConnection {
+  edges: [ModelUserEdge]
+  pageInfo: PageInfo
+}
+
+input ModelUserFilterInput {
+  id: ModelIDInput
+  username: ModelStringInput
+  and: [ModelUserFilterInput]
+  or: [ModelUserFilterInput]
+  not: ModelUserFilterInput
+}
+
+input CreateUserInput {
+  id: ID
+  username: String!
+}
+
+input UpdateUserInput {
+  id: ID!
+  username: String
+}
+
+input DeleteUserInput {
+  id: ID!
+}
+
+input ModelUserConditionInput {
+  username: ModelStringInput
+  and: [ModelUserConditionInput]
+  or: [ModelUserConditionInput]
+  not: ModelUserConditionInput
+}
+
+input ModelIDKeyConditionInput {
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  between: [ID]
+  beginsWith: ID
+}
+
+type ModelPostEditorConnection {
+  edges: [ModelPostEditorEdge]
+  pageInfo: PageInfo
+}
+
+type ModelPostEditorEdge {
+  node: PostEditor
+  cursor: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+input ModelPostEditorFilterInput {
+  id: ModelIDInput
+  postID: ModelIDInput
+  editorID: ModelIDInput
+  and: [ModelPostEditorFilterInput]
+  or: [ModelPostEditorFilterInput]
+  not: ModelPostEditorFilterInput
+}
+"
+`;

--- a/packages/graphql-relay-transformer/src/connection/ModelRelayConnectionTransformer.ts
+++ b/packages/graphql-relay-transformer/src/connection/ModelRelayConnectionTransformer.ts
@@ -1,0 +1,809 @@
+import { Transformer, TransformerContext, InvalidDirectiveError, gql, getDirectiveArguments } from 'graphql-transformer-core';
+import {
+  DirectiveNode,
+  ObjectTypeDefinitionNode,
+  Kind,
+  FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  EnumTypeDefinitionNode,
+  ObjectTypeExtensionNode,
+  getNamedType,
+} from 'graphql';
+import { ResourceFactory } from './resources';
+import {
+  makeScalarFilterInputs,
+  makeModelXFilterInputObject,
+  makeModelSortDirectionEnumObject,
+  SortKeyFieldInfoTypeName,
+  CONDITIONS_MINIMUM_VERSION,
+  makeAttributeTypeEnum,
+  makeEnumFilterInputObjects,
+} from 'graphql-dynamodb-transformer';
+import {
+  getBaseType,
+  isListType,
+  getDirectiveArgument,
+  blankObject,
+  isScalar,
+  isScalarOrEnum,
+  STANDARD_SCALARS,
+  toCamelCase,
+  isNonNullType,
+  attributeTypeFromScalar,
+  makeScalarKeyConditionForType,
+  makeNamedType,
+} from 'graphql-transformer-common';
+import { ResolverResourceIDs, ModelResourceIDs } from 'graphql-transformer-common';
+import { updateCreateInputWithConnectionField, updateUpdateInputWithConnectionField } from './definitions';
+import Table, { KeySchema, GlobalSecondaryIndex, LocalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
+import { makeModelConnectionType, makeModelEdgeType, makeModelConnectionField } from '../model/definition';
+
+const CONNECTION_STACK_NAME = 'RelayConnectionStack';
+
+interface RelationArguments {
+  keyName?: string;
+  fields: string[];
+  limit?: number;
+}
+
+function makeConnectionAttributeName(type: string, field?: string) {
+  // The same logic is used in amplify-codegen-appsync-model-plugin package to generate association field
+  // Make sure the logic gets update in that package
+  return field ? toCamelCase([type, field, 'id']) : toCamelCase([type, 'id']);
+}
+
+function validateKeyField(field: FieldDefinitionNode): void {
+  if (!field) {
+    return;
+  }
+  const baseType = getBaseType(field.type);
+  const isAList = isListType(field.type);
+  // The only valid key fields are single String and ID fields.
+  if ((baseType === 'ID' || baseType === 'String') && !isAList) {
+    return;
+  }
+  throw new InvalidDirectiveError(`If you define a field and specify it as a 'keyField', it must be of type 'ID' or 'String'.`);
+}
+
+/**
+ * Ensure that the field passed in is compatible to be a key field
+ * (Not a list and of type ID or String)
+ * @param field: the field to be checked.
+ */
+function validateKeyFieldConnectionWithKey(field: FieldDefinitionNode, ctx: TransformerContext): void {
+  const isAList = isListType(field.type);
+  const isAScalarOrEnum = isScalarOrEnum(field.type, ctx.getTypeDefinitionsOfKind(Kind.ENUM_TYPE_DEFINITION) as EnumTypeDefinitionNode[]);
+
+  // The only valid key fields are single non-null fields.
+  if (!isAList && isAScalarOrEnum) {
+    return;
+  }
+  throw new InvalidDirectiveError(`All fields provided to an @relayConnection must be scalar or enum fields.`);
+}
+
+/**
+ * Returns the type of the field with the field name specified by finding it from the array of fields
+ * and returning its type.
+ * @param fields Array of FieldDefinitionNodes to search within.
+ * @param fieldName Name of the field whose type is to be fetched.
+ */
+function getFieldType(relatedType: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, fieldName: string) {
+  const foundField = relatedType.fields.find(f => f.name.value === fieldName);
+  if (!foundField) {
+    throw new InvalidDirectiveError(`${fieldName} is not defined in ${relatedType.name.value}.`);
+  }
+  return foundField.type;
+}
+
+/**
+ * Checks that the fields being used to query match the expected key types for the index being used.
+ * @param parent: All fields of the parent object.
+ * @param relatedTypeFields: All fields of the related object.
+ * @param inputFieldNames: The fields passed in to the @relayConnection directive.
+ * @param keySchema: The key schema for the index being used.
+ */
+function checkFieldsAgainstIndex(
+  parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  relatedType: ObjectTypeDefinitionNode,
+  inputFieldNames: string[],
+  keySchema: KeySchema[],
+  field: Readonly<FieldDefinitionNode>,
+): void {
+  const hashAttributeName = keySchema[0].AttributeName;
+  const tablePKType = getFieldType(relatedType, String(hashAttributeName));
+  const queryPKType = getFieldType(parent, inputFieldNames[0]);
+  const numFields = inputFieldNames.length;
+
+  if (getBaseType(tablePKType) !== getBaseType(queryPKType)) {
+    throw new InvalidDirectiveError(`${inputFieldNames[0]} field is not of type ${getBaseType(tablePKType)}`);
+  }
+  if (numFields > keySchema.length && keySchema.length !== 2) {
+    throw new InvalidDirectiveError('Too many fields passed in to @relayConnection directive.');
+  }
+  // when sort key is passed, ensure that the length of composite sort key matches the length of the fields passed
+  if (numFields > 1) {
+    const querySortFields = inputFieldNames.slice(1);
+    const tableSortFields = String(keySchema[1].AttributeName).split(ModelResourceIDs.ModelCompositeKeySeparator());
+    if (querySortFields.length !== tableSortFields.length) {
+      throw new InvalidDirectiveError(`Invalid @relayConnection directive  ${field.name.value}. fields does not accept partial sort key`);
+    }
+  }
+  if (numFields === 2) {
+    const sortAttributeName = String(keySchema[1].AttributeName).split(ModelResourceIDs.ModelCompositeKeySeparator())[0];
+    const tableSKType = getFieldType(relatedType, String(sortAttributeName));
+    const querySKType = getFieldType(parent, inputFieldNames[1]);
+
+    if (getBaseType(tableSKType) !== getBaseType(querySKType)) {
+      throw new InvalidDirectiveError(`${inputFieldNames[1]} field is not of type ${getBaseType(tableSKType)}`);
+    }
+  } else if (numFields > 2) {
+    const tableSortFields = String(keySchema[1].AttributeName).split(ModelResourceIDs.ModelCompositeKeySeparator());
+    const tableSortKeyTypes = tableSortFields.map(name => getFieldType(relatedType, name));
+    const querySortFields = inputFieldNames.slice(1);
+    const querySortKeyTypes = querySortFields.map(name => getFieldType(parent, name));
+
+    // Check that types of each attribute match types of the fields that make up the composite sort key for the
+    // table or index being queried.
+    querySortKeyTypes.forEach((fieldType, index) => {
+      if (getBaseType(fieldType) !== getBaseType(tableSortKeyTypes[index])) {
+        throw new InvalidDirectiveError(
+          `${querySortFields[index]} field is not of type ${getBaseType(tableSortKeyTypes[index])} arguments`,
+        );
+      }
+    });
+  }
+}
+
+/**
+ * The @relayConnection transform.
+ *
+ * This transform configures the GSIs and resolvers needed to implement
+ * relationships at the GraphQL level.
+ */
+export class ModelRelayConnectionTransformer extends Transformer {
+  resources: ResourceFactory;
+
+  constructor() {
+    super(
+      'ModelRelayConnectionTransformer',
+      gql`
+        directive @relayConnection(
+          name: String
+          keyField: String
+          sortField: String
+          keyName: String
+          limit: Int
+          fields: [String!]
+        ) on FIELD_DEFINITION
+
+        type PageInfo {
+          hasPrevPage: Boolean
+          hasNextPage: Boolean
+          startCursor: Int
+          endCursor: Int
+        }
+      `,
+    );
+    this.resources = new ResourceFactory();
+  }
+
+  public before = (ctx: TransformerContext): void => {
+    const template = this.resources.initTemplate();
+    ctx.mergeResources(template.Resources);
+    ctx.mergeParameters(template.Parameters);
+    ctx.mergeOutputs(template.Outputs);
+  };
+
+  /**
+   * Create a 1-1, 1-M, or M-1 connection between two model types.
+   * Throws an error if the related type is not an object type annotated with @relayModel
+   */
+  public field = (
+    parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    field: FieldDefinitionNode,
+    directive: DirectiveNode,
+    ctx: TransformerContext,
+  ): void => {
+    const parentTypeName = parent.name.value;
+    const fieldName = field.name.value;
+
+    ctx.mapResourceToStack(CONNECTION_STACK_NAME, ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName));
+
+    const parentModelDirective = parent.directives.find((dir: DirectiveNode) => dir.name.value === 'relayModel');
+    if (!parentModelDirective) {
+      throw new InvalidDirectiveError(`@relayConnection must be on an @relayModel object type field.`);
+    }
+
+    const relatedTypeName = getBaseType(field.type);
+    const relatedType = ctx.inputDocument.definitions.find(
+      d => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === relatedTypeName,
+    ) as ObjectTypeDefinitionNode | undefined;
+    if (!relatedType) {
+      throw new InvalidDirectiveError(`Could not find an object type named ${relatedTypeName}.`);
+    }
+    const modelDirective = relatedType.directives.find((dir: DirectiveNode) => dir.name.value === 'relayModel');
+    if (!modelDirective) {
+      throw new InvalidDirectiveError(`Object type ${relatedTypeName} must be annotated with @relayModel.`);
+    }
+
+    // Checks if "fields" argument is provided which indicates use of the new parameterization
+    // hence dive straight to new logic and return.
+    if (getDirectiveArgument(directive, 'fields')) {
+      this.connectionWithKey(parent, field, directive, ctx);
+      return;
+    }
+
+    let connectionName = getDirectiveArgument(directive, 'name');
+    let associatedSortFieldName = null;
+    let sortType = null;
+    // Find the associated connection field if one exists.
+    const associatedConnectionField = relatedType.fields.find((f: FieldDefinitionNode) => {
+      // Make sure we don't associate with the same field in a self connection
+      if (f === field) {
+        return false;
+      }
+      const relatedDirective = f.directives.find((dir: DirectiveNode) => dir.name.value === 'relayConnection');
+      if (relatedDirective) {
+        const relatedDirectiveName = getDirectiveArgument(relatedDirective, 'name');
+        if (connectionName && relatedDirectiveName && relatedDirectiveName === connectionName) {
+          associatedSortFieldName = getDirectiveArgument(relatedDirective, 'sortField');
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (connectionName && !associatedConnectionField) {
+      throw new InvalidDirectiveError(
+        `Found one half of relayConnection "${connectionName}" at ${parentTypeName}.${fieldName} but no related field on type ${relatedTypeName}`,
+      );
+    }
+
+    connectionName = connectionName || `${parentTypeName}.${fieldName}`;
+    const leftConnectionIsList = isListType(field.type);
+    const leftConnectionIsNonNull = isNonNullType(field.type);
+    const rightConnectionIsList = associatedConnectionField ? isListType(associatedConnectionField.type) : undefined;
+    const rightConnectionIsNonNull = associatedConnectionField ? isNonNullType(associatedConnectionField.type) : undefined;
+    const limit = getDirectiveArgument(directive, 'limit');
+
+    let connectionAttributeName = getDirectiveArgument(directive, 'keyField');
+    const associatedSortField =
+      associatedSortFieldName && parent.fields.find((f: FieldDefinitionNode) => f.name.value === associatedSortFieldName);
+
+    if (associatedSortField) {
+      if (isListType(associatedSortField.type)) {
+        throw new InvalidDirectiveError(`sortField "${associatedSortFieldName}" is a list. It should be a scalar.`);
+      }
+      sortType = getBaseType(associatedSortField.type);
+      if (!isScalar(associatedSortField.type) || sortType === STANDARD_SCALARS.Boolean) {
+        throw new InvalidDirectiveError(
+          `sortField "${associatedSortFieldName}" is of type "${sortType}". ` +
+            `It should be a scalar that maps to a DynamoDB "String", "Number", or "Binary"`,
+        );
+      }
+    }
+
+    // This grabs the definition of the sort field when it lives on the foreign model.
+    // We use this to configure key condition arguments for the resolver on the many side of the @relayConnection.
+    const foreignAssociatedSortField =
+      associatedSortFieldName && relatedType.fields.find((f: FieldDefinitionNode) => f.name.value === associatedSortFieldName);
+    const sortKeyInfo = foreignAssociatedSortField
+      ? {
+          fieldName: foreignAssociatedSortField.name.value,
+          attributeType: attributeTypeFromScalar(foreignAssociatedSortField.type),
+          typeName: getBaseType(foreignAssociatedSortField.type),
+        }
+      : undefined;
+
+    // Relationship Cardinalities:
+    // 1. [] to []
+    // 2. [] to {}
+    // 3. {} to []
+    // 4. [] to ?
+    // 5. {} to ?
+    if (leftConnectionIsList && rightConnectionIsList) {
+      // 1. TODO.
+      // Use an intermediary table or other strategy like embedded string sets for many to many.
+      throw new InvalidDirectiveError(`Invalid Connection (${connectionName}): Many to Many connections are not yet supported.`);
+    } else if (leftConnectionIsList && rightConnectionIsList === false) {
+      // 2. [] to {} when the association exists. Note: false and undefined are not equal.
+      // Store a foreign key on the related table and wire up a Query resolver.
+      // This is the inverse of 3.
+      const primaryKeyField = this.getPrimaryKeyField(ctx, parent);
+      const idFieldName = primaryKeyField ? primaryKeyField.name.value : 'id';
+
+      if (!connectionAttributeName) {
+        connectionAttributeName = makeConnectionAttributeName(relatedTypeName, associatedConnectionField.name.value);
+      }
+      // Validate the provided key field is legit.
+      const existingKeyField = relatedType.fields.find(f => f.name.value === connectionAttributeName);
+      validateKeyField(existingKeyField);
+
+      const queryResolver = this.resources.makeQueryConnectionResolver(
+        parentTypeName,
+        fieldName,
+        relatedTypeName,
+        connectionAttributeName,
+        connectionName,
+        idFieldName,
+        // If there is a sort field for this connection query then use
+        sortKeyInfo,
+        limit,
+      );
+      ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver);
+
+      this.extendTypeWithConnection(ctx, parent, field, relatedType, sortKeyInfo);
+    } else if (!leftConnectionIsList && rightConnectionIsList) {
+      // 3. {} to [] when the association exists.
+      // Store foreign key on this table and wire up a GetItem resolver.
+      // This is the inverse of 2.
+
+      // if the sortField is not defined as a field, throw an error
+      // Cannot assume the required type of the field
+      if (associatedSortFieldName && !associatedSortField) {
+        throw new InvalidDirectiveError(
+          `sortField "${associatedSortFieldName}" not found on type "${parent.name.value}", other half of connection "${connectionName}".`,
+        );
+      }
+
+      const primaryKeyField = this.getPrimaryKeyField(ctx, relatedType);
+      const idFieldName = primaryKeyField ? primaryKeyField.name.value : 'id';
+
+      if (!connectionAttributeName) {
+        connectionAttributeName = makeConnectionAttributeName(parentTypeName, fieldName);
+      }
+      // Validate the provided key field is legit.
+      const existingKeyField = parent.fields.find(f => f.name.value === connectionAttributeName);
+      validateKeyField(existingKeyField);
+
+      const tableLogicalId = ModelResourceIDs.ModelTableResourceID(parentTypeName);
+      const table = ctx.getResource(tableLogicalId) as Table;
+      const sortField = associatedSortField ? { name: associatedSortFieldName, type: sortType } : null;
+      const updated = this.resources.updateTableForConnection(table, connectionName, connectionAttributeName, sortField);
+      ctx.setResource(tableLogicalId, updated);
+
+      const getResolver = this.resources.makeGetItemConnectionResolver(
+        parentTypeName,
+        fieldName,
+        relatedTypeName,
+        connectionAttributeName,
+        idFieldName,
+      );
+      ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), getResolver);
+
+      // Update the create & update input objects for this
+      const createInputName = ModelResourceIDs.ModelCreateInputObjectName(parentTypeName);
+      const createInput = ctx.getType(createInputName) as InputObjectTypeDefinitionNode;
+      if (createInput) {
+        const updated = updateCreateInputWithConnectionField(createInput, connectionAttributeName, leftConnectionIsNonNull);
+        ctx.putType(updated);
+      }
+      const updateInputName = ModelResourceIDs.ModelUpdateInputObjectName(parentTypeName);
+      const updateInput = ctx.getType(updateInputName) as InputObjectTypeDefinitionNode;
+      if (updateInput) {
+        const updated = updateUpdateInputWithConnectionField(updateInput, connectionAttributeName);
+        ctx.putType(updated);
+      }
+    } else if (leftConnectionIsList) {
+      // 4. [] to ?
+      // Store foreign key on the related table and wire up a Query resolver.
+      // This has no inverse and has limited knowlege of the connection.
+      const primaryKeyField = this.getPrimaryKeyField(ctx, parent);
+      const idFieldName = primaryKeyField ? primaryKeyField.name.value : 'id';
+
+      if (!connectionAttributeName) {
+        connectionAttributeName = makeConnectionAttributeName(parentTypeName, fieldName);
+      }
+
+      // Validate the provided key field is legit.
+      const existingKeyField = relatedType.fields.find(f => f.name.value === connectionAttributeName);
+      validateKeyField(existingKeyField);
+
+      const tableLogicalId = ModelResourceIDs.ModelTableResourceID(relatedTypeName);
+      const table = ctx.getResource(tableLogicalId) as Table;
+      const updated = this.resources.updateTableForConnection(table, connectionName, connectionAttributeName);
+      ctx.setResource(tableLogicalId, updated);
+
+      const queryResolver = this.resources.makeQueryConnectionResolver(
+        parentTypeName,
+        fieldName,
+        relatedTypeName,
+        connectionAttributeName,
+        connectionName,
+        idFieldName,
+        sortKeyInfo,
+        limit,
+      );
+      ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver);
+
+      this.extendTypeWithConnection(ctx, parent, field, relatedType, sortKeyInfo);
+
+      // Update the create & update input objects for the related type
+      const createInputName = ModelResourceIDs.ModelCreateInputObjectName(relatedTypeName);
+      const createInput = ctx.getType(createInputName) as InputObjectTypeDefinitionNode;
+      if (createInput) {
+        const updated = updateCreateInputWithConnectionField(createInput, connectionAttributeName);
+        ctx.putType(updated);
+      }
+      const updateInputName = ModelResourceIDs.ModelUpdateInputObjectName(relatedTypeName);
+      const updateInput = ctx.getType(updateInputName) as InputObjectTypeDefinitionNode;
+      if (updateInput) {
+        const updated = updateUpdateInputWithConnectionField(updateInput, connectionAttributeName);
+        ctx.putType(updated);
+      }
+    } else {
+      // 5. {} to ?
+      // Store foreign key on this table and wire up a GetItem resolver.
+      // This has no inverse and has limited knowlege of the connection.
+      const primaryKeyField = this.getPrimaryKeyField(ctx, relatedType);
+      const idFieldName = primaryKeyField ? primaryKeyField.name.value : 'id';
+
+      if (!connectionAttributeName) {
+        connectionAttributeName = makeConnectionAttributeName(parentTypeName, fieldName);
+      }
+
+      // Issue #2100 - in a 1:1 mapping that's based on sortField, we need to validate both sides
+      // and getItemResolver has to be aware of the soft field.
+      let sortFieldInfo;
+      const sortFieldName = getDirectiveArgument(directive, 'sortField');
+      if (sortFieldName) {
+        // Related type has to have a primary key directive and has to have a soft key
+        // defined
+        const relatedSortField = this.getSortField(relatedType);
+
+        if (!relatedSortField) {
+          throw new InvalidDirectiveError(
+            `sortField "${sortFieldName}" requires a primary @key on type "${relatedTypeName}" with a sort key that was not found.`,
+          );
+        }
+
+        const sortField = parent.fields.find(f => f.name.value === sortFieldName);
+
+        if (!sortField) {
+          throw new InvalidDirectiveError(`sortField with name "${sortFieldName} cannot be found on type: ${parent.name.value}`);
+        }
+
+        const relatedSortFieldType = getBaseType(relatedSortField.type);
+        const sortFieldType = getBaseType(sortField.type);
+
+        if (relatedSortFieldType !== sortFieldType) {
+          throw new InvalidDirectiveError(
+            `sortField "${relatedSortField.name.value}" on type "${relatedTypeName}" is not matching the ` +
+              `type of field "${sortFieldName}" on type "${parentTypeName}"`,
+          );
+        }
+
+        let sortFieldIsStringLike = true;
+
+        // We cannot use $util.defaultIfNullOrBlank on non-string types
+        if (
+          sortFieldType === STANDARD_SCALARS.Int ||
+          sortFieldType === STANDARD_SCALARS.Float ||
+          sortFieldType === STANDARD_SCALARS.Bolean
+        ) {
+          sortFieldIsStringLike = false;
+        }
+
+        sortFieldInfo = {
+          primarySortFieldName: relatedSortField.name.value,
+          sortFieldName,
+          sortFieldIsStringLike,
+        };
+      }
+
+      // Validate the provided key field is legit.
+      const existingKeyField = parent.fields.find(f => f.name.value === connectionAttributeName);
+      validateKeyField(existingKeyField);
+
+      const getResolver = this.resources.makeGetItemConnectionResolver(
+        parentTypeName,
+        fieldName,
+        relatedTypeName,
+        connectionAttributeName,
+        idFieldName,
+        sortFieldInfo,
+      );
+      ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), getResolver);
+
+      // Update the create & update input objects for this type
+      const createInputName = ModelResourceIDs.ModelCreateInputObjectName(parentTypeName);
+      const createInput = ctx.getType(createInputName) as InputObjectTypeDefinitionNode;
+      if (createInput) {
+        const updated = updateCreateInputWithConnectionField(createInput, connectionAttributeName, leftConnectionIsNonNull);
+        ctx.putType(updated);
+      }
+      const updateInputName = ModelResourceIDs.ModelUpdateInputObjectName(parentTypeName);
+      const updateInput = ctx.getType(updateInputName) as InputObjectTypeDefinitionNode;
+      if (updateInput) {
+        const updated = updateUpdateInputWithConnectionField(updateInput, connectionAttributeName);
+        ctx.putType(updated);
+      }
+    }
+  };
+
+  /**
+   * The @relayConnection parameterization with "fields" can be used to connect objects by running a query on a table.
+   * The directive is given an index to query and a list of fields to query by such that it
+   * returns a list objects (or in certain cases a single object) that are connected to the
+   * object it is called on.
+   * This directive is designed to leverage indices configured using @key to create relationships.
+   *
+   * Directive Definition:
+   * @relayConnection(keyName: String, fields: [String!]!) on FIELD_DEFINITION
+   * param @keyName The name of the index configured using @key that should be queried to get
+   *      connected objects
+   * param @fields The names of the fields on the current object to query by.
+   */
+  public connectionWithKey = (
+    parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    field: FieldDefinitionNode,
+    directive: DirectiveNode,
+    ctx: TransformerContext,
+  ): void => {
+    const parentTypeName = parent.name.value;
+    const fieldName = field.name.value;
+    const args: RelationArguments = getDirectiveArguments(directive);
+
+    // Ensure that there is at least one field provided.
+    if (args.fields.length === 0) {
+      throw new InvalidDirectiveError('No fields passed in to @relayConnection directive.');
+    }
+
+    // Check that related type exists and that the connected object is annotated with @relayModel.
+    const relatedTypeName = getBaseType(field.type);
+    const relatedType = ctx.inputDocument.definitions.find(
+      d => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === relatedTypeName,
+    ) as ObjectTypeDefinitionNode | undefined;
+
+    // Get Child object's table.
+    const tableLogicalID = ModelResourceIDs.ModelTableResourceID(relatedType.name.value);
+    const tableResource = ctx.getResource(tableLogicalID) as Table;
+
+    // Check that each field provided exists in the parent model and that it is a valid key type (single non-null).
+    let inputFields: FieldDefinitionNode[] = [];
+    args.fields.forEach(item => {
+      const fieldsArrayLength = inputFields.length;
+      inputFields.push(parent.fields.find(f => f.name.value === item));
+      if (!inputFields[fieldsArrayLength]) {
+        throw new InvalidDirectiveError(`${item} is not a field in ${parentTypeName}`);
+      }
+
+      validateKeyFieldConnectionWithKey(inputFields[fieldsArrayLength], ctx);
+    });
+
+    let index: GlobalSecondaryIndex = undefined;
+    // If no index is provided use the default index for the related model type and
+    // check that the query fields match the PK/SK of the table. Else confirm that index exists.
+    if (!args.keyName) {
+      checkFieldsAgainstIndex(parent, relatedType, args.fields, <KeySchema[]>tableResource.Properties.KeySchema, field);
+    } else {
+      index =
+        (tableResource.Properties.GlobalSecondaryIndexes
+          ? (<GlobalSecondaryIndex[]>tableResource.Properties.GlobalSecondaryIndexes).find(GSI => GSI.IndexName === args.keyName)
+          : null) ||
+        (tableResource.Properties.LocalSecondaryIndexes
+          ? (<LocalSecondaryIndex[]>tableResource.Properties.LocalSecondaryIndexes).find(LSI => LSI.IndexName === args.keyName)
+          : null);
+      if (!index) {
+        throw new InvalidDirectiveError(`Key ${args.keyName} does not exist for model ${relatedTypeName}`);
+      }
+
+      // check the arity
+
+      // Confirm that types of query fields match types of PK/SK of the index being queried.
+      checkFieldsAgainstIndex(parent, relatedType, args.fields, <KeySchema[]>index.KeySchema, field);
+    }
+
+    // If the related type is not a list, the index has to be the default index and the fields provided must match the PK/SK of the index.
+    if (!isListType(field.type)) {
+      if (args.keyName) {
+        // tslint:disable-next-line: max-line-length
+        throw new InvalidDirectiveError(
+          `Connection is to a single object but the keyName ${args.keyName} was provided which does not reference the default table.`,
+        );
+      }
+
+      // Start with GetItem resolver for case where the connection is to a single object.
+      const getResolver = this.resources.makeGetItemConnectionWithKeyResolver(
+        parentTypeName,
+        fieldName,
+        relatedTypeName,
+        args.fields,
+        <KeySchema[]>tableResource.Properties.KeySchema,
+      );
+
+      ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), getResolver);
+    } else {
+      const keySchema: KeySchema[] = index ? <KeySchema[]>index.KeySchema : <KeySchema[]>tableResource.Properties.KeySchema;
+
+      const queryResolver = this.resources.makeQueryConnectionWithKeyResolver(
+        parentTypeName,
+        fieldName,
+        relatedType,
+        args.fields,
+        keySchema,
+        index ? String(index.IndexName) : undefined,
+        args.limit,
+      );
+
+      ctx.setResource(ResolverResourceIDs.ResolverResourceID(parentTypeName, fieldName), queryResolver);
+
+      let sortKeyInfo: { fieldName: string; typeName: SortKeyFieldInfoTypeName; model: string; keyName: string } = undefined;
+      if (args.fields.length > 1) {
+        sortKeyInfo = undefined;
+      } else {
+        const compositeSortKeyType: SortKeyFieldInfoTypeName = 'Composite';
+        const compositeSortKeyName = keySchema[1] ? this.resources.makeCompositeSortKeyName(String(keySchema[1].AttributeName)) : undefined;
+        const sortKeyField = keySchema[1] ? relatedType.fields.find(f => f.name.value === keySchema[1].AttributeName) : undefined;
+
+        // If a sort key field is found then add a simple sort key, else add a composite sort key.
+        if (sortKeyField) {
+          sortKeyInfo = keySchema[1]
+            ? {
+                fieldName: String(keySchema[1].AttributeName),
+                typeName: getBaseType(sortKeyField.type),
+                model: relatedTypeName,
+                keyName: index ? String(index.IndexName) : 'Primary',
+              }
+            : undefined;
+        } else {
+          sortKeyInfo = keySchema[1]
+            ? {
+                fieldName: compositeSortKeyName,
+                typeName: compositeSortKeyType,
+                model: relatedTypeName,
+                keyName: index ? String(index.IndexName) : 'Primary',
+              }
+            : undefined;
+        }
+      }
+
+      this.extendTypeWithConnection(ctx, parent, field, relatedType, sortKeyInfo);
+    }
+  };
+
+  private typeExist(type: string, ctx: TransformerContext): boolean {
+    return Boolean(type in ctx.nodeMap);
+  }
+
+  private generateModelXConnectionType(ctx: TransformerContext, typeDef: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode): void {
+    const tableXConnectionName = ModelResourceIDs.ModelConnectionTypeName(typeDef.name.value);
+    if (this.typeExist(tableXConnectionName, ctx)) {
+      return;
+    }
+
+    // Create the ModelXConnection
+    const connectionType = blankObject(tableXConnectionName);
+    ctx.addObject(connectionType);
+
+    ctx.addObject(makeModelEdgeType(typeDef.name.value));
+    ctx.addObjectExtension(makeModelConnectionType(typeDef.name.value));
+  }
+
+  private generateFilterAndKeyConditionInputs(
+    ctx: TransformerContext,
+    field: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    sortKeyInfo?: { fieldName: string; typeName: SortKeyFieldInfoTypeName },
+  ): void {
+    const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
+    for (const filter of scalarFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    // Create the Enum filters
+    const enumFilters = makeEnumFilterInputObjects(field, ctx, this.supportsConditions(ctx));
+    for (const filter of enumFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    // Create the ModelXFilterInput
+    const tableXQueryFilterInput = makeModelXFilterInputObject(field, ctx, this.supportsConditions(ctx));
+    if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
+      ctx.addInput(tableXQueryFilterInput);
+    }
+
+    if (this.supportsConditions(ctx)) {
+      const attributeTypeEnum = makeAttributeTypeEnum();
+      if (!this.typeExist(attributeTypeEnum.name.value, ctx)) {
+        ctx.addType(attributeTypeEnum);
+      }
+    }
+
+    // Create sort key condition inputs for valid sort key types
+    // We only create the KeyConditionInput if it is being used.
+    // Don't create a key condition input for composite sort keys since it already done by @key.
+    if (sortKeyInfo && sortKeyInfo.typeName !== 'Composite') {
+      const sortKeyConditionInput = makeScalarKeyConditionForType(makeNamedType(sortKeyInfo.typeName));
+      if (!this.typeExist(sortKeyConditionInput.name.value, ctx)) {
+        ctx.addInput(sortKeyConditionInput);
+      }
+    }
+  }
+
+  private supportsConditions(context: TransformerContext) {
+    return context.getTransformerVersion() >= CONDITIONS_MINIMUM_VERSION;
+  }
+
+  private extendTypeWithConnection(
+    ctx: TransformerContext,
+    parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    field: FieldDefinitionNode,
+    returnType: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    sortKeyInfo?: { fieldName: string; typeName: SortKeyFieldInfoTypeName; model?: string; keyName?: string },
+  ) {
+    this.generateModelXConnectionType(ctx, returnType);
+
+    // Extensions are not allowed to redeclare fields so we must replace
+    // it in place.
+    const type = ctx.getType(parent.name.value) as ObjectTypeDefinitionNode;
+    if (type && (type.kind === Kind.OBJECT_TYPE_DEFINITION || type.kind === Kind.INTERFACE_TYPE_DEFINITION)) {
+      // Find the field and replace it in place.
+      const newFields = type.fields.map((f: FieldDefinitionNode) => {
+        if (f.name.value === field.name.value) {
+          const updated = makeModelConnectionField(field.name.value, returnType.name.value, sortKeyInfo, [...f.directives]);
+          return updated;
+        }
+        return f;
+      });
+      const updatedType = {
+        ...type,
+        fields: newFields,
+      };
+      ctx.putType(updatedType);
+
+      if (!this.typeExist('ModelSortDirection', ctx)) {
+        const modelSortDirection = makeModelSortDirectionEnumObject();
+        ctx.addEnum(modelSortDirection);
+      }
+
+      this.generateFilterAndKeyConditionInputs(ctx, returnType, sortKeyInfo);
+    } else {
+      throw new InvalidDirectiveError(`Could not find a object or interface type named ${parent.name.value}.`);
+    }
+  }
+
+  private getPrimaryKeyField(ctx: TransformerContext, type: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode): FieldDefinitionNode {
+    let field: FieldDefinitionNode;
+
+    for (const keyDirective of type.directives.filter(d => d.name.value === 'key')) {
+      if (getDirectiveArgument(keyDirective, 'name') === undefined) {
+        const fieldsArg = getDirectiveArgument(keyDirective, 'fields');
+
+        if (fieldsArg && fieldsArg.length && fieldsArg.length >= 1 && fieldsArg.length <= 2) {
+          field = type.fields.find(f => f.name.value === fieldsArg[0]);
+        }
+
+        // Exit the loop even if field was not set above, @key will throw validation
+        // error anyway
+        break;
+      }
+    }
+
+    return field;
+  }
+
+  private getSortField(type: ObjectTypeDefinitionNode) {
+    let field: FieldDefinitionNode;
+
+    for (const keyDirective of type.directives.filter(d => d.name.value === 'key')) {
+      if (getDirectiveArgument(keyDirective, 'name') === undefined) {
+        const fieldsArg = getDirectiveArgument(keyDirective, 'fields');
+
+        if (fieldsArg && fieldsArg.length && fieldsArg.length === 2) {
+          field = type.fields.find(f => f.name.value === fieldsArg[1]);
+        }
+
+        // Exit the loop even if field was not set above, @key will throw validation
+        // error anyway
+        break;
+      }
+    }
+
+    return field;
+  }
+}

--- a/packages/graphql-relay-transformer/src/connection/ModelRelayConnectionTransformer.ts
+++ b/packages/graphql-relay-transformer/src/connection/ModelRelayConnectionTransformer.ts
@@ -7,8 +7,6 @@ import {
   InterfaceTypeDefinitionNode,
   InputObjectTypeDefinitionNode,
   EnumTypeDefinitionNode,
-  ObjectTypeExtensionNode,
-  getNamedType,
 } from 'graphql';
 import { ResourceFactory } from './resources';
 import {

--- a/packages/graphql-relay-transformer/src/connection/definitions.ts
+++ b/packages/graphql-relay-transformer/src/connection/definitions.ts
@@ -1,0 +1,40 @@
+import { InputObjectTypeDefinitionNode } from 'graphql';
+import { makeInputValueDefinition, makeNonNullType, makeNamedType } from 'graphql-transformer-common';
+
+export function updateCreateInputWithConnectionField(
+  input: InputObjectTypeDefinitionNode,
+  connectionFieldName: string,
+  nonNull: boolean = false,
+): InputObjectTypeDefinitionNode {
+  const keyFieldExists = Boolean(input.fields.find(f => f.name.value === connectionFieldName));
+  // If the key field already exists then do not change the input.
+  // The @relayConnection field will validate that the key field is valid.
+  if (keyFieldExists) {
+    return input;
+  }
+  const updatedFields = [
+    ...input.fields,
+    makeInputValueDefinition(connectionFieldName, nonNull ? makeNonNullType(makeNamedType('ID')) : makeNamedType('ID')),
+  ];
+  return {
+    ...input,
+    fields: updatedFields,
+  };
+}
+
+export function updateUpdateInputWithConnectionField(
+  input: InputObjectTypeDefinitionNode,
+  connectionFieldName: string,
+): InputObjectTypeDefinitionNode {
+  const keyFieldExists = Boolean(input.fields.find(f => f.name.value === connectionFieldName));
+  // If the key field already exists then do not change the input.
+  // The @relayConnection field will validate that the key field is valid.
+  if (keyFieldExists) {
+    return input;
+  }
+  const updatedFields = [...input.fields, makeInputValueDefinition(connectionFieldName, makeNamedType('ID'))];
+  return {
+    ...input,
+    fields: updatedFields,
+  };
+}

--- a/packages/graphql-relay-transformer/src/connection/resources.ts
+++ b/packages/graphql-relay-transformer/src/connection/resources.ts
@@ -1,0 +1,495 @@
+import Table, { GlobalSecondaryIndex, KeySchema, Projection, AttributeDefinition } from 'cloudform-types/types/dynamoDb/table';
+import Resolver from 'cloudform-types/types/appSync/resolver';
+import Template from 'cloudform-types/types/template';
+import { Fn, Refs } from 'cloudform-types';
+import { ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode } from 'graphql';
+import {
+  DynamoDBMappingTemplate,
+  str,
+  print,
+  ref,
+  obj,
+  set,
+  nul,
+  ObjectNode,
+  ifElse,
+  compoundExpression,
+  bool,
+  equals,
+  raw,
+  Expression,
+  or,
+  list,
+  forEach,
+} from 'graphql-mapping-template';
+import {
+  ResourceConstants,
+  ModelResourceIDs,
+  DEFAULT_SCALARS,
+  NONE_VALUE,
+  NONE_INT_VALUE,
+  applyKeyConditionExpression,
+  attributeTypeFromScalar,
+  toCamelCase,
+  applyCompositeKeyConditionExpression,
+} from 'graphql-transformer-common';
+import { InvalidDirectiveError } from 'graphql-transformer-core';
+
+export class ResourceFactory {
+  public makeParams() {
+    return {};
+  }
+
+  /**
+   * Creates the barebones template for an application.
+   */
+  public initTemplate(): Template {
+    return {
+      Parameters: this.makeParams(),
+      Resources: {},
+      Outputs: {},
+    };
+  }
+
+  /**
+   * Add a GSI for the connection if one does not already exist.
+   * @param table The table to add the GSI to.
+   */
+  public updateTableForConnection(
+    table: Table,
+    connectionName: string,
+    connectionAttributeName: string,
+    sortField: { name: string; type: string } = null,
+  ): Table {
+    const gsis = <GlobalSecondaryIndex[]>table.Properties.GlobalSecondaryIndexes || ([] as GlobalSecondaryIndex[]);
+    if (gsis.length >= 20) {
+      throw new InvalidDirectiveError(
+        `Cannot create connection ${connectionName}. Table ${table.Properties.TableName} out of GSI capacity.`,
+      );
+    }
+    const connectionGSIName = `gsi-${connectionName}`;
+
+    // If the GSI does not exist yet then add it.
+    const existingGSI = gsis.find(gsi => gsi.IndexName === connectionGSIName);
+    if (!existingGSI) {
+      const keySchema = [new KeySchema({ AttributeName: connectionAttributeName, KeyType: 'HASH' })];
+      if (sortField) {
+        keySchema.push(new KeySchema({ AttributeName: sortField.name, KeyType: 'RANGE' }));
+      }
+      gsis.push(
+        new GlobalSecondaryIndex({
+          IndexName: connectionGSIName,
+          KeySchema: keySchema,
+          Projection: new Projection({
+            ProjectionType: 'ALL',
+          }),
+          ProvisionedThroughput: Fn.If(ResourceConstants.CONDITIONS.ShouldUsePayPerRequestBilling, Refs.NoValue, {
+            ReadCapacityUnits: Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS),
+            WriteCapacityUnits: Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS),
+          }) as any,
+        }),
+      );
+    }
+
+    // If the attribute definition does not exist yet, add it.
+    const attributeDefinitions = table.Properties.AttributeDefinitions as AttributeDefinition[];
+    const existingAttribute = attributeDefinitions.find(attr => attr.AttributeName === connectionAttributeName);
+    if (!existingAttribute) {
+      attributeDefinitions.push(
+        new AttributeDefinition({
+          AttributeName: connectionAttributeName,
+          AttributeType: 'S',
+        }),
+      );
+    }
+
+    // If the attribute definition does not exist yet, add it.
+    if (sortField) {
+      const existingSortAttribute = attributeDefinitions.find(attr => attr.AttributeName === sortField.name);
+      if (!existingSortAttribute) {
+        const scalarType = DEFAULT_SCALARS[sortField.type];
+        const attributeType = scalarType === 'String' ? 'S' : 'N';
+        attributeDefinitions.push(new AttributeDefinition({ AttributeName: sortField.name, AttributeType: attributeType }));
+      }
+    }
+
+    table.Properties.GlobalSecondaryIndexes = gsis;
+    table.Properties.AttributeDefinitions = attributeDefinitions;
+    return table;
+  }
+
+  /**
+   * Create a get item resolver for singular connections.
+   * @param type The parent type name.
+   * @param field The connection field name.
+   * @param relatedType The name of the related type to fetch from.
+   * @param connectionAttribute The name of the underlying attribute containing the id.
+   * @param idFieldName The name of the field within the type that serve as the id.
+   * @param sortFieldInfo The info about the sort field if specified.
+   */
+  public makeGetItemConnectionResolver(
+    type: string,
+    field: string,
+    relatedType: string,
+    connectionAttribute: string,
+    idFieldName: string,
+    sortFieldInfo?: { primarySortFieldName: string; sortFieldName: string; sortFieldIsStringLike: boolean },
+  ): Resolver {
+    let keyObj: ObjectNode = obj({
+      [`${idFieldName}`]: ref(
+        `util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${connectionAttribute}, "${NONE_VALUE}"))`,
+      ),
+    });
+
+    if (sortFieldInfo) {
+      if (sortFieldInfo.sortFieldIsStringLike) {
+        keyObj.attributes.push([
+          sortFieldInfo.primarySortFieldName,
+          ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${sortFieldInfo.sortFieldName}, "${NONE_VALUE}"))`),
+        ]);
+      } else {
+        // Use Int minvalue as default
+        keyObj.attributes.push([
+          sortFieldInfo.primarySortFieldName,
+          ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNull($ctx.source.${sortFieldInfo.sortFieldName}, ${NONE_INT_VALUE}))`),
+        ]);
+      }
+    }
+
+    return new Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(relatedType), 'Name'),
+      FieldName: field,
+      TypeName: type,
+      RequestMappingTemplate: print(
+        ifElse(
+          or([
+            raw(`$util.isNull($ctx.source.${connectionAttribute})`),
+            ...(sortFieldInfo ? [raw(`$util.isNull($ctx.source.${connectionAttribute})`)] : []),
+          ]),
+          raw('#return'),
+          DynamoDBMappingTemplate.getItem({
+            key: keyObj,
+          }),
+        ),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(false)),
+    }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
+  }
+
+  /**
+   * Create a resolver that queries an item in DynamoDB.
+   * @param type
+   */
+  public makeQueryConnectionResolver(
+    type: string,
+    field: string,
+    relatedType: string,
+    connectionAttribute: string,
+    connectionName: string,
+    idFieldName: string,
+    sortKeyInfo?: { fieldName: string; attributeType: 'S' | 'B' | 'N' },
+    limit?: number,
+  ) {
+    const pageLimit = limit || ResourceConstants.DEFAULT_PAGE_LIMIT;
+    const setup: Expression[] = [
+      set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${pageLimit})`)),
+      set(
+        ref('query'),
+        obj({
+          expression: str('#connectionAttribute = :connectionAttribute'),
+          expressionNames: obj({
+            '#connectionAttribute': str(connectionAttribute),
+          }),
+          expressionValues: obj({
+            ':connectionAttribute': obj({
+              S: str(`$context.source.${idFieldName}`),
+            }),
+          }),
+        }),
+      ),
+    ];
+    if (sortKeyInfo) {
+      setup.push(applyKeyConditionExpression(sortKeyInfo.fieldName, sortKeyInfo.attributeType, 'query'));
+    }
+    return new Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(relatedType), 'Name'),
+      FieldName: field,
+      TypeName: type,
+      RequestMappingTemplate: print(
+        ifElse(
+          raw(`$util.isNull($context.source.${idFieldName})`),
+          compoundExpression([set(ref('result'), obj({ edges: list([]) })), raw('#return($result)')]),
+          compoundExpression([
+            ...setup,
+            DynamoDBMappingTemplate.query({
+              query: raw('$util.toJson($query)'),
+              scanIndexForward: ifElse(
+                ref('context.args.sortDirection'),
+                ifElse(equals(ref('context.args.sortDirection'), str('ASC')), bool(true), bool(false)),
+                bool(true),
+              ),
+              filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
+              limit: ref('limit'),
+              nextToken: ifElse(ref('context.args.after'), ref('util.toJson($context.args.after)'), nul()),
+              index: str(`gsi-${connectionName}`),
+            }),
+          ]),
+        ),
+      ),
+      ResponseMappingTemplate: print(
+        DynamoDBMappingTemplate.dynamoDBResponse(
+          false,
+          compoundExpression([
+            ifElse(ref('context.args.after'), set(ref('hasNextPage'), bool(true)), set(ref('hasNextPage'), bool(false))),
+            set(
+              ref('result'),
+              obj({
+                edges: list([]),
+                pageInfo: obj({
+                  hasPrevPage: bool(false),
+                  hasNextPage: ref('hasNextPage'),
+                  endCursor: ref('context.args.after'),
+                }),
+              }),
+            ),
+            forEach(ref('item'), ref('context.result.items'), [
+              set(ref('node'), obj({ node: ref('item') })),
+              raw('$util.qr($result.edges.add($node))'),
+            ]),
+            raw('$util.toJson($result)'),
+          ]),
+        ),
+      ),
+    }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
+  }
+
+  // Resources for new way to parameterize @connection
+
+  /**
+   * Create a get item resolver for singular connections.
+   * @param type The parent type name.
+   * @param field The connection field name.
+   * @param relatedType The name of the related type to fetch from.
+   * @param connectionAttributes The names of the underlying attributes containing the fields to query by.
+   * @param keySchema Key schema of the index or table being queried.
+   */
+  public makeGetItemConnectionWithKeyResolver(
+    type: string,
+    field: string,
+    relatedType: string,
+    connectionAttributes: string[],
+    keySchema: KeySchema[],
+  ): Resolver {
+    const partitionKeyName = keySchema[0].AttributeName as string;
+
+    let keyObj: ObjectNode = obj({
+      [partitionKeyName]: ref(
+        `util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${connectionAttributes[0]}, "${NONE_VALUE}"))`,
+      ),
+    });
+
+    // Add a composite sort key or simple sort key if there is one.
+    if (connectionAttributes.length > 2) {
+      const rangeKeyFields = connectionAttributes.slice(1);
+      const sortKeyName = keySchema[1].AttributeName as string;
+      const condensedSortKeyValue = this.condenseRangeKey(rangeKeyFields.map(keyField => `\${ctx.source.${keyField}}`));
+
+      keyObj.attributes.push([
+        sortKeyName,
+        ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank("${condensedSortKeyValue}", "${NONE_VALUE}"))`),
+      ]);
+    } else if (connectionAttributes[1]) {
+      const sortKeyName = keySchema[1].AttributeName as string;
+      keyObj.attributes.push([
+        sortKeyName,
+        ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${connectionAttributes[1]}, "${NONE_VALUE}"))`),
+      ]);
+    }
+
+    return new Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(relatedType), 'Name'),
+      FieldName: field,
+      TypeName: type,
+      RequestMappingTemplate: print(
+        ifElse(
+          or(connectionAttributes.map(ca => raw(`$util.isNull($ctx.source.${ca})`))),
+          raw('#return'),
+          compoundExpression([
+            DynamoDBMappingTemplate.getItem({
+              key: keyObj,
+            }),
+          ]),
+        ),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(false)),
+    }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
+  }
+
+  /**
+   * Create a resolver that queries an item in DynamoDB.
+   * @param type The parent type name.
+   * @param field The connection field name.
+   * @param relatedType The related type to fetch from.
+   * @param connectionAttributes The names of the underlying attributes containing the fields to query by.
+   * @param keySchema The keySchema for the table or index being queried.
+   * @param indexName The index to run the query on.
+   */
+  public makeQueryConnectionWithKeyResolver(
+    type: string,
+    field: string,
+    relatedType: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    connectionAttributes: string[],
+    keySchema: KeySchema[],
+    indexName: string,
+    limit?: number,
+  ) {
+    const pageLimit = limit || ResourceConstants.DEFAULT_PAGE_LIMIT;
+    const setup: Expression[] = [
+      set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${pageLimit})`)),
+      set(ref('query'), this.makeExpression(keySchema, connectionAttributes)),
+    ];
+
+    // If the key schema has a sort key but one is not provided for the query, let a sort key be
+    // passed in via $ctx.args.
+    if (keySchema[1] && !connectionAttributes[1]) {
+      const sortKeyField = relatedType.fields.find(f => f.name.value === keySchema[1].AttributeName);
+
+      if (sortKeyField) {
+        setup.push(applyKeyConditionExpression(String(keySchema[1].AttributeName), attributeTypeFromScalar(sortKeyField.type), 'query'));
+      } else {
+        setup.push(
+          applyCompositeKeyConditionExpression(
+            this.getSortKeyNames(String(keySchema[1].AttributeName)),
+            'query',
+            this.makeCompositeSortKeyName(String(keySchema[1].AttributeName)),
+            String(keySchema[1].AttributeName),
+          ),
+        );
+      }
+    }
+
+    let queryArguments = {
+      query: raw('$util.toJson($query)'),
+      scanIndexForward: ifElse(
+        ref('context.args.sortDirection'),
+        ifElse(equals(ref('context.args.sortDirection'), str('ASC')), bool(true), bool(false)),
+        bool(true),
+      ),
+      filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
+      limit: ref('limit'),
+      nextToken: ifElse(ref('context.args.after'), ref('util.toJson($context.args.after)'), nul()),
+      index: indexName ? str(indexName) : undefined,
+    };
+
+    if (!indexName) {
+      const indexArg = 'index';
+      delete queryArguments[indexArg];
+    }
+
+    const queryObj = DynamoDBMappingTemplate.query(queryArguments);
+
+    /**
+     * #foreach($item in $ctx.result.items)
+     #set($node = { "node": $item })
+     $util.qr($result.edges.add($node))
+     #end
+     */
+    return new Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(relatedType.name.value), 'Name'),
+      FieldName: field,
+      TypeName: type,
+      RequestMappingTemplate: print(
+        ifElse(
+          raw(`$util.isNull($ctx.source.${connectionAttributes[0]})`),
+          compoundExpression([set(ref('result'), obj({ edges: list([]) })), raw('#return($result)')]),
+          compoundExpression([...setup, queryObj]),
+        ),
+      ),
+      ResponseMappingTemplate: print(
+        DynamoDBMappingTemplate.dynamoDBResponse(
+          false,
+          compoundExpression([
+            ifElse(ref('context.args.after'), set(ref('hasNextPage'), bool(true)), set(ref('hasNextPage'), bool(false))),
+            set(
+              ref('result'),
+              obj({
+                edges: list([]),
+                pageInfo: obj({
+                  hasPrevPage: bool(false),
+                  hasNextPage: ref('hasNextPage'),
+                  endCursor: ref('context.args.after'),
+                }),
+              }),
+            ),
+            forEach(ref('item'), ref('context.result.items'), [
+              set(ref('node'), obj({ node: ref('item') })),
+              raw('$util.qr($result.edges.add($node))'),
+            ]),
+            raw('$util.toJson($result)'),
+          ]),
+        ),
+      ),
+    }).dependsOn(ResourceConstants.RESOURCES.GraphQLSchemaLogicalID);
+  }
+
+  /**
+   * Makes the query expression based on whether there is a sort key to be used for the query
+   * or not.
+   * @param keySchema The key schema for the table or index being queried.
+   * @param connectionAttributes The names of the underlying attributes containing the fields to query by.
+   */
+  public makeExpression(keySchema: KeySchema[], connectionAttributes: string[]): ObjectNode {
+    if (keySchema[1] && connectionAttributes[1]) {
+      let condensedSortKeyValue: string = undefined;
+      if (connectionAttributes.length > 2) {
+        const rangeKeyFields = connectionAttributes.slice(1);
+        condensedSortKeyValue = this.condenseRangeKey(rangeKeyFields.map(keyField => `\${context.source.${keyField}}`));
+      }
+
+      return obj({
+        expression: str('#partitionKey = :partitionKey AND #sortKey = :sortKey'),
+        expressionNames: obj({
+          '#partitionKey': str(String(keySchema[0].AttributeName)),
+          '#sortKey': str(String(keySchema[1].AttributeName)),
+        }),
+        expressionValues: obj({
+          ':partitionKey': obj({
+            S: str(`$context.source.${connectionAttributes[0]}`),
+          }),
+          ':sortKey': obj({
+            S: str(condensedSortKeyValue || `$context.source.${connectionAttributes[1]}`),
+          }),
+        }),
+      });
+    }
+
+    return obj({
+      expression: str('#partitionKey = :partitionKey'),
+      expressionNames: obj({
+        '#partitionKey': str(String(keySchema[0].AttributeName)),
+      }),
+      expressionValues: obj({
+        ':partitionKey': obj({
+          S: str(`$context.source.${connectionAttributes[0]}`),
+        }),
+      }),
+    });
+  }
+
+  private condenseRangeKey(fields: string[]) {
+    return fields.join(ModelResourceIDs.ModelCompositeKeySeparator());
+  }
+
+  public makeCompositeSortKeyName(sortKeyName: string) {
+    const attributeNames = sortKeyName.split(ModelResourceIDs.ModelCompositeKeySeparator());
+    return toCamelCase(attributeNames);
+  }
+
+  private getSortKeyNames(compositeSK: string) {
+    return compositeSK.split(ModelResourceIDs.ModelCompositeKeySeparator());
+  }
+}

--- a/packages/graphql-relay-transformer/src/index.ts
+++ b/packages/graphql-relay-transformer/src/index.ts
@@ -1,0 +1,2 @@
+export * from './connection/ModelRelayConnectionTransformer';
+export * from './model/DynamoDBRelayModelTransformer';

--- a/packages/graphql-relay-transformer/src/model/DynamoDBRelayModelTransformer.ts
+++ b/packages/graphql-relay-transformer/src/model/DynamoDBRelayModelTransformer.ts
@@ -1,0 +1,774 @@
+import { DeletionPolicy, AppSync } from 'cloudform-types';
+import { DirectiveNode, ObjectTypeDefinitionNode, InputObjectTypeDefinitionNode, FieldDefinitionNode } from 'graphql';
+import {
+  blankObject,
+  makeField,
+  makeInputValueDefinition,
+  wrapNonNull,
+  makeNamedType,
+  makeNonNullType,
+  ModelResourceIDs,
+  ResolverResourceIDs,
+  getBaseType,
+} from 'graphql-transformer-common';
+import { getDirectiveArguments, gql, Transformer, TransformerContext, SyncConfig, InvalidDirectiveError } from 'graphql-transformer-core';
+import {
+  getNonModelObjectArray,
+  makeCreateInputObject,
+  makeDeleteInputObject,
+  makeEnumFilterInputObjects,
+  makeModelConnectionType,
+  makeModelSortDirectionEnumObject,
+  makeModelXFilterInputObject,
+  makeNonModelInputObject,
+  makeScalarFilterInputs,
+  makeSubscriptionField,
+  makeUpdateInputObject,
+  makeModelXConditionInputObject,
+  makeAttributeTypeEnum,
+  getFieldsOptionalNonNullableField,
+  makeConnectionField,
+} from './definition';
+import { ResourceFactory } from './resources';
+import { getCreatedAtFieldName, getUpdatedAtFieldName, ModelDirectiveArgs } from 'graphql-dynamodb-transformer';
+
+const METADATA_KEY = 'DynamoDBRelayTransformerMetadata';
+
+export interface DynamoDBRelayModelTransformerOptions {
+  EnableDeletionProtection?: boolean;
+  SyncConfig?: SyncConfig;
+}
+
+// Transform config version constants
+// We have constants instead of magic number all around, later these should be moved to feature
+// flags and transformers should be feature and not version dependent.
+
+// To support generation of conditions and new naming, version 5 was introduced
+export const CONDITIONS_MINIMUM_VERSION = 5;
+
+/**
+ * The @model transformer.
+ *
+ * This transform creates a single DynamoDB table for all of your application's
+ * data. It uses a standard key structure and nested map to store object values.
+ * A relationKey field
+ *
+ * {
+ *  type (HASH),
+ *  id (SORT),
+ *  value (MAP),
+ *  createdAt, (LSI w/ type)
+ *  updatedAt (LSI w/ type)
+ * }
+ */
+
+export const directiveDefinition = gql`
+  directive @relayModel(
+    queries: RelayModelQueryMap
+    mutations: RelayModelMutationMap
+    subscriptions: RelayModelSubscriptionMap
+    timestamps: RelayTimestampConfiguration
+  ) on OBJECT
+  input RelayModelMutationMap {
+    create: String
+    update: String
+    delete: String
+  }
+  input RelayModelQueryMap {
+    get: String
+    list: String
+  }
+  input RelayModelSubscriptionMap {
+    onCreate: [String]
+    onUpdate: [String]
+    onDelete: [String]
+    level: RelayModelSubscriptionLevel
+  }
+  enum RelayModelSubscriptionLevel {
+    off
+    public
+    on
+  }
+  input RelayTimestampConfiguration {
+    createdAt: String
+    updatedAt: String
+  }
+`;
+
+export class DynamoDBRelayModelTransformer extends Transformer {
+  resources: ResourceFactory;
+  opts: DynamoDBRelayModelTransformerOptions;
+
+  constructor(opts: DynamoDBRelayModelTransformerOptions = {}) {
+    super('DynamoDBRelayModelTransformer', directiveDefinition);
+    this.opts = this.getOpts(opts);
+    this.resources = new ResourceFactory();
+  }
+
+  public before = (ctx: TransformerContext): void => {
+    const template = this.resources.initTemplate();
+    ctx.mergeResources(template.Resources);
+    ctx.mergeParameters(template.Parameters);
+    ctx.mergeOutputs(template.Outputs);
+    ctx.mergeConditions(template.Conditions);
+  };
+
+  public after = (ctx: TransformerContext): void => {
+    // append hoisted initalization code to the top of request mapping template
+    const ddbMetata = ctx.metadata.get(METADATA_KEY);
+    if (ddbMetata) {
+      Object.entries(ddbMetata.hoistedRequestMappingContent || {}).forEach(
+        ([resourceId, hoistedContentGenerator]: [string, () => string | void]) => {
+          const hoistedContent = hoistedContentGenerator();
+          if (hoistedContent) {
+            const resource: AppSync.Resolver = ctx.getResource(resourceId) as any;
+            resource.Properties.RequestMappingTemplate = [hoistedContent, resource.Properties.RequestMappingTemplate].join('\n');
+            ctx.setResource(resourceId, resource);
+          }
+        },
+      );
+    }
+  };
+
+  /**
+   * Given the initial input and context manipulate the context to handle this object directive.
+   * @param initial The input passed to the transform.
+   * @param ctx The accumulated context for the transform.
+   */
+  public object = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
+    const isTypeNameReserved =
+      def.name.value === ctx.getQueryTypeName() ||
+      def.name.value === ctx.getMutationTypeName() ||
+      def.name.value === ctx.getSubscriptionTypeName();
+
+    if (isTypeNameReserved && ctx.featureFlags.getBoolean('validateTypeNameReservedWords', true)) {
+      throw new InvalidDirectiveError(
+        `'${def.name.value}' is a reserved type name and currently in use within the default schema element.`,
+      );
+    }
+
+    // Add a stack mapping so that all model resources are pulled
+    // into their own stack at the end of the transformation.
+    const stackName = def.name.value;
+
+    const nonModelArray: ObjectTypeDefinitionNode[] = getNonModelObjectArray(def, ctx, new Map<string, ObjectTypeDefinitionNode>());
+
+    nonModelArray.forEach((value: ObjectTypeDefinitionNode) => {
+      const nonModelObject = makeNonModelInputObject(value, nonModelArray, ctx);
+      if (!this.typeExist(nonModelObject.name.value, ctx)) {
+        ctx.addInput(nonModelObject);
+      }
+    });
+
+    this.addIdField(def, directive, ctx);
+
+    // Set Sync Config if it exists
+
+    // Create the dynamodb table to hold the @model type
+    // TODO: Handle types with more than a single "id" hash key
+    const typeName = def.name.value;
+    this.setSyncConfig(ctx, typeName);
+    const isSyncEnabled = this.opts.SyncConfig ? true : false;
+    const tableLogicalID = ModelResourceIDs.ModelTableResourceID(typeName);
+    const iamRoleLogicalID = ModelResourceIDs.ModelTableIAMRoleID(typeName);
+    const dataSourceRoleLogicalID = ModelResourceIDs.ModelTableDataSourceID(typeName);
+    const deletionPolicy = this.opts.EnableDeletionProtection ? DeletionPolicy.Retain : DeletionPolicy.Delete;
+    ctx.setResource(tableLogicalID, this.resources.makeModelTable(typeName, undefined, undefined, deletionPolicy, isSyncEnabled));
+    ctx.mapResourceToStack(stackName, tableLogicalID);
+    ctx.setResource(iamRoleLogicalID, this.resources.makeIAMRole(typeName, this.opts.SyncConfig));
+    ctx.mapResourceToStack(stackName, iamRoleLogicalID);
+    ctx.setResource(
+      dataSourceRoleLogicalID,
+      this.resources.makeDynamoDBDataSource(tableLogicalID, iamRoleLogicalID, typeName, isSyncEnabled),
+    );
+    ctx.mapResourceToStack(stackName, dataSourceRoleLogicalID);
+
+    const streamArnOutputId = `GetAtt${ModelResourceIDs.ModelTableStreamArn(typeName)}`;
+    ctx.setOutput(
+      // "GetAtt" is a backward compatibility addition to prevent breaking current deploys.
+      streamArnOutputId,
+      this.resources.makeTableStreamArnOutput(tableLogicalID),
+    );
+    ctx.mapResourceToStack(stackName, streamArnOutputId);
+
+    const datasourceOutputId = `GetAtt${dataSourceRoleLogicalID}Name`;
+    ctx.setOutput(datasourceOutputId, this.resources.makeDataSourceOutput(dataSourceRoleLogicalID));
+    ctx.mapResourceToStack(stackName, datasourceOutputId);
+
+    const tableNameOutputId = `GetAtt${tableLogicalID}Name`;
+    ctx.setOutput(tableNameOutputId, this.resources.makeTableNameOutput(tableLogicalID));
+    ctx.mapResourceToStack(stackName, tableNameOutputId);
+
+    this.createQueries(def, directive, ctx);
+    this.createMutations(def, directive, ctx, nonModelArray);
+    this.createSubscriptions(def, directive, ctx);
+
+    // Update ModelXConditionInput type
+    this.updateMutationConditionInput(ctx, def);
+
+    // change type to include sync related fields if sync is enabled
+    if (isSyncEnabled) {
+      const obj = ctx.getObject(def.name.value);
+      const newFields = [
+        ...obj.fields,
+        makeField('_version', [], wrapNonNull(makeNamedType('Int'))),
+        makeField('_deleted', [], makeNamedType('Boolean')),
+        makeField('_lastChangedAt', [], wrapNonNull(makeNamedType('AWSTimestamp'))),
+      ];
+
+      const newObj = {
+        ...obj,
+        fields: newFields,
+      };
+
+      ctx.updateObject(newObj);
+    }
+    this.addTimestampFields(def, directive, ctx);
+  };
+
+  private addTimestampFields(def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void {
+    const createdAtField = getCreatedAtFieldName(directive);
+    const updatedAtField = getUpdatedAtFieldName(directive);
+    const existingCreatedAtField = def.fields.find(f => f.name.value === createdAtField);
+    const existingUpdatedAtField = def.fields.find(f => f.name.value === updatedAtField);
+    // Todo: Consolidate how warnings are shown. Instead of printing them here, the invoker of transformer should get
+    // all the warnings together and decide how to render those warning
+    if (!DynamoDBRelayModelTransformer.isTimestampCompatibleField(existingCreatedAtField)) {
+      console.log(
+        `${def.name.value}.${existingCreatedAtField.name.value} is of type ${getBaseType(
+          existingCreatedAtField.type,
+        )}. To support auto population change the type to AWSDateTime or String`,
+      );
+    }
+    if (!DynamoDBRelayModelTransformer.isTimestampCompatibleField(existingUpdatedAtField)) {
+      console.log(
+        `${def.name.value}.${existingUpdatedAtField.name.value} is of type ${getBaseType(
+          existingUpdatedAtField.type,
+        )}. To support auto population change the type to AWSDateTime or String`,
+      );
+    }
+    const obj = ctx.getObject(def.name.value);
+    const newObj: ObjectTypeDefinitionNode = {
+      ...obj,
+      fields: [
+        ...obj.fields,
+        ...(createdAtField && !existingCreatedAtField ? [makeField(createdAtField, [], wrapNonNull(makeNamedType('AWSDateTime')))] : []), // createdAt field
+        ...(updatedAtField && !existingUpdatedAtField ? [makeField(updatedAtField, [], wrapNonNull(makeNamedType('AWSDateTime')))] : []), // updated field
+      ],
+    };
+    ctx.updateObject(newObj);
+  }
+
+  // Add ID field to type when does not have id
+  private addIdField(def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void {
+    const hasIdField = def.fields.find(f => f.name.value === 'id');
+    if (!hasIdField) {
+      const obj = ctx.getObject(def.name.value);
+      const newObj: ObjectTypeDefinitionNode = {
+        ...obj,
+        fields: [makeField('id', [], wrapNonNull(makeNamedType('ID'))), ...obj.fields],
+      };
+      ctx.updateObject(newObj);
+    }
+  }
+
+  private createMutations = (
+    def: ObjectTypeDefinitionNode,
+    directive: DirectiveNode,
+    ctx: TransformerContext,
+    nonModelArray: ObjectTypeDefinitionNode[],
+  ) => {
+    const typeName = def.name.value;
+    const isSyncEnabled = this.opts.SyncConfig ? true : false;
+
+    const mutationFields = [];
+    // Get any name overrides provided by the user. If an empty map it provided
+    // then we do not generate those fields.
+    const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
+
+    // Configure mutations based on *mutations* argument
+    let shouldMakeCreate = true;
+    let shouldMakeUpdate = true;
+    let shouldMakeDelete = true;
+    let createFieldNameOverride = undefined;
+    let updateFieldNameOverride = undefined;
+    let deleteFieldNameOverride = undefined;
+
+    // timestamp fields
+    const createdAtField = getCreatedAtFieldName(directive);
+    const updatedAtField = getUpdatedAtFieldName(directive);
+
+    const existingCreatedAtField = def.fields.find(f => f.name.value === createdAtField);
+    const existingUpdatedAtField = def.fields.find(f => f.name.value === updatedAtField);
+
+    // auto populate the timestamp field only if they are of AWSDateTime type
+    const timestampFields = {
+      createdAtField: DynamoDBRelayModelTransformer.isTimestampCompatibleField(existingCreatedAtField) ? createdAtField : undefined,
+      updatedAtField: DynamoDBRelayModelTransformer.isTimestampCompatibleField(existingUpdatedAtField) ? updatedAtField : undefined,
+    };
+
+    // Figure out which mutations to make and if they have name overrides
+    if (directiveArguments.mutations === null) {
+      shouldMakeCreate = false;
+      shouldMakeUpdate = false;
+      shouldMakeDelete = false;
+    } else if (directiveArguments.mutations) {
+      if (!directiveArguments.mutations.create) {
+        shouldMakeCreate = false;
+      } else {
+        createFieldNameOverride = directiveArguments.mutations.create;
+      }
+      if (!directiveArguments.mutations.update) {
+        shouldMakeUpdate = false;
+      } else {
+        updateFieldNameOverride = directiveArguments.mutations.update;
+      }
+      if (!directiveArguments.mutations.delete) {
+        shouldMakeDelete = false;
+      } else {
+        deleteFieldNameOverride = directiveArguments.mutations.delete;
+      }
+    }
+
+    const conditionInputName = ModelResourceIDs.ModelConditionInputTypeName(typeName);
+
+    // Create the mutations.
+    if (shouldMakeCreate) {
+      const createInput = makeCreateInputObject(def, directive, nonModelArray, ctx, isSyncEnabled);
+      if (!ctx.getType(createInput.name.value)) {
+        ctx.addInput(createInput);
+      }
+      const createResolver = this.resources.makeCreateResolver({
+        type: def.name.value,
+        nameOverride: createFieldNameOverride,
+        syncConfig: this.opts.SyncConfig,
+      });
+      const resourceId = ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName);
+      this.addInitalizationMetadata(ctx, resourceId, () => {
+        const inputObj = ctx.getType(createInput.name.value) as InputObjectTypeDefinitionNode;
+        if (inputObj) {
+          return this.resources.initalizeDefaultInputForCreateMutation(inputObj, timestampFields);
+        }
+      });
+
+      ctx.setResource(resourceId, createResolver);
+      ctx.mapResourceToStack(typeName, resourceId);
+      const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(createInput.name.value)))];
+      if (this.supportsConditions(ctx)) {
+        args.push(makeInputValueDefinition('condition', makeNamedType(conditionInputName)));
+      }
+      mutationFields.push(makeField(createResolver.Properties.FieldName.toString(), args, makeNamedType(def.name.value)));
+    }
+
+    if (shouldMakeUpdate) {
+      const updateInput = makeUpdateInputObject(def, nonModelArray, ctx, isSyncEnabled);
+      const optionalNonNullableFields = getFieldsOptionalNonNullableField(
+        updateInput.fields.map(r => r),
+        def,
+      );
+      if (!ctx.getType(updateInput.name.value)) {
+        ctx.addInput(updateInput);
+      }
+      const updateResolver = this.resources.makeUpdateResolver({
+        type: def.name.value,
+        nameOverride: updateFieldNameOverride,
+        syncConfig: this.opts.SyncConfig,
+        timestamps: timestampFields,
+        optionalNonNullableFields,
+      });
+      const resourceId = ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName);
+      ctx.setResource(resourceId, updateResolver);
+      ctx.mapResourceToStack(typeName, resourceId);
+      const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(updateInput.name.value)))];
+      if (this.supportsConditions(ctx)) {
+        args.push(makeInputValueDefinition('condition', makeNamedType(conditionInputName)));
+      }
+      mutationFields.push(makeField(updateResolver.Properties.FieldName.toString(), args, makeNamedType(def.name.value)));
+    }
+
+    if (shouldMakeDelete) {
+      const deleteInput = makeDeleteInputObject(def, isSyncEnabled);
+      if (!ctx.getType(deleteInput.name.value)) {
+        ctx.addInput(deleteInput);
+      }
+      const deleteResolver = this.resources.makeDeleteResolver({
+        type: def.name.value,
+        nameOverride: deleteFieldNameOverride,
+        syncConfig: this.opts.SyncConfig,
+      });
+      const resourceId = ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName);
+      ctx.setResource(resourceId, deleteResolver);
+      ctx.mapResourceToStack(typeName, resourceId);
+      const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(deleteInput.name.value)))];
+      if (this.supportsConditions(ctx)) {
+        args.push(makeInputValueDefinition('condition', makeNamedType(conditionInputName)));
+      }
+      mutationFields.push(makeField(deleteResolver.Properties.FieldName.toString(), args, makeNamedType(def.name.value)));
+    }
+    ctx.addMutationFields(mutationFields);
+
+    if (shouldMakeCreate || shouldMakeUpdate || shouldMakeDelete) {
+      this.generateConditionInputs(ctx, def);
+    }
+  };
+
+  private createQueries = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+    const typeName = def.name.value;
+    const queryFields = [];
+    const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
+
+    // Configure queries based on *queries* argument
+    let shouldMakeGet = true;
+    let shouldMakeList = true;
+    let getFieldNameOverride = undefined;
+    let listFieldNameOverride = undefined;
+    const isSyncEnabled = this.opts.SyncConfig ? true : false;
+
+    // Figure out which queries to make and if they have name overrides.
+    // If queries is undefined (default), create all queries
+    // If queries is explicetly set to null, do not create any
+    // else if queries is defined, check overrides
+    if (directiveArguments.queries === null) {
+      shouldMakeGet = false;
+      shouldMakeList = false;
+    } else if (directiveArguments.queries) {
+      if (!directiveArguments.queries.get) {
+        shouldMakeGet = false;
+      } else {
+        getFieldNameOverride = directiveArguments.queries.get;
+      }
+      if (!directiveArguments.queries.list) {
+        shouldMakeList = false;
+      } else {
+        listFieldNameOverride = directiveArguments.queries.list;
+      }
+    }
+
+    if (shouldMakeList) {
+      if (!this.typeExist('RelayModelSortDirection', ctx)) {
+        const tableSortDirection = makeModelSortDirectionEnumObject();
+        ctx.addEnum(tableSortDirection);
+      }
+    }
+
+    // Create sync query if @model present for datastore
+    if (isSyncEnabled) {
+      // change here for selective Sync for @model (Just add the queryMap for table and query expression)
+      const syncResolver = this.resources.makeSyncResolver(typeName);
+      const syncResourceID = ResolverResourceIDs.SyncResolverResourceID(typeName);
+      ctx.setResource(syncResourceID, syncResolver);
+      ctx.mapResourceToStack(typeName, syncResourceID);
+      this.generateModelXConnectionType(ctx, def, isSyncEnabled);
+      this.generateFilterInputs(ctx, def);
+      queryFields.push(
+        makeField(
+          syncResolver.Properties.FieldName.toString(),
+          [
+            makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(def.name.value))),
+            makeInputValueDefinition('first', makeNamedType('Int')),
+            makeInputValueDefinition('after', makeNamedType('String')),
+            makeInputValueDefinition('lastSync', makeNamedType('AWSTimestamp')),
+          ],
+          makeNamedType(ModelResourceIDs.ModelConnectionTypeName(def.name.value)),
+        ),
+      );
+    }
+
+    // Create get queries
+    if (shouldMakeGet) {
+      const getResolver = this.resources.makeGetResolver(def.name.value, getFieldNameOverride, isSyncEnabled, ctx.getQueryTypeName());
+      const resourceId = ResolverResourceIDs.DynamoDBGetResolverResourceID(typeName);
+      ctx.setResource(resourceId, getResolver);
+      ctx.mapResourceToStack(typeName, resourceId);
+
+      queryFields.push(
+        makeField(
+          getResolver.Properties.FieldName.toString(),
+          [makeInputValueDefinition('id', makeNonNullType(makeNamedType('ID')))],
+          makeNamedType(def.name.value),
+        ),
+      );
+    }
+
+    if (shouldMakeList) {
+      this.generateModelXConnectionType(ctx, def);
+
+      // Create the list resolver
+      const listResolver = this.resources.makeListResolver(
+        def.name.value,
+        ctx.featureFlags.getBoolean('improvePluralization'),
+        listFieldNameOverride,
+        isSyncEnabled,
+        ctx.getQueryTypeName(),
+      );
+      const resourceId = ResolverResourceIDs.DynamoDBListResolverResourceID(typeName);
+      ctx.setResource(resourceId, listResolver);
+      ctx.mapResourceToStack(typeName, resourceId);
+
+      queryFields.push(makeConnectionField(listResolver.Properties.FieldName.toString(), def.name.value));
+      this.generateFilterInputs(ctx, def);
+    }
+
+    ctx.addQueryFields(queryFields);
+  };
+
+  /**
+   * Creates subscriptions for a @model object type. By default creates a subscription for
+   * create, update, and delete mutations.
+   *
+   * Subscriptions are one to many in that a subscription may subscribe to multiple mutations.
+   * You may thus provide multiple names of the subscriptions that will be triggered by each
+   * mutation.
+   *
+   * type Post @model(subscriptions: { onCreate: ["onPostCreated", "onFeedUpdated"] }) {
+   *      id: ID!
+   *      title: String!
+   * }
+   *
+   * will create two subscription fields:
+   *
+   * type Subscription {
+   *      onPostCreated: Post @aws_subscribe(mutations: ["createPost"])
+   *      onFeedUpdated: Post @aws_subscribe(mutations: ["createPost"])
+   * }
+   *  Subscription Levels
+   *   subscriptions.level === OFF || subscriptions === null
+   *      Will not create subscription operations
+   *   subcriptions.level === PUBLIC
+   *      Will continue as is creating subscription operations
+   *   subscriptions.level === ON || subscriptions === undefined
+   *      If auth is enabled it will enabled protection on subscription operations and resolvers
+   */
+  private createSubscriptions = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
+    const typeName = def.name.value;
+    const subscriptionFields = [];
+
+    const directiveArguments: ModelDirectiveArgs = getDirectiveArguments(directive);
+
+    const subscriptionsArgument = directiveArguments.subscriptions;
+    const createResolver = ctx.getResource(ResolverResourceIDs.DynamoDBCreateResolverResourceID(typeName));
+    const updateResolver = ctx.getResource(ResolverResourceIDs.DynamoDBUpdateResolverResourceID(typeName));
+    const deleteResolver = ctx.getResource(ResolverResourceIDs.DynamoDBDeleteResolverResourceID(typeName));
+
+    if (subscriptionsArgument === null) {
+      return;
+    }
+    if (subscriptionsArgument && subscriptionsArgument.level === 'off') {
+      return;
+    }
+    if (subscriptionsArgument && (subscriptionsArgument.onCreate || subscriptionsArgument.onUpdate || subscriptionsArgument.onDelete)) {
+      // Add the custom subscriptions
+      const subscriptionToMutationsMap: { [subField: string]: string[] } = {};
+      const onCreate = subscriptionsArgument.onCreate || [];
+      const onUpdate = subscriptionsArgument.onUpdate || [];
+      const onDelete = subscriptionsArgument.onDelete || [];
+      const subFields = [...onCreate, ...onUpdate, ...onDelete];
+      // initialize the reverse lookup
+      for (const field of subFields) {
+        subscriptionToMutationsMap[field] = [];
+      }
+      // Add the correct mutation to the lookup
+      for (const field of Object.keys(subscriptionToMutationsMap)) {
+        if (onCreate.includes(field) && createResolver) {
+          subscriptionToMutationsMap[field].push(createResolver.Properties.FieldName);
+        }
+        if (onUpdate.includes(field) && updateResolver) {
+          subscriptionToMutationsMap[field].push(updateResolver.Properties.FieldName);
+        }
+        if (onDelete.includes(field) && deleteResolver) {
+          subscriptionToMutationsMap[field].push(deleteResolver.Properties.FieldName);
+        }
+      }
+      for (const subFieldName of Object.keys(subscriptionToMutationsMap)) {
+        const subField = makeSubscriptionField(subFieldName, typeName, subscriptionToMutationsMap[subFieldName]);
+        subscriptionFields.push(subField);
+      }
+    } else {
+      // Add the default subscriptions
+      if (createResolver) {
+        const onCreateField = makeSubscriptionField(ModelResourceIDs.ModelOnCreateSubscriptionName(typeName), typeName, [
+          createResolver.Properties.FieldName,
+        ]);
+        subscriptionFields.push(onCreateField);
+      }
+      if (updateResolver) {
+        const onUpdateField = makeSubscriptionField(ModelResourceIDs.ModelOnUpdateSubscriptionName(typeName), typeName, [
+          updateResolver.Properties.FieldName,
+        ]);
+        subscriptionFields.push(onUpdateField);
+      }
+      if (deleteResolver) {
+        const onDeleteField = makeSubscriptionField(ModelResourceIDs.ModelOnDeleteSubscriptionName(typeName), typeName, [
+          deleteResolver.Properties.FieldName,
+        ]);
+        subscriptionFields.push(onDeleteField);
+      }
+    }
+
+    ctx.addSubscriptionFields(subscriptionFields);
+  };
+
+  private typeExist(type: string, ctx: TransformerContext): boolean {
+    return Boolean(type in ctx.nodeMap);
+  }
+
+  private generateModelXConnectionType(ctx: TransformerContext, def: ObjectTypeDefinitionNode, isSync: Boolean = false): void {
+    const tableXConnectionName = ModelResourceIDs.ModelConnectionTypeName(def.name.value);
+    if (this.typeExist(tableXConnectionName, ctx)) {
+      return;
+    }
+
+    // Create the ModelXConnection
+    const connectionType = blankObject(tableXConnectionName);
+    ctx.addObject(connectionType);
+    ctx.addObjectExtension(makeModelConnectionType(def.name.value, isSync));
+  }
+
+  private generateFilterInputs(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {
+    const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
+    for (const filter of scalarFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    // Create the Enum filters
+    const enumFilters = makeEnumFilterInputObjects(def, ctx, this.supportsConditions(ctx));
+    for (const filter of enumFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    // Create the ModelXFilterInput
+    const tableXQueryFilterInput = makeModelXFilterInputObject(def, ctx, this.supportsConditions(ctx));
+    if (!this.typeExist(tableXQueryFilterInput.name.value, ctx)) {
+      ctx.addInput(tableXQueryFilterInput);
+    }
+
+    if (this.supportsConditions(ctx)) {
+      const attributeTypeEnum = makeAttributeTypeEnum();
+      if (!this.typeExist(attributeTypeEnum.name.value, ctx)) {
+        ctx.addType(attributeTypeEnum);
+      }
+    }
+  }
+
+  /**
+   * Generate Predicate type for Sync Query for DataStore
+   * @param ctx : transformer context
+   * @param def : ObjectTypeDefinition
+   */
+
+  private generateConditionInputs(ctx: TransformerContext, def: ObjectTypeDefinitionNode): void {
+    const scalarFilters = makeScalarFilterInputs(this.supportsConditions(ctx));
+    for (const filter of scalarFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    // Create the Enum filters
+    const enumFilters = makeEnumFilterInputObjects(def, ctx, this.supportsConditions(ctx));
+    for (const filter of enumFilters) {
+      if (!this.typeExist(filter.name.value, ctx)) {
+        ctx.addInput(filter);
+      }
+    }
+
+    if (this.supportsConditions(ctx)) {
+      // Create the ModelXConditionInput
+      const tableXMutationConditionInput = makeModelXConditionInputObject(def, ctx, this.supportsConditions(ctx));
+      if (!this.typeExist(tableXMutationConditionInput.name.value, ctx)) {
+        ctx.addInput(tableXMutationConditionInput);
+      }
+
+      const attributeTypeEnum = makeAttributeTypeEnum();
+      if (!this.typeExist(attributeTypeEnum.name.value, ctx)) {
+        ctx.addType(attributeTypeEnum);
+      }
+    }
+  }
+
+  private getOpts(opts: DynamoDBRelayModelTransformerOptions) {
+    const defaultOpts = {
+      EnableDeletionProtection: false,
+    };
+    return {
+      ...defaultOpts,
+      ...opts,
+    };
+  }
+
+  private setSyncConfig(ctx: TransformerContext, typeName: string) {
+    let syncConfig: SyncConfig;
+    const resolverConfig = ctx.getResolverConfig();
+    if (resolverConfig && resolverConfig.project) {
+      syncConfig = resolverConfig.project;
+    }
+    if (resolverConfig && resolverConfig.models && resolverConfig.models[typeName]) {
+      const typeResolverConfig = resolverConfig.models[typeName];
+      if (typeResolverConfig.ConflictDetection && typeResolverConfig.ConflictHandler) {
+        syncConfig = typeResolverConfig;
+      } else {
+        console.warn(`Invalid resolverConfig for type ${typeName}. Using the project resolverConfig instead.`);
+      }
+    }
+    return (this.opts.SyncConfig = syncConfig);
+  }
+
+  // Due to the current architecture of Transformers we've to handle the 'id' field removal
+  // here, because KeyTransformer will not be invoked if there are no @key directives declared
+  // on the type.
+  private updateMutationConditionInput(ctx: TransformerContext, type: ObjectTypeDefinitionNode): void {
+    if (this.supportsConditions(ctx)) {
+      // Get the existing ModelXConditionInput
+      const tableXMutationConditionInputName = ModelResourceIDs.ModelConditionInputTypeName(type.name.value);
+
+      if (this.typeExist(tableXMutationConditionInputName, ctx)) {
+        const tableXMutationConditionInput = <InputObjectTypeDefinitionNode>ctx.getType(tableXMutationConditionInputName);
+
+        const keyDirectives = type.directives.filter(d => d.name.value === 'key');
+
+        // If there are @key directives defined we've nothing to do, it will handle everything
+        if (keyDirectives && keyDirectives.length > 0) {
+          return;
+        }
+
+        // Remove the field named 'id' from the condition if there is one
+        const idField = tableXMutationConditionInput.fields.find(f => f.name.value === 'id');
+
+        if (idField) {
+          const reducedFields = tableXMutationConditionInput.fields.filter(f => Boolean(f.name.value !== 'id'));
+
+          const updatedInput = {
+            ...tableXMutationConditionInput,
+            fields: reducedFields,
+          };
+
+          ctx.putType(updatedInput);
+        }
+      }
+    }
+  }
+
+  private supportsConditions(context: TransformerContext) {
+    return context.getTransformerVersion() >= CONDITIONS_MINIMUM_VERSION;
+  }
+
+  private static isTimestampCompatibleField(field?: FieldDefinitionNode): boolean {
+    if (field && !(getBaseType(field.type) === 'AWSDateTime' || getBaseType(field.type) === 'String')) {
+      return false;
+    }
+    return true;
+  }
+
+  private addInitalizationMetadata(ctx: TransformerContext, resourceId: string, initCodeGenerator: () => string | void): void {
+    const ddbMetadata = ctx.metadata.has(METADATA_KEY) ? ctx.metadata.get(METADATA_KEY) : {};
+    ddbMetadata.hoistedRequestMappingContent = {
+      ...ddbMetadata?.hoistedRequestMappingContent,
+      [resourceId]: initCodeGenerator,
+    };
+    ctx.metadata.set(METADATA_KEY, ddbMetadata);
+  }
+}

--- a/packages/graphql-relay-transformer/src/model/definition.ts
+++ b/packages/graphql-relay-transformer/src/model/definition.ts
@@ -1,0 +1,836 @@
+import {
+  ObjectTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+  FieldDefinitionNode,
+  Kind,
+  TypeNode,
+  EnumTypeDefinitionNode,
+  ObjectTypeExtensionNode,
+  NamedTypeNode,
+  DirectiveNode,
+  InterfaceTypeDefinitionNode,
+  EnumValueDefinitionNode,
+} from 'graphql';
+import {
+  wrapNonNull,
+  unwrapNonNull,
+  isNonNullType,
+  makeNamedType,
+  toUpper,
+  graphqlName,
+  makeListType,
+  isScalar,
+  getBaseType,
+  blankObjectExtension,
+  extensionWithFields,
+  makeField,
+  makeInputValueDefinition,
+  ModelResourceIDs,
+  makeDirective,
+  makeArgument,
+  makeValueNode,
+  withNamedNodeNamed,
+  isListType,
+  blankObject,
+} from 'graphql-transformer-common';
+import { TransformerContext } from 'graphql-transformer-core';
+import { getCreatedAtFieldName, getUpdatedAtFieldName } from 'graphql-dynamodb-transformer';
+
+const STRING_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith'];
+const ID_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith'];
+const INT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
+const FLOAT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
+const BOOLEAN_CONDITIONS = ['ne', 'eq'];
+const SIZE_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
+
+const STRING_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType', 'size']);
+const ID_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType', 'size']);
+const INT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
+const FLOAT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
+const BOOLEAN_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);
+
+const ATTRIBUTE_TYPES = ['binary', 'binarySet', 'bool', 'list', 'map', 'number', 'numberSet', 'string', 'stringSet', '_null'];
+
+export function getNonModelObjectArray(
+  obj: ObjectTypeDefinitionNode,
+  ctx: TransformerContext,
+  pMap: Map<string, ObjectTypeDefinitionNode>,
+): ObjectTypeDefinitionNode[] {
+  // loop over all fields in the object, picking out all nonscalars that are not @model types
+  for (const field of obj.fields) {
+    if (!isScalar(field.type)) {
+      const def = ctx.getType(getBaseType(field.type));
+
+      if (
+        def &&
+        def.kind === Kind.OBJECT_TYPE_DEFINITION &&
+        !def.directives.find(e => e.name.value === 'relayModel') &&
+        pMap.get(def.name.value) === undefined
+      ) {
+        // recursively find any non @model types referenced by the current
+        // non @model type
+        pMap.set(def.name.value, def);
+        getNonModelObjectArray(def, ctx, pMap);
+      }
+    }
+  }
+
+  return Array.from(pMap.values());
+}
+
+export function makeNonModelInputObject(
+  obj: ObjectTypeDefinitionNode,
+  nonModelTypes: ObjectTypeDefinitionNode[],
+  ctx: TransformerContext,
+): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.NonModelInputObjectName(obj.name.value);
+  const fields: InputValueDefinitionNode[] = obj.fields
+    .filter((field: FieldDefinitionNode) => {
+      const fieldType = ctx.getType(getBaseType(field.type));
+      if (
+        isScalar(field.type) ||
+        nonModelTypes.find(e => e.name.value === getBaseType(field.type)) ||
+        (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)
+      ) {
+        return true;
+      }
+      return false;
+    })
+    .map((field: FieldDefinitionNode) => {
+      const type = nonModelTypes.find(e => e.name.value === getBaseType(field.type))
+        ? withNamedNodeNamed(field.type, ModelResourceIDs.NonModelInputObjectName(getBaseType(field.type)))
+        : field.type;
+      return {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: field.name,
+        type,
+        // TODO: Service does not support new style descriptions so wait.
+        // description: field.description,
+        directives: [],
+      };
+    });
+  return {
+    kind: 'InputObjectTypeDefinition',
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
+export function makeCreateInputObject(
+  obj: ObjectTypeDefinitionNode,
+  directive: DirectiveNode,
+  nonModelTypes: ObjectTypeDefinitionNode[],
+  ctx: TransformerContext,
+  isSync: boolean = false,
+): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelCreateInputObjectName(obj.name.value);
+  const createdAtField = getCreatedAtFieldName(directive);
+  const updatedAtField = getUpdatedAtFieldName(directive);
+
+  // List of fields that can be assigend in resolver if they are not passed in input
+  const autoGeneratableFieldsWithType: Record<string, string[]> = {
+    id: ['ID'],
+    [createdAtField]: ['AWSDateTime', 'String'],
+    [updatedAtField]: ['AWSDateTime', 'String'],
+  };
+
+  const hasIdField = obj.fields.find(f => f.name.value === 'id');
+  const fields: InputValueDefinitionNode[] = obj.fields
+    .filter((field: FieldDefinitionNode) => {
+      const fieldType = ctx.getType(getBaseType(field.type));
+      if (
+        isScalar(field.type) ||
+        nonModelTypes.find(e => e.name.value === getBaseType(field.type)) ||
+        (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)
+      ) {
+        return true;
+      }
+      return false;
+    })
+    .map((field: FieldDefinitionNode) => {
+      let type: TypeNode;
+      const fieldName = field.name.value;
+      if (
+        Object.keys(autoGeneratableFieldsWithType).indexOf(fieldName) !== -1 &&
+        autoGeneratableFieldsWithType[fieldName].indexOf(unwrapNonNull(field.type).name.value) !== -1
+      ) {
+        // ids are always optional. when provided the value is used.
+        // when not provided the value is not used.
+        type = unwrapNonNull(field.type);
+      } else {
+        type = nonModelTypes.find(e => e.name.value === getBaseType(field.type))
+          ? withNamedNodeNamed(field.type, ModelResourceIDs.NonModelInputObjectName(getBaseType(field.type)))
+          : field.type;
+      }
+      return {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: field.name,
+        type,
+        // TODO: Service does not support new style descriptions so wait.
+        // description: field.description,
+        directives: [],
+      };
+    });
+  // add the version if this project is a sync project
+  if (isSync) {
+    fields.push(makeInputValueDefinition('_version', makeNamedType('Int')));
+  }
+  return {
+    kind: 'InputObjectTypeDefinition',
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields: [
+      // add default id field and expose that
+      ...(hasIdField ? [] : [makeInputValueDefinition('id', makeNamedType('ID'))]),
+      ...fields,
+    ],
+    directives: [],
+  };
+}
+export function getFieldsOptionalNonNullableField(fields: InputValueDefinitionNode[], obj: ObjectTypeDefinitionNode): string[] {
+  const fieldMap = fields.reduce((map, field) => {
+    map.set(field.name.value, field);
+    return map;
+  }, new Map<string, InputValueDefinitionNode>());
+
+  return obj.fields
+    .filter(
+      r =>
+        fieldMap.has(r.name.value) && //field exists in the model
+        isNonNullType(r.type) && // field was non null type in model
+        fieldMap.get(r.name.value).type.kind !== Kind.NON_NULL_TYPE, // field is not nullable type in update mutation model
+    )
+    .map(r => r.name.value);
+}
+
+export function makeUpdateInputObject(
+  obj: ObjectTypeDefinitionNode,
+  nonModelTypes: ObjectTypeDefinitionNode[],
+  ctx: TransformerContext,
+  isSync: boolean = false,
+): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelUpdateInputObjectName(obj.name.value);
+  const fields: InputValueDefinitionNode[] = obj.fields
+    .filter(f => {
+      const fieldType = ctx.getType(getBaseType(f.type));
+      if (
+        isScalar(f.type) ||
+        nonModelTypes.find(e => e.name.value === getBaseType(f.type)) ||
+        (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)
+      ) {
+        return true;
+      }
+      return false;
+    })
+    .map((field: FieldDefinitionNode) => {
+      let type;
+      if (field.name.value === 'id') {
+        type = wrapNonNull(field.type);
+      } else {
+        type = unwrapNonNull(field.type);
+      }
+      type = nonModelTypes.find(e => e.name.value === getBaseType(field.type))
+        ? withNamedNodeNamed(type, ModelResourceIDs.NonModelInputObjectName(getBaseType(field.type)))
+        : type;
+      return {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: field.name,
+        type,
+        // TODO: Service does not support new style descriptions so wait.
+        // description: field.description,
+        directives: [],
+      };
+    });
+  if (isSync) {
+    fields.push(makeInputValueDefinition('_version', makeNamedType('Int')));
+  }
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
+export function makeDeleteInputObject(obj: ObjectTypeDefinitionNode, isSync: boolean = false): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelDeleteInputObjectName(obj.name.value);
+  const fields: InputValueDefinitionNode[] = [
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: { kind: 'Name', value: 'id' },
+      type: wrapNonNull(makeNamedType('ID')),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: {
+      //     kind: 'StringValue',
+      //     value: `The id of the ${obj.name.value} to delete.`
+      // },
+      directives: [],
+    },
+  ];
+  if (isSync) {
+    fields.push(makeInputValueDefinition('_version', makeNamedType('Int')));
+  }
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} delete mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
+export function makeModelXFilterInputObject(
+  obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  ctx: TransformerContext,
+  supportsConditions: Boolean,
+): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelFilterInputTypeName(obj.name.value);
+  const fields: InputValueDefinitionNode[] = obj.fields
+    .filter((field: FieldDefinitionNode) => {
+      const fieldType = ctx.getType(getBaseType(field.type));
+      if (isScalar(field.type) || (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)) {
+        return true;
+      }
+    })
+    .map((field: FieldDefinitionNode) => {
+      const baseType = getBaseType(field.type);
+      const fieldType = ctx.getType(baseType);
+      const isList = isListType(field.type);
+      const isEnumType = fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
+      const filterTypeName =
+        isEnumType && isList
+          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, !supportsConditions)
+          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, !supportsConditions);
+
+      return {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: field.name,
+        type: makeNamedType(filterTypeName),
+        // TODO: Service does not support new style descriptions so wait.
+        // description: field.description,
+        directives: [],
+      };
+    });
+
+  fields.push(
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'and',
+      },
+      type: makeListType(makeNamedType(name)),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'or',
+      },
+      type: makeListType(makeNamedType(name)),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'not',
+      },
+      type: makeNamedType(name),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+  );
+
+  return {
+    kind: 'InputObjectTypeDefinition',
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
+export function makeModelXConditionInputObject(
+  obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  ctx: TransformerContext,
+  supportsConditions: Boolean,
+): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelConditionInputTypeName(obj.name.value);
+  const fields: InputValueDefinitionNode[] = obj.fields
+    .filter((field: FieldDefinitionNode) => {
+      const fieldType = ctx.getType(getBaseType(field.type));
+      if (isScalar(field.type) || (fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION)) {
+        return true;
+      }
+    })
+    .map((field: FieldDefinitionNode) => {
+      const baseType = getBaseType(field.type);
+      const fieldType = ctx.getType(baseType);
+      const isList = isListType(field.type);
+      const isEnumType = fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
+      const conditionTypeName =
+        isEnumType && isList
+          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, !supportsConditions)
+          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, !supportsConditions);
+
+      return {
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: field.name,
+        type: makeNamedType(conditionTypeName),
+        // TODO: Service does not support new style descriptions so wait.
+        // description: field.description,
+        directives: [],
+      };
+    });
+
+  fields.push(
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'and',
+      },
+      type: makeListType(makeNamedType(name)),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'or',
+      },
+      type: makeListType(makeNamedType(name)),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+    {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: {
+        kind: 'Name',
+        value: 'not',
+      },
+      type: makeNamedType(name),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    },
+  );
+
+  return {
+    kind: 'InputObjectTypeDefinition',
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
+export function makeEnumFilterInputObjects(
+  obj: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  ctx: TransformerContext,
+  supportsConditions: Boolean,
+): InputObjectTypeDefinitionNode[] {
+  return obj.fields
+    .filter((field: FieldDefinitionNode) => {
+      const fieldType = ctx.getType(getBaseType(field.type));
+      return fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
+    })
+    .map((enumField: FieldDefinitionNode) => {
+      const typeName = getBaseType(enumField.type);
+      const isList = isListType(enumField.type);
+      const name = isList
+        ? ModelResourceIDs.ModelFilterListInputTypeName(typeName, !supportsConditions)
+        : ModelResourceIDs.ModelScalarFilterInputTypeName(typeName, !supportsConditions);
+      const fields = [];
+
+      fields.push({
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: {
+          kind: 'Name',
+          value: 'eq',
+        },
+        type: isList ? makeListType(makeNamedType(typeName)) : makeNamedType(typeName),
+        directives: [],
+      });
+
+      fields.push({
+        kind: Kind.INPUT_VALUE_DEFINITION,
+        name: {
+          kind: 'Name',
+          value: 'ne',
+        },
+        type: isList ? makeListType(makeNamedType(typeName)) : makeNamedType(typeName),
+        directives: [],
+      });
+
+      if (isList) {
+        fields.push({
+          kind: Kind.INPUT_VALUE_DEFINITION,
+          name: {
+            kind: 'Name',
+            value: 'contains',
+          },
+          type: makeNamedType(typeName),
+          directives: [],
+        });
+
+        fields.push({
+          kind: Kind.INPUT_VALUE_DEFINITION,
+          name: {
+            kind: 'Name',
+            value: 'notContains',
+          },
+          type: makeNamedType(typeName),
+          directives: [],
+        });
+      }
+
+      return {
+        kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+        name: {
+          kind: 'Name',
+          value: name,
+        },
+        fields,
+        directives: [],
+      } as InputObjectTypeDefinitionNode;
+    });
+}
+
+export function makeModelSortDirectionEnumObject(): EnumTypeDefinitionNode {
+  const name = graphqlName('RelayModelSortDirection');
+  return {
+    kind: Kind.ENUM_TYPE_DEFINITION,
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    values: [
+      {
+        kind: Kind.ENUM_VALUE_DEFINITION,
+        name: { kind: 'Name', value: 'ASC' },
+        directives: [],
+      },
+      {
+        kind: Kind.ENUM_VALUE_DEFINITION,
+        name: { kind: 'Name', value: 'DESC' },
+        directives: [],
+      },
+    ],
+    directives: [],
+  };
+}
+
+export function makeModelScalarFilterInputObject(type: string, supportsConditions: Boolean): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelFilterScalarInputTypeName(type, !supportsConditions);
+  const conditions = getScalarConditions(type);
+  const fields: InputValueDefinitionNode[] = conditions.map((condition: string) => ({
+    kind: Kind.INPUT_VALUE_DEFINITION,
+    name: { kind: 'Name' as const, value: condition },
+    type: getScalarFilterInputType(condition, type, name),
+    // TODO: Service does not support new style descriptions so wait.
+    // description: field.description,
+    directives: [],
+  }));
+  let functionInputFields = [];
+  if (supportsConditions) {
+    functionInputFields = makeFunctionInputFields(type);
+  }
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields: [...fields, ...functionInputFields],
+    directives: [],
+  };
+}
+
+function getScalarFilterInputType(condition: string, type: string, filterInputName: string): TypeNode {
+  switch (condition) {
+    case 'between':
+      return makeListType(makeNamedType(type));
+    case 'and':
+    case 'or':
+      return makeNamedType(filterInputName);
+    default:
+      return makeNamedType(type);
+  }
+}
+
+function getScalarConditions(type: string): string[] {
+  switch (type) {
+    case 'String':
+      return STRING_CONDITIONS;
+    case 'ID':
+      return ID_CONDITIONS;
+    case 'Int':
+      return INT_CONDITIONS;
+    case 'Float':
+      return FLOAT_CONDITIONS;
+    case 'Boolean':
+      return BOOLEAN_CONDITIONS;
+    default:
+      throw new Error('Valid types are String, ID, Int, Float, Boolean');
+  }
+}
+
+function makeSizeInputType(): InputObjectTypeDefinitionNode {
+  const name = ModelResourceIDs.ModelSizeInputTypeName();
+  const fields: InputValueDefinitionNode[] = SIZE_CONDITIONS.map((condition: string) => ({
+    kind: Kind.INPUT_VALUE_DEFINITION,
+    name: { kind: 'Name' as const, value: condition },
+    type: getScalarFilterInputType(condition, 'Int', '' /* unused */),
+    // TODO: Service does not support new style descriptions so wait.
+    // description: field.description,
+    directives: [],
+  }));
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    // TODO: Service does not support new style descriptions so wait.
+    // description: {
+    //     kind: 'StringValue',
+    //     value: `Input type for ${obj.name.value} mutations`
+    // },
+    name: {
+      kind: 'Name',
+      value: name,
+    },
+    fields,
+    directives: [],
+  };
+}
+
+function getFunctionListForType(typeName: string): Set<string> {
+  switch (typeName) {
+    case 'String':
+      return STRING_FUNCTIONS;
+    case 'ID':
+      return ID_FUNCTIONS;
+    case 'Int':
+      return INT_FUNCTIONS;
+    case 'Float':
+      return FLOAT_FUNCTIONS;
+    case 'Boolean':
+      return BOOLEAN_FUNCTIONS;
+    default:
+      throw new Error('Valid types are String, ID, Int, Float, Boolean');
+  }
+}
+
+function makeFunctionInputFields(typeName: string): InputValueDefinitionNode[] {
+  const functions = getFunctionListForType(typeName);
+  const fields = new Array<InputValueDefinitionNode>();
+
+  if (functions.has('attributeExists')) {
+    fields.push({
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: { kind: 'Name' as const, value: 'attributeExists' },
+      type: makeNamedType('Boolean'),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    });
+  }
+
+  if (functions.has('attributeType')) {
+    fields.push({
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: { kind: 'Name' as const, value: 'attributeType' },
+      type: makeNamedType(ModelResourceIDs.ModelAttributeTypesName()),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    });
+  }
+
+  if (functions.has('size')) {
+    fields.push({
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      name: { kind: 'Name' as const, value: 'size' },
+      type: makeNamedType(ModelResourceIDs.ModelSizeInputTypeName()),
+      // TODO: Service does not support new style descriptions so wait.
+      // description: field.description,
+      directives: [],
+    });
+  }
+
+  return fields;
+}
+
+export function makeAttributeTypeEnum(): EnumTypeDefinitionNode {
+  const makeEnumValue = (enumValue: string): EnumValueDefinitionNode => ({
+    kind: Kind.ENUM_VALUE_DEFINITION,
+    name: { kind: 'Name' as const, value: enumValue },
+    directives: [],
+  });
+
+  return {
+    kind: Kind.ENUM_TYPE_DEFINITION,
+    name: { kind: 'Name' as const, value: ModelResourceIDs.ModelAttributeTypesName() },
+    values: ATTRIBUTE_TYPES.map(t => makeEnumValue(t)),
+    directives: [],
+  };
+}
+
+export const modelEdgeTypeName = (typeName: string): string => {
+  return `Model${typeName}Edge`;
+};
+
+export function makeModelEdgeType(typeName: string, isSync: Boolean = false): ObjectTypeDefinitionNode {
+  const edgeName = modelEdgeTypeName(typeName);
+  const edgeTypeExtension = blankObject(edgeName);
+
+  return {
+    ...edgeTypeExtension,
+    fields: [makeField('node', [], makeNamedType(typeName)), makeField('cursor', [], makeNamedType('String'))],
+  };
+}
+
+export function makeModelConnectionType(typeName: string, isSync: Boolean = false): ObjectTypeExtensionNode {
+  const connectionName = ModelResourceIDs.ModelConnectionTypeName(typeName);
+  const edgeName = modelEdgeTypeName(typeName);
+
+  let connectionTypeExtension = blankObjectExtension(connectionName);
+  connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('edges', [], makeListType(makeNamedType(edgeName)))]);
+  connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('pageInfo', [], makeNamedType('PageInfo'))]);
+  if (isSync) {
+    connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('startedAt', [], makeNamedType('AWSTimestamp'))]);
+  }
+  return connectionTypeExtension;
+}
+
+export function makeConnectionField(fieldName: string, returnTypeName: string, args: InputValueDefinitionNode[] = []): FieldDefinitionNode {
+  return makeField(
+    fieldName,
+    [
+      ...args,
+      makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
+      makeInputValueDefinition('first', makeNamedType('Int')),
+      makeInputValueDefinition('after', makeNamedType('String')),
+    ],
+    makeNamedType(ModelResourceIDs.ModelConnectionTypeName(returnTypeName)),
+  );
+}
+
+export function makeSubscriptionField(fieldName: string, returnTypeName: string, mutations: string[]): FieldDefinitionNode {
+  return makeField(fieldName, [], makeNamedType(returnTypeName), [
+    makeDirective('aws_subscribe', [makeArgument('mutations', makeValueNode(mutations))]),
+  ]);
+}
+
+export type SortKeyFieldInfoTypeName = 'Composite' | string;
+
+export interface SortKeyFieldInfo {
+  // The name of the sort key field.
+  fieldName: string;
+  // The GraphQL type of the sort key field.
+  typeName: SortKeyFieldInfoTypeName;
+  // Name of the model this field is on.
+  model?: string;
+  // The name of the key  that this sortKey is on.
+  keyName?: string;
+}
+
+export function makeModelConnectionField(
+  fieldName: string,
+  returnTypeName: string,
+  sortKeyInfo?: SortKeyFieldInfo,
+  directives?: DirectiveNode[],
+): FieldDefinitionNode {
+  const args = [
+    makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(returnTypeName))),
+    makeInputValueDefinition('sortDirection', makeNamedType('RelayModelSortDirection')),
+    makeInputValueDefinition('first', makeNamedType('Int')),
+    makeInputValueDefinition('after', makeNamedType('String')),
+  ];
+  if (sortKeyInfo) {
+    let namedType: NamedTypeNode;
+    if (sortKeyInfo.typeName === 'Composite') {
+      namedType = makeNamedType(ModelResourceIDs.ModelCompositeKeyConditionInputTypeName(sortKeyInfo.model, toUpper(sortKeyInfo.keyName)));
+    } else {
+      namedType = makeNamedType(ModelResourceIDs.ModelKeyConditionInputTypeName(sortKeyInfo.typeName));
+    }
+
+    args.unshift(makeInputValueDefinition(sortKeyInfo.fieldName, namedType));
+  }
+  return makeField(fieldName, args, makeNamedType(ModelResourceIDs.ModelConnectionTypeName(returnTypeName)), directives);
+}
+
+export function makeScalarFilterInputs(supportsConditions: Boolean): InputObjectTypeDefinitionNode[] {
+  const inputs = [
+    makeModelScalarFilterInputObject('String', supportsConditions),
+    makeModelScalarFilterInputObject('ID', supportsConditions),
+    makeModelScalarFilterInputObject('Int', supportsConditions),
+    makeModelScalarFilterInputObject('Float', supportsConditions),
+    makeModelScalarFilterInputObject('Boolean', supportsConditions),
+  ];
+
+  if (supportsConditions) {
+    inputs.push(makeSizeInputType());
+  }
+
+  return inputs;
+}

--- a/packages/graphql-relay-transformer/src/model/resources.ts
+++ b/packages/graphql-relay-transformer/src/model/resources.ts
@@ -1,0 +1,868 @@
+import { DynamoDB, AppSync, IAM, Fn, StringParameter, NumberParameter, Refs, IntrinsicFunction, DeletionPolicy } from 'cloudform-types';
+import Output from 'cloudform-types/types/output';
+import {
+  DynamoDBMappingTemplate,
+  printBlock,
+  str,
+  print,
+  ref,
+  obj,
+  set,
+  nul,
+  ifElse,
+  compoundExpression,
+  qref,
+  bool,
+  equals,
+  iff,
+  raw,
+  comment,
+  forEach,
+  list,
+  and,
+  RESOLVER_VERSION_ID,
+  Expression,
+} from 'graphql-mapping-template';
+import {
+  ResourceConstants,
+  plurality,
+  graphqlName,
+  toUpper,
+  ModelResourceIDs,
+  SyncResourceIDs,
+  getBaseType,
+} from 'graphql-transformer-common';
+import { plural } from 'pluralize';
+import { SyncConfig, SyncUtils } from 'graphql-transformer-core';
+import Template from 'cloudform-types/types/template';
+import md5 from 'md5';
+import { InputObjectTypeDefinitionNode } from 'graphql';
+
+type MutationResolverInput = {
+  type: string;
+  syncConfig: SyncConfig;
+  nameOverride?: string;
+  mutationTypeName?: string;
+  timestamps?: {
+    createdAtField?: string;
+    updatedAtField?: string;
+  };
+};
+
+type MutationUpdateResolverInput = MutationResolverInput & {
+  optionalNonNullableFields: string[];
+};
+
+export class ResourceFactory {
+  public makeParams() {
+    return {
+      [ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS]: new NumberParameter({
+        Description: 'The number of read IOPS the table should support.',
+        Default: 5,
+      }),
+      [ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS]: new NumberParameter({
+        Description: 'The number of write IOPS the table should support.',
+        Default: 5,
+      }),
+      [ResourceConstants.PARAMETERS.DynamoDBBillingMode]: new StringParameter({
+        Description: 'Configure @model types to create DynamoDB tables with PAY_PER_REQUEST or PROVISIONED billing modes.',
+        Default: 'PAY_PER_REQUEST',
+        AllowedValues: ['PAY_PER_REQUEST', 'PROVISIONED'],
+      }),
+      [ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery]: new StringParameter({
+        Description: 'Whether to enable Point in Time Recovery on the table',
+        Default: 'false',
+        AllowedValues: ['true', 'false'],
+      }),
+      [ResourceConstants.PARAMETERS.DynamoDBEnableServerSideEncryption]: new StringParameter({
+        Description: 'Enable server side encryption powered by KMS.',
+        Default: 'true',
+        AllowedValues: ['true', 'false'],
+      }),
+    };
+  }
+
+  /**
+   * Creates the barebones template for an application.
+   */
+  public initTemplate(): Template {
+    return {
+      Parameters: this.makeParams(),
+      Resources: {
+        [ResourceConstants.RESOURCES.GraphQLAPILogicalID]: this.makeAppSyncAPI(),
+      },
+      Outputs: {
+        [ResourceConstants.OUTPUTS.GraphQLAPIIdOutput]: this.makeAPIIDOutput(),
+        [ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput]: this.makeAPIEndpointOutput(),
+      },
+      Conditions: {
+        [ResourceConstants.CONDITIONS.ShouldUsePayPerRequestBilling]: Fn.Equals(
+          Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBBillingMode),
+          'PAY_PER_REQUEST',
+        ),
+
+        [ResourceConstants.CONDITIONS.ShouldUsePointInTimeRecovery]: Fn.Equals(
+          Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery),
+          'true',
+        ),
+        [ResourceConstants.CONDITIONS.ShouldUseServerSideEncryption]: Fn.Equals(
+          Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBEnableServerSideEncryption),
+          'true',
+        ),
+      },
+    };
+  }
+
+  /**
+   * Create the AppSync API.
+   */
+  public makeAppSyncAPI() {
+    return new AppSync.GraphQLApi({
+      Name: Fn.If(
+        ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+        Fn.Join('-', [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiName), Fn.Ref(ResourceConstants.PARAMETERS.Env)]),
+        Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiName),
+      ),
+      AuthenticationType: 'API_KEY',
+    });
+  }
+
+  public makeAppSyncSchema(schema: string) {
+    return new AppSync.GraphQLSchema({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      Definition: schema,
+    });
+  }
+
+  /**
+   * Outputs
+   */
+  public makeAPIIDOutput(): Output {
+    return {
+      Description: 'Your GraphQL API ID.',
+      Value: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      Export: {
+        Name: Fn.Join(':', [Refs.StackName, 'GraphQLApiId']),
+      },
+    };
+  }
+
+  public makeAPIEndpointOutput(): Output {
+    return {
+      Description: 'Your GraphQL API endpoint.',
+      Value: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'GraphQLUrl'),
+      Export: {
+        Name: Fn.Join(':', [Refs.StackName, 'GraphQLApiEndpoint']),
+      },
+    };
+  }
+
+  public makeTableStreamArnOutput(resourceId: string): Output {
+    return {
+      Description: 'Your DynamoDB table StreamArn.',
+      Value: Fn.GetAtt(resourceId, 'StreamArn'),
+      Export: {
+        Name: Fn.Join(':', [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), 'GetAtt', resourceId, 'StreamArn']),
+      },
+    };
+  }
+
+  public makeDataSourceOutput(resourceId: string): Output {
+    return {
+      Description: 'Your model DataSource name.',
+      Value: Fn.GetAtt(resourceId, 'Name'),
+      Export: {
+        Name: Fn.Join(':', [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), 'GetAtt', resourceId, 'Name']),
+      },
+    };
+  }
+
+  public makeTableNameOutput(resourceId: string): Output {
+    return {
+      Description: 'Your DynamoDB table name.',
+      Value: Fn.Ref(resourceId),
+      Export: {
+        Name: Fn.Join(':', [Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId), 'GetAtt', resourceId, 'Name']),
+      },
+    };
+  }
+
+  /**
+   * Create a DynamoDB table for a specific type.
+   */
+  public makeModelTable(
+    typeName: string,
+    hashKey: string = 'id',
+    rangeKey?: string,
+    deletionPolicy: DeletionPolicy = DeletionPolicy.Delete,
+    isSyncEnabled: boolean = false,
+  ) {
+    const keySchema =
+      hashKey && rangeKey
+        ? [
+            {
+              AttributeName: hashKey,
+              KeyType: 'HASH',
+            },
+            {
+              AttributeName: rangeKey,
+              KeyType: 'RANGE',
+            },
+          ]
+        : [{ AttributeName: hashKey, KeyType: 'HASH' }];
+    const attributeDefinitions =
+      hashKey && rangeKey
+        ? [
+            {
+              AttributeName: hashKey,
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: rangeKey,
+              AttributeType: 'S',
+            },
+          ]
+        : [{ AttributeName: hashKey, AttributeType: 'S' }];
+    return new DynamoDB.Table({
+      TableName: this.dynamoDBTableName(typeName),
+      KeySchema: keySchema,
+      AttributeDefinitions: attributeDefinitions,
+      StreamSpecification: {
+        StreamViewType: 'NEW_AND_OLD_IMAGES',
+      },
+      BillingMode: Fn.If(ResourceConstants.CONDITIONS.ShouldUsePayPerRequestBilling, 'PAY_PER_REQUEST', Refs.NoValue),
+      ProvisionedThroughput: Fn.If(ResourceConstants.CONDITIONS.ShouldUsePayPerRequestBilling, Refs.NoValue, {
+        ReadCapacityUnits: Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS),
+        WriteCapacityUnits: Fn.Ref(ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS),
+      }) as any,
+      SSESpecification: {
+        SSEEnabled: Fn.If(ResourceConstants.CONDITIONS.ShouldUseServerSideEncryption, true, false),
+      },
+      PointInTimeRecoverySpecification: Fn.If(
+        ResourceConstants.CONDITIONS.ShouldUsePointInTimeRecovery,
+        {
+          PointInTimeRecoveryEnabled: true,
+        },
+        Refs.NoValue,
+      ) as any,
+      ...(isSyncEnabled && {
+        TimeToLiveSpecification: SyncUtils.syncTTLConfig(),
+      }),
+    }).deletionPolicy(deletionPolicy);
+  }
+
+  private dynamoDBTableName(typeName: string): IntrinsicFunction {
+    return Fn.If(
+      ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+      Fn.Join('-', [
+        typeName,
+        Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+        Fn.Ref(ResourceConstants.PARAMETERS.Env),
+      ]),
+      Fn.Join('-', [typeName, Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId')]),
+    );
+  }
+
+  /**
+   * Create a single role that has access to all the resources created by the
+   * transform.
+   * @param name  The name of the IAM role to create.
+   */
+  public makeIAMRole(typeName: string, syncConfig?: SyncConfig) {
+    return new IAM.Role({
+      RoleName: Fn.If(
+        ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+        Fn.Join('-', [
+          typeName.slice(0, 14) + md5(typeName).slice(15, 21), // max of 64. 64-10-26-4-3 = 21
+          'role', // 4
+          Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'), // 26
+          Fn.Ref(ResourceConstants.PARAMETERS.Env), // 10
+        ]),
+        Fn.Join('-', [
+          typeName.slice(0, 24) + md5(typeName).slice(25, 31), // max of 64. 64-26-4-3 = 31
+          'role',
+          Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+        ]),
+      ),
+      AssumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: {
+              Service: 'appsync.amazonaws.com',
+            },
+            Action: 'sts:AssumeRole',
+          },
+        ],
+      },
+      Policies: [
+        new IAM.Role.Policy({
+          PolicyName: 'DynamoDBAccess',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: [
+                  'dynamodb:BatchGetItem',
+                  'dynamodb:BatchWriteItem',
+                  'dynamodb:PutItem',
+                  'dynamodb:DeleteItem',
+                  'dynamodb:GetItem',
+                  'dynamodb:Scan',
+                  'dynamodb:Query',
+                  'dynamodb:UpdateItem',
+                ],
+                Resource: [
+                  Fn.Sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tablename}', {
+                    tablename: this.dynamoDBTableName(typeName),
+                  }),
+                  Fn.Sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tablename}/*', {
+                    tablename: this.dynamoDBTableName(typeName),
+                  }),
+                  ...(syncConfig
+                    ? [
+                        Fn.Sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tablename}', {
+                          tablename: Fn.If(
+                            ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+                            Fn.Join('-', [
+                              SyncResourceIDs.syncTableName,
+                              Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+                              Fn.Ref(ResourceConstants.PARAMETERS.Env),
+                            ]),
+                            Fn.Join('-', [
+                              SyncResourceIDs.syncTableName,
+                              Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+                            ]),
+                          ),
+                        }),
+                        Fn.Sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tablename}/*', {
+                          tablename: Fn.If(
+                            ResourceConstants.CONDITIONS.HasEnvironmentParameter,
+                            Fn.Join('-', [
+                              SyncResourceIDs.syncTableName,
+                              Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+                              Fn.Ref(ResourceConstants.PARAMETERS.Env),
+                            ]),
+                            Fn.Join('-', [
+                              SyncResourceIDs.syncTableName,
+                              Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+                            ]),
+                          ),
+                        }),
+                      ]
+                    : []),
+                ],
+              },
+            ],
+          },
+        }),
+        ...(syncConfig && SyncUtils.isLambdaSyncConfig(syncConfig)
+          ? [SyncUtils.createSyncLambdaIAMPolicy(syncConfig.LambdaConflictHandler)]
+          : []),
+      ],
+    });
+  }
+
+  /**
+   * Given the name of a data source and optional logical id return a CF
+   * spec for a data source pointing to the dynamodb table.
+   */
+  public makeDynamoDBDataSource(tableId: string, iamRoleLogicalID: string, typeName: string, isSyncEnabled: boolean = false) {
+    return new AppSync.DataSource({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      Name: tableId,
+      Type: 'AMAZON_DYNAMODB',
+      ServiceRoleArn: Fn.GetAtt(iamRoleLogicalID, 'Arn'),
+      DynamoDBConfig: {
+        AwsRegion: Refs.Region,
+        TableName: this.dynamoDBTableName(typeName),
+        ...(isSyncEnabled && {
+          DeltaSyncConfig: SyncUtils.syncDataSourceConfig(),
+          Versioned: true,
+        }),
+      },
+    }).dependsOn([iamRoleLogicalID]);
+  }
+
+  /**
+   * Create a resolver that creates an item in DynamoDB.
+   * @param type
+   */
+  public makeCreateResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation' }: MutationResolverInput) {
+    const fieldName = nameOverride ? nameOverride : graphqlName('create' + toUpper(type));
+    const isSyncEnabled = syncConfig ? true : false;
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: mutationTypeName,
+      RequestMappingTemplate: printBlock('Prepare DynamoDB PutItem Request')(
+        compoundExpression([
+          qref(`$context.args.input.put("__typename", "${type}")`),
+          this.addDefaultConditionExpression('create'),
+          iff(
+            ref('context.args.condition'),
+            compoundExpression([
+              set(ref('condition.expressionValues'), obj({})),
+              set(
+                ref('conditionFilterExpressions'),
+                raw('$util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition))'),
+              ),
+              // tslint:disable-next-line
+              qref(`$condition.put("expression", "($condition.expression) AND $conditionFilterExpressions.expression")`),
+              qref(`$condition.expressionNames.putAll($conditionFilterExpressions.expressionNames)`),
+              qref(`$condition.expressionValues.putAll($conditionFilterExpressions.expressionValues)`),
+            ]),
+          ),
+          iff(
+            and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
+            set(
+              ref('condition'),
+              obj({
+                expression: ref('condition.expression'),
+                expressionNames: ref('condition.expressionNames'),
+              }),
+            ),
+          ),
+          DynamoDBMappingTemplate.putItem({
+            key: ifElse(
+              ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+              raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+              obj({
+                id: raw(`$util.dynamodb.toDynamoDBJson($ctx.args.input.id)`),
+              }),
+              true,
+            ),
+            attributeValues: ref('util.dynamodb.toMapValuesJson($context.args.input)'),
+            condition: ref('util.toJson($condition)'),
+          }),
+        ]),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(isSyncEnabled)),
+      ...(syncConfig && { SyncConfig: SyncUtils.syncResolverConfig(syncConfig) }),
+    });
+  }
+
+  public initalizeDefaultInputForCreateMutation(input: InputObjectTypeDefinitionNode, timestamps): string {
+    const hasDefaultIdField = input.fields?.find(field => field.name.value === 'id' && ['ID', 'String'].includes(getBaseType(field.type)));
+    return printBlock('Set default values')(
+      compoundExpression([
+        ...(hasDefaultIdField ? [qref(`$context.args.input.put("id", $util.defaultIfNull($ctx.args.input.id, $util.autoId()))`)] : []),
+        ...(timestamps && (timestamps.createdAtField || timestamps.updatedAtField)
+          ? [set(ref('createdAt'), ref('util.time.nowISO8601()'))]
+          : []),
+        ...(timestamps && timestamps.createdAtField
+          ? [
+              comment(`Automatically set the createdAt timestamp.`),
+              qref(
+                `$context.args.input.put("${timestamps.createdAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.createdAtField}, $createdAt))`,
+              ),
+            ]
+          : []),
+        ...(timestamps && timestamps.updatedAtField
+          ? [
+              comment(`Automatically set the updatedAt timestamp.`),
+              qref(
+                `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $createdAt))`,
+              ),
+            ]
+          : []),
+      ]),
+    );
+  }
+
+  public makeUpdateResolver({
+    type,
+    nameOverride,
+    syncConfig,
+    mutationTypeName = 'Mutation',
+    timestamps,
+    optionalNonNullableFields,
+  }: MutationUpdateResolverInput) {
+    const fieldName = nameOverride ? nameOverride : graphqlName(`update` + toUpper(type));
+    const isSyncEnabled = syncConfig ? true : false;
+    const optionalNonNullableExpression: Expression[] = optionalNonNullableFields.map(str);
+
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: mutationTypeName,
+      RequestMappingTemplate: print(
+        compoundExpression([
+          set(ref('optionalNonNullableFields'), list(optionalNonNullableExpression)),
+          forEach(ref('field'), ref('optionalNonNullableFields'), [
+            iff(
+              and([ref('context.arguments.input.keySet().contains($field)'), ref('util.isNull($context.args.input.get($field))')]),
+              ref('util.error("An argument you marked as Non-Null is set to Null in the query or the body of your request.")'),
+            ),
+          ]),
+
+          ifElse(
+            raw(`$${ResourceConstants.SNIPPETS.AuthCondition} && $${ResourceConstants.SNIPPETS.AuthCondition}.expression != ""`),
+            compoundExpression([
+              set(ref('condition'), ref(ResourceConstants.SNIPPETS.AuthCondition)),
+              ifElse(
+                ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
+                  qref('$condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
+                  qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")'),
+                ]),
+                compoundExpression([
+                  qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
+                  qref('$condition.expressionNames.put("#id", "id")'),
+                ]),
+              ),
+            ]),
+            this.addDefaultConditionExpression('update'),
+          ),
+          ...(timestamps && timestamps.updatedAtField
+            ? [
+                comment(`Automatically set the updatedAt timestamp.`),
+                qref(
+                  `$context.args.input.put("${timestamps.updatedAtField}", $util.defaultIfNull($ctx.args.input.${timestamps.updatedAtField}, $util.time.nowISO8601()))`,
+                ),
+              ]
+            : []),
+          qref(`$context.args.input.put("__typename", "${type}")`),
+          comment('Update condition if type is @versioned'),
+          iff(
+            ref(ResourceConstants.SNIPPETS.VersionedCondition),
+            compoundExpression([
+              // tslint:disable-next-line
+              qref(
+                `$condition.put("expression", "($condition.expression) AND $${ResourceConstants.SNIPPETS.VersionedCondition}.expression")`,
+              ),
+              qref(`$condition.expressionNames.putAll($${ResourceConstants.SNIPPETS.VersionedCondition}.expressionNames)`),
+              qref(`$condition.expressionValues.putAll($${ResourceConstants.SNIPPETS.VersionedCondition}.expressionValues)`),
+            ]),
+          ),
+          iff(
+            ref('context.args.condition'),
+            compoundExpression([
+              set(
+                ref('conditionFilterExpressions'),
+                raw('$util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition))'),
+              ),
+              // tslint:disable-next-line
+              qref(`$condition.put("expression", "($condition.expression) AND $conditionFilterExpressions.expression")`),
+              qref(`$condition.expressionNames.putAll($conditionFilterExpressions.expressionNames)`),
+              qref(`$condition.expressionValues.putAll($conditionFilterExpressions.expressionValues)`),
+            ]),
+          ),
+          iff(
+            and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
+            set(
+              ref('condition'),
+              obj({
+                expression: ref('condition.expression'),
+                expressionNames: ref('condition.expressionNames'),
+              }),
+            ),
+          ),
+          DynamoDBMappingTemplate.updateItem({
+            key: ifElse(
+              ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+              raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+              obj({
+                id: obj({ S: ref('util.toJson($context.args.input.id)') }),
+              }),
+              true,
+            ),
+            condition: ref('util.toJson($condition)'),
+            objectKeyVariable: ResourceConstants.SNIPPETS.ModelObjectKey,
+            nameOverrideMap: ResourceConstants.SNIPPETS.DynamoDBNameOverrideMap,
+            isSyncEnabled,
+          }),
+        ]),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(isSyncEnabled)),
+      ...(syncConfig && { SyncConfig: SyncUtils.syncResolverConfig(syncConfig) }),
+    });
+  }
+
+  /**
+   * Create a resolver that creates an item in DynamoDB.
+   * @param type
+   */
+  public makeGetResolver(type: string, nameOverride?: string, isSyncEnabled: boolean = false, queryTypeName: string = 'Query') {
+    const fieldName = nameOverride ? nameOverride : graphqlName('get' + toUpper(type));
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: queryTypeName,
+      RequestMappingTemplate: print(
+        DynamoDBMappingTemplate.getItem({
+          key: ifElse(
+            ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+            raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+            obj({
+              id: ref('util.dynamodb.toDynamoDBJson($ctx.args.id)'),
+            }),
+            true,
+          ),
+          isSyncEnabled,
+        }),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(isSyncEnabled)),
+    });
+  }
+
+  /**
+   * Create a resolver that syncs local storage with cloud storage
+   * @param type
+   */
+  public makeSyncResolver(type: string, queryTypeName: string = 'Query') {
+    const fieldName = graphqlName('sync' + toUpper(plural(type)));
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: queryTypeName,
+      RequestMappingTemplate: print(
+        DynamoDBMappingTemplate.syncItem({
+          filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
+          limit: ref(`util.defaultIfNull($ctx.args.first, ${ResourceConstants.DEFAULT_SYNC_QUERY_PAGE_LIMIT})`),
+          lastSync: ref('util.toJson($util.defaultIfNull($ctx.args.lastSync, null))'),
+          nextToken: ref('util.toJson($util.defaultIfNull($ctx.args.after, null))'),
+        }),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(true)),
+    });
+  }
+
+  /**
+   * Create a resolver that queries an item in DynamoDB.
+   * @param type
+   */
+  public makeQueryResolver(type: string, nameOverride?: string, isSyncEnabled: boolean = false, queryTypeName: string = 'Query') {
+    const fieldName = nameOverride ? nameOverride : graphqlName(`query${toUpper(type)}`);
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: queryTypeName,
+      RequestMappingTemplate: print(
+        compoundExpression([
+          set(ref('limit'), ref(`util.defaultIfNull($context.args.first, ${ResourceConstants.DEFAULT_PAGE_LIMIT})`)),
+          DynamoDBMappingTemplate.query({
+            query: obj({
+              expression: str('#typename = :typename'),
+              expressionNames: obj({
+                '#typename': str('__typename'),
+              }),
+              expressionValues: obj({
+                ':typename': obj({
+                  S: str(type),
+                }),
+              }),
+            }),
+            scanIndexForward: ifElse(
+              ref('context.args.sortDirection'),
+              ifElse(equals(ref('context.args.sortDirection'), str('ASC')), bool(true), bool(false)),
+              bool(true),
+            ),
+            filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
+            limit: ref('limit'),
+            nextToken: ifElse(ref('context.args.after'), ref('util.toJson($context.args.after)'), nul()),
+          }),
+        ]),
+      ),
+      ResponseMappingTemplate: print(
+        DynamoDBMappingTemplate.dynamoDBResponse(
+          isSyncEnabled,
+          compoundExpression([iff(raw('!$result'), set(ref('result'), ref('ctx.result'))), raw('$util.toJson($result)')]),
+        ),
+      ),
+    });
+  }
+
+  /**
+   * Create a resolver that lists items in DynamoDB.
+   * TODO: actually fill out the right filter expression. This is a placeholder only.
+   * @param type
+   */
+  public makeListResolver(
+    type: string,
+    improvePluralization: boolean,
+    nameOverride?: string,
+    isSyncEnabled: boolean = false,
+    queryTypeName: string = 'Query',
+  ) {
+    const fieldName = nameOverride ? nameOverride : graphqlName('list' + plurality(toUpper(type), improvePluralization));
+    const requestVariable = 'ListRequest';
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: queryTypeName,
+      RequestMappingTemplate: print(
+        compoundExpression([
+          set(ref('first'), ref(`util.defaultIfNull($context.args.first, ${ResourceConstants.DEFAULT_PAGE_LIMIT})`)),
+          set(
+            ref(requestVariable),
+            obj({
+              version: str(RESOLVER_VERSION_ID),
+              limit: ref('first'),
+            }),
+          ),
+          iff(ref('context.args.after'), set(ref(`${requestVariable}.nextToken`), ref('context.args.after'))),
+          iff(
+            ref('context.args.filter'),
+            set(ref(`${requestVariable}.filter`), ref('util.parseJson("$util.transform.toDynamoDBFilterExpression($ctx.args.filter)")')),
+          ),
+          ifElse(
+            raw(`!$util.isNull($${ResourceConstants.SNIPPETS.ModelQueryExpression})
+                        && !$util.isNullOrEmpty($${ResourceConstants.SNIPPETS.ModelQueryExpression}.expression)`),
+            compoundExpression([
+              qref(`$${requestVariable}.put("operation", "Query")`),
+              qref(`$${requestVariable}.put("query", $${ResourceConstants.SNIPPETS.ModelQueryExpression})`),
+              ifElse(
+                raw(`!$util.isNull($ctx.args.sortDirection) && $ctx.args.sortDirection == "DESC"`),
+                set(ref(`${requestVariable}.scanIndexForward`), bool(false)),
+                set(ref(`${requestVariable}.scanIndexForward`), bool(true)),
+              ),
+            ]),
+            qref(`$${requestVariable}.put("operation", "Scan")`),
+          ),
+          raw(`$util.toJson($${requestVariable})`),
+        ]),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(isSyncEnabled)),
+    });
+  }
+
+  /**
+   * Create a resolver that deletes an item from DynamoDB.
+   * @param type The name of the type to delete an item of.
+   * @param nameOverride A user provided override for the field name.
+   */
+  public makeDeleteResolver({ type, nameOverride, syncConfig, mutationTypeName = 'Mutation' }: MutationResolverInput) {
+    const fieldName = nameOverride ? nameOverride : graphqlName('delete' + toUpper(type));
+    const isSyncEnabled = syncConfig ? true : false;
+    return new AppSync.Resolver({
+      ApiId: Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'),
+      DataSourceName: Fn.GetAtt(ModelResourceIDs.ModelTableDataSourceID(type), 'Name'),
+      FieldName: fieldName,
+      TypeName: mutationTypeName,
+      RequestMappingTemplate: print(
+        compoundExpression([
+          ifElse(
+            ref(ResourceConstants.SNIPPETS.AuthCondition),
+            compoundExpression([
+              set(ref('condition'), ref(ResourceConstants.SNIPPETS.AuthCondition)),
+              ifElse(
+                ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+                forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
+                  qref('$condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)")'),
+                  qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")'),
+                ]),
+                compoundExpression([
+                  qref('$condition.put("expression", "$condition.expression AND attribute_exists(#id)")'),
+                  qref('$condition.expressionNames.put("#id", "id")'),
+                ]),
+              ),
+            ]),
+            this.addDefaultConditionExpression('delete'),
+          ),
+          iff(
+            ref(ResourceConstants.SNIPPETS.VersionedCondition),
+            compoundExpression([
+              // tslint:disable-next-line
+              qref(
+                `$condition.put("expression", "($condition.expression) AND $${ResourceConstants.SNIPPETS.VersionedCondition}.expression")`,
+              ),
+              qref(`$condition.expressionNames.putAll($${ResourceConstants.SNIPPETS.VersionedCondition}.expressionNames)`),
+              set(ref('expressionValues'), raw('$util.defaultIfNull($condition.expressionValues, {})')),
+              qref(`$expressionValues.putAll($${ResourceConstants.SNIPPETS.VersionedCondition}.expressionValues)`),
+              set(ref('condition.expressionValues'), ref('expressionValues')),
+            ]),
+          ),
+          iff(
+            ref('context.args.condition'),
+            compoundExpression([
+              set(
+                ref('conditionFilterExpressions'),
+                raw('$util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition))'),
+              ),
+              // tslint:disable-next-line
+              qref(`$condition.put("expression", "($condition.expression) AND $conditionFilterExpressions.expression")`),
+              qref(`$condition.expressionNames.putAll($conditionFilterExpressions.expressionNames)`),
+              set(ref('conditionExpressionValues'), raw('$util.defaultIfNull($condition.expressionValues, {})')),
+              qref(`$conditionExpressionValues.putAll($conditionFilterExpressions.expressionValues)`),
+              set(ref('condition.expressionValues'), ref('conditionExpressionValues')),
+              qref(`$condition.expressionValues.putAll($conditionFilterExpressions.expressionValues)`),
+            ]),
+          ),
+          iff(
+            and([ref('condition.expressionValues'), raw('$condition.expressionValues.size() == 0')]),
+            set(
+              ref('condition'),
+              obj({
+                expression: ref('condition.expression'),
+                expressionNames: ref('condition.expressionNames'),
+              }),
+            ),
+          ),
+          DynamoDBMappingTemplate.deleteItem({
+            key: ifElse(
+              ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+              raw(`$util.toJson(\$${ResourceConstants.SNIPPETS.ModelObjectKey})`),
+              obj({
+                id: ref('util.dynamodb.toDynamoDBJson($ctx.args.input.id)'),
+              }),
+              true,
+            ),
+            condition: ref('util.toJson($condition)'),
+            isSyncEnabled,
+          }),
+        ]),
+      ),
+      ResponseMappingTemplate: print(DynamoDBMappingTemplate.dynamoDBResponse(isSyncEnabled)),
+      ...(syncConfig && { SyncConfig: SyncUtils.syncResolverConfig(syncConfig) }),
+    });
+  }
+
+  /**
+   * Adds the default Condition Expression uses ModelObjectkey if @key is used
+   * @returns
+   */
+
+  private addDefaultConditionExpression = (operation: string): Expression => {
+    const attributeCheck = operation === 'create' ? 'attribute_not_exists' : 'attribute_exists';
+    return ifElse(
+      ref(ResourceConstants.SNIPPETS.ModelObjectKey),
+      compoundExpression([
+        set(
+          ref('condition'),
+          obj({
+            expression: str(''),
+            expressionNames: obj({}),
+            expressionValues: obj({}),
+          }),
+        ),
+        forEach(ref('entry'), ref(`${ResourceConstants.SNIPPETS.ModelObjectKey}.entrySet()`), [
+          ifElse(
+            raw('$velocityCount == 1'),
+            qref(`$condition.put("expression", "${attributeCheck}(#keyCondition$velocityCount)")`),
+            qref('$condition.put(' + `"expression", "$condition.expression AND ${attributeCheck}(#keyCondition$velocityCount)")`),
+          ),
+          qref('$condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key")'),
+        ]),
+      ]),
+      set(
+        ref('condition'),
+        obj({
+          expression: str(`${attributeCheck}(#id)`),
+          expressionNames: obj({
+            '#id': str('id'),
+          }),
+          expressionValues: obj({}),
+        }),
+      ),
+    );
+  };
+}

--- a/packages/graphql-relay-transformer/tsconfig.json
+++ b/packages/graphql-relay-transformer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "strict": false, // TODO enable
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [
+    {"path": "../graphql-dynamodb-transformer"},
+    {"path": "../graphql-key-transformer"},
+    {"path": "../graphql-mapping-template"},
+    {"path": "../graphql-transformer-common"},
+    {"path": "../graphql-transformer-core"}
+  ]
+}


### PR DESCRIPTION
#### Description of changes

This change duplicates the DynamoDBModelTransformer and ModelConnectionTransformer and changes the input schemas to use `first` instead of `limit` and `after` instead of `nextCursor`. The directive parameters are all the same as before. Instead of using `@model`, use `@relayModel` and instead of `@connection` use `@relayConnection`. Avoid using `@model` and `@relayModel` together in the same schema.

The generated VTL for resource resolvers on connections has been modified to support the Relay Modern style of using `edges`, which is a list of Edge types which have a `node` property mapped to the Model object, and a `pageInfo` property which contains `hasNextPage`, a boolean for whether there are more results, and `endCursor` which is the value of `nextCursor`.

Changes to the input and output comply with the server requirements defined in the [React Relay Server Specifications](https://relay.dev/docs/guides/graphql-server-specification/#connections).


#### Issue aws-amplify/amplify-category-api#844 



#### Description of how you validated changes



#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.