### PR TITLE
auth directive support for index, searchable, predictions, functions, and relational directives

### DIFF
--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -30,6 +30,7 @@
     "@aws-amplify/graphql-transformer-core": "0.9.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.9.0",
     "@aws-amplify/graphql-model-transformer": "0.6.1",
+    "@aws-amplify/graphql-index-transformer": "0.3.1",
     "@aws-cdk/aws-appsync": "~1.119.0",
     "@aws-cdk/aws-dynamodb": "~1.119.0",
     "@aws-cdk/core": "~1.119.0",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/accesscontrol.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/accesscontrol.test.ts
@@ -1,5 +1,5 @@
-import { AccessControlMatrix } from '../../accesscontrol';
-import { MODEL_OPERATIONS } from '../../utils';
+import { AccessControlMatrix } from '../accesscontrol';
+import { MODEL_OPERATIONS } from '../utils';
 
 test('test access control', () => {
   /*

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -1,0 +1,330 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import _ from 'lodash';
+
+test('test simple model with public auth rule and amplify admin app is present', () => {
+  const validSchema = `
+  type Post @model @auth(rules: [{allow: public}]) {
+    id: ID!
+    title: String!
+    createdAt: String
+    updatedAt: String
+  }`;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'API_KEY',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: true,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('Post @aws_api_key @aws_iam');
+});
+
+test('Test simple model with public auth rule and amplify admin app is not enabled', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: public}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'API_KEY',
+          },
+          additionalAuthenticationProviders: [],
+        },
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).not.toContain('Post @aws_api_key @aws_iam');
+});
+
+test('Test model with public auth rule without all operations and amplify admin app is present', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: public, operations: [read, update]}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'API_KEY',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: true,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  expect(out.schema).toContain('type Post @aws_iam @aws_api_key');
+  expect(out.schema).toContain('createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam');
+  expect(out.schema).toContain('updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam');
+  expect(out.schema).toContain('deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post @aws_api_key @aws_iam');
+
+  // No parameter for Auth and UnAuth policy
+  expect(out.rootStack.Parameters!.authRoleName).toBeUndefined();
+  expect(out.rootStack.Parameters!.unauthRoleName).toBeUndefined();
+
+  // No Resource extending Auth and UnAuth role
+  const policyResources = Object.values(out.rootStack.Resources!).filter(r => r.Type === 'AWS::IAM::ManagedPolicy');
+  expect(policyResources).toHaveLength(0);
+});
+
+test('Test simple model with private auth rule and amplify admin app is present', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: groups, groups: ["Admin", "Dev"]}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: true,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('type Post @aws_iam @aws_cognito_user_pools');
+});
+
+test('Test simple model with private auth rule and amplify admin app not enabled', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: groups, groups: ["Admin", "Dev"]}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).not.toContain('type Post @aws_iam @aws_cognito_user_pools');
+});
+
+test('Test simple model with private auth rule, few operations, and amplify admin app enabled', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: groups, groups: ["Admin", "Dev"], operations: [read]}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: true,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('type Post @aws_iam @aws_cognito_user_pools');
+  expect(out.schema).toContain(
+    'createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+  expect(out.schema).toContain(
+    'updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+  expect(out.schema).toContain(
+    'deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+
+  // No parameter for Auth and UnAuth policy
+  expect(out.rootStack.Parameters!.authRoleName).toBeUndefined();
+  expect(out.rootStack.Parameters!.unauthRoleName).toBeUndefined();
+
+  // No Resource extending Auth and UnAuth role
+  const policyResources = Object.values(out.rootStack.Resources!).filter(r => r.Type === 'AWS::IAM::ManagedPolicy');
+  expect(policyResources).toHaveLength(0);
+});
+
+test('Test simple model with private IAM auth rule, few operations, and amplify admin app is not enabled', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: private, provider: iam, operations: [read]}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('Post @aws_iam');
+  expect(out.schema).not.toContain(
+    'createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+  expect(out.schema).not.toContain('deletePost(input: DeletePostInput!): Post @aws_iam');
+  expect(out.schema).not.toContain('updatePost(input: UpdatePostInput!): Post @aws_iam');
+
+  expect(out.schema).toContain('getPost(id: ID!): Post @aws_iam');
+  expect(out.schema).toContain('listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection @aws_iam');
+});
+
+test('Test simple model with AdminUI enabled should add IAM policy only for fields that have explicit IAM auth', () => {
+  const validSchema = `
+      type Post @model @auth(rules: [{allow: private, provider: iam, operations: [read]}]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+      }
+      `;
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+          },
+          additionalAuthenticationProviders: [
+            {
+              authenticationType: 'AWS_IAM',
+            },
+          ],
+        },
+        addAwsIamAuthInOutputSchema: true,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('Post @aws_iam @aws_cognito_user_pool');
+  expect(out.schema).toContain(
+    'createPost(input: CreatePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+  expect(out.schema).toContain(
+    'updatePost(input: UpdatePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+  expect(out.schema).toContain(
+    'deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post @aws_iam @aws_cognito_user_pools',
+  );
+
+  expect(out.schema).toContain('getPost(id: ID!): Post @aws_iam');
+  expect(out.schema).toContain('listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection @aws_iam');
+  const policyResources = _.filter(out.rootStack.Resources, r => r.Type === 'AWS::IAM::ManagedPolicy');
+  expect(policyResources).toHaveLength(1);
+  const resources = _.get(policyResources, '[0].Properties.PolicyDocument.Statement[0].Resource');
+  const typeFieldList = _.map(resources, r => _.get(r, 'Fn::Sub[1]')).map(r => `${_.get(r, 'typeName')}.${_.get(r, 'fieldName', '*')}`);
+  expect(typeFieldList).toEqual([
+    'Post.*',
+    'Query.getPost',
+    'Query.listPosts',
+    'Mutation.createPost',
+    'Mutation.updatePost',
+    'Mutation.deletePost',
+    'Subscription.onCreatePost',
+    'Subscription.onUpdatePost',
+    'Subscription.onDeletePost',
+  ]);
+  // should throw unauthorized if it's not signed by the admin ui iam role
+  ['Mutation.createPost.auth.1.req.vtl', 'Mutation.updatePost.auth.1.res.vtl', 'Mutation.deletePost.auth.1.res.vtl'].forEach(r => {
+    expect(out.pipelineFunctions[r]).toContain(
+      '#if( $util.authType() == "IAM Authorization" )\n' +
+        '  #if( $ctx.identity.userArn.contains("_Full-access/CognitoIdentityCredentials") || $ctx.identity.userArn.contains("_Manage-only/CognitoIdentityCredentials") )\n' +
+        '    #return($util.toJson({})\n' +
+        '  #end\n' +
+        '$util.unauthorized()\n' +
+        '#end',
+    );
+  });
+});

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -1,0 +1,96 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { AppSyncAuthConfiguration, GraphQLTransform, TransformerContractError } from '@aws-amplify/graphql-transformer-core';
+import { ResourceConstants } from 'graphql-transformer-common';
+
+test('happy case with static groups', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const validSchema = `
+  type Post @model @auth(rules: [{allow: groups, groups: ["Admin", "Dev"]}]) {
+    id: ID!
+    title: String!
+    createdAt: String
+    updatedAt: String
+  }`;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.rootStack!.Resources![ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
+    'AMAZON_COGNITO_USER_POOLS',
+  );
+});
+
+test('happy case with dynamic groups', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const validSchema = `
+    type Post @model @auth(rules: [{allow: groups, groupsField: "groups"}]) {
+        id: ID!
+        title: String!
+        groups: [String]
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.rootStack!.Resources![ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
+    'AMAZON_COGNITO_USER_POOLS',
+  );
+});
+
+test('validation on @auth on a non-@model type', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const invalidSchema = `
+    type Post @auth(rules: [{allow: groups, groupsField: "groups"}]) {
+        id: ID!
+        title: String!
+        group: String
+        createdAt: String
+        updatedAt: String
+    }`;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  expect(() => transformer.transform(invalidSchema)).toThrowError('Types annotated with @auth must also be annotated with @model.');
+});

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -1,0 +1,622 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { IndexTransformer } from '@aws-amplify/graphql-index-transformer';
+import {
+  AppSyncAuthConfiguration,
+  AppSyncAuthConfigurationOIDCEntry,
+  AppSyncAuthMode,
+  GraphQLTransform,
+  TransformerContractError,
+} from '@aws-amplify/graphql-transformer-core';
+import { DocumentNode, ObjectTypeDefinitionNode, Kind, FieldDefinitionNode, parse, InputValueDefinitionNode } from 'graphql';
+
+const noAuthModeDefaultConfig: AppSyncAuthConfiguration = {
+  defaultAuthentication: {
+    authenticationType: undefined,
+  },
+  additionalAuthenticationProviders: [],
+};
+
+const userPoolsDefaultConfig: AppSyncAuthConfiguration = {
+  defaultAuthentication: {
+    authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+  },
+  additionalAuthenticationProviders: [],
+};
+
+const apiKeyDefaultConfig: AppSyncAuthConfiguration = {
+  defaultAuthentication: {
+    authenticationType: 'API_KEY',
+  },
+  additionalAuthenticationProviders: [],
+};
+
+const openIdDefaultConfig: AppSyncAuthConfiguration = {
+  defaultAuthentication: {
+    authenticationType: 'OPENID_CONNECT',
+  },
+  additionalAuthenticationProviders: [],
+};
+
+const iamDefaultConfig: AppSyncAuthConfiguration = {
+  defaultAuthentication: {
+    authenticationType: 'AWS_IAM',
+  },
+  additionalAuthenticationProviders: [],
+};
+
+const withAuthModes = (authConfig: AppSyncAuthConfiguration, authModes: AppSyncAuthMode[]): AppSyncAuthConfiguration => {
+  const newAuthConfig = {
+    defaultAuthentication: {
+      authenticationType: authConfig.defaultAuthentication.authenticationType,
+    },
+    additionalAuthenticationProviders: [],
+  };
+
+  for (const authMode of authModes) {
+    newAuthConfig.additionalAuthenticationProviders.push({
+      authenticationType: authMode,
+    });
+  }
+
+  return newAuthConfig;
+};
+
+const apiKeyDirectiveName = 'aws_api_key';
+const userPoolsDirectiveName = 'aws_cognito_user_pools';
+const iamDirectiveName = 'aws_iam';
+const openIdDirectiveName = 'aws_oidc';
+
+const multiAuthDirective =
+  '@auth(rules: [{allow: private}, {allow: public}, {allow: private, provider: iam }, {allow: owner, provider: oidc }])';
+const ownerAuthDirective = '@auth(rules: [{allow: owner}])';
+const ownerWithIAMAuthDirective = '@auth(rules: [{allow: owner, provider: iam }])';
+const ownerRestrictedPublicAuthDirective = '@auth(rules: [{allow: owner},{allow: public, operations: [read]}])';
+const ownerRestrictedIAMPrivateAuthDirective = '@auth(rules: [{allow: owner},{allow: private, operations: [read], provider: iam }])';
+const groupsAuthDirective = '@auth(rules: [{allow: groups, groups: ["admin"] }])';
+const groupsWithApiKeyAuthDirective = '@auth(rules: [{allow: groups, groups: ["admin"]}, {allow: public, operations: [read]}])';
+const groupsWithProviderAuthDirective = '@auth(rules: [{allow: groups,groups: ["admin"], provider: iam }])';
+const ownerOpenIdAuthDirective = '@auth(rules: [{allow: owner, provider: oidc }])';
+const privateAuthDirective = '@auth(rules: [{allow: private}])';
+const publicIAMAuthDirective = '@auth(rules: [{allow: public, provider: iam }])';
+const privateWithApiKeyAuthDirective = '@auth(rules: [{allow: private, provider: apiKey }])';
+const publicAuthDirective = '@auth(rules: [{allow: public}])';
+const publicUserPoolsAuthDirective = '@auth(rules: [{allow: public, provider: userPools}])';
+const privateAndPublicDirective = '@auth(rules: [{allow: private}, {allow: public}])';
+const privateAndPrivateIAMDirective = '@auth(rules: [{allow: private}, {allow: private, provider: iam}])';
+const privateIAMDirective = '@auth(rules: [{allow: private, provider: iam}])';
+
+const getSchema = (authDirective: string) => {
+  return `
+    type Post @model ${authDirective} {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+    }`;
+};
+
+const getSchemaWithFieldAuth = (authDirective: string) => {
+  return `
+    type Post @model {
+        id: ID
+        title: String
+        createdAt: String
+        updatedAt: String
+        protected: String ${authDirective}
+    }`;
+};
+
+const getSchemaWithTypeAndFieldAuth = (typeAuthDirective: string, fieldAuthDirective: string) => {
+  return `
+    type Post @model ${typeAuthDirective} {
+        id: ID
+        title: String
+        createdAt: String
+        updatedAt: String
+        protected: String ${fieldAuthDirective}
+    }`;
+};
+
+const getSchemaWithNonModelField = (authDirective: string) => {
+  return `
+    type Post @model ${authDirective} {
+        id: ID!
+        title: String!
+        location: Location
+        status: Status
+        createdAt: String
+        updatedAt: String
+    }
+
+    type Location {
+      name: String
+      address: Address
+    }
+
+    type Address {
+      street: String
+      city: String
+      state: String
+      zip: String
+    }
+
+    enum Status {
+      PUBLISHED,
+      DRAFT
+    }`;
+};
+
+const getSchemaWithRecursiveNonModelField = (authDirective: string) => {
+  return `
+    type Post @model ${authDirective} {
+      id: ID!
+      title: String!
+      tags: [Tag]
+    }
+
+    type Tag {
+      id: ID
+      tags: [Tag]
+    }
+  `;
+};
+
+const getRecursiveSchemaWithDiffModesOnParentType = (authDir1: string, authDir2: string) => {
+  return `
+  type Post @model ${authDir1} {
+    id: ID!
+    title: String!
+    tags: [Tag]
+  }
+
+  type Comment @model ${authDir2} {
+    id: ID!
+    content: String
+    tags: [Tag]
+  }
+
+  type Tag {
+    id: ID
+    tags: [Tag]
+  }
+  `;
+};
+
+const getTransformer = (authConfig: AppSyncAuthConfiguration) =>
+  new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new IndexTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+
+const getObjectType = (doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined => {
+  return doc.definitions.find(def => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | ObjectTypeDefinitionNode
+    | undefined;
+};
+
+const expectNone = fieldOrType => {
+  expect(fieldOrType.directives.length === 0);
+};
+
+const expectOne = (fieldOrType, directiveName) => {
+  expect(fieldOrType.directives.length).toBe(1);
+  expect(fieldOrType.directives.find(d => d.name.value === directiveName)).toBeDefined();
+};
+
+const expectTwo = (fieldOrType, directiveNames) => {
+  expect(directiveNames).toBeDefined();
+  expect(directiveNames).toHaveLength(2);
+  expect(fieldOrType.directives.length === 2);
+  expect(fieldOrType.directives.find(d => d.name.value === directiveNames[0])).toBeDefined();
+  expect(fieldOrType.directives.find(d => d.name.value === directiveNames[1])).toBeDefined();
+};
+
+const expectMultiple = (fieldOrType: ObjectTypeDefinitionNode | FieldDefinitionNode, directiveNames: string[]) => {
+  expect(directiveNames).toBeDefined();
+  expect(directiveNames).toHaveLength(directiveNames.length);
+  expect(fieldOrType.directives.length).toEqual(directiveNames.length);
+  directiveNames.forEach(directiveName => {
+    expect(fieldOrType.directives).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.objectContaining({ value: directiveName }),
+        }),
+      ]),
+    );
+  });
+};
+
+const getField = (type, name) => type.fields.find(f => f.name.value === name);
+
+// describe('validation tests', () => {
+//   const validationTest = (authDirective, authConfig, expectedError) => {
+//     const schema = getSchema(authDirective);
+//     const transformer = getTransformer(authConfig);
+
+//     const t = () => {
+//       const out = transformer.transform(schema);
+//     };
+
+//     expect(t).toThrowError(expectedError);
+//   };
+
+//   test('AMAZON_COGNITO_USER_POOLS not configured for project', () => {
+//     validationTest(
+//       privateAuthDirective,
+//       apiKeyDefaultConfig,
+//       `@auth directive with 'userPools' provider found, but the project has no Cognito User \
+// Pools authentication provider configured.`,
+//     );
+//   });
+
+//   test('API_KEY not configured for project', () => {
+//     validationTest(
+//       publicAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'apiKey' provider found, but the project has no API Key \
+// authentication provider configured.`,
+//     );
+//   });
+
+//   test('AWS_IAM not configured for project', () => {
+//     validationTest(
+//       publicIAMAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'iam' provider found, but the project has no IAM \
+// authentication provider configured.`,
+//     );
+//   });
+
+//   test('OPENID_CONNECT not configured for project', () => {
+//     validationTest(
+//       ownerOpenIdAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT \
+// authentication provider configured.`,
+//     );
+//   });
+
+//   test(`'group' cannot have provider`, () => {
+//     validationTest(
+//       groupsWithProviderAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found \
+// 'iam' assigned`,
+//     );
+//   });
+
+//   test(`'owner' has invalid IAM provider`, () => {
+//     validationTest(
+//       ownerWithIAMAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'owner' strategy only supports 'userPools' (default) and \
+// 'oidc' providers, but found 'iam' assigned.`,
+//     );
+//   });
+
+//   test(`'public' has invalid 'userPools' provider`, () => {
+//     validationTest(
+//       publicUserPoolsAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'public' strategy only supports 'apiKey' (default) and 'iam' providers, but \
+// found 'userPools' assigned.`,
+//     );
+//   });
+
+//   test(`'private' has invalid 'apiKey' provider`, () => {
+//     validationTest(
+//       privateWithApiKeyAuthDirective,
+//       userPoolsDefaultConfig,
+//       `@auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, but \
+// found 'apiKey' assigned.`,
+//     );
+//   });
+// });
+
+describe('schema generation directive tests', () => {
+  const transformTest = (authDirective, authConfig, expectedDirectiveNames?: string[] | undefined) => {
+    const schema = getSchema(authDirective);
+    const transformer = getTransformer(authConfig);
+
+    const out = transformer.transform(schema);
+
+    const schemaDoc = parse(out.schema);
+
+    const postType = getObjectType(schemaDoc, 'Post');
+
+    if (expectedDirectiveNames && expectedDirectiveNames.length > 0) {
+      let expectedDireciveNameCount = 0;
+
+      for (const expectedDirectiveName of expectedDirectiveNames) {
+        expect(postType.directives.find(d => d.name.value === expectedDirectiveName)).toBeDefined();
+        expectedDireciveNameCount++;
+      }
+
+      expect(expectedDireciveNameCount).toEqual(postType.directives.length);
+    }
+  };
+
+  test(`When provider is the same as default, then no directive added`, () => {
+    transformTest(ownerAuthDirective, userPoolsDefaultConfig);
+  });
+
+  test(`When all providers are configured all of them are added`, () => {
+    const authConfig = withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS', 'AWS_IAM', 'OPENID_CONNECT']);
+
+    (authConfig.additionalAuthenticationProviders[2] as AppSyncAuthConfigurationOIDCEntry).openIDConnectConfig = {
+      name: 'Test Provider',
+      issuerUrl: 'https://abc.def/',
+    };
+
+    transformTest(multiAuthDirective, authConfig, [userPoolsDirectiveName, iamDirectiveName, openIdDirectiveName, apiKeyDirectiveName]);
+  });
+
+  test(`Operation fields are getting the directive added, when type has the @auth for all operations`, () => {
+    const schema = getSchema(ownerAuthDirective);
+    const transformer = getTransformer(withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+    const queryType = getObjectType(schemaDoc, 'Query');
+    const mutationType = getObjectType(schemaDoc, 'Mutation');
+    const subscriptionType = getObjectType(schemaDoc, 'Subscription');
+
+    const fields = [...queryType.fields, ...mutationType.fields];
+
+    for (const field of fields) {
+      expect(field.directives.length === 1);
+      expect(field.directives.find(d => d.name.value === userPoolsDirectiveName)).toBeDefined();
+    }
+
+    // Check that owner is required when only using owner auth rules
+    for (const field of subscriptionType.fields) {
+      expect(field.arguments).toHaveLength(1);
+      let arg: InputValueDefinitionNode = field.arguments[0];
+      expect(arg.name.value).toEqual('owner');
+      expect(arg.type.kind).toEqual(Kind.NAMED_TYPE);
+    }
+
+    // Check that resolvers containing the authMode check block
+    const authStepSnippet = '## [Start] Authorization Steps. **';
+
+    expect(out.pipelineFunctions['Query.getPost.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.pipelineFunctions['Query.listPosts.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.pipelineFunctions['Mutation.updatePost.auth.1.res.vtl']).toContain(authStepSnippet);
+    expect(out.pipelineFunctions['Mutation.deletePost.auth.1.res.vtl']).toContain(authStepSnippet);
+  });
+
+  test(`Operation fields are getting the directive added, when type has the @auth only for allowed operations`, () => {
+    const schema = getSchema(ownerRestrictedPublicAuthDirective);
+    const transformer = getTransformer(withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+    const queryType = getObjectType(schemaDoc, 'Query');
+    const mutationType = getObjectType(schemaDoc, 'Mutation');
+    const subscriptionType = getObjectType(schemaDoc, 'Subscription');
+
+    expectTwo(getField(queryType, 'getPost'), ['aws_cognito_user_pools', 'aws_api_key']);
+    expectTwo(getField(queryType, 'listPosts'), ['aws_cognito_user_pools', 'aws_api_key']);
+
+    expectOne(getField(mutationType, 'createPost'), 'aws_cognito_user_pools');
+    expectOne(getField(mutationType, 'updatePost'), 'aws_cognito_user_pools');
+    expectOne(getField(mutationType, 'deletePost'), 'aws_cognito_user_pools');
+
+    const onCreate = getField(subscriptionType, 'onCreatePost');
+    expectMultiple(onCreate, ['aws_subscribe', 'aws_api_key', 'aws_cognito_user_pools']);
+    expectMultiple(getField(subscriptionType, 'onUpdatePost'), ['aws_subscribe', 'aws_api_key', 'aws_cognito_user_pools']);
+    expectMultiple(getField(subscriptionType, 'onDeletePost'), ['aws_subscribe', 'aws_api_key', 'aws_cognito_user_pools']);
+    expect(onCreate.arguments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.objectContaining({ value: 'owner' }),
+          type: expect.objectContaining({ kind: 'NamedType' }),
+        }),
+      ]),
+    );
+  });
+
+  test(`Field level @auth is propagated to type and the type related operations`, () => {
+    const schema = getSchemaWithFieldAuth(ownerRestrictedPublicAuthDirective);
+    const transformer = getTransformer(withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+    const queryType = getObjectType(schemaDoc, 'Query');
+    const mutationType = getObjectType(schemaDoc, 'Mutation');
+
+    expectTwo(getField(queryType, 'getPost'), ['aws_cognito_user_pools', 'aws_api_key']);
+    expectTwo(getField(queryType, 'listPosts'), ['aws_cognito_user_pools', 'aws_api_key']);
+
+    expectOne(getField(mutationType, 'createPost'), 'aws_cognito_user_pools');
+    expectOne(getField(mutationType, 'updatePost'), 'aws_cognito_user_pools');
+    // since there is only one field allowed on delete it does not have access to delete
+    expectNone(getField(mutationType, 'deletePost'));
+
+    // Check that resolvers containing the authMode check block
+    const authModeCheckSnippet = '## [Start] Field Authorization Steps. **';
+    // resolvers to check is all other resolvers other than protected
+    expect(out.resolvers['Post.id.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.title.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.createdAt.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.updatedAt.req.vtl']).toContain(authModeCheckSnippet);
+  });
+
+  test(`'groups' @auth at field level is propagated to type and the type related operations`, () => {
+    const schema = getSchemaWithFieldAuth(groupsAuthDirective);
+    const transformer = getTransformer(withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+    const queryType = getObjectType(schemaDoc, 'Query');
+    const mutationType = getObjectType(schemaDoc, 'Mutation');
+
+    expectOne(getField(queryType, 'getPost'), 'aws_cognito_user_pools');
+    expectOne(getField(queryType, 'listPosts'), 'aws_cognito_user_pools');
+
+    expectOne(getField(mutationType, 'createPost'), 'aws_cognito_user_pools');
+    expectOne(getField(mutationType, 'updatePost'), 'aws_cognito_user_pools');
+    // since there is only one field allowed on delete it does not have access to delete
+    expectNone(getField(mutationType, 'deletePost'));
+
+    // Check that resolvers containing the authMode check block
+    const authModeCheckSnippet = '## [Start] Field Authorization Steps. **';
+
+    // resolvers to check is all other resolvers other than protected
+    expect(out.resolvers['Post.id.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.title.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.createdAt.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.updatedAt.req.vtl']).toContain(authModeCheckSnippet);
+  });
+
+  test(`'groups' @auth at field level is propagated to type and the type related operations, also default provider for read`, () => {
+    const schema = getSchemaWithTypeAndFieldAuth(groupsAuthDirective, groupsWithApiKeyAuthDirective);
+    const transformer = getTransformer(withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+    const queryType = getObjectType(schemaDoc, 'Query');
+    const mutationType = getObjectType(schemaDoc, 'Mutation');
+
+    expectTwo(getField(queryType, 'getPost'), ['aws_cognito_user_pools', 'aws_api_key']);
+    expectTwo(getField(queryType, 'listPosts'), ['aws_cognito_user_pools', 'aws_api_key']);
+
+    expectOne(getField(mutationType, 'createPost'), 'aws_cognito_user_pools');
+    expectOne(getField(mutationType, 'updatePost'), 'aws_cognito_user_pools');
+    expectOne(getField(mutationType, 'deletePost'), 'aws_cognito_user_pools');
+
+    // Check that resolvers containing the authMode group check
+    const groupCheckSnippet = '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"admin"}] )';
+
+    // resolvers to check is all other resolvers other than protected by the group rule
+    expect(out.resolvers['Post.id.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.title.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.createdAt.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.updatedAt.req.vtl']).toContain(groupCheckSnippet);
+  });
+
+  test(`Nested types without @model not getting directives applied for iam, and no policy is generated`, () => {
+    const schema = getSchemaWithNonModelField('');
+    const transformer = getTransformer(withAuthModes(iamDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+
+    const locationType = getObjectType(schemaDoc, 'Location');
+    const addressType = getObjectType(schemaDoc, 'Address');
+
+    expect(locationType.directives.length).toBe(0);
+    expect(addressType.directives.length).toBe(0);
+
+    const authPolicyIdx = Object.keys(out.rootStack.Resources).find(r => r.includes('AuthRolePolicy'));
+
+    expect(out.rootStack.Resources[authPolicyIdx]).toBeUndefined();
+  });
+
+  test(`Nested types without @model not getting directives applied for iam, but policy is generated`, () => {
+    const schema = getSchemaWithNonModelField(privateIAMDirective);
+    const transformer = getTransformer(withAuthModes(iamDefaultConfig, ['AMAZON_COGNITO_USER_POOLS']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+
+    const locationType = getObjectType(schemaDoc, 'Location');
+    const addressType = getObjectType(schemaDoc, 'Address');
+
+    expect(locationType.directives.length).toBe(0);
+    expect(addressType.directives.length).toBe(0);
+
+    // find the key to account for the hash
+    const authPolicyIdx = Object.keys(out.rootStack.Resources).find(r => r.includes('AuthRolePolicy01'));
+    expect(out.rootStack.Resources[authPolicyIdx]).toBeDefined;
+    const authRolePolicy = out.rootStack.Resources[authPolicyIdx];
+
+    const locationPolicy = authRolePolicy.Properties.PolicyDocument.Statement[0].Resource.filter(
+      r =>
+        r['Fn::Sub'] &&
+        r['Fn::Sub'].length &&
+        r['Fn::Sub'].length === 2 &&
+        r['Fn::Sub'][1].typeName &&
+        r['Fn::Sub'][1].typeName === 'Location',
+    );
+    expect(locationPolicy).toHaveLength(1);
+
+    const addressPolicy = authRolePolicy.Properties.PolicyDocument.Statement[0].Resource.filter(
+      r =>
+        r['Fn::Sub'] &&
+        r['Fn::Sub'].length &&
+        r['Fn::Sub'].length === 2 &&
+        r['Fn::Sub'][1].typeName &&
+        r['Fn::Sub'][1].typeName === 'Address',
+    );
+    expect(addressPolicy).toHaveLength(1);
+  });
+
+  test(`Recursive types with diff auth modes on parent @model types`, () => {
+    const schema = getRecursiveSchemaWithDiffModesOnParentType(ownerAuthDirective, privateIAMDirective);
+    const transformer = getTransformer(withAuthModes(userPoolsDefaultConfig, ['AWS_IAM']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+
+    const tagType = getObjectType(schemaDoc, 'Tag');
+    const expectedDirectiveNames = [userPoolsDirectiveName, iamDirectiveName];
+
+    expectMultiple(tagType, expectedDirectiveNames);
+  });
+
+  test(`Recursive types without @model`, () => {
+    const schema = getSchemaWithRecursiveNonModelField(ownerRestrictedIAMPrivateAuthDirective);
+    const transformer = getTransformer(withAuthModes(userPoolsDefaultConfig, ['AWS_IAM']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+
+    const tagType = getObjectType(schemaDoc, 'Tag');
+    const expectedDirectiveNames = [userPoolsDirectiveName, iamDirectiveName];
+
+    expectMultiple(tagType, expectedDirectiveNames);
+  });
+
+  test(`Nested types without @model getting directives applied (cognito default, api key additional)`, () => {
+    const schema = getSchemaWithNonModelField(privateAndPublicDirective);
+    const transformer = getTransformer(withAuthModes(userPoolsDefaultConfig, ['API_KEY']));
+
+    const out = transformer.transform(schema);
+    const schemaDoc = parse(out.schema);
+
+    const locationType = getObjectType(schemaDoc, 'Location');
+    const addressType = getObjectType(schemaDoc, 'Address');
+    const expectedDirectiveNames = [userPoolsDirectiveName, apiKeyDirectiveName];
+
+    if (expectedDirectiveNames && expectedDirectiveNames.length > 0) {
+      let expectedDireciveNameCount = 0;
+
+      for (const expectedDirectiveName of expectedDirectiveNames) {
+        expect(locationType.directives.find(d => d.name.value === expectedDirectiveName)).toBeDefined();
+        expectedDireciveNameCount++;
+      }
+
+      expect(expectedDireciveNameCount).toEqual(locationType.directives.length);
+
+      expectedDireciveNameCount = 0;
+
+      for (const expectedDirectiveName of expectedDirectiveNames) {
+        expect(addressType.directives.find(d => d.name.value === expectedDirectiveName)).toBeDefined();
+        expectedDireciveNameCount++;
+      }
+
+      expect(expectedDireciveNameCount).toEqual(addressType.directives.length);
+    }
+  });
+});

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -56,7 +56,6 @@ import {
   InterfaceTypeDefinitionNode,
   Kind,
   TypeDefinitionNode,
-  OperationTypeDefinitionNode,
 } from 'graphql';
 import { SubscriptionLevel, ModelDirectiveConfiguration } from '@aws-amplify/graphql-model-transformer';
 import { AccessControlMatrix } from './accesscontrol';

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -10,7 +10,6 @@ import {
   compoundExpression,
   printBlock,
   toJson,
-  comment,
   set,
   methodCall,
   nul,

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -18,7 +18,6 @@ import {
   list,
   equals,
   or,
-  comment,
 } from 'graphql-mapping-template';
 import { NONE_VALUE } from 'graphql-transformer-common';
 import {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -38,7 +38,7 @@ import {
   NULL_ALLOWED_FIELDS,
   DENIED_FIELDS,
 } from '../utils';
-import { getIdentityClaimExp, responseCheckForErrors, getOwnerClaim, getInputFields, emptyPayload } from './helpers';
+import { getIdentityClaimExp, responseCheckForErrors, getOwnerClaim, getInputFields } from './helpers';
 
 /**
  * There is only one role for ApiKey we can use the first index

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -14,11 +14,9 @@ import {
   bool,
   forEach,
   list,
-  ObjectNode,
   qref,
   raw,
   set,
-  print,
 } from 'graphql-mapping-template';
 import { getIdentityClaimExp, getOwnerClaim, apiKeyExpression, iamExpression, emptyPayload } from './helpers';
 import {

--- a/packages/amplify-graphql-auth-transformer/src/utils/constants.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/constants.ts
@@ -4,7 +4,6 @@ export const DEFAULT_GROUPS_FIELD = 'groups';
 export const DEFAULT_IDENTITY_CLAIM = 'username';
 export const DEFAULT_COGNITO_IDENTITY_CLAIM = 'cognito:username';
 export const DEFAULT_GROUP_CLAIM = 'cognito:groups';
-export const NONE_VALUE = '';
 export const ON_CREATE_FIELD = 'onCreate';
 export const ON_UPDATE_FIELD = 'onUpdate';
 export const ON_DELETE_FIELD = 'onDelete';

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -6,9 +6,9 @@ export type ModelMutation = 'create' | 'update' | 'delete';
 export type ModelOperation = 'create' | 'update' | 'delete' | 'read';
 
 export interface RolesByProvider {
-  cognitoStaticGroupRoles: Array<RoleDefinition>;
+  cogntoStaticRoles: Array<RoleDefinition>;
   cognitoDynamicRoles: Array<RoleDefinition>;
-  oidcStaticGroupRoles: Array<RoleDefinition>;
+  oidcStaticRoles: Array<RoleDefinition>;
   oidcDynamicRoles: Array<RoleDefinition>;
   iamRoles: Array<RoleDefinition>;
   apiKeyRoles: Array<RoleDefinition>;

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -5,6 +5,13 @@ export type ModelQuery = 'get' | 'list';
 export type ModelMutation = 'create' | 'update' | 'delete';
 export type ModelOperation = 'create' | 'update' | 'delete' | 'read';
 
+export type QuerySource = 'dynamodb' | 'opensearch';
+export interface SearchableConfig {
+  queries: {
+    search: string;
+  };
+}
+
 export interface RolesByProvider {
   cogntoStaticRoles: Array<RoleDefinition>;
   cognitoDynamicRoles: Array<RoleDefinition>;

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -1,8 +1,18 @@
 import { ModelDirectiveConfiguration, SubscriptionLevel } from '@aws-amplify/graphql-model-transformer';
 import { AppSyncAuthMode, DirectiveWrapper } from '@aws-amplify/graphql-transformer-core';
-import { DirectiveNode } from 'graphql';
-import { toCamelCase, plurality } from 'graphql-transformer-common';
-import { AuthProvider, AuthRule, AuthTransformerConfig, ConfiguredAuthProviders, RoleDefinition, RolesByProvider } from './definitions';
+import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { Stack } from '@aws-cdk/core';
+import { DirectiveNode, ObjectTypeDefinitionNode } from 'graphql';
+import { toCamelCase, plurality, graphqlName, toUpper } from 'graphql-transformer-common';
+import {
+  AuthProvider,
+  AuthRule,
+  AuthTransformerConfig,
+  ConfiguredAuthProviders,
+  RoleDefinition,
+  RolesByProvider,
+  SearchableConfig,
+} from './definitions';
 
 export * from './constants';
 export * from './definitions';
@@ -75,6 +85,37 @@ export const getModelConfig = (directive: DirectiveNode, typeName: string): Mode
     },
   });
   return options;
+};
+
+export const getSearchableConfig = (directive: DirectiveNode, typeName: string): SearchableConfig | null => {
+  const directiveWrapped: DirectiveWrapper = new DirectiveWrapper(directive);
+  const options = directiveWrapped.getArguments<SearchableConfig>({
+    queries: {
+      search: graphqlName(`search${plurality(toUpper(typeName), true)}`),
+    },
+  });
+  return options;
+};
+/**
+ * gets stack name if the field is paired with function, predictions, or by itself
+ */
+export const getStackForField = (
+  ctx: TransformerContextProvider,
+  obj: ObjectTypeDefinitionNode,
+  fieldName: string,
+  hasModelDirective: boolean,
+): Stack => {
+  const fieldNode = obj.fields.find(f => f.name.value === fieldName);
+  const fieldDirectives = fieldNode.directives.map(d => d.name.value);
+  if (fieldDirectives.includes('function')) {
+    return ctx.stackManager.getStack('FunctionDirectiveStack');
+  } else if (fieldDirectives.includes('predictions')) {
+    return ctx.stackManager.getStack('PredictionsDirectiveStack');
+  } else if (hasModelDirective) {
+    return ctx.stackManager.getStack(obj.name.value);
+  } else {
+    return ctx.stackManager.rootStack;
+  }
 };
 
 export const getConfiguredAuthProviders = (config: AuthTransformerConfig): ConfiguredAuthProviders => {

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -12,9 +12,9 @@ export * from './iam';
 
 export const splitRoles = (roles: Array<RoleDefinition>): RolesByProvider => {
   return {
-    cognitoStaticGroupRoles: roles.filter(r => r.static && r.provider === 'userPools'),
+    cogntoStaticRoles: roles.filter(r => r.static && r.provider === 'userPools'),
     cognitoDynamicRoles: roles.filter(r => !r.static && r.provider === 'userPools'),
-    oidcStaticGroupRoles: roles.filter(r => r.static && r.provider === 'oidc'),
+    oidcStaticRoles: roles.filter(r => r.static && r.provider === 'oidc'),
     oidcDynamicRoles: roles.filter(r => !r.static && r.provider === 'oidc'),
     iamRoles: roles.filter(r => r.provider === 'iam'),
     apiKeyRoles: roles.filter(r => r.provider === 'apiKey'),

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -1,5 +1,9 @@
 import { ModelDirectiveConfiguration, SubscriptionLevel } from '@aws-amplify/graphql-model-transformer';
-import { QueryFieldType, MutationFieldType, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  QueryFieldType,
+  MutationFieldType,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
 import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode, NamedTypeNode } from 'graphql';
 import {
   blankObjectExtension,
@@ -21,14 +25,18 @@ export const fieldIsList = (fields: ReadonlyArray<FieldDefinitionNode>, fieldNam
   return fields.some(field => field.name.value === fieldName && isListType(field.type));
 };
 
-export const extendTypeWithDirectives = (ctx: TransformerContextProvider, typeName: string, directives: Array<DirectiveNode>): void => {
+export const extendTypeWithDirectives = (
+  ctx: TransformerTransformSchemaStepContextProvider,
+  typeName: string,
+  directives: Array<DirectiveNode>,
+): void => {
   let objectTypeExtension = blankObjectExtension(typeName);
   objectTypeExtension = extensionWithDirectives(objectTypeExtension, directives);
   ctx.output.addObjectExtension(objectTypeExtension);
 };
 
 export const addDirectivesToField = (
-  ctx: TransformerContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   typeName: string,
   fieldName: string,
   directives: Array<DirectiveNode>,
@@ -50,7 +58,7 @@ export const addDirectivesToField = (
 };
 
 export const addSubscriptionArguments = (
-  ctx: TransformerContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   operationName: string,
   subscriptionRoles: Array<RoleDefinition>,
 ) => {
@@ -71,7 +79,7 @@ export const addSubscriptionArguments = (
 };
 
 export const addDirectivesToOperation = (
-  ctx: TransformerContextProvider,
+  ctx: TransformerTransformSchemaStepContextProvider,
   typeName: string,
   operationName: string,
   directives: Array<DirectiveNode>,

--- a/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
@@ -10,6 +10,9 @@ export const validateRuleAuthStrategy = (rule: AuthRule, configuredAuthProviders
       `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found '${rule.provider}' assigned.`,
     );
   }
+  if (rule.allow === 'groups' && !rule.groups && !rule.groupsField) {
+    throw new InvalidDirectiveError(`@auth directive with 'groups' should have a defined groups list or a groupsField.`);
+  }
 
   //
   // Owner

--- a/packages/amplify-graphql-auth-transformer/tsconfig.json
+++ b/packages/amplify-graphql-auth-transformer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "strict": false, // TODO enable
     "rootDir": "src",
     "outDir": "lib"
   },

--- a/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer.test.ts.snap
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`it generates the expected resources 1`] = `
 Object {
   "InvokeEchofunctionLambdaDataSource.req.vtl": "## [Start] Invoke AWS Lambda data source: EchofunctionLambdaDataSource. **
-{
+$util.toJson({
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Invoke\\",
   \\"payload\\": {
@@ -15,7 +15,7 @@ Object {
       \\"request\\": $util.toJson($ctx.request),
       \\"prev\\": $util.toJson($ctx.prev)
   }
-}
+})
 ## [End] Invoke AWS Lambda data source: EchofunctionLambdaDataSource. **",
   "InvokeEchofunctionLambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
 #if( $ctx.error )

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -124,14 +124,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -202,14 +202,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -375,14 +375,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -404,17 +404,20 @@ $util.toJson($UpdateItem)
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -542,7 +545,27 @@ $util.unauthorized()
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.listByEmailKindDate.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -557,8 +580,8 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -594,13 +617,13 @@ $util.toJson($ctx.result)",
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.testsByCategory.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -673,7 +696,27 @@ $util.toJson($ListRequest)
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByCategory.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -833,14 +876,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -911,14 +954,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -1084,14 +1127,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1113,17 +1156,20 @@ $util.toJson($UpdateItem)
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -1251,7 +1297,27 @@ $util.unauthorized()
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.listByEmailKindDate.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -1266,8 +1332,8 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -1303,13 +1369,13 @@ $util.toJson($ctx.result)",
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1464,14 +1530,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1542,14 +1608,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -1715,14 +1781,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1744,17 +1810,20 @@ $util.toJson($UpdateItem)
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -1882,7 +1951,27 @@ $util.unauthorized()
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.listByEmailKindDate.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -1897,8 +1986,8 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -1934,13 +2023,13 @@ $util.toJson($ctx.result)",
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.testsByCategory.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -2013,7 +2102,27 @@ $util.toJson($ListRequest)
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByCategory.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -2051,7 +2160,27 @@ $util.toJson($ctx.result)",
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByEmail.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -2415,14 +2544,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2491,14 +2620,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2649,14 +2778,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -2685,17 +2814,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -2823,7 +2955,27 @@ $util.unauthorized()
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.listByEmailKindDate.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -2900,8 +3052,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -2937,13 +3089,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.testsByCategory.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -3016,7 +3168,27 @@ $util.toJson($ListRequest)
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByCategory.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -3054,7 +3226,27 @@ $util.toJson($ctx.result)",
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByEmail.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -3214,14 +3406,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"ContentCategory\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.addContentToCategory.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.addContentToCategory.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createBlog.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -3317,14 +3509,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Blog\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createBlog.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createBlog.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createItem.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -3439,14 +3631,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Item\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createItem.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createItem.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -3554,14 +3746,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTodo.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -3657,14 +3849,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Todo\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTodo.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTodo.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteBlog.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3722,14 +3914,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteBlog.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteBlog.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteContentFromCategory.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3800,14 +3992,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteContentFromCategory.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteContentFromCategory.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3876,14 +4068,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteItem.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteItem.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3952,14 +4144,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTodo.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -4017,14 +4209,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTodo.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTodo.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateBlog.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -4163,14 +4355,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateBlog.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateBlog.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateItem.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -4328,14 +4520,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateItem.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateItem.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -4486,14 +4678,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTodo.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -4632,14 +4824,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTodo.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTodo.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.byCreatedAt.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -4672,7 +4864,27 @@ $util.toJson($UpdateItem)
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.byCreatedAt.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -4699,17 +4911,20 @@ $util.toJson($ctx.result)",
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getBlog.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -4747,17 +4962,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getItem.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -4795,17 +5013,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -4836,17 +5057,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTodo.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -4928,7 +5152,27 @@ $util.unauthorized()
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.itemsByCreatedAt.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -5006,7 +5250,27 @@ $util.toJson($ctx.result)",
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.itemsByStatus.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -5021,8 +5285,8 @@ $util.toJson($ctx.result)",
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -5058,13 +5322,13 @@ $util.toJson($ctx.result)",
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listBlogs.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listBlogs.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listByEmailKindDate.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -5183,7 +5447,27 @@ $util.toJson($ListRequest)
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.listByEmailKindDate.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -5324,7 +5608,27 @@ $util.toJson($ctx.result)",
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.listContentByCategory.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -5447,8 +5751,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -5484,13 +5788,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listItems.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listItems.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'email'.\\", \\"InvalidArgumentsError\\")
@@ -5562,8 +5866,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -5599,13 +5903,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.testsByCategory.req.vtl": "## [Start] Set query expression for key **
 #set( $modelQueryExpression = {} )
 ## [Start] Validate key arguments. **
@@ -5678,7 +5982,27 @@ $util.toJson($ListRequest)
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByCategory.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -5716,7 +6040,27 @@ $util.toJson($ctx.result)",
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByEmail.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
@@ -5794,7 +6138,27 @@ $util.toJson($ctx.result)",
   #set( $QueryRequest.scanIndexForward = true )
 #end
 #if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-#if( $context.args.filter ) #set( $QueryRequest.filter = $util.parseJson(\\"$util.transform.toDynamoDBFilterExpression($ctx.args.filter)\\") ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
 $util.toJson($QueryRequest)",
   "Query.testsByEmailByUpdatedAt.res.vtl": "#if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -116,14 +116,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -192,14 +192,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -357,14 +357,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -393,17 +393,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -530,8 +533,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -567,13 +570,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -713,14 +716,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -789,14 +792,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -947,14 +950,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email),
@@ -983,17 +986,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -1074,8 +1080,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -1111,13 +1117,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1256,14 +1262,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1331,14 +1337,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -1488,14 +1494,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email)
@@ -1523,17 +1529,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -1571,8 +1580,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -1608,13 +1617,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -1754,14 +1763,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -1830,14 +1839,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -1988,14 +1997,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"status\\": $util.dynamodb.toDynamoDB($ctx.args.status),
@@ -2024,17 +2033,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -2115,8 +2127,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -2152,13 +2164,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -2298,14 +2310,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2374,14 +2386,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.testCreate.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -2489,14 +2501,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.testCreate.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.testCreate.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.testDelete.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -2565,14 +2577,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.testDelete.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.testDelete.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.testUpdate.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2723,14 +2735,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.testUpdate.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.testUpdate.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2881,14 +2893,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email)
@@ -2916,17 +2928,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -2964,8 +2979,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3001,13 +3016,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.testGet.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -3036,17 +3051,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.testGet.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3127,8 +3145,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3164,13 +3182,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.testList.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.testList.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -3309,14 +3327,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3384,14 +3402,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.testCreate.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -3499,14 +3517,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.testCreate.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.testCreate.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.testDelete.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -3575,14 +3593,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.testDelete.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.testDelete.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.testUpdate.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -3733,14 +3751,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.testUpdate.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.testUpdate.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -3890,14 +3908,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"email\\": $util.dynamodb.toDynamoDB($ctx.args.email)
@@ -3925,17 +3943,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3973,8 +3994,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -4010,13 +4031,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.testGet.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id),
@@ -4045,17 +4066,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.testGet.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -4136,8 +4160,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -4173,13 +4197,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.testList.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.testList.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -322,6 +322,16 @@ export function ensureQueryField(config: IndexDirectiveConfiguration, ctx: Trans
   if (!queryField) {
     return;
   }
+  // add query field to metadata
+  const keyName = `${object.name.value}:indicies`;
+  let indicies: Set<string>;
+  if (!ctx.metadata.has(keyName)) {
+    indicies = new Set([queryField]);
+  } else {
+    indicies = ctx.metadata.get<Set<string>>(keyName)!;
+    indicies.add(queryField);
+  }
+  ctx.metadata.set(keyName, indicies);
 
   const args = [createHashField(config)];
 

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -680,14 +680,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Author\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -783,14 +783,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Comment\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createEmail.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -886,14 +886,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Email\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -989,14 +989,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createRequire.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -1092,14 +1092,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Require\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -1195,14 +1195,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -1298,14 +1298,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"User\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customCreatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -1401,14 +1401,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.customCreatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customCreatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1466,14 +1466,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.customDeletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customDeletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customUpdatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -1612,14 +1612,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.customUpdatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customUpdatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1677,14 +1677,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1742,14 +1742,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1807,14 +1807,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1873,14 +1873,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 $util.qr($DeleteRequest.put(\\"_version\\", $util.defaultIfNull($ctx.args.input[\\"_version\\"], \\"0\\")))
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1938,14 +1938,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -2003,14 +2003,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -2068,14 +2068,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateAuthor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2214,14 +2214,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2360,14 +2360,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateEmail.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2506,14 +2506,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2653,14 +2653,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateRequire.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2799,14 +2799,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -2945,14 +2945,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -3091,14 +3091,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3120,17 +3120,20 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.customGetPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3149,8 +3152,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3186,13 +3189,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.customListPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.customListPost.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -3214,17 +3217,20 @@ $util.toJson($ListRequest)
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getAuthor.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3255,17 +3261,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getComment.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3296,17 +3305,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getEmail.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3337,17 +3349,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getEntity.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3378,17 +3393,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3419,17 +3437,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getRequire.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3460,17 +3481,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3501,17 +3525,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getUser.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -3530,8 +3557,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3567,13 +3594,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listAuthors.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listAuthors.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3583,8 +3610,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3620,13 +3647,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listComments.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listComments.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3636,8 +3663,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3673,13 +3700,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listEmails.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listEmails.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3689,8 +3716,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3726,13 +3753,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3742,8 +3769,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3779,13 +3806,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listRequires.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listRequires.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3795,8 +3822,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3832,13 +3859,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -3848,8 +3875,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -3885,13 +3912,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listUsers.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listUsers.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 {
   \\"version\\": \\"2018-05-29\\",
@@ -3906,13 +3933,13 @@ null
   \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null))
 }
 ## [End] Sync Request template. **",
-  "Query.syncPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.syncPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -4202,14 +4229,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Author\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4305,14 +4332,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Comment\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createEmail.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4408,14 +4435,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Email\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4511,14 +4538,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createRequire.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4614,14 +4641,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Require\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4717,14 +4744,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4820,14 +4847,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"User\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customCreatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -4923,14 +4950,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.customCreatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customCreatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -4988,14 +5015,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.customDeletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customDeletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customUpdatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -5134,14 +5161,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.customUpdatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customUpdatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5199,14 +5226,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5264,14 +5291,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5329,14 +5356,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5395,14 +5422,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 $util.qr($DeleteRequest.put(\\"_version\\", $util.defaultIfNull($ctx.args.input[\\"_version\\"], \\"0\\")))
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5460,14 +5487,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5525,14 +5552,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5590,14 +5617,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateAuthor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -5736,14 +5763,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -5882,14 +5909,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateEmail.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -6028,14 +6055,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -6175,14 +6202,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateRequire.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -6321,14 +6348,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -6467,14 +6494,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -6613,14 +6640,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6642,17 +6669,20 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.customGetPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6671,8 +6701,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -6708,13 +6738,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.customListPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.customListPost.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -6736,17 +6766,20 @@ $util.toJson($ListRequest)
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getAuthor.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6777,17 +6810,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getComment.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6818,17 +6854,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getEmail.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6859,17 +6898,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getEntity.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6900,17 +6942,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6941,17 +6986,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getRequire.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -6982,17 +7030,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -7023,17 +7074,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getUser.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -7052,8 +7106,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7089,13 +7143,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listAuthors.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listAuthors.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7105,8 +7159,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7142,13 +7196,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listComments.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listComments.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7158,8 +7212,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7195,13 +7249,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listEmails.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listEmails.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7211,8 +7265,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7248,13 +7302,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7264,8 +7318,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7301,13 +7355,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listRequires.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listRequires.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7317,8 +7371,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7354,13 +7408,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -7370,8 +7424,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -7407,13 +7461,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listUsers.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listUsers.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 {
   \\"version\\": \\"2018-05-29\\",
@@ -7428,13 +7482,13 @@ null
   \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null))
 }
 ## [End] Sync Request template. **",
-  "Query.syncPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.syncPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -7724,14 +7778,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Author\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -7827,14 +7881,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Comment\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createEmail.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -7930,14 +7984,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Email\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8033,14 +8087,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createRequire.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8136,14 +8190,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Require\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8239,14 +8293,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8342,14 +8396,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"User\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customCreatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8445,14 +8499,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.customCreatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customCreatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8510,14 +8564,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.customDeletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customDeletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.customUpdatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -8656,14 +8710,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.customUpdatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.customUpdatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8721,14 +8775,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8786,14 +8840,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8851,14 +8905,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8917,14 +8971,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 $util.qr($DeleteRequest.put(\\"_version\\", $util.defaultIfNull($ctx.args.input[\\"_version\\"], \\"0\\")))
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -8982,14 +9036,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9047,14 +9101,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9112,14 +9166,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateAuthor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -9258,14 +9312,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateAuthor.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -9404,14 +9458,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateComment.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateEmail.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -9550,14 +9604,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateEmail.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateEmail.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -9697,14 +9751,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateRequire.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -9843,14 +9897,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateRequire.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateRequire.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -9989,14 +10043,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -10135,14 +10189,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateUser.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10164,17 +10218,20 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.customGetPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10193,8 +10250,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10230,13 +10287,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.customListPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.customListPost.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10258,17 +10315,20 @@ $util.toJson($ListRequest)
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getAuthor.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10299,17 +10359,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getComment.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10340,17 +10403,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getEmail.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10381,17 +10447,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getEntity.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10422,17 +10491,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10463,17 +10535,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getRequire.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10504,17 +10579,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10545,17 +10623,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getUser.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -10574,8 +10655,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10611,13 +10692,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listAuthors.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listAuthors.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10627,8 +10708,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10664,13 +10745,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listComments.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listComments.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10680,8 +10761,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10717,13 +10798,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listEmails.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listEmails.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10733,8 +10814,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10770,13 +10851,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10786,8 +10867,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10823,13 +10904,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listRequires.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listRequires.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10839,8 +10920,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10876,13 +10957,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -10892,8 +10973,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -10929,13 +11010,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listUsers.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listUsers.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 {
   \\"version\\": \\"2018-05-29\\",
@@ -10950,13 +11031,13 @@ null
   \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null))
 }
 ## [End] Sync Request template. **",
-  "Query.syncPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.syncPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -324,7 +324,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     typeName: string,
     fieldName: string,
   ): TransformerResolverProvider => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
     const dataSource = this.datasourceMap[type.name.value];
     const resolverKey = `Get${generateResolverKey(typeName, fieldName)}`;
     if (!this.resolverMap[resolverKey]) {
@@ -345,7 +345,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     typeName: string,
     fieldName: string,
   ): TransformerResolverProvider => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
     const dataSource = this.datasourceMap[type.name.value];
     const resolverKey = `List${generateResolverKey(typeName, fieldName)}`;
     if (!this.resolverMap[resolverKey]) {
@@ -369,7 +369,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     typeName: string,
     fieldName: string,
   ): TransformerResolverProvider => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
     const dataSource = this.datasourceMap[type.name.value];
     const resolverKey = `Update${generateResolverKey(typeName, fieldName)}`;
     if (!this.resolverMap[resolverKey]) {
@@ -404,7 +404,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     typeName: string,
     fieldName: string,
   ): TransformerResolverProvider => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
     const dataSource = this.datasourceMap[type.name.value];
     const resolverKey = `delete${generateResolverKey(typeName, fieldName)}`;
     if (!this.resolverMap[resolverKey]) {
@@ -479,7 +479,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     typeName: string,
     fieldName: string,
   ): TransformerResolverProvider => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
     const dataSource = this.datasourceMap[type.name.value];
     const resolverKey = `Sync${generateResolverKey(typeName, fieldName)}`;
     if (!this.resolverMap[resolverKey]) {
@@ -714,7 +714,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     typeName: string,
     fieldName: string,
   ): TransformerResolverProvider => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
     const dataSource = this.datasourceMap[type.name.value];
     const resolverKey = `Create${generateResolverKey(typeName, fieldName)}`;
     if (!this.resolverMap[resolverKey]) {
@@ -749,7 +749,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       type: QueryFieldType | MutationFieldType | SubscriptionFieldType;
     },
   ): InputValueDefinitionNode[] => {
-    const isSyncEnabled = !!this.options.SyncConfig;
+    const isSyncEnabled = ctx.isProjectUsingDataStore();
 
     const knownModels = this.typesWithModelDirective;
     let conditionInput: InputObjectTypeDefinitionNode;
@@ -879,7 +879,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
         break;
       case QueryFieldType.SYNC:
       case QueryFieldType.LIST:
-        const isSyncEnabled = !!this.options.SyncConfig;
+        const isSyncEnabled = ctx.isProjectUsingDataStore();
         const connectionFieldName = toPascalCase(['Model', type.name.value, 'Connection']);
         outputType = makeListQueryModel(type, connectionFieldName, isSyncEnabled);
         break;

--- a/packages/amplify-graphql-model-transformer/src/resolvers/common.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/common.ts
@@ -79,7 +79,7 @@ export const generateDefaultResponseMappingTemplate = (isSyncEnabled: boolean, m
     );
   }
 
-  return printBlock('Get ResponseTemplate')(compoundExpression(statements));
+  return printBlock('ResponseTemplate')(compoundExpression(statements));
 };
 
 /**

--- a/packages/amplify-graphql-model-transformer/src/resolvers/common.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/common.ts
@@ -62,7 +62,7 @@ export const generateConditionSlot = (inputConditionObjectName: string, conditio
  * Generate common response template used by most of the resolvers.
  * Append operation if response is coming from a mutation, this is to protect field resolver for subscriptions
  */
-export const generateDefaultResponseMappingTemplate = (isSyncEnabled: boolean, mutation: boolean = false): string => {
+export const generateDefaultResponseMappingTemplate = (isSyncEnabled: boolean, mutation = false): string => {
   const statements: Expression[] = [];
   if (mutation) statements.push(qref(methodCall(ref('ctx.result.put'), str(OPERATION_KEY), str('Mutation'))));
   if (isSyncEnabled) {

--- a/packages/amplify-graphql-model-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/query.ts
@@ -22,7 +22,7 @@ import {
   nul,
 } from 'graphql-mapping-template';
 import { ResourceConstants } from 'graphql-transformer-common';
-const authFilter = methodCall(ref('ctx.stash.get'), str('authFilter'));
+const authFilter = ref('ctx.stash.authFilter');
 
 /**
  * Generate get query resolver template
@@ -73,24 +73,21 @@ export const generateGetResponseTemplate = (isSyncEnabled: boolean): string => {
   const statements = new Array<Expression>();
   if (isSyncEnabled) {
     statements.push(
-      iff(
-        ref('ctx.error'),
-        methodCall(ref('util.error'), ref('ctx.error.message'), ref('ctx.error.type'), ref('ctx.result'))
-      ),
+      iff(ref('ctx.error'), methodCall(ref('util.error'), ref('ctx.error.message'), ref('ctx.error.type'), ref('ctx.result'))),
     );
   } else {
-    statements.push(
-      iff(ref('ctx.error'), methodCall(ref('util.error'), ref('ctx.error.message'), ref('ctx.error.type'))),
-    );
+    statements.push(iff(ref('ctx.error'), methodCall(ref('util.error'), ref('ctx.error.message'), ref('ctx.error.type'))));
   }
-  statements.push(ifElse(
-    and([not(ref('ctx.result.items.isEmpty()')), equals(ref('ctx.result.scannedCount'), int(1))]),
-    toJson(ref('ctx.result.items[0]')),
-    compoundExpression([
-      iff(and([ref('ctx.result.items.isEmpty()'), equals(ref('ctx.result.scannedCount'), int(1))]), ref('util.unauthorized()')),
-      toJson(nul()),
-    ]),
-  ));
+  statements.push(
+    ifElse(
+      and([not(ref('ctx.result.items.isEmpty()')), equals(ref('ctx.result.scannedCount'), int(1))]),
+      toJson(ref('ctx.result.items[0]')),
+      compoundExpression([
+        iff(and([ref('ctx.result.items.isEmpty()'), equals(ref('ctx.result.scannedCount'), int(1))]), ref('util.unauthorized()')),
+        toJson(nul()),
+      ]),
+    ),
+  );
   return printBlock('Get Response template')(compoundExpression(statements));
 };
 

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -8018,6 +8018,27 @@ Object {
     $util.qr($query.expressionValues.put(\\":sortKey\\", { \\"S\\": \\"$ctx.args.childName.ge\\" }))
   #end
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -8031,8 +8052,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -8130,6 +8151,27 @@ $util.error($ctx.error.message, $ctx.error.type)
 
 
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -8143,8 +8185,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -8271,14 +8313,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Child\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createChild.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createChild.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8374,14 +8416,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Comment\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createComment.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createFriendship.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8477,14 +8519,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Friendship\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createFriendship.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createFriendship.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createParent.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8580,14 +8622,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Parent\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createParent.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createParent.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8694,14 +8736,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPost.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPostAuthor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8797,14 +8839,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"PostAuthor\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPostAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPostAuthor.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPostEditor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -8900,14 +8942,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"PostEditor\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPostEditor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPostEditor.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createPostModel.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -9003,14 +9045,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"PostModel\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPostModel.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPostModel.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -9106,14 +9148,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createTest1.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -9228,14 +9270,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Test1\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createTest1.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createTest1.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -9350,14 +9392,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"User\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createUser.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.createUserModel.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $createdAt = $util.time.nowISO8601() )
@@ -9492,14 +9534,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"UserModel\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createUserModel.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createUserModel.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9568,14 +9610,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteChild.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteChild.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9633,14 +9675,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteComment.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteFriendship.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9698,14 +9740,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteFriendship.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteFriendship.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteParent.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9763,14 +9805,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteParent.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteParent.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -9838,14 +9880,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePost.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePostAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9903,14 +9945,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePostAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePostAuthor.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePostEditor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -9968,14 +10010,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePostEditor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePostEditor.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePostModel.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10033,14 +10075,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePostModel.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePostModel.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -10098,14 +10140,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10174,14 +10216,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteTest1.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteTest1.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10250,14 +10292,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteUser.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deleteUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
@@ -10339,14 +10381,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deleteUserModel.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deleteUserModel.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateChild.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -10497,14 +10539,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateChild.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateChild.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateComment.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -10643,14 +10685,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateComment.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateComment.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateFriendship.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -10789,14 +10831,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateFriendship.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateFriendship.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateParent.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -10935,14 +10977,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateParent.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateParent.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -11092,14 +11134,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePostAuthor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -11238,14 +11280,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePostAuthor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePostAuthor.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePostEditor.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -11384,14 +11426,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePostEditor.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePostEditor.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePostModel.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -11530,14 +11572,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePostModel.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePostModel.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -11676,14 +11718,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateTest1.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -11841,14 +11883,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateTest1.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateTest1.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateUser.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -12006,14 +12048,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateUser.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateUser.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updateUserModel.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -12191,46 +12233,74 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updateUserModel.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updateUserModel.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
-  $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Parent.child.req.vtl": "#if( $util.isNull($ctx.source.childID) || $util.isNull($ctx.source.childName) )
   #return
 #else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"GetItem\\",
-      \\"key\\": {
-          \\"id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.childID, \\"___xamznone____\\")),
-          \\"name\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.childName, \\"___xamznone____\\"))
-    }
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"id = :id AND name = :name\\",
+  \\"expressionValues\\": {
+      \\":id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.childID, \\"___xamznone____\\")),
+      \\":name\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.childName, \\"___xamznone____\\"))
   }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
 #end",
   "Parent.child.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-$util.toJson($ctx.result)
+  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    $util.toJson($ctx.result.items[0])
+  #else
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+    #end
+    $util.toJson(null)
+  #end
 #end",
   "Post.author.req.vtl": "#if( $util.isNull($ctx.source.owner) )
   #return
 #else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"GetItem\\",
-      \\"key\\": {
-          \\"id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.owner, \\"___xamznone____\\"))
-    }
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.owner, \\"___xamznone____\\"))
   }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
 #end",
   "Post.author.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-$util.toJson($ctx.result)
+  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    $util.toJson($ctx.result.items[0])
+  #else
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+    #end
+    $util.toJson(null)
+  #end
 #end",
   "Post.authors.req.vtl": "#if( $util.isNull($ctx.source.authorID) )
   #set( $result = {
@@ -12309,6 +12379,27 @@ $util.toJson($ctx.result)
 
 
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -12322,8 +12413,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -12359,6 +12450,27 @@ $util.error($ctx.error.message, $ctx.error.type)
       \\":partitionKey\\": $util.dynamodb.toDynamoDB($context.source.id)
   }
 } )
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -12372,8 +12484,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -12448,6 +12560,27 @@ $util.error($ctx.error.message, $ctx.error.type)
     $util.qr($query.expressionValues.put(\\":sortKey\\", { \\"S\\": \\"$ctx.args.editorID.ge\\" }))
   #end
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -12461,8 +12594,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -12486,50 +12619,92 @@ $util.error($ctx.error.message, $ctx.error.type)
   "PostAuthor.post.req.vtl": "#if( $util.isNull($ctx.source.postID) )
   #return
 #else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"GetItem\\",
-      \\"key\\": {
-          \\"id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.postID, \\"___xamznone____\\"))
-    }
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.postID, \\"___xamznone____\\"))
   }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
 #end",
   "PostAuthor.post.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-$util.toJson($ctx.result)
+  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    $util.toJson($ctx.result.items[0])
+  #else
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+    #end
+    $util.toJson(null)
+  #end
 #end",
   "PostEditor.editor.req.vtl": "#if( $util.isNull($ctx.source.editorID) )
   #return
 #else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"GetItem\\",
-      \\"key\\": {
-          \\"id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.editorID, \\"___xamznone____\\"))
-    }
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.editorID, \\"___xamznone____\\"))
   }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
 #end",
   "PostEditor.editor.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-$util.toJson($ctx.result)
+  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    $util.toJson($ctx.result.items[0])
+  #else
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+    #end
+    $util.toJson(null)
+  #end
 #end",
   "PostEditor.post.req.vtl": "#if( $util.isNull($ctx.source.postID) )
   #return
 #else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"GetItem\\",
-      \\"key\\": {
-          \\"id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.postID, \\"___xamznone____\\"))
-    }
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.postID, \\"___xamznone____\\"))
   }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
 #end",
   "PostEditor.post.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-$util.toJson($ctx.result)
+  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    $util.toJson($ctx.result.items[0])
+  #else
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+    #end
+    $util.toJson(null)
+  #end
 #end",
   "PostModel.authors.req.vtl": "#if( $util.isNull($ctx.source.authorID) )
   #set( $result = {
@@ -12549,6 +12724,27 @@ $util.toJson($ctx.result)
       \\":sortKey\\": $util.dynamodb.toDynamoDB(\\"\${context.source.authorName}#\${context.source.authorSurname}\\")
   }
 } )
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -12562,8 +12758,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -12587,19 +12783,33 @@ $util.error($ctx.error.message, $ctx.error.type)
   "PostModel.singleAuthor.req.vtl": "#if( $util.isNull($ctx.source.authorID) || $util.isNull($ctx.source.authorName) || $util.isNull($ctx.source.authorSurname) )
   #return
 #else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"GetItem\\",
-      \\"key\\": {
-          \\"id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.authorID, \\"___xamznone____\\")),
-          \\"name#surname\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank(\\"\${ctx.source.authorName}#\${ctx.source.authorSurname}\\", \\"___xamznone____\\"))
-    }
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"id = :id AND name#surname = :name#surname\\",
+  \\"expressionValues\\": {
+      \\":id\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.authorID, \\"___xamznone____\\")),
+      \\":name#surname\\": $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank(\\"\${ctx.source.authorName}#\${ctx.source.authorSurname}\\", \\"___xamznone____\\"))
   }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
 #end",
   "PostModel.singleAuthor.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-$util.toJson($ctx.result)
+  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    $util.toJson($ctx.result.items[0])
+  #else
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+    #end
+    $util.toJson(null)
+  #end
 #end",
   "Query.getChild.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -12629,17 +12839,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getChild.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12670,17 +12883,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getComment.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12711,17 +12927,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getFriendship.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12752,17 +12971,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getParent.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12799,17 +13021,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12840,17 +13065,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPostAuthor.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12881,17 +13109,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPostModel.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12922,17 +13153,20 @@ $util.unauthorized()
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -12970,17 +13204,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getTest1.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -13018,17 +13255,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getUser.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -13066,17 +13306,20 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getUserModel.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -13157,8 +13400,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13194,13 +13437,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listChildren.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listChildren.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13210,8 +13453,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13247,13 +13490,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listComments.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listComments.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listFriendships.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13263,8 +13506,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13300,13 +13543,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listFriendships.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listFriendships.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listParents.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13316,8 +13559,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13353,13 +13596,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listParents.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listParents.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listPostAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13369,8 +13612,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13406,13 +13649,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPostAuthors.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPostAuthors.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listPostModels.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13422,8 +13665,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13459,13 +13702,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPostModels.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPostModels.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listPosts.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
@@ -13494,8 +13737,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13531,13 +13774,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listTest1s.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -13655,8 +13898,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13692,13 +13935,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTest1s.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTest1s.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
 #set( $ListRequest = {
@@ -13708,8 +13951,8 @@ $util.toJson($ListRequest)
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13745,13 +13988,13 @@ $util.toJson($ListRequest)
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listTests.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listTests.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listUserModels.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -13823,8 +14066,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -13860,13 +14103,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listUserModels.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listUserModels.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.listUsers.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
   $util.error(\\"When providing argument 'sortDirection' you must also provide argument 'id'.\\", \\"InvalidArgumentsError\\")
@@ -13984,8 +14227,8 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -14021,13 +14264,13 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listUsers.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listUsers.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Subscription.onCreateChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
   \\"version\\": \\"2018-05-29\\",
@@ -14429,6 +14672,27 @@ $util.toJson(null)
 
 
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -14442,8 +14706,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -14540,6 +14804,27 @@ $util.error($ctx.error.message, $ctx.error.type)
 
 
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -14553,8 +14838,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -14629,6 +14914,27 @@ $util.error($ctx.error.message, $ctx.error.type)
     $util.qr($query.expressionValues.put(\\":sortKey\\", { \\"S\\": \\"$ctx.args.friendID.ge\\" }))
   #end
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -14642,8 +14948,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -14718,6 +15024,27 @@ $util.error($ctx.error.message, $ctx.error.type)
     $util.qr($query.expressionValues.put(\\":sortKey\\", { \\"S\\": \\"$ctx.args.postID.ge\\" }))
   #end
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -14731,8 +15058,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,
@@ -14807,6 +15134,27 @@ $util.error($ctx.error.message, $ctx.error.type)
     $util.qr($query.expressionValues.put(\\":sortKey\\", { \\"S\\": \\"$ctx.args.postID.ge\\" }))
   #end
   ## [End] Applying Key Condition **
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($ctx.args.filter) )
+      #set( $filter = $ctx.args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterEpression.expressionValues.size() == 0 )
+        $util.qr($filterEpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
 {
       \\"version\\": \\"2018-05-29\\",
       \\"operation\\": \\"Query\\",
@@ -14820,8 +15168,8 @@ false
     #else
 true
     #end,
-      \\"filter\\":     #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+      \\"filter\\":     #if( $filter )
+$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
     #else
 null
     #end,

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -6,6 +6,7 @@ import { Table } from '@aws-cdk/aws-dynamodb';
 import * as cdk from '@aws-cdk/core';
 import { ObjectTypeDefinitionNode } from 'graphql';
 import {
+  and,
   bool,
   compoundExpression,
   DynamoDBMappingTemplate,
@@ -13,16 +14,22 @@ import {
   Expression,
   ifElse,
   iff,
+  int,
+  isNullOrEmpty,
   list,
+  methodCall,
+  not,
   nul,
   obj,
   ObjectNode,
   or,
   print,
+  qref,
   raw,
   ref,
   set,
   str,
+  toJson,
 } from 'graphql-mapping-template';
 import {
   applyCompositeKeyConditionExpression,
@@ -36,6 +43,8 @@ import {
 import { HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from './types';
 import { getConnectionAttributeName } from './utils';
 
+const authFilter = ref('ctx.stash.authFilter');
+
 export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider) {
   const { connectionFields, field, fields, object, relatedType, relatedTypeIndex } = config;
   assert(relatedTypeIndex.length > 0);
@@ -44,8 +53,11 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
   const { keySchema } = table as any;
   const dataSource = ctx.api.host.getDataSource(`${relatedType.name.value}Table`);
   const partitionKeyName = keySchema[0].attributeName;
-  const keyObj = {
-    [partitionKeyName]: ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${localFields[0]}, "${NONE_VALUE}"))`),
+  let totalExpressions = [`${partitionKeyName} = :${partitionKeyName}`];
+  let totalExpressionValues: Record<string, Expression> = {
+    [`:${partitionKeyName}`]: ref(
+      `util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${localFields[0]}, "${NONE_VALUE}"))`,
+    ),
   };
 
   // Add a composite sort key or simple sort key if there is one.
@@ -54,11 +66,16 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
     const sortKeyName = keySchema[1].attributeName;
     const condensedSortKeyValue = condenseRangeKey(rangeKeyFields.map(keyField => `\${ctx.source.${keyField}}`));
 
-    keyObj[sortKeyName] = ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank("${condensedSortKeyValue}", "${NONE_VALUE}"))`);
+    totalExpressions.push(`${sortKeyName} = :${sortKeyName}`);
+    totalExpressionValues[`:${sortKeyName}`] = ref(
+      `util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank("${condensedSortKeyValue}", "${NONE_VALUE}"))`,
+    );
   } else if (relatedTypeIndex.length === 2) {
     const sortKeyName = keySchema[1].attributeName;
-
-    keyObj[sortKeyName] = ref(`util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${localFields[1]}, "${NONE_VALUE}"))`);
+    totalExpressions.push(`${sortKeyName} = :${sortKeyName}`);
+    totalExpressionValues[`:${sortKeyName}`] = ref(
+      `util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${localFields[1]}, "${NONE_VALUE}"))`,
+    );
   }
 
   const resolver = ctx.resolvers.generateQueryResolver(
@@ -71,16 +88,49 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
           or(localFields.map(f => raw(`$util.isNull($ctx.source.${f})`))),
           raw('#return'),
           compoundExpression([
-            DynamoDBMappingTemplate.getItem({
-              key: obj(keyObj),
-            }),
+            set(ref('GetRequest'), obj({ version: str('2018-05-29'), operation: str('Query') })),
+            qref(
+              methodCall(
+                ref('GetRequest.put'),
+                str('query'),
+                obj({
+                  expression: str(totalExpressions.join(' AND ')),
+                  expressionValues: obj(totalExpressionValues),
+                }),
+              ),
+            ),
+            iff(
+              not(isNullOrEmpty(authFilter)),
+              qref(
+                methodCall(
+                  ref('GetRequest.put'),
+                  str('filter'),
+                  methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), authFilter)),
+                ),
+              ),
+            ),
+            toJson(ref('GetRequest')),
           ]),
         ),
       ),
       `${object.name.value}.${field.name.value}.req.vtl`,
     ),
     MappingTemplate.s3MappingTemplateFromString(
-      print(DynamoDBMappingTemplate.dynamoDBResponse(false)),
+      print(
+        DynamoDBMappingTemplate.dynamoDBResponse(
+          false,
+          compoundExpression([
+            ifElse(
+              and([not(ref('ctx.result.items.isEmpty()')), equals(ref('ctx.result.scannedCount'), int(1))]),
+              toJson(ref('ctx.result.items[0]')),
+              compoundExpression([
+                iff(and([ref('ctx.result.items.isEmpty()'), equals(ref('ctx.result.scannedCount'), int(1))]), ref('util.unauthorized()')),
+                toJson(nul()),
+              ]),
+            ),
+          ]),
+        ),
+      ),
       `${object.name.value}.${field.name.value}.res.vtl`,
     ),
   );
@@ -115,6 +165,39 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
       setup.push(applyCompositeKeyConditionExpression(sortKeyFieldNames, 'query', toCamelCase(sortKeyFieldNames), sortKeyFieldName));
     }
   }
+  // add setup filter to query
+  setup.push(
+    ifElse(
+      not(isNullOrEmpty(authFilter)),
+      compoundExpression([
+        set(ref('filter'), authFilter),
+        iff(
+          not(isNullOrEmpty(ref('ctx.args.filter'))),
+          set(ref('filter'), list([obj({ and: list([ref('filter'), ref('ctx.args.filter')]) })])),
+        ),
+      ]),
+      iff(not(isNullOrEmpty(ref('ctx.args.filter'))), set(ref('filter'), ref('ctx.args.filter'))),
+    ),
+    iff(
+      not(isNullOrEmpty(ref('filter'))),
+      compoundExpression([
+        set(
+          ref(`filterExpression`),
+          methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('filter'))),
+        ),
+        iff(
+          not(methodCall(ref('util.isNullOrBlank'), ref('filterExpression.expression'))),
+          compoundExpression([
+            iff(
+              equals(methodCall(ref('filterEpression.expressionValues.size')), int(0)),
+              qref(methodCall(ref('filterEpression.remove'), str('expressionValues'))),
+            ),
+            set(ref('filter'), ref('filterExpression')),
+          ]),
+        ),
+      ]),
+    ),
+  );
 
   const queryArguments = {
     query: raw('$util.toJson($query)'),
@@ -123,7 +206,7 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
       ifElse(equals(ref('context.args.sortDirection'), str('ASC')), bool(true), bool(false)),
       bool(true),
     ),
-    filter: ifElse(ref('context.args.filter'), ref('util.transform.toDynamoDBFilterExpression($ctx.args.filter)'), nul()),
+    filter: ifElse(ref('filter'), ref('util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))'), nul()),
     limit: ref('limit'),
     nextToken: ifElse(ref('context.args.nextToken'), ref('util.toJson($context.args.nextToken)'), nul()),
   } as any;

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -688,14 +688,14 @@ $util.qr($mergedValues.put(\\"__typename\\", \\"Post\\"))
 #end
 $util.toJson($PutObject)
 ## [End] Create Request template. **",
-  "Mutation.createPost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.createPost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -753,14 +753,14 @@ $util.qr($DeleteRequest.put(\\"key\\", $Key))
 #end
 $util.toJson($DeleteRequest)
 ## [End] Delete Request template. **",
-  "Mutation.deletePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.deletePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Mutation.updatePost.init.1.req.vtl": "## [Start] Initialization default values. **
 $util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
 #set( $updatedAt = $util.time.nowISO8601() )
@@ -899,14 +899,14 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **",
-  "Mutation.updatePost.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -928,17 +928,20 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   #set( $query = {
   \\"expression\\": \\"id = :id\\",
   \\"expressionValues\\": {
-      \\":id\\":     $util.dynamodb.toDynamoDBJson($ctx.args.id)
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
   }
 } )
 #end
 $util.qr($GetRequest.put(\\"query\\", $query))
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  $util.qr($GetRequest.put(\\"filter\\", $ctx.stash.get(\\"authFilter\\")))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
 #end
 $util.toJson($GetRequest)
 ## [End] Get Request template. **",
   "Query.getPost.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
 #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
   $util.toJson($ctx.result.items[0])
 #else
@@ -957,8 +960,8 @@ $util.unauthorized()
 #if( $context.args.nextToken )
   #set( $ListRequest.nextToken = $context.args.nextToken )
 #end
-#if( !$util.isNullOrEmpty($ctx.stash.get(\\"authFilter\\")) )
-  #set( $filter = $ctx.stash.get(\\"authFilter\\") )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
   #if( !$util.isNullOrEmpty($ctx.args.filter) )
     #set( $filter = [{
   \\"and\\":   [$filter, $ctx.args.filter]
@@ -994,13 +997,13 @@ $util.unauthorized()
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
-  "Query.listPosts.res.vtl": "## [Start] Get ResponseTemplate. **
+  "Query.listPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #else
   $util.toJson($ctx.result)
 #end
-## [End] Get ResponseTemplate. **",
+## [End] ResponseTemplate. **",
   "Query.searchPosts.req.vtl": "#set( $indexPath = \\"/post/doc/_search\\" )
 #set( $nonKeywordFields = [] )
 #set( $sortValues = [] )
@@ -1040,6 +1043,25 @@ $util.toJson($ListRequest)
     $util.qr($aggregateValues.put(\\"$aggItem.name\\", {\\"$aggItem.type\\": {\\"field\\": \\"\${aggItem.field}.keyword\\"}}))
   #end
 #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"bool\\": {
+      \\"must\\":     [$ctx.stash.authFilter, $util.transform.toElasticsearchQueryDSL($ctx.args.filter)]
+  }
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( $util.isNullOrEmpty($filter) )
+  #set( $filter = {
+  \\"match_all\\": {}
+} )
+#end
 {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"GET\\",
@@ -1051,13 +1073,7 @@ $util.toJson($ListRequest)
                 \\"size\\": #if( $context.args.limit ) $context.args.limit #else 100 #end,
                 \\"sort\\": $sortValues,
                 \\"version\\": false,
-                \\"query\\": #if( $context.args.filter )
-$util.transform.toElasticsearchQueryDSL($ctx.args.filter)
-#else
-{
-      \\"match_all\\": {}
-  }
-#end,
+                \\"query\\": $util.toJson($filter),
                 \\"aggs\\": $util.toJson($aggregateValues)
                 }
   }

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -138,7 +138,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
         MappingTemplate.s3MappingTemplateFromString(responseTemplate(false), `${typeName}.${def.fieldName}.res.vtl`),
       );
       resolver.mapToStack(stack);
-      context.resolvers.addResolver(type, def.fieldName, resolver);
+      context.resolvers.addResolver(typeName, def.fieldName, resolver);
     }
 
     createStackOutputs(stack, domain.domainEndpoint, context.api.apiId, domain.domainArn);

--- a/packages/amplify-graphql-transformer-core/src/config/transformer-config.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/transformer-config.ts
@@ -18,11 +18,11 @@ export type AppSyncAuthConfigurationEntry =
   | AppSyncAuthConfigurationOIDCEntry;
 export type AppSyncAuthConfigurationAPIKeyEntry = {
   authenticationType: 'API_KEY';
-  apiKeyConfig: ApiKeyConfig;
+  apiKeyConfig?: ApiKeyConfig;
 };
 export type AppSyncAuthConfigurationUserPoolEntry = {
   authenticationType: 'AMAZON_COGNITO_USER_POOLS';
-  userPoolConfig: UserPoolConfig;
+  userPoolConfig?: UserPoolConfig;
 };
 export type AppSyncAuthConfigurationIAMEntry = {
   authenticationType: 'AWS_IAM';
@@ -30,7 +30,7 @@ export type AppSyncAuthConfigurationIAMEntry = {
 
 export type AppSyncAuthConfigurationOIDCEntry = {
   authenticationType: 'OPENID_CONNECT';
-  openIDConnectConfig: OpenIDConnectConfig;
+  openIDConnectConfig?: OpenIDConnectConfig;
 };
 
 export type ApiKeyConfig = {

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -26,6 +26,7 @@ export interface DefaultTransformHostOptions {
 
 export class DefaultTransformHost implements TransformHostProvider {
   private dataSources: Map<string, BaseDataSource> = new Map();
+  private resolvers: Map<string, CfnResolver> = new Map();
   private api: GraphQLApi;
 
   public constructor(options: DefaultTransformHostOptions) {
@@ -42,6 +43,16 @@ export class DefaultTransformHost implements TransformHostProvider {
   public getDataSource = (name: string): BaseDataSource | void => {
     if (this.hasDataSource(name)) {
       return this.dataSources.get(name);
+    }
+  };
+
+  public hasResolver = (typeName: string, fieldName: string) => {
+    return this.resolvers.has(`${typeName}:${fieldName}`);
+  };
+
+  public getResolver = (typeName: string, fieldName: string): CfnResolver | void => {
+    if (this.resolvers.has(`${typeName}:${fieldName}`)) {
+      return this.resolvers.get(`${typeName}:${fieldName}`);
     }
   };
 
@@ -125,7 +136,7 @@ export class DefaultTransformHost implements TransformHostProvider {
     dataSourceName?: string,
     pipelineConfig?: string[],
     stack?: Stack,
-  ) {
+  ): CfnResolver {
     if (dataSourceName && !Token.isUnresolved(dataSourceName) && !this.dataSources.has(dataSourceName)) {
       throw new Error(`DataSource ${dataSourceName} is missing in the API`);
     }
@@ -168,6 +179,7 @@ export class DefaultTransformHost implements TransformHostProvider {
         },
       });
       this.api.addSchemaDependency(resolver);
+      this.resolvers.set(`${typeName}:${fieldName}`, resolver);
       return resolver;
     } else {
       throw new Error('Resolver needs either dataSourceName or pipelineConfig to be passed');

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -6,6 +6,7 @@ import {
   TransformerContextProvider,
   TransformerDataSourceManagerProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transformer-interfaces/src/transformer-context/transformer-context-provider';
 import { App } from '@aws-cdk/core';
 import { DocumentNode } from 'graphql';
 import { ResolverConfig } from '../config/transformer-config';
@@ -18,6 +19,25 @@ import { ResolverManager } from './resolver';
 import { TransformerResourceHelper } from './resource-helper';
 import { StackManager } from './stack-manager';
 
+export class TransformerContextMetadata implements TransformerContextMetadataProvider {
+  /**
+   * Used by transformers to pass information between one another.
+   */
+  private metadata: { [key: string]: any } = new Map<string, any>();
+
+  public get<T>(key: string): T | undefined {
+    return this.metadata[key] as T;
+  }
+
+  public set<T>(key: string, val: T): void {
+    this.metadata[key] = val;
+  }
+
+  public has(key: string) {
+    return this.metadata[key] !== undefined;
+  }
+}
+
 export class TransformerContext implements TransformerContextProvider {
   public readonly output: TransformerContextOutputProvider;
   public readonly resolvers: ResolverManager;
@@ -29,6 +49,7 @@ export class TransformerContext implements TransformerContextProvider {
   public _api?: GraphQLAPIProvider;
   private resolverConfig: ResolverConfig | undefined;
 
+  public metadata: TransformerContextMetadata;
   constructor(
     app: App,
     public readonly inputDocument: DocumentNode,
@@ -45,6 +66,7 @@ export class TransformerContext implements TransformerContextProvider {
     this.resourceHelper = new TransformerResourceHelper(stackManager);
     this.featureFlags = featureFlags ?? new NoopFeatureFlagProvider();
     this.resolverConfig = resolverConfig;
+    this.metadata = new TransformerContextMetadata();
   }
 
   /**

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -96,6 +96,11 @@ export class ResolverManager implements TransformerResolversManagerProvider {
     }
   };
 
+  hasResolver = (typeName: string, fieldName: string): boolean => {
+    const key = `${typeName}.${fieldName}`;
+    return this.resolvers.has(key);
+  };
+
   removeResolver = (typeName: string, fieldName: string): TransformerResolverProvider => {
     const key = `${typeName}.${fieldName}`;
     if (this.resolvers.has(key)) {

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/stack-manager.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/stack-manager.ts
@@ -23,6 +23,7 @@ export class StackManager implements StackManagerProvider {
   }
   createStack = (stackName: string): Stack => {
     const newStack = new TransformerNestedStack(this.rootStack, stackName);
+    this.stacks.set(stackName, newStack);
     return newStack;
   };
 

--- a/packages/amplify-graphql-transformer-core/src/utils/authType.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/authType.ts
@@ -24,8 +24,10 @@ export function adoptAuthMode(stackManager: StackManager, entry: AppSyncAuthConf
       return {
         authorizationType: authType,
         apiKeyConfig: {
-          description: entry.apiKeyConfig.description,
-          expires: Expiration.after(Duration.days(entry.apiKeyConfig.apiKeyExpirationDays)),
+          description: entry.apiKeyConfig?.description,
+          expires: entry.apiKeyConfig?.apiKeyExpirationDays
+            ? Expiration.after(Duration.days(entry.apiKeyConfig.apiKeyExpirationDays))
+            : undefined,
         },
       };
     case AuthorizationType.USER_POOL:

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -73,4 +73,7 @@ export interface TransformHostProvider {
 
   getDataSource: (name: string) => BaseDataSource | void;
   hasDataSource: (name: string) => boolean;
+
+  getResolver: (typeName: string, fieldName: string) => CfnResolver | void;
+  hasResolver: (typeName: string, fieldName: string) => boolean;
 }

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -8,7 +8,14 @@ import { GraphQLAPIProvider } from '../graphql-api-provider';
 import { TransformerResourceProvider } from './resource-resource-provider';
 import { FeatureFlagProvider } from '../feature-flag-provider';
 
+export interface TransformerContextMetadataProvider {
+  set<T>(key: string, value: T): void;
+  get<T>(key: string): T | undefined;
+  has(key: string): boolean;
+}
+
 export interface TransformerContextProvider {
+  metadata: TransformerContextMetadataProvider;
   resolvers: TransformerResolversManagerProvider;
   dataSources: TransformerDataSourceManagerProvider;
   providerRegistry: TransformerProviderRegistry;
@@ -30,11 +37,11 @@ export type TransformerBeforeStepContextProvider = Pick<
 >;
 export type TransformerSchemaVisitStepContextProvider = Pick<
   TransformerContextProvider,
-  'inputDocument' | 'output' | 'providerRegistry' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig'
+  'inputDocument' | 'output' | 'providerRegistry' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata'
 >;
 export type TransformerValidationStepContextProvider = Pick<
   TransformerContextProvider,
-  'inputDocument' | 'output' | 'providerRegistry' | 'dataSources' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig'
+  'inputDocument' | 'output' | 'providerRegistry' | 'dataSources' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata'
 >;
 export type TransformerPrepareStepContextProvider = TransformerValidationStepContextProvider;
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -17,6 +17,7 @@ export interface TransformerResolverProvider {
 export interface TransformerResolversManagerProvider {
   addResolver: (typeName: string, fieldName: string, resolver: TransformerResolverProvider) => TransformerResolverProvider;
   getResolver: (typeName: string, fieldName: string) => TransformerResolverProvider | void;
+  hasResolver: (typeName: string, fieldName: string) => boolean;
   removeResolver: (typeName: string, fieldName: string) => TransformerResolverProvider;
   collectResolvers: () => Map<string, TransformerResolverProvider>;
 


### PR DESCRIPTION
#### Description of changes
- `@auth` support for the following
  - `@function`
  - `@predictions`
  - `@searchable`
  - relational directives `@hasOne` `@hasMany` `@belongsTo`
    -  Change Get Item to Query to support auth filter for any relational directive which creates a get item resolver
- updated `@function` resolver to use util.toJson
-  transformer core changes
  -  added metadata into the context
  - use a resolver map for `ctx.api.host`
  - add get resolver for `ctx.api.host`
  - add a getStack for a particular stack name
- updated unit tests 
- added a few unit tests for `@auth`

#### Description of how you validated changes
- local testing
- unit testing


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.