### PR TITLE
fix(cli): fixed addPluginDirectory

### DIFF
--- a/packages/amplify-cli/src/commands/plugin/configure.ts
+++ b/packages/amplify-cli/src/commands/plugin/configure.ts
@@ -144,6 +144,8 @@ async function addPluginDirectory(pluginPlatform: PluginPlatform) {
       validate: (input: string) => {
         if (!fs.existsSync(input) || !fs.statSync(input).isDirectory()) {
           return 'Must enter a valid full path of a directory';
+        } else if (pluginPlatform.pluginDirectories.includes(input)) {
+          return 'Entered directory is already contained in scannable directories.';
         }
         return true;
       },


### PR DESCRIPTION
Fix to prevent adding a directory that is already included in pluginDirectories.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

When I ran `amplify plugin configure` -> select **scannable plugin directories** -> select **add** , if I specified a directory that was already included, it was registered as a duplicate.

I thought this behavior is maybe undesirable.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

I don't know how to test automatically a validator function in `inquirer.prompt` 😢 

- manual test 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.