### PR TITLE
Handles AWSDate coming from RDS Datasources

### DIFF
--- a/packages/amplify-appsync-simulator/src/schema/appsync-scalars/index.ts
+++ b/packages/amplify-appsync-simulator/src/schema/appsync-scalars/index.ts
@@ -54,7 +54,7 @@ const AWSDate = new GraphQLScalarType({
   name: 'AWSDate',
   description: GraphQLDate.description,
   serialize(value) {
-    return GraphQLDate.serialize(value);
+    return GraphQLDate.serialize(value.substring(0, 10));
   },
   parseValue(value) {
     return GraphQLDate.parseValue(value) ? value : undefined;


### PR DESCRIPTION
#### Description of changes
Updates serialization on AWSDate scalar to handle returned `stringValue` from RDS Datasources.

#### Issue 8139
aws-amplify/amplify-category-api#164

#### Description of how you validated changes
Tested on serverless project using `serverless-appsync-simulator`. Detailed description on [issue](aws-amplify/amplify-category-api#164) 

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.