### PR TITLE
fix(cli): amplify plugin scan command print correct version of inactive hosting plugins

### DIFF
--- a/packages/amplify-cli/src/__tests__/plugin-helpers/platform-health-check.test.ts
+++ b/packages/amplify-cli/src/__tests__/plugin-helpers/platform-health-check.test.ts
@@ -1,0 +1,167 @@
+import { JSONUtilities } from '../../../../amplify-cli-core/lib';
+import { PluginInfo } from '../../domain/plugin-info';
+import { PluginManifest } from '../../domain/plugin-manifest';
+import { PluginPlatform } from '../../domain/plugin-platform';
+import { checkPlatformHealth, getOfficialPlugins } from '../../plugin-helpers/platform-health-check';
+
+jest.mock('chalk', () => ({
+  yellow: jest.fn().mockImplementation(input => input),
+}));
+
+const corePackageJson = {
+  name: '@aws-amplify/cli',
+  version: '5.4.0',
+  amplify: {
+    officialPlugins: {
+      core: {
+        name: 'core',
+        type: 'core',
+        packageName: '@aws-amplify/cli',
+      },
+      api: {
+        name: 'api',
+        type: 'category',
+        packageName: 'amplify-category-api',
+      },
+      hosting: [
+        {
+          name: 'hosting',
+          type: 'category',
+          packageName: 'amplify-category-hosting',
+        },
+        {
+          name: 'hosting',
+          type: 'category',
+          packageName: 'amplify-console-hosting',
+        },
+      ],
+      codegen: {
+        name: 'codegen',
+        type: 'util',
+        packageName: 'amplify-codegen',
+      },
+    },
+  },
+  dependencies: {
+    'amplify-category-api': '2.31.20',
+    'amplify-category-hosting': '2.7.18',
+    'amplify-codegen': '^2.23.1',
+    'amplify-console-hosting': '1.9.9',
+    'amplify-container-hosting': '1.3.20',
+  },
+};
+
+jest.mock('amplify-cli-core', () => ({
+  JSONUtilities: {
+    readJson: jest.fn(),
+  },
+}));
+
+describe('platform-health-check', () => {
+  beforeAll(() => {
+    const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
+    JSONUtilitiesMock.readJson.mockReturnValue(corePackageJson);
+  });
+
+  describe('getOfficialPlugins', () => {
+    it('returns official plugin descriptions', () => {
+      expect(getOfficialPlugins()).toEqual({
+        core: {
+          name: 'core',
+          packageName: '@aws-amplify/cli',
+          packageVersion: '5.4.0',
+          type: 'core',
+        },
+        api: {
+          name: 'api',
+          packageName: 'amplify-category-api',
+          packageVersion: '2.31.20',
+          type: 'category',
+        },
+        codegen: {
+          name: 'codegen',
+          packageName: 'amplify-codegen',
+          packageVersion: '^2.23.1',
+          type: 'util',
+        },
+        hosting: [
+          {
+            name: 'hosting',
+            packageName: 'amplify-category-hosting',
+            packageVersion: '2.7.18',
+            type: 'category',
+          },
+          {
+            name: 'hosting',
+            packageName: 'amplify-console-hosting',
+            packageVersion: '1.9.9',
+            type: 'category',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('checkPlatformHealth', () => {
+    beforeEach(() => {
+      console.log = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns true when every official plugins is active and match plugin description', async () => {
+      const pluginPlatform: PluginPlatform = new PluginPlatform();
+      pluginPlatform.plugins = {
+        core: [new PluginInfo('@aws-amplify/cli', '5.4.0', '', new PluginManifest('core', 'core'))],
+        hosting: [
+          new PluginInfo('amplify-category-hosting', '2.7.18', '', new PluginManifest('hosting', 'category')),
+          new PluginInfo('amplify-console-hosting', '1.9.9', '', new PluginManifest('hosting', 'category')),
+        ],
+        codegen: [new PluginInfo('amplify-codegen', '2.27.0', '', new PluginManifest('codegen', 'util'))],
+        api: [new PluginInfo('amplify-category-api', '2.31.20', '', new PluginManifest('api', 'category'))],
+      };
+      expect(await checkPlatformHealth(pluginPlatform)).toBe(true);
+    });
+
+    it('returns false when mismatch plugins exists', async () => {
+      const pluginPlatform: PluginPlatform = new PluginPlatform();
+      pluginPlatform.plugins = {
+        core: [new PluginInfo('@aws-amplify/cli', '5.4.0', '', new PluginManifest('core', 'core'))],
+        hosting: [
+          new PluginInfo('amplify-category-hosting', '2.7.18', '', new PluginManifest('hosting', 'category')),
+          new PluginInfo('amplify-console-hosting', '1.9.9', '', new PluginManifest('hosting', 'category')),
+        ],
+        codegen: [
+          // version mismatch
+          new PluginInfo('amplify-codegen', '1.30.0', '', new PluginManifest('codegen', 'util')),
+        ],
+        api: [new PluginInfo('amplify-category-api', '2.31.20', '', new PluginManifest('api', 'category'))],
+      };
+
+      expect(await checkPlatformHealth(pluginPlatform)).toBe(false);
+      expect(console.log).toBeCalledWith('The following official plugins have mismatched packages:');
+      expect(console.log).toBeCalledWith('Expected:');
+      expect(console.log).toBeCalledWith('    codegen: util | amplify-codegen@^2.23.1');
+    });
+
+    it('returns false when missing or inactive plugins exists', async () => {
+      const pluginPlatform: PluginPlatform = new PluginPlatform();
+      pluginPlatform.plugins = {
+        core: [new PluginInfo('@aws-amplify/cli', '5.4.0', '', new PluginManifest('core', 'core'))],
+        hosting: [
+          new PluginInfo('amplify-category-hosting', '2.7.18', '', new PluginManifest('hosting', 'category')),
+          // missing 'amplify-console-hosting'
+        ],
+        codegen: [new PluginInfo('amplify-codegen', '2.27.0', '', new PluginManifest('codegen', 'util'))],
+        // missing 'api'
+      };
+
+      expect(await checkPlatformHealth(pluginPlatform)).toBe(false);
+      expect(console.log).toBeCalledWith('The following official plugins are missing or inactive:');
+      expect(console.log).toBeCalledWith('    hosting: category | amplify-console-hosting@1.9.9');
+      expect(console.log).toBeCalledWith('    api: category | amplify-category-api@2.31.20');
+    });
+  });
+});

--- a/packages/amplify-cli/src/plugin-helpers/platform-health-check.ts
+++ b/packages/amplify-cli/src/plugin-helpers/platform-health-check.ts
@@ -16,7 +16,7 @@ const indent = '    ';
 
 export async function checkPlatformHealth(pluginPlatform: PluginPlatform): Promise<boolean> {
   const activePlugins = pluginPlatform.plugins;
-  const officialPlugins: { [key: string]: PluginDescription | Array<PluginDescription> } = getOfficialPlugins();
+  const officialPlugins = getOfficialPlugins();
   const missingOfficialPlugins: Array<PluginDescription> = [];
   const mismatchedOfficialPlugins: Array<PluginDescription> = [];
 
@@ -91,7 +91,7 @@ function isMatching(pluginDescription: PluginDescription, pluginInfo: PluginInfo
   return result;
 }
 
-export function getOfficialPlugins() {
+export function getOfficialPlugins(): { [key: string]: PluginDescription | Array<PluginDescription> } {
   const packageJsonFilePath = path.normalize(path.join(__dirname, '../../package.json'));
   const packageJson = JSONUtilities.readJson<$TSAny>(packageJsonFilePath);
   const { officialPlugins } = packageJson.amplify;
@@ -99,13 +99,19 @@ export function getOfficialPlugins() {
   const dependencies: { [key: string]: string } = packageJson.dependencies;
 
   Object.keys(officialPlugins).forEach((plugin: string) => {
-    const { packageName } = officialPlugins[plugin];
-    if (dependencies[packageName]) {
-      const version = dependencies[packageName];
-      officialPlugins[plugin].packageVersion = version;
-    } else {
-      delete officialPlugins[plugin].packageVersion;
+    let plugins = officialPlugins[plugin];
+    if (!Array.isArray(plugins)) {
+      plugins = [plugins];
     }
+    plugins.forEach(officialPlugin => {
+      const { packageName } = officialPlugin;
+      if (dependencies[packageName]) {
+        const version = dependencies[packageName];
+        officialPlugin.packageVersion = version;
+      } else {
+        delete officialPlugin.packageVersion;
+      }
+    });
   });
 
   const coreVersion = packageJson.version;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fix missing plugin version case of exists multiple plugins in same category

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

fix #8127

#### Description of how you validated changes

- Unit Testing (`lerna --scope @aws-amplify/cli run test`)
- Manual Testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.