### PR TITLE
chore: remove value prompt for auth challenge trigger

### DIFF
--- a/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/CreateAuthChallenge.map.json
+++ b/packages/amplify-category-auth/provider-utils/awscloudformation/triggers/CreateAuthChallenge/CreateAuthChallenge.map.json
@@ -5,18 +5,6 @@
   },
   "boilerplate-create-challenge": {
     "name": "Custom Auth Challenge Scaffolding (Creation)",
-    "description": "1 of 3 triggers needed to set-up the basic scaffolding for a custom authentication flow.  Please note that this scaffolding should be built out using your desired functionality before being used in production.",
-    "env": [
-      {
-        "key": "CHALLENGEANSWER",
-        "value": "askUser",
-        "private": true,
-        "question": {
-          "name" : "CHALLENGEANSWER",
-          "type": "input",
-          "message": "Enter the answer to your custom auth challenge"
-        }
-      }
-    ]
+    "description": "1 of 3 triggers needed to set-up the basic scaffolding for a custom authentication flow. Please note that this scaffolding should be built out using your desired functionality before being used in production."
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove prompt: "Enter the answer to your custom auth challenge"


#### Description of how you validated changes
`yarn test`, manually set up auth challenge triggers.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.