### PR TITLE
feat: update pick styling, hint text, and ctrl+z listener

### DIFF
--- a/packages/amplify-prompts/src/demo/demo.ts
+++ b/packages/amplify-prompts/src/demo/demo.ts
@@ -111,22 +111,16 @@ const demo = async () => {
   printTypeofResult(result2);
 
   printer.info('A default selection can be specified by providing the index of the option');
-  printResult(
-    await prompter.pick<'one', number>('Pick it again, this time with a default value', choices2, { initial: 2 }),
-  );
+  printResult(await prompter.pick<'one', number>('Pick it again, this time with a default value', choices2, { initial: 2 }));
 
   printer.info('Multiple choices can be selected by specifying multiSelect true');
   printer.info('When multiSelect is on, an array of initial indexes can be specified');
-  printResult(
-    await prompter.pick<'many', number>('Pick your favorite colors', choices2, { returnSize: 'many', initial: [1, 2] }),
-  );
+  printResult(await prompter.pick<'many', number>('Pick your favorite colors', choices2, { returnSize: 'many', initial: [1, 2] }));
 
   printer.info('Individual choices can be disabled or have hint text next to them');
   (choices2[1] as any).hint = 'definitely the best';
   (choices2[2] as any).disabled = true;
-  printResult(
-    await prompter.pick<'many', number>('Pick your favorite Skittle color', choices2, { returnSize: 'many' }),
-  );
+  printResult(await prompter.pick<'many', number>('Pick your favorite Skittle color', choices2, { returnSize: 'many' }));
 };
 
-demo();
+demo().catch(console.error);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Makes a few small changes to the behavior of `prompter.pick`:
1. The hint text `(Use arrow keys or type to filter)` is printed after the prompt text
2. An an arrow prefix indicates the location of the cursor in the list
3. `enquirer` does not clear the stdout buffer on `SIGTSTP` (`ctrl + Z`), so added a listener to map it to process.exit() which is properly handled by `enquirer`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-cli/pull/8155#discussion_r707527629


#### Description of how you validated changes
Validated manually. All of these changes are config changes to the `enquirer` lib. There isn't any logic in our codebase to write tests for


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.