### PR TITLE
feat: generate list types as non-null

### DIFF
--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -14,7 +14,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 
@@ -224,7 +224,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 
@@ -538,7 +538,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 
@@ -855,7 +855,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 
@@ -1164,7 +1164,7 @@ enum ModelSortDirection {
 }
 
 type ModelEntityConnection {
-  items: [Entity]
+  items: [Entity!]!
   nextToken: String
 }
 
@@ -1283,7 +1283,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 
@@ -1593,7 +1593,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 
@@ -1703,7 +1703,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post]
+  items: [Post!]!
   nextToken: String
 }
 

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -32,6 +32,7 @@ import {
   makeValueNode,
   withNamedNodeNamed,
   isListType,
+  makeNonNullType,
 } from 'graphql-transformer-common';
 import { TransformerContext } from 'graphql-transformer-core';
 import { getCreatedAtFieldName, getUpdatedAtFieldName } from './ModelDirectiveArgs';
@@ -737,7 +738,9 @@ export function makeAttributeTypeEnum(): EnumTypeDefinitionNode {
 export function makeModelConnectionType(typeName: string, isSync: Boolean = false): ObjectTypeExtensionNode {
   const connectionName = ModelResourceIDs.ModelConnectionTypeName(typeName);
   let connectionTypeExtension = blankObjectExtension(connectionName);
-  connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('items', [], makeListType(makeNamedType(typeName)))]);
+  connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
+    makeField('items', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(typeName))))),
+  ]);
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('nextToken', [], makeNamedType('String'))]);
   if (isSync) {
     connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('startedAt', [], makeNamedType('AWSTimestamp'))]);

--- a/packages/graphql-transformer-common/src/definition.ts
+++ b/packages/graphql-transformer-common/src/definition.ts
@@ -396,7 +396,7 @@ export function makeNonNullType(type: NamedTypeNode | ListTypeNode): NonNullType
   };
 }
 
-export function makeListType(type: TypeNode): TypeNode {
+export function makeListType(type: TypeNode): ListTypeNode {
   return {
     kind: 'ListType',
     type,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Update `makeModelConnectionType` to generate a non-null list of non-null elements. The list returned by the query will always be defined, even if it is empty, it will be an empty array, not a null value.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fixes https://github.com/aws-amplify/amplify-cli/issues/7890


#### Description of how you validated changes
tested manually against a gql API that has items to return and one that doesn't have any items. Also updated snapshot tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.