### PR TITLE
chore: clarify pull override warning

### DIFF
--- a/packages/amplify-cli/src/pull-backend.ts
+++ b/packages/amplify-cli/src/pull-backend.ts
@@ -15,7 +15,7 @@ export async function pullBackend(context: $TSContext, inputParams: $TSAny) {
 
   if (hasChanges && context.exeInfo.restoreBackend) {
     context.print.warning('Local changes detected.');
-    context.print.warning('Pulling changes from the cloud will override your local changes.');
+    context.print.warning('Pulling changes from the cloud will override your local changes. This includes local changes to generated files in the \'src\' and \'amplify\' directories.');
     if (!context.exeInfo.inputParams.yes) {
       const confirmOverride = await context.amplify.confirmPrompt('Are you sure you would like to continue?', false);
       if (!confirmOverride) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

We currently have a warning message that is emitted when running `amplify pull`:

> Pulling changes from the cloud will override your local changes.

However, that language isn't clear enough about what local changes are being referred to. For example, running `amplify pull` could blitz any local changes to `src/models` files generated by DataStore.

The new message makes it more clear what local changes could be impacted:

> Pulling changes from the cloud will override your local changes. This includes local changes to generated files in the 'src' and 'amplify' directories.


#### Description of how you validated changes

Ran `amplify pull` and saw the updated message.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.