### PR TITLE
feat(graphql-model-transformer): set up transformer for sandbox mode directive

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -18,7 +18,6 @@ import _ from 'lodash';
 import { getAppSyncResourceName, getAppSyncAuthConfig, checkIfAuthExists, authConfigHasApiKey } from './utils/amplify-meta-utils';
 import { printApiKeyWarnings } from './utils/print-api-key-warnings';
 import { isNameUnique } from './utils/check-case-sensitivity';
-import { FeatureFlags } from 'amplify-cli-core';
 
 // keep in sync with ServiceName in amplify-category-function, but probably it will not change
 const FunctionServiceNameLambdaFunction = 'Lambda';
@@ -91,20 +90,7 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
       authConfig,
     });
 
-    const useExperimentalPipelineTransformer = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
-    let globalSandboxModeConfig;
-
-    if (useExperimentalPipelineTransformer) {
-      const envName = this.context.amplify.getEnvInfo().envName;
-      globalSandboxModeConfig = {};
-      globalSandboxModeConfig[envName] = { enabled: true };
-    }
-
-    this.context.amplify.updateamplifyMetaAfterResourceAdd(
-      category,
-      serviceConfig.apiName,
-      this.createAmplifyMeta(authConfig, globalSandboxModeConfig),
-    );
+    this.context.amplify.updateamplifyMetaAfterResourceAdd(category, serviceConfig.apiName, this.createAmplifyMeta(authConfig));
     return serviceConfig.apiName;
   };
 
@@ -149,12 +135,11 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
 
   private getResourceDir = (apiName: string) => path.join(this.context.amplify.pathManager.getBackendDirPath(), category, apiName);
 
-  private createAmplifyMeta = (authConfig, globalSandboxModeConfig) => ({
+  private createAmplifyMeta = authConfig => ({
     service: 'AppSync',
     providerPlugin: provider,
     output: {
       authConfig,
-      globalSandboxModeConfig,
     },
   });
 

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-api-key-config.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-api-key-config.test.ts
@@ -9,7 +9,7 @@ jest.mock('amplify-cli-core', () => {
     ...original,
     stateManager: {
       metaFileExists: jest.fn(),
-      getCurrentMeta: jest.fn().mockImplementation(() => JSON.parse(amplifyMeta.toString())),
+      getMeta: jest.fn().mockImplementation(() => JSON.parse(amplifyMeta.toString())),
     },
   };
 });

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-api-key-config.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-api-key-config.test.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { getAppSyncApiConfig, getApiKeyConfig, apiKeyIsActive, hasApiKey } from '../../../extensions/amplify-helpers/get-api-key-config';
-import { stateManager } from 'amplify-cli-core';
 
 let amplifyMeta;
 
@@ -10,12 +9,10 @@ jest.mock('amplify-cli-core', () => {
     ...original,
     stateManager: {
       metaFileExists: jest.fn(),
-      getMeta: jest.fn().mockImplementation(() => JSON.parse(amplifyMeta.toString())),
+      getCurrentMeta: jest.fn().mockImplementation(() => JSON.parse(amplifyMeta.toString())),
     },
   };
 });
-
-const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
 
 describe('getAppSyncApiConfig', () => {
   beforeAll(() => {
@@ -45,9 +42,7 @@ describe('getAppSyncApiConfig', () => {
           ],
         },
         globalSandboxModeConfig: {
-          dev: {
-            enabled: true,
-          },
+          env: 'dev',
         },
       },
     });

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/show-global-sandbox-mode-warning.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/show-global-sandbox-mode-warning.test.ts
@@ -10,7 +10,7 @@ let ctx, amplifyMeta;
 
 jest.mock('amplify-cli-core', () => ({
   stateManager: {
-    getMeta: jest.fn(() => JSON.parse(amplifyMeta.toString())),
+    getCurrentMeta: jest.fn(() => JSON.parse(amplifyMeta.toString())),
   },
 }));
 
@@ -65,11 +65,11 @@ describe('global sandbox mode warning', () => {
         await showGlobalSandboxModeWarning(ctx);
 
         expect(ctx.print.info).toBeCalledWith(`
-⚠️  WARNING: ${chalk.green('"type AMPLIFY_GLOBAL @allow_public_data_access_with_api_key"')} in your GraphQL schema
+${chalk.yellow(`⚠️  WARNING: ${chalk.green('"type AMPLIFY_GLOBAL @allow_public_data_access_with_api_key"')} in your GraphQL schema
 allows public create, read, update, and delete access to all models via API Key. This
 should only be used for testing purposes. API Key expiration date is: 8/20/2021
 
-To configure PRODUCTION-READY authorization rules, review: https://docs.amplify.aws/cli/graphql-transformer/auth
+To configure PRODUCTION-READY authorization rules, review: https://docs.amplify.aws/cli/graphql-transformer/auth`)}
 `);
       });
     });

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/show-global-sandbox-mode-warning.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/show-global-sandbox-mode-warning.test.ts
@@ -10,7 +10,7 @@ let ctx, amplifyMeta;
 
 jest.mock('amplify-cli-core', () => ({
   stateManager: {
-    getCurrentMeta: jest.fn(() => JSON.parse(amplifyMeta.toString())),
+    getMeta: jest.fn(() => JSON.parse(amplifyMeta.toString())),
   },
 }));
 

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/testData/mockLocalCloud/amplify-meta.json
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/testData/mockLocalCloud/amplify-meta.json
@@ -20,9 +20,7 @@
           ]
         },
         "globalSandboxModeConfig": {
-          "dev": {
-            "enabled": true
-          }
+          "env": "dev"
         }
       }
     }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-api-key-config.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-api-key-config.ts
@@ -2,7 +2,7 @@ import { stateManager } from 'amplify-cli-core';
 import { ApiKeyConfig } from '@aws-amplify/graphql-transformer-core';
 
 export function getAppSyncApiConfig(): any {
-  const apiConfig = stateManager.getMeta()?.api;
+  const apiConfig = stateManager.getCurrentMeta()?.api;
   let appSyncApi;
 
   Object.keys(apiConfig).forEach(k => {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-api-key-config.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-api-key-config.ts
@@ -2,7 +2,7 @@ import { stateManager } from 'amplify-cli-core';
 import { ApiKeyConfig } from '@aws-amplify/graphql-transformer-core';
 
 export function getAppSyncApiConfig(): any {
-  const apiConfig = stateManager.getCurrentMeta()?.api;
+  const apiConfig = stateManager.getMeta()?.api;
   let appSyncApi;
 
   Object.keys(apiConfig).forEach(k => {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/show-global-sandbox-mode-warning.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/show-global-sandbox-mode-warning.ts
@@ -5,11 +5,11 @@ import { getAppSyncApiConfig, getApiKeyConfig } from './get-api-key-config';
 export function globalSandboxModeEnabled(context: $TSContext): boolean {
   const appSyncApi = getAppSyncApiConfig();
   const currEnvName = context.amplify.getEnvInfo().envName;
-  const { globalSandboxModeConfig } = appSyncApi.output || {};
+  const { globalSandboxModeConfig } = appSyncApi?.output || {};
 
   if (!globalSandboxModeConfig) return false;
 
-  return globalSandboxModeConfig[currEnvName]?.enabled;
+  return globalSandboxModeConfig.env === currEnvName;
 }
 
 export function showGlobalSandboxModeWarning(context: $TSContext): void {
@@ -21,11 +21,11 @@ export function showGlobalSandboxModeWarning(context: $TSContext): void {
 
   if (apiKeyConfig && globalSandboxModeEnabled(context)) {
     context.print.info(`
-⚠️  WARNING: ${chalk.green('"type AMPLIFY_GLOBAL @allow_public_data_access_with_api_key"')} in your GraphQL schema
+${chalk.yellow(`⚠️  WARNING: ${chalk.green('"type AMPLIFY_GLOBAL @allow_public_data_access_with_api_key"')} in your GraphQL schema
 allows public create, read, update, and delete access to all models via API Key. This
 should only be used for testing purposes. API Key expiration date is: ${expirationDate.toLocaleDateString()}
 
-To configure PRODUCTION-READY authorization rules, review: https://docs.amplify.aws/cli/graphql-transformer/auth
+To configure PRODUCTION-READY authorization rules, review: https://docs.amplify.aws/cli/graphql-transformer/auth`)}
 `);
   }
 }

--- a/packages/amplify-e2e-tests/src/__tests__/sandbox-mode.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/sandbox-mode.test.ts
@@ -31,7 +31,7 @@ describe('api directives @allow_public_data_access_with_api_key', () => {
     const { output } = meta.api.simplemodel;
     const { authConfig, globalSandboxModeConfig, GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
 
-    expect(globalSandboxModeConfig[envName].enabled).toBe(true);
+    expect(globalSandboxModeConfig.env).toBeDefined();
     expect(authConfig.defaultAuthentication.authenticationType).toBe('API_KEY');
     expect(authConfig.defaultAuthentication.apiKeyConfig.apiKeyExpirationDate).toBeDefined();
 

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -13,6 +13,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -132,6 +135,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -219,6 +225,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -383,6 +392,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -571,6 +583,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -722,6 +737,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -731,6 +749,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -740,6 +761,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -765,6 +789,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -884,6 +911,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -971,6 +1001,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1135,6 +1168,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1323,6 +1359,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -1376,6 +1415,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1385,6 +1427,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1394,6 +1439,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1419,6 +1467,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1538,6 +1589,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1625,6 +1679,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1789,6 +1846,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1977,6 +2037,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -2186,6 +2249,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2195,6 +2261,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2204,6 +2273,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2448,6 +2520,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2552,6 +2627,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2637,6 +2715,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2786,6 +2867,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -2981,6 +3065,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -3252,6 +3339,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3261,6 +3351,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3270,6 +3363,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3295,6 +3391,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.addContentToCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.addContentToCategory.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3425,6 +3524,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createBlog.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -3528,6 +3630,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3650,6 +3755,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3765,6 +3873,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTodo.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -3857,6 +3968,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteBlog.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3922,6 +4036,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteContentFromCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteContentFromCategory.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -4000,6 +4117,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -4076,6 +4196,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -4152,6 +4275,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTodo.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -4226,6 +4352,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateBlog.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4372,6 +4501,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -4537,6 +4669,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -4695,6 +4830,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTodo.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4890,6 +5028,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.getBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getBlog.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -4934,6 +5075,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getItem.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"orderId\\": $util.dynamodb.toDynamoDB($ctx.args.orderId),
@@ -4985,6 +5129,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -5036,6 +5183,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTodo.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5276,6 +5426,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.listBlogs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listBlogs.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -5634,6 +5787,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Query.listItems.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listItems.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.orderId) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'orderId'.\\", \\"InvalidArgumentsError\\")
@@ -5795,6 +5951,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -6164,6 +6323,9 @@ $util.toJson($QueryRequest)",
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)",
+  "Subscription.onCreateBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateBlog.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6173,6 +6335,9 @@ $util.toJson({
   "Subscription.onCreateBlog.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateContentCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateContentCategory.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6182,6 +6347,9 @@ $util.toJson({
   "Subscription.onCreateContentCategory.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateItem.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6191,6 +6359,9 @@ $util.toJson({
   "Subscription.onCreateItem.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6200,6 +6371,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTodo.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6209,6 +6383,9 @@ $util.toJson({
   "Subscription.onCreateTodo.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteBlog.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6218,6 +6395,9 @@ $util.toJson({
   "Subscription.onDeleteBlog.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteContentCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteContentCategory.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6227,6 +6407,9 @@ $util.toJson({
   "Subscription.onDeleteContentCategory.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteItem.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6236,6 +6419,9 @@ $util.toJson({
   "Subscription.onDeleteItem.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6245,6 +6431,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTodo.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6254,6 +6443,9 @@ $util.toJson({
   "Subscription.onDeleteTodo.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateBlog.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6263,6 +6455,9 @@ $util.toJson({
   "Subscription.onUpdateBlog.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateItem.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6272,6 +6467,9 @@ $util.toJson({
   "Subscription.onUpdateItem.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -6281,6 +6479,9 @@ $util.toJson({
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTodo.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -13,6 +13,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -124,6 +127,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -209,6 +215,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -365,6 +374,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -416,6 +428,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -577,6 +592,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -586,6 +604,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -595,6 +616,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -620,6 +644,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -724,6 +751,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -809,6 +839,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -958,6 +991,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -1009,6 +1045,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -1124,6 +1163,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1133,6 +1175,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1142,6 +1187,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1167,6 +1215,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1270,6 +1321,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1354,6 +1408,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1502,6 +1559,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email)
@@ -1552,6 +1612,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -1624,6 +1687,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1633,6 +1699,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1642,6 +1711,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1667,6 +1739,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1771,6 +1846,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1856,6 +1934,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2005,6 +2086,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"status\\": $util.dynamodb.toDynamoDB($ctx.args.status),
@@ -2056,6 +2140,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.status) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'status'.\\", \\"InvalidArgumentsError\\")
@@ -2171,6 +2258,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2180,6 +2270,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2189,6 +2282,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2214,6 +2310,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2318,6 +2417,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2405,6 +2507,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.testCreate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.testCreate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2509,6 +2614,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.testDelete.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.testDelete.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2594,6 +2702,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.testUpdate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.testUpdate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2752,6 +2863,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2901,6 +3015,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email)
@@ -2951,6 +3068,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -3023,6 +3143,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.testGet.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.testGet.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -3074,6 +3197,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.testList.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.testList.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -3189,6 +3315,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3198,6 +3327,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3207,6 +3339,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3232,6 +3367,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3335,6 +3473,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3421,6 +3562,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.testCreate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.testCreate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3525,6 +3669,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.testDelete.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.testDelete.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3610,6 +3757,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.testUpdate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.testUpdate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3768,6 +3918,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3916,6 +4069,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email)
@@ -3966,6 +4122,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -4038,6 +4197,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.testGet.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.testGet.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -4089,6 +4251,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.testList.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.testList.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -4204,6 +4369,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4213,6 +4381,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4222,6 +4393,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -596,6 +596,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -699,6 +702,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -802,6 +808,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createEmail.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -905,6 +914,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -1008,6 +1020,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createRequire.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -1111,6 +1126,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -1214,6 +1232,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -1317,6 +1338,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.customCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customCreatePost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -1409,6 +1433,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.customDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1483,6 +1510,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.customUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customUpdatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1620,6 +1650,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1685,6 +1718,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1750,6 +1786,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1815,6 +1854,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1881,6 +1923,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1946,6 +1991,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -2011,6 +2059,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -2085,6 +2136,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2231,6 +2285,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2377,6 +2434,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateEmail.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2523,6 +2583,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2670,6 +2733,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateRequire.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2816,6 +2882,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2962,6 +3031,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3099,6 +3171,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.customGetPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3143,6 +3218,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.customListPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.customListPost.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3196,6 +3274,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3240,6 +3321,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3284,6 +3368,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getEmail.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3328,6 +3415,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getEntity.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getEntity.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3372,6 +3462,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3416,6 +3509,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getRequire.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3460,6 +3556,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3504,6 +3603,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getUser.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3548,6 +3650,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3601,6 +3706,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3654,6 +3762,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listEmails.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3707,6 +3818,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3760,6 +3874,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listRequires.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3813,6 +3930,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3866,6 +3986,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3919,6 +4042,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.syncPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 {
   \\"version\\": \\"2018-05-29\\",
@@ -3940,6 +4066,9 @@ null
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3949,6 +4078,9 @@ $util.toJson({
   "Subscription.onCreateAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3958,6 +4090,9 @@ $util.toJson({
   "Subscription.onCreateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3967,6 +4102,9 @@ $util.toJson({
   "Subscription.onCreateEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3976,6 +4114,9 @@ $util.toJson({
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3985,6 +4126,9 @@ $util.toJson({
   "Subscription.onCreateRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3994,6 +4138,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4003,6 +4150,9 @@ $util.toJson({
   "Subscription.onCreateUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4012,6 +4162,9 @@ $util.toJson({
   "Subscription.onDeleteAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4021,6 +4174,9 @@ $util.toJson({
   "Subscription.onDeleteComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4030,6 +4186,9 @@ $util.toJson({
   "Subscription.onDeleteEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4039,6 +4198,9 @@ $util.toJson({
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4048,6 +4210,9 @@ $util.toJson({
   "Subscription.onDeleteRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4057,6 +4222,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4066,6 +4234,9 @@ $util.toJson({
   "Subscription.onDeleteUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4075,6 +4246,9 @@ $util.toJson({
   "Subscription.onUpdateAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4084,6 +4258,9 @@ $util.toJson({
   "Subscription.onUpdateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4093,6 +4270,9 @@ $util.toJson({
   "Subscription.onUpdateEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4102,6 +4282,9 @@ $util.toJson({
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4111,6 +4294,9 @@ $util.toJson({
   "Subscription.onUpdateRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4120,6 +4306,9 @@ $util.toJson({
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4145,6 +4334,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4248,6 +4440,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4351,6 +4546,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createEmail.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4454,6 +4652,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4557,6 +4758,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createRequire.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4660,6 +4864,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4763,6 +4970,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4866,6 +5076,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.customCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customCreatePost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -4958,6 +5171,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.customDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5032,6 +5248,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.customUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customUpdatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -5169,6 +5388,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5234,6 +5456,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5299,6 +5524,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5364,6 +5592,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5430,6 +5661,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5495,6 +5729,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5560,6 +5797,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5634,6 +5874,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -5780,6 +6023,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -5926,6 +6172,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateEmail.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -6072,6 +6321,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -6219,6 +6471,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateRequire.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -6365,6 +6620,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -6511,6 +6769,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -6648,6 +6909,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.customGetPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6692,6 +6956,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.customListPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.customListPost.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -6745,6 +7012,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6789,6 +7059,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6833,6 +7106,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getEmail.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6877,6 +7153,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getEntity.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getEntity.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6921,6 +7200,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6965,6 +7247,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getRequire.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -7009,6 +7294,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -7053,6 +7341,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getUser.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -7097,6 +7388,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7150,6 +7444,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7203,6 +7500,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listEmails.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7256,6 +7556,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7309,6 +7612,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listRequires.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7362,6 +7668,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7415,6 +7724,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7468,6 +7780,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.syncPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 {
   \\"version\\": \\"2018-05-29\\",
@@ -7489,6 +7804,9 @@ null
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7498,6 +7816,9 @@ $util.toJson({
   "Subscription.onCreateAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7507,6 +7828,9 @@ $util.toJson({
   "Subscription.onCreateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7516,6 +7840,9 @@ $util.toJson({
   "Subscription.onCreateEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7525,6 +7852,9 @@ $util.toJson({
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7534,6 +7864,9 @@ $util.toJson({
   "Subscription.onCreateRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7543,6 +7876,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7552,6 +7888,9 @@ $util.toJson({
   "Subscription.onCreateUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7561,6 +7900,9 @@ $util.toJson({
   "Subscription.onDeleteAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7570,6 +7912,9 @@ $util.toJson({
   "Subscription.onDeleteComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7579,6 +7924,9 @@ $util.toJson({
   "Subscription.onDeleteEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7588,6 +7936,9 @@ $util.toJson({
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7597,6 +7948,9 @@ $util.toJson({
   "Subscription.onDeleteRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7606,6 +7960,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7615,6 +7972,9 @@ $util.toJson({
   "Subscription.onDeleteUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7624,6 +7984,9 @@ $util.toJson({
   "Subscription.onUpdateAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7633,6 +7996,9 @@ $util.toJson({
   "Subscription.onUpdateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7642,6 +8008,9 @@ $util.toJson({
   "Subscription.onUpdateEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7651,6 +8020,9 @@ $util.toJson({
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7660,6 +8032,9 @@ $util.toJson({
   "Subscription.onUpdateRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7669,6 +8044,9 @@ $util.toJson({
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7694,6 +8072,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -7797,6 +8178,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -7900,6 +8284,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createEmail.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8003,6 +8390,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8106,6 +8496,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createRequire.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8209,6 +8602,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8312,6 +8708,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8415,6 +8814,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.customCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customCreatePost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8507,6 +8909,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.customDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8581,6 +8986,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.customUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.customUpdatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -8718,6 +9126,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8783,6 +9194,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8848,6 +9262,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8913,6 +9330,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8979,6 +9399,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9044,6 +9467,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9109,6 +9535,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9183,6 +9612,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9329,6 +9761,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9475,6 +9910,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateEmail.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9621,6 +10059,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9768,6 +10209,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateRequire.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9914,6 +10358,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10060,6 +10507,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10197,6 +10647,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.customGetPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10241,6 +10694,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.customListPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.customListPost.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10294,6 +10750,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10338,6 +10797,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10382,6 +10844,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getEmail.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10426,6 +10891,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getEntity.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getEntity.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10470,6 +10938,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10514,6 +10985,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getRequire.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10558,6 +11032,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10602,6 +11079,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getUser.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10646,6 +11126,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10699,6 +11182,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10752,6 +11238,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listEmails.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10805,6 +11294,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10858,6 +11350,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listRequires.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10911,6 +11406,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10964,6 +11462,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -11017,6 +11518,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.syncPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 {
   \\"version\\": \\"2018-05-29\\",
@@ -11038,6 +11542,9 @@ null
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11047,6 +11554,9 @@ $util.toJson({
   "Subscription.onCreateAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11056,6 +11566,9 @@ $util.toJson({
   "Subscription.onCreateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11065,6 +11578,9 @@ $util.toJson({
   "Subscription.onCreateEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11074,6 +11590,9 @@ $util.toJson({
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11083,6 +11602,9 @@ $util.toJson({
   "Subscription.onCreateRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11092,6 +11614,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11101,6 +11626,9 @@ $util.toJson({
   "Subscription.onCreateUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11110,6 +11638,9 @@ $util.toJson({
   "Subscription.onDeleteAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11119,6 +11650,9 @@ $util.toJson({
   "Subscription.onDeleteComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11128,6 +11662,9 @@ $util.toJson({
   "Subscription.onDeleteEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11137,6 +11674,9 @@ $util.toJson({
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11146,6 +11686,9 @@ $util.toJson({
   "Subscription.onDeleteRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11155,6 +11698,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11164,6 +11710,9 @@ $util.toJson({
   "Subscription.onDeleteUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11173,6 +11722,9 @@ $util.toJson({
   "Subscription.onUpdateAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11182,6 +11734,9 @@ $util.toJson({
   "Subscription.onUpdateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11191,6 +11746,9 @@ $util.toJson({
   "Subscription.onUpdateEmail.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11200,6 +11758,9 @@ $util.toJson({
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11209,6 +11770,9 @@ $util.toJson({
   "Subscription.onUpdateRequire.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -11218,6 +11782,9 @@ $util.toJson({
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -982,4 +982,25 @@ describe('ModelTransformer: ', () => {
 
     validateModelSchema(parse(definition));
   });
+
+  it('should support sandbox mode of api', async () => {
+    const validSchema = `
+      type AMPLIFY_GLOBAL @allow_public_data_access_with_api_key(in: "staging")
+
+      type Post @model {
+          id: ID!
+          title: String!
+      }
+    `;
+
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+      featureFlags,
+    });
+
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+
+    parse(out.schema);
+  });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -54,6 +54,7 @@ import {
   makeUpdateInputField,
 } from './graphql-types';
 import {
+  generateAuthExpressionForSandboxMode,
   generateCreateInitSlotTemplate,
   generateCreateRequestTemplate,
   generateDefaultResponseMappingTemplate,
@@ -267,7 +268,13 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
           default:
             throw new Error('Unknown query field type');
         }
-
+        resolver.addToSlot(
+          'postAuth',
+          MappingTemplate.s3MappingTemplateFromString(
+            generateAuthExpressionForSandboxMode(context),
+            `${query.typeName}.${query.fieldName}.{slotName}.{slotIndex}.req.vtl`,
+          ),
+        );
         resolver.mapToStack(stack);
         context.resolvers.addResolver(query.typeName, query.fieldName, resolver);
       }
@@ -286,8 +293,15 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
             resolver = this.generateUpdateResolver(context, def!, mutation.typeName, mutation.fieldName);
             break;
           default:
-            throw new Error('Unknown query field type');
+            throw new Error('Unknown mutation field type');
         }
+        resolver.addToSlot(
+          'postAuth',
+          MappingTemplate.s3MappingTemplateFromString(
+            generateAuthExpressionForSandboxMode(context),
+            `${mutation.typeName}.${mutation.fieldName}.{slotName}.{slotIndex}.req.vtl`,
+          ),
+        );
         resolver.mapToStack(stack);
         context.resolvers.addResolver(mutation.typeName, mutation.fieldName, resolver);
       }
@@ -309,8 +323,15 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
               resolver = this.generateOnDeleteResolver(context, def, subscription.typeName, subscription.fieldName);
               break;
             default:
-              throw new Error('Unkown subscription field type');
+              throw new Error('Unknown subscription field type');
           }
+          resolver.addToSlot(
+            'postAuth',
+            MappingTemplate.s3MappingTemplateFromString(
+              generateAuthExpressionForSandboxMode(context),
+              `${subscription.typeName}.${subscription.fieldName}.{slotName}.{slotIndex}.req.vtl`,
+            ),
+          );
           resolver.mapToStack(stack);
           context.resolvers.addResolver(subscription.typeName, subscription.fieldName, resolver);
         }

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -8217,6 +8217,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -8332,6 +8335,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8435,6 +8441,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createFriendship.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8538,6 +8547,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createParent.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8641,6 +8653,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -8755,6 +8770,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPostAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8858,6 +8876,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPostEditor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -8961,6 +8982,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPostModel.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -9064,6 +9088,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -9167,6 +9194,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9289,6 +9319,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9411,6 +9444,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9542,6 +9578,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9618,6 +9657,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9683,6 +9725,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteFriendship.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9748,6 +9793,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteParent.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9813,6 +9861,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9888,6 +9939,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePostAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9953,6 +10007,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePostEditor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10018,6 +10075,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePostModel.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10083,6 +10143,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10148,6 +10211,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10224,6 +10290,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10300,6 +10369,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deleteUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10398,6 +10470,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10556,6 +10631,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10702,6 +10780,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateFriendship.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10848,6 +10929,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateParent.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10994,6 +11078,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -11151,6 +11238,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePostAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -11297,6 +11387,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePostEditor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -11443,6 +11536,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePostModel.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -11589,6 +11685,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -11735,6 +11834,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -11900,6 +12002,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -12065,6 +12170,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -12811,6 +12919,9 @@ $util.unauthorized()
     $util.toJson(null)
   #end
 #end",
+  "Query.getChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getChild.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -12862,6 +12973,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -12906,6 +13020,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getFriendship.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -12950,6 +13067,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getParent.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -12994,6 +13114,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPost.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"title\\": $util.dynamodb.toDynamoDB($ctx.args.title)
@@ -13044,6 +13167,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getPostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPostAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -13088,6 +13214,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getPostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPostModel.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -13132,6 +13261,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -13176,6 +13308,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getTest1.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -13227,6 +13362,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getUser.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -13278,6 +13416,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.getUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getUserModel.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -13329,6 +13470,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listChildren.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listChildren.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -13444,6 +13588,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13497,6 +13644,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listFriendships.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listFriendships.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13550,6 +13700,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listParents.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listParents.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13603,6 +13756,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listPostAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPostAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13656,6 +13812,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listPostModels.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPostModels.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13709,6 +13868,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -13781,6 +13943,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listTest1s.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTest1s.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -13942,6 +14107,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13995,6 +14163,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listUserModels.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listUserModels.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -14110,6 +14281,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -14271,6 +14445,9 @@ $util.toJson($ListRequest)
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Subscription.onCreateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14280,6 +14457,9 @@ $util.toJson({
   "Subscription.onCreateChild.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14289,6 +14469,9 @@ $util.toJson({
   "Subscription.onCreateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateFriendship.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14298,6 +14481,9 @@ $util.toJson({
   "Subscription.onCreateFriendship.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateParent.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14307,6 +14493,9 @@ $util.toJson({
   "Subscription.onCreateParent.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14316,6 +14505,9 @@ $util.toJson({
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePostAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14325,6 +14517,9 @@ $util.toJson({
   "Subscription.onCreatePostAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePostEditor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14334,6 +14529,9 @@ $util.toJson({
   "Subscription.onCreatePostEditor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePostModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14343,6 +14541,9 @@ $util.toJson({
   "Subscription.onCreatePostModel.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14352,6 +14553,9 @@ $util.toJson({
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest1.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14361,6 +14565,9 @@ $util.toJson({
   "Subscription.onCreateTest1.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14370,6 +14577,9 @@ $util.toJson({
   "Subscription.onCreateUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onCreateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUserModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14379,6 +14589,9 @@ $util.toJson({
   "Subscription.onCreateUserModel.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14388,6 +14601,9 @@ $util.toJson({
   "Subscription.onDeleteChild.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14397,6 +14613,9 @@ $util.toJson({
   "Subscription.onDeleteComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteFriendship.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14406,6 +14625,9 @@ $util.toJson({
   "Subscription.onDeleteFriendship.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteParent.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14415,6 +14637,9 @@ $util.toJson({
   "Subscription.onDeleteParent.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14424,6 +14649,9 @@ $util.toJson({
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePostAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14433,6 +14661,9 @@ $util.toJson({
   "Subscription.onDeletePostAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePostEditor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14442,6 +14673,9 @@ $util.toJson({
   "Subscription.onDeletePostEditor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePostModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14451,6 +14685,9 @@ $util.toJson({
   "Subscription.onDeletePostModel.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14460,6 +14697,9 @@ $util.toJson({
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest1.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14469,6 +14709,9 @@ $util.toJson({
   "Subscription.onDeleteTest1.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14478,6 +14721,9 @@ $util.toJson({
   "Subscription.onDeleteUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeleteUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUserModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14487,6 +14733,9 @@ $util.toJson({
   "Subscription.onDeleteUserModel.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14496,6 +14745,9 @@ $util.toJson({
   "Subscription.onUpdateChild.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14505,6 +14757,9 @@ $util.toJson({
   "Subscription.onUpdateComment.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateFriendship.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14514,6 +14769,9 @@ $util.toJson({
   "Subscription.onUpdateFriendship.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateParent.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14523,6 +14781,9 @@ $util.toJson({
   "Subscription.onUpdateParent.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14532,6 +14793,9 @@ $util.toJson({
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePostAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14541,6 +14805,9 @@ $util.toJson({
   "Subscription.onUpdatePostAuthor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePostEditor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14550,6 +14817,9 @@ $util.toJson({
   "Subscription.onUpdatePostEditor.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePostModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14559,6 +14829,9 @@ $util.toJson({
   "Subscription.onUpdatePostModel.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14568,6 +14841,9 @@ $util.toJson({
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest1.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14577,6 +14853,9 @@ $util.toJson({
   "Subscription.onUpdateTest1.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14586,6 +14865,9 @@ $util.toJson({
   "Subscription.onUpdateUser.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUserModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -604,6 +604,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
 #if( $ctx.stash.metadata.modelObjectKey )
@@ -696,6 +699,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -770,6 +776,9 @@ $util.toJson({
   \\"payload\\": {}
 })
 ## [End] Initialization default values. **",
+  "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -907,6 +916,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
+  "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -951,6 +963,9 @@ $util.unauthorized()
   $util.toJson(null)
 #end
 ## [End] Get Response template. **",
+  "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -1109,6 +1124,9 @@ $util.toJson({
   \\"nextToken\\": $nextToken,
   \\"aggregateItems\\": $aggregateValues
 })",
+  "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1118,6 +1136,9 @@ $util.toJson({
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1127,6 +1148,9 @@ $util.toJson({
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Resonse template. **
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
+  "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+$util.unauthorized()
+## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -52,7 +52,6 @@
         "@aws-cdk/custom-resources": "~1.119.0",
         "@aws-cdk/cx-api": "~1.119.0",
         "@aws-cdk/region-info": "~1.119.0",
-        "amplify-cli-core": "1.26.0",
         "change-case": "^4.1.1",
         "constructs": "^3.3.125",
         "deep-diff": "^1.0.2",

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -52,6 +52,7 @@
         "@aws-cdk/custom-resources": "~1.119.0",
         "@aws-cdk/cx-api": "~1.119.0",
         "@aws-cdk/region-info": "~1.119.0",
+        "amplify-cli-core": "1.26.0",
         "change-case": "^4.1.1",
         "constructs": "^3.3.125",
         "deep-diff": "^1.0.2",

--- a/packages/amplify-graphql-transformer-core/src/graphql-api.ts
+++ b/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -17,6 +17,7 @@ import { Grant, IGrantable, ManagedPolicy, Role, ServicePrincipal } from '@aws-c
 import { CfnResource, Construct, Duration, Stack } from '@aws-cdk/core';
 import { TransformerSchema } from './cdk-compat/schema-asset';
 import { DefaultTransformHost } from './transform-host';
+import { stateManager } from 'amplify-cli-core';
 
 export interface GraphqlApiProps {
   /**
@@ -113,6 +114,7 @@ export class IamResource implements APIIAMResourceProvider {
 export type TransformerAPIProps = GraphqlApiProps & {
   readonly createApiKey?: boolean;
   readonly host?: TransformHostProvider;
+  readonly globalSandboxModeEnv?: string;
 };
 export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
   /**
@@ -125,7 +127,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
    * The TransformHost object provides resource creation utilities in AWS
    * such as a LambdaDataSource or a DynamoDBDataSource
    */
-  public readonly host: TransformHostProvider
+  public readonly host: TransformHostProvider;
 
   /**
    * the ARN of the API
@@ -160,6 +162,11 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
    * @default - no api key
    */
   public readonly apiKey?: string;
+
+  /**
+   * Global Sandbox Mode for GraphQL API
+   */
+  public readonly globalSandboxModeEnabled?: boolean;
 
   private schemaResource: CfnGraphQLSchema;
   private api: CfnGraphQLApi;
@@ -198,7 +205,9 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
     this.schema = props.schema ?? new TransformerSchema();
     this.schemaResource = this.schema.bind(this);
 
-    if (props.createApiKey && modes.some(mode => mode.authorizationType === AuthorizationType.API_KEY)) {
+    const hasApiKey = modes.some(mode => mode.authorizationType === AuthorizationType.API_KEY);
+
+    if (props.createApiKey && hasApiKey) {
       const config = modes.find((mode: AuthorizationMode) => {
         return mode.authorizationType === AuthorizationType.API_KEY && mode.apiKeyConfig;
       })?.apiKeyConfig;
@@ -207,13 +216,14 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
       this.apiKey = this.apiKeyResource.attrApiKey;
     }
 
+    if (hasApiKey && !!props.globalSandboxModeEnv) this.globalSandboxModeEnabled = true;
+
     if (props.host) {
       this.host = props.host;
       this.host.setAPI(this);
-    }
-    else {
+    } else {
       this.host = new DefaultTransformHost({
-        api: this
+        api: this,
       });
     }
   }

--- a/packages/amplify-graphql-transformer-core/src/graphql-api.ts
+++ b/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -17,7 +17,6 @@ import { Grant, IGrantable, ManagedPolicy, Role, ServicePrincipal } from '@aws-c
 import { CfnResource, Construct, Duration, Stack } from '@aws-cdk/core';
 import { TransformerSchema } from './cdk-compat/schema-asset';
 import { DefaultTransformHost } from './transform-host';
-import { stateManager } from 'amplify-cli-core';
 
 export interface GraphqlApiProps {
   /**

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -23,7 +23,13 @@ export {
   AppSyncAuthMode,
   UserPoolConfig,
 } from './config/index';
-export { collectDirectives, collectDirectivesByTypeNames, DirectiveWrapper } from './utils';
+export {
+  collectDirectives,
+  collectDirectivesByTypeNames,
+  DirectiveWrapper,
+  getSandboxModeEnvNameFromDirectiveSet,
+  getSandboxModeEnvNameFromNodeMap,
+} from './utils';
 export * from './errors';
 export {
   TransformerModelBase,

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -43,6 +43,7 @@ import {
   sortTransformerPlugins,
 } from './utils';
 import { validateModelSchema, validateAuthModes } from './validation';
+import { getSandboxModeEnvNameFromNodeMap } from '../utils/sandbox-mode';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 function isFunction(obj: any): obj is Function {
@@ -258,11 +259,13 @@ export class GraphQLTransform {
     const authorizationConfig = adoptAuthModes(stackManager, this.authConfig);
     const apiName = stackManager.addParameter('AppSyncApiName', { type: 'String' }).valueAsString;
     const envName = stackManager.getParameter('env');
+    const globalSandboxModeEnv = getSandboxModeEnvNameFromNodeMap(output.nodeMap);
     assert(envName);
     const api = new GraphQLApi(rootStack, 'GraphQLAPI', {
       name: `${apiName}-${envName.valueAsString}`,
       authorizationConfig,
       host: this.options.host,
+      globalSandboxModeEnv
     });
     const authModes = [authorizationConfig.defaultAuthorization, ...(authorizationConfig.additionalAuthorizationModes || [])].map(
       mode => mode?.authorizationType,

--- a/packages/amplify-graphql-transformer-core/src/utils/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/index.ts
@@ -2,3 +2,4 @@ export { DirectiveWrapper } from './directive-wrapper';
 export { collectDirectives, collectDirectivesByTypeNames } from './type-map-utils';
 export { stripDirectives } from './strip-directives';
 export { DEFAULT_SCHEMA_DEFINITION } from './defaultSchema';
+export { getSandboxModeEnvNameFromNodeMap, getSandboxModeEnvNameFromDirectiveSet } from './sandbox-mode';

--- a/packages/amplify-graphql-transformer-core/src/utils/sandbox-mode.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/sandbox-mode.ts
@@ -1,0 +1,16 @@
+export function getSandboxModeEnvNameFromNodeMap(input: any): string {
+  const ampGlobalType: any = input.AMPLIFY_GLOBAL;
+
+  if (!ampGlobalType) return '';
+
+  return getSandboxModeEnvNameFromDirectiveSet(ampGlobalType.directives);
+}
+
+export function getSandboxModeEnvNameFromDirectiveSet(input: any): string {
+  const sandboxModeDirective = input.find((el: any) => el.name.value === 'allow_public_data_access_with_api_key');
+
+  if (!sandboxModeDirective) return '';
+
+  const inField = sandboxModeDirective.arguments.find((el: any) => el.name.value === 'in');
+  return inField.value.value;
+}

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -74,9 +74,8 @@ function getTransformerFactory(
     }
 
     const customTransformersConfig = await readTransformerConfiguration(resourceDir);
-    const customTransformers = (customTransformersConfig && customTransformersConfig.transformers
-      ? customTransformersConfig.transformers
-      : []
+    const customTransformers = (
+      customTransformersConfig && customTransformersConfig.transformers ? customTransformersConfig.transformers : []
     )
       .map(transformer => {
         const fileUrlMatch = /^file:\/\/(.*)\s*$/m.exec(transformer);
@@ -427,7 +426,9 @@ export async function buildAPIProject(opts: ProjectOptions<TransformerFactoryArg
     // Todo: Move sanity check to its own package. Run sanity check
     // await Sanity.check(lastBuildPath, thisBuildPath, opts.rootStackFileName);
   }
-  await _updateCurrentMeta(opts);
+
+  // TODO: update local env on api compile
+  // await _updateCurrentMeta(opts);
 
   return builtProject;
 }
@@ -448,12 +449,4 @@ async function _buildProject(opts: ProjectOptions<TransformerFactoryArgs>) {
     featureFlags: new AmplifyCLIFeatureFlagAdapter(),
   });
   return transform.transform(userProjectConfig.schema.toString());
-}
-
-async function _updateCurrentMeta(opts: ProjectOptions<TransformerFactoryArgs>) {
-  const currentMeta = stateManager.getCurrentMeta();
-  const buildParams: any = opts.buildParameters;
-  const apiName = buildParams.AppSyncApiName;
-  currentMeta.api[apiName].output.globalSandboxModeConfig = { env: opts.sandboxModeEnv };
-  stateManager.setCurrentMeta(undefined, currentMeta);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,17 @@
     "@aws-cdk/cx-api" "1.119.0"
     constructs "^3.3.69"
 
+"@aws-cdk/assert@~1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.72.0.tgz#2811b89536a34d970ba43f73f9c77228a73c90ca"
+  integrity sha512-ikzkFtpTyJeJdQb9ajxa8/wVouEp6dKGU2NhaBrn1gR3r7Qekp3VFZHYytz8RRsf9vLy3P7vzqlT3k8WLeUm4g==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "1.72.0"
+    "@aws-cdk/cloudformation-diff" "1.72.0"
+    "@aws-cdk/core" "1.72.0"
+    "@aws-cdk/cx-api" "1.72.0"
+    constructs "^3.2.0"
+
 "@aws-cdk/assets@1.119.0", "@aws-cdk/assets@~1.119.0":
   version "1.119.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.119.0.tgz#b9be641fd19b1b91335318d48eaca0ee4aeb6186"
@@ -1014,6 +1025,13 @@
   dependencies:
     md5 "^2.3.0"
 
+"@aws-cdk/cfnspec@1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.72.0.tgz#5f6324477e15d75a5fea73eb1cab8b7b9fc9d197"
+  integrity sha512-m8Zs6H0pMlT491Y+HfQLVGpccEcai6Yu9S/QhilD6M8FB+oh3mF0BwpMR2tPl0pnccnW+e+EAIxXiAWQ5ahrKA==
+  dependencies:
+    md5 "^2.3.0"
+
 "@aws-cdk/cloud-assembly-schema@1.119.0", "@aws-cdk/cloud-assembly-schema@~1.119.0":
   version "1.119.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.119.0.tgz#b587fc3e6ae65bf5b541a50f6f655704ae56903b"
@@ -1021,6 +1039,14 @@
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
+
+"@aws-cdk/cloud-assembly-schema@1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.72.0.tgz#68e4062e2db1601a224f9b106d13838222a2fbd5"
+  integrity sha512-8h0+SslWBxHpt4LAM5W9indlQkuUY9bpxu49mXR6Yesi1L9vyGwB/bnfhqMTX/fL6KUuk28HpaO41iIWvoMh0g==
+  dependencies:
+    jsonschema "^1.4.0"
+    semver "^7.3.2"
 
 "@aws-cdk/cloudformation-diff@1.119.0", "@aws-cdk/cloudformation-diff@~1.119.0":
   version "1.119.0"
@@ -1035,6 +1061,18 @@
     string-width "^4.2.2"
     table "^6.7.1"
 
+"@aws-cdk/cloudformation-diff@1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.72.0.tgz#fb49a14c91ad72bde588c41b14c1ccc6fb097a9c"
+  integrity sha512-5x1+PMSWtWy/TSu0eWGpjIEf0/fGCLkBcYN6kshEzO/9hVdGJdc921Ftv71PevibTDuFln8d0W9E+fm3Z2j13Q==
+  dependencies:
+    "@aws-cdk/cfnspec" "1.72.0"
+    colors "^1.4.0"
+    diff "^4.0.2"
+    fast-deep-equal "^3.1.3"
+    string-width "^4.2.0"
+    table "^6.0.3"
+
 "@aws-cdk/core@1.119.0", "@aws-cdk/core@~1.119.0":
   version "1.119.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.119.0.tgz#3fe2dcf8274c7d980c46ba1e0a52222b0222dadc"
@@ -1047,6 +1085,18 @@
     constructs "^3.3.69"
     fs-extra "^9.1.0"
     ignore "^5.1.8"
+    minimatch "^3.0.4"
+
+"@aws-cdk/core@1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.72.0.tgz#db97bcd30bf879103aaf382eb0c5f21066a0d6ef"
+  integrity sha512-QaXG46NCawlL9lAEIxsh4WZqnMxssDhMKZHh7HfkG/7hOCODhEe9yAN67dIUwmBX7C6DReVGICY9wELjJ069BQ==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "1.72.0"
+    "@aws-cdk/cx-api" "1.72.0"
+    "@aws-cdk/region-info" "1.72.0"
+    constructs "^3.2.0"
+    fs-extra "^9.0.1"
     minimatch "^3.0.4"
 
 "@aws-cdk/custom-resources@1.119.0", "@aws-cdk/custom-resources@~1.119.0":
@@ -1071,10 +1121,23 @@
     "@aws-cdk/cloud-assembly-schema" "1.119.0"
     semver "^7.3.5"
 
+"@aws-cdk/cx-api@1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.72.0.tgz#dc4ec9558b96731dfb2120484bb09f7f4c0b9d54"
+  integrity sha512-w+Fd7wiroA7rlU/wD6M00PYDQ3QbLrxm8dtMuu9s8/nq2viFM22JOf1VH+dNSS/Y7wGBBtyv4TvdhpZ7TVoZVQ==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "1.72.0"
+    semver "^7.3.2"
+
 "@aws-cdk/region-info@1.119.0", "@aws-cdk/region-info@~1.119.0":
   version "1.119.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.119.0.tgz#2a09551170471fd01e5fc94c45b98f83a26a0aa8"
   integrity sha512-wtUNIKNK80d/YDh04imshlvYV/e6+Z0fDrrbfImJzkwwFR3bdAOKafi8Fo2YsjzLYQiqwthVOZFv+Z2Oh6pBGA==
+
+"@aws-cdk/region-info@1.72.0":
+  version "1.72.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.72.0.tgz#62b9a2b69fcd89073ba423b5ddb999134d0da7ed"
+  integrity sha512-fzsqHX842OZ6I1tOTrScFN5PJvintrkbHU+MekKWYWXWBuGvGCnyC8Lx+NRdfGpWUWo0Wv8ILjOQ4MlS8STBCg==
 
 "@aws-crypto/crc32@^1.0.0":
   version "1.1.0"
@@ -6654,28 +6717,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-cli-core@1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/amplify-cli-core/-/amplify-cli-core-1.26.0.tgz#de4579b73c97f1a020e4fc404460a41a51ad4a48"
-  integrity sha512-XG21+eAvpaDfdGFvlmfqDL3DdsZDp2ds7QgLZ5deSHWW0FtZqdXdfd7kW0ehZWvTj2ILyjroWARa6YkKFb79FA==
-  dependencies:
-    ajv "^6.12.3"
-    amplify-cli-logger "1.1.0"
-    ci-info "^2.0.0"
-    cloudform-types "^4.2.0"
-    dotenv "^8.2.0"
-    folder-hash "^4.0.1"
-    fs-extra "^8.1.0"
-    globby "^11.0.3"
-    hjson "^3.2.1"
-    js-yaml "^4.0.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.1"
-    open "^7.3.1"
-    proxy-agent "^4.0.1"
-    semver "^7.3.5"
-    which "^2.0.2"
-
 amplify-codegen@^2.23.1:
   version "2.26.2"
   resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-2.26.2.tgz#f5837dae2a15eaee214fe7eb318aa577a1f7e198"
@@ -9231,6 +9272,11 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
+
+constructs@^3.2.0:
+  version "3.3.147"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.147.tgz#0616cb1aeb7a916665a74ceae0a1b34b38386937"
+  integrity sha512-xTSA87W5hscsHdFC2NcbJWALeMt8QWoCvVXRHPIuoBDDXdvBuNoqL2a5kY1yEWSMLQvBPnrDyinfz3twTX6dAw==
 
 constructs@^3.3.125, constructs@^3.3.69:
   version "3.3.126"
@@ -21336,7 +21382,7 @@ sync-fetch@0.3.0:
     buffer "^5.7.0"
     node-fetch "^2.6.1"
 
-table@^6.0.9, table@^6.7.1:
+table@^6.0.3, table@^6.0.9, table@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
   integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6654,6 +6654,28 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+amplify-cli-core@1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/amplify-cli-core/-/amplify-cli-core-1.26.0.tgz#de4579b73c97f1a020e4fc404460a41a51ad4a48"
+  integrity sha512-XG21+eAvpaDfdGFvlmfqDL3DdsZDp2ds7QgLZ5deSHWW0FtZqdXdfd7kW0ehZWvTj2ILyjroWARa6YkKFb79FA==
+  dependencies:
+    ajv "^6.12.3"
+    amplify-cli-logger "1.1.0"
+    ci-info "^2.0.0"
+    cloudform-types "^4.2.0"
+    dotenv "^8.2.0"
+    folder-hash "^4.0.1"
+    fs-extra "^8.1.0"
+    globby "^11.0.3"
+    hjson "^3.2.1"
+    js-yaml "^4.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.1"
+    open "^7.3.1"
+    proxy-agent "^4.0.1"
+    semver "^7.3.5"
+    which "^2.0.2"
+
 amplify-codegen@^2.23.1:
   version "2.26.2"
   resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-2.26.2.tgz#f5837dae2a15eaee214fe7eb318aa577a1f7e198"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Changes set up the transformers to take in the sandbox directive (`allow_public_data_access_with_api_key`) and write to the auth resolvers. When sandbox mode is enabled, it allows API Key auth; when disabled, calls without an `@auth` directive are unauthorized.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.