### PR TITLE
chore: add missing amplify-prompts dependency to package.json

### DIFF
--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "ajv": "^6.12.3",
     "amplify-cli-logger": "1.1.0",
+    "amplify-prompts": "1.1.2",
     "ci-info": "^2.0.0",
     "cloudform-types": "^4.2.0",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add missing `amplify-prompts` dependency to `amplify-cli-core`


#### Description of how you validated changes
`yarn test` passes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.