### PR TITLE
test: fix version gating e2e test deletion

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/version-gating.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/version-gating.test.ts
@@ -22,6 +22,7 @@ type VersionGatingMetadata = {
 
 describe('version gating', () => {
   let projRoot: string;
+  let projectInitialized = false;
   const projName = 'versiongating';
 
   // Extreme version numbers for testing purposes
@@ -56,7 +57,10 @@ describe('version gating', () => {
   });
 
   afterEach(async () => {
-    await deleteProject(projRoot);
+    if (projectInitialized) {
+      await deleteProject(projRoot);
+    }
+
     deleteProjectDir(projRoot);
   });
 
@@ -72,6 +76,7 @@ describe('version gating', () => {
       updateVersionInPackageJson(baseCLIVersion, baseMinimumCLIVersion);
 
       await initJSProjectWithProfile(projRoot, { name: projName });
+      projectInitialized = true;
 
       const meta = stateManager.getMeta(projRoot);
 


### PR DESCRIPTION
#### Description of changes

In CI project deletion is failing when the test was skipped for packaged CLI, a flag is added to control if we need to delete the project or not.

This only affects E2E test execution for packaged CLI for this particular test.

#### Description of how you validated changes

Manually ran E2E locally

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.