### PR TITLE
@auth support for datastore and add has auth flag

### DIFF
--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -31,6 +31,8 @@
     "@aws-amplify/graphql-transformer-interfaces": "1.9.0",
     "@aws-amplify/graphql-model-transformer": "0.6.1",
     "@aws-amplify/graphql-index-transformer": "0.3.1",
+    "@aws-amplify/graphql-relational-transformer": "0.2.0",
+    "@aws-amplify/graphql-searchable-transformer": "0.5.1",
     "@aws-cdk/aws-appsync": "~1.119.0",
     "@aws-cdk/aws-dynamodb": "~1.119.0",
     "@aws-cdk/core": "~1.119.0",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`per-field @auth without @model 1`] = `
+Object {
+  "Properties": Object {
+    "Description": "",
+    "Path": "/",
+    "PolicyDocument": Object {
+      "Statement": Array [
+        Object {
+          "Action": "appsync:GraphQL",
+          "Effect": "Allow",
+          "Resource": Object {
+            "Fn::Sub": Array [
+              "arn:aws:appsync:\${AWS::Region}:\${AWS::AccountId}:apis/\${apiId}/types/\${typeName}/fields/\${fieldName}",
+              Object {
+                "apiId": Object {
+                  "Fn::GetAtt": Array [
+                    "GraphQLAPI",
+                    "ApiId",
+                  ],
+                },
+                "fieldName": "listContext",
+                "typeName": "Query",
+              },
+            ],
+          },
+        },
+      ],
+      "Version": "2012-10-17",
+    },
+  },
+  "Type": "AWS::IAM::ManagedPolicy",
+}
+`;

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -26,6 +26,7 @@ test('test simple model with public auth rule and amplify admin app is present',
           ],
         },
         addAwsIamAuthInOutputSchema: true,
+        adminUserPoolID: 'us-fake-1_uuid',
       }),
     ],
   });
@@ -86,6 +87,7 @@ test('Test model with public auth rule without all operations and amplify admin 
           ],
         },
         addAwsIamAuthInOutputSchema: true,
+        adminUserPoolID: 'us-fake-1_uuid',
       }),
     ],
   });
@@ -130,6 +132,7 @@ test('Test simple model with private auth rule and amplify admin app is present'
           ],
         },
         addAwsIamAuthInOutputSchema: true,
+        adminUserPoolID: 'us-fake-1_uuid',
       }),
     ],
   });
@@ -194,6 +197,7 @@ test('Test simple model with private auth rule, few operations, and amplify admi
           ],
         },
         addAwsIamAuthInOutputSchema: true,
+        adminUserPoolID: 'us-fake-1_uuid',
       }),
     ],
   });
@@ -283,6 +287,7 @@ test('Test simple model with AdminUI enabled should add IAM policy only for fiel
           ],
         },
         addAwsIamAuthInOutputSchema: true,
+        adminUserPoolID: 'us-fake-1_uuid',
       }),
     ],
   });
@@ -320,7 +325,7 @@ test('Test simple model with AdminUI enabled should add IAM policy only for fiel
   ['Mutation.createPost.auth.1.req.vtl', 'Mutation.updatePost.auth.1.res.vtl', 'Mutation.deletePost.auth.1.res.vtl'].forEach(r => {
     expect(out.pipelineFunctions[r]).toContain(
       '#if( $util.authType() == "IAM Authorization" )\n' +
-        '  #if( $ctx.identity.userArn.contains("_Full-access/CognitoIdentityCredentials") || $ctx.identity.userArn.contains("_Manage-only/CognitoIdentityCredentials") )\n' +
+        '  #if( $ctx.identity.userArn.contains("us-fake-1_uuid_Full-access/CognitoIdentityCredentials") || $ctx.identity.userArn.contains("us-fake-1_uuid_Manage-only/CognitoIdentityCredentials") )\n' +
         '    #return($util.toJson({})\n' +
         '  #end\n' +
         '$util.unauthorized()\n' +

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -4,83 +4,85 @@ import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer'
 import { GraphQLTransform, AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';
 
-// test('subscriptions are only generated if the respective mutation operation exists', () => {
-//   const validSchema = `
-//       type Salary
-//         @model
-//         @auth(rules: [
-//                 {allow: owner},
-//                 {allow: groups, groups: ["Moderator"]}
-//             ]) {
-//         id: ID!
-//         wage: Int
-//         owner: String
-//         secret: String @auth(rules: [{allow: owner}])
-//       }`;
-//   const authConfig: AppSyncAuthConfiguration = {
-//     defaultAuthentication: {
-//       authenticationType: 'AMAZON_COGNITO_USER_POOLS',
-//     },
-//     additionalAuthenticationProviders: [],
-//   };
-//   const transformer = new GraphQLTransform({
-//     authConfig,
-//     transformers: [
-//       new ModelTransformer(),
-//       new HasManyTransformer(),
-//       new AuthTransformer({
-//         authConfig,
-//         addAwsIamAuthInOutputSchema: false,
-//       }),
-//     ],
-//   });
-//   const out = transformer.transform(validSchema);
-//    // expect to generate subscription resolvers for create and update only
-//    expect(out).toBeDefined();
-//    expect(out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
-//      'AMAZON_COGNITO_USER_POOLS',
-//   );
-//   expect(out.resolvers['Salary.secret.res.vtl']).toContain('#if( $operation == "Mutation" )');
+test('subscriptions are only generated if the respective mutation operation exists', () => {
+  const validSchema = `
+      type Salary
+        @model
+        @auth(rules: [
+                {allow: owner},
+                {allow: groups, groups: ["Moderator"]}
+            ]) {
+        id: ID!
+        wage: Int
+        owner: String
+        secret: String @auth(rules: [{allow: owner}])
+      }`;
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new HasManyTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  // expect to generate subscription resolvers for create and update only
+  expect(out).toBeDefined();
+  expect(out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
+    'AMAZON_COGNITO_USER_POOLS',
+  );
+  expect(out.resolvers['Salary.secret.res.vtl']).toContain('#if( $operation == "Mutation" )');
 
-//   expect(out.pipelineFunctions['Mutation.createSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
-//   expect(out.pipelineFunctions['Mutation.updateSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
-//   expect(out.pipelineFunctions['Mutation.deleteSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
-// });
+  expect(out.pipelineFunctions['Mutation.createSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+  expect(out.pipelineFunctions['Mutation.updateSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+  expect(out.pipelineFunctions['Mutation.deleteSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+});
 
-// test('per-field auth on relational field', () => {
-//   const validSchema = `
-//   type Post @model @auth(rules: [ { allow: groups, groups: ["admin"] }, { allow: groups, groups: ["viewer"], operations: [read] } ]){
-//     id: ID!
-//     title: String!
-//     comments: [Comment] @hasMany @auth(rules: [ { allow: groups, groups: ["admin"] } ])
-//   }
+test('per-field auth on relational field', () => {
+  const validSchema = `
+  type Post @model @auth(rules: [ { allow: groups, groups: ["admin"] }, { allow: groups, groups: ["viewer"], operations: [read] } ]){
+    id: ID!
+    title: String!
+    comments: [Comment] @hasMany @auth(rules: [ { allow: groups, groups: ["admin"] } ])
+  }
 
-//   type Comment @model {
-//     id: ID!
-//     content: String
-//   }`;
-//   const authConfig: AppSyncAuthConfiguration = {
-//     defaultAuthentication: {
-//       authenticationType: 'AMAZON_COGNITO_USER_POOLS',
-//     },
-//     additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }],
-//   };
-//   const transformer = new GraphQLTransform({
-//     authConfig,
-//     transformers: [
-//       new ModelTransformer(),
-//       new HasManyTransformer(),
-//       new AuthTransformer({
-//         authConfig,
-//         addAwsIamAuthInOutputSchema: false,
-//       }),
-//     ],
-//   });
-//   const out = transformer.transform(validSchema);
-//   expect(out).toBeDefined();
+  type Comment @model {
+    id: ID!
+    content: String
+  }`;
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new HasManyTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
 
-//   expect(out.pipelineFunctions['Post.comments.auth.1.req.vtl']).toContain('#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"admin"}] )');
-// });
+  expect(out.pipelineFunctions['Post.comments.auth.1.req.vtl']).toContain(
+    '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"admin"}] )',
+  );
+});
 
 test('per-field @auth without @model', () => {
   const validSchema = `

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -1,0 +1,115 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
+import { GraphQLTransform, AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-core';
+import { ResourceConstants } from 'graphql-transformer-common';
+
+// test('subscriptions are only generated if the respective mutation operation exists', () => {
+//   const validSchema = `
+//       type Salary
+//         @model
+//         @auth(rules: [
+//                 {allow: owner},
+//                 {allow: groups, groups: ["Moderator"]}
+//             ]) {
+//         id: ID!
+//         wage: Int
+//         owner: String
+//         secret: String @auth(rules: [{allow: owner}])
+//       }`;
+//   const authConfig: AppSyncAuthConfiguration = {
+//     defaultAuthentication: {
+//       authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+//     },
+//     additionalAuthenticationProviders: [],
+//   };
+//   const transformer = new GraphQLTransform({
+//     authConfig,
+//     transformers: [
+//       new ModelTransformer(),
+//       new HasManyTransformer(),
+//       new AuthTransformer({
+//         authConfig,
+//         addAwsIamAuthInOutputSchema: false,
+//       }),
+//     ],
+//   });
+//   const out = transformer.transform(validSchema);
+//    // expect to generate subscription resolvers for create and update only
+//    expect(out).toBeDefined();
+//    expect(out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
+//      'AMAZON_COGNITO_USER_POOLS',
+//   );
+//   expect(out.resolvers['Salary.secret.res.vtl']).toContain('#if( $operation == "Mutation" )');
+
+//   expect(out.pipelineFunctions['Mutation.createSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+//   expect(out.pipelineFunctions['Mutation.updateSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+//   expect(out.pipelineFunctions['Mutation.deleteSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+// });
+
+// test('per-field auth on relational field', () => {
+//   const validSchema = `
+//   type Post @model @auth(rules: [ { allow: groups, groups: ["admin"] }, { allow: groups, groups: ["viewer"], operations: [read] } ]){
+//     id: ID!
+//     title: String!
+//     comments: [Comment] @hasMany @auth(rules: [ { allow: groups, groups: ["admin"] } ])
+//   }
+
+//   type Comment @model {
+//     id: ID!
+//     content: String
+//   }`;
+//   const authConfig: AppSyncAuthConfiguration = {
+//     defaultAuthentication: {
+//       authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+//     },
+//     additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }],
+//   };
+//   const transformer = new GraphQLTransform({
+//     authConfig,
+//     transformers: [
+//       new ModelTransformer(),
+//       new HasManyTransformer(),
+//       new AuthTransformer({
+//         authConfig,
+//         addAwsIamAuthInOutputSchema: false,
+//       }),
+//     ],
+//   });
+//   const out = transformer.transform(validSchema);
+//   expect(out).toBeDefined();
+
+//   expect(out.pipelineFunctions['Post.comments.auth.1.req.vtl']).toContain('#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"admin"}] )');
+// });
+
+test('per-field @auth without @model', () => {
+  const validSchema = `
+    type Query {
+      listContext: String @auth(rules: [{ allow: groups, groups: ["Allowed"] }, { allow: private, provider: iam }])
+    }`;
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const resources = out.rootStack.Resources;
+  const authPolicyIdx = Object.keys(out.rootStack.Resources).find(r => r.includes('AuthRolePolicy'));
+  expect(resources[authPolicyIdx]).toMatchSnapshot();
+  expect(out.resolvers['Query.listContext.req.vtl']).toContain(
+    '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"Allowed"}] )',
+  );
+});

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -1,6 +1,6 @@
 import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { AppSyncAuthConfiguration, GraphQLTransform, TransformerContractError } from '@aws-amplify/graphql-transformer-core';
+import { AppSyncAuthConfiguration, GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';
 
 test('happy case with static groups', () => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -9,20 +9,6 @@ import {
 } from '@aws-amplify/graphql-transformer-core';
 import { DocumentNode, ObjectTypeDefinitionNode, Kind, FieldDefinitionNode, parse, InputValueDefinitionNode } from 'graphql';
 
-// const noAuthModeDefaultConfig: AppSyncAuthConfiguration = {
-//   defaultAuthentication: {
-//     authenticationType: undefined,
-//   },
-//   additionalAuthenticationProviders: [],
-// };
-
-// const openIdDefaultConfig: AppSyncAuthConfiguration = {
-//   defaultAuthentication: {
-//     authenticationType: 'OPENID_CONNECT',
-//   },
-//   additionalAuthenticationProviders: [],
-// };
-
 const userPoolsDefaultConfig: AppSyncAuthConfiguration = {
   defaultAuthentication: {
     authenticationType: 'AMAZON_COGNITO_USER_POOLS',

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -6,16 +6,22 @@ import {
   AppSyncAuthConfigurationOIDCEntry,
   AppSyncAuthMode,
   GraphQLTransform,
-  TransformerContractError,
 } from '@aws-amplify/graphql-transformer-core';
 import { DocumentNode, ObjectTypeDefinitionNode, Kind, FieldDefinitionNode, parse, InputValueDefinitionNode } from 'graphql';
 
-const noAuthModeDefaultConfig: AppSyncAuthConfiguration = {
-  defaultAuthentication: {
-    authenticationType: undefined,
-  },
-  additionalAuthenticationProviders: [],
-};
+// const noAuthModeDefaultConfig: AppSyncAuthConfiguration = {
+//   defaultAuthentication: {
+//     authenticationType: undefined,
+//   },
+//   additionalAuthenticationProviders: [],
+// };
+
+// const openIdDefaultConfig: AppSyncAuthConfiguration = {
+//   defaultAuthentication: {
+//     authenticationType: 'OPENID_CONNECT',
+//   },
+//   additionalAuthenticationProviders: [],
+// };
 
 const userPoolsDefaultConfig: AppSyncAuthConfiguration = {
   defaultAuthentication: {
@@ -27,13 +33,6 @@ const userPoolsDefaultConfig: AppSyncAuthConfiguration = {
 const apiKeyDefaultConfig: AppSyncAuthConfiguration = {
   defaultAuthentication: {
     authenticationType: 'API_KEY',
-  },
-  additionalAuthenticationProviders: [],
-};
-
-const openIdDefaultConfig: AppSyncAuthConfiguration = {
-  defaultAuthentication: {
-    authenticationType: 'OPENID_CONNECT',
   },
   additionalAuthenticationProviders: [],
 };
@@ -83,8 +82,8 @@ const privateWithApiKeyAuthDirective = '@auth(rules: [{allow: private, provider:
 const publicAuthDirective = '@auth(rules: [{allow: public}])';
 const publicUserPoolsAuthDirective = '@auth(rules: [{allow: public, provider: userPools}])';
 const privateAndPublicDirective = '@auth(rules: [{allow: private}, {allow: public}])';
-const privateAndPrivateIAMDirective = '@auth(rules: [{allow: private}, {allow: private, provider: iam}])';
 const privateIAMDirective = '@auth(rules: [{allow: private, provider: iam}])';
+// const privateAndPrivateIAMDirective = '@auth(rules: [{allow: private}, {allow: private, provider: iam}])';
 
 const getSchema = (authDirective: string) => {
   return `
@@ -236,90 +235,90 @@ const expectMultiple = (fieldOrType: ObjectTypeDefinitionNode | FieldDefinitionN
 
 const getField = (type, name) => type.fields.find(f => f.name.value === name);
 
-// describe('validation tests', () => {
-//   const validationTest = (authDirective, authConfig, expectedError) => {
-//     const schema = getSchema(authDirective);
-//     const transformer = getTransformer(authConfig);
+describe('validation tests', () => {
+  const validationTest = (authDirective, authConfig, expectedError) => {
+    const schema = getSchema(authDirective);
+    const transformer = getTransformer(authConfig);
 
-//     const t = () => {
-//       const out = transformer.transform(schema);
-//     };
+    const t = () => {
+      const out = transformer.transform(schema);
+    };
 
-//     expect(t).toThrowError(expectedError);
-//   };
+    expect(t).toThrowError(expectedError);
+  };
 
-//   test('AMAZON_COGNITO_USER_POOLS not configured for project', () => {
-//     validationTest(
-//       privateAuthDirective,
-//       apiKeyDefaultConfig,
-//       `@auth directive with 'userPools' provider found, but the project has no Cognito User \
-// Pools authentication provider configured.`,
-//     );
-//   });
+  test('AMAZON_COGNITO_USER_POOLS not configured for project', () => {
+    validationTest(
+      privateAuthDirective,
+      apiKeyDefaultConfig,
+      `@auth directive with 'userPools' provider found, but the project has no Cognito User \
+Pools authentication provider configured.`,
+    );
+  });
 
-//   test('API_KEY not configured for project', () => {
-//     validationTest(
-//       publicAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'apiKey' provider found, but the project has no API Key \
-// authentication provider configured.`,
-//     );
-//   });
+  test('API_KEY not configured for project', () => {
+    validationTest(
+      publicAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'apiKey' provider found, but the project has no API Key \
+authentication provider configured.`,
+    );
+  });
 
-//   test('AWS_IAM not configured for project', () => {
-//     validationTest(
-//       publicIAMAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'iam' provider found, but the project has no IAM \
-// authentication provider configured.`,
-//     );
-//   });
+  test('AWS_IAM not configured for project', () => {
+    validationTest(
+      publicIAMAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'iam' provider found, but the project has no IAM \
+authentication provider configured.`,
+    );
+  });
 
-//   test('OPENID_CONNECT not configured for project', () => {
-//     validationTest(
-//       ownerOpenIdAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT \
-// authentication provider configured.`,
-//     );
-//   });
+  test('OPENID_CONNECT not configured for project', () => {
+    validationTest(
+      ownerOpenIdAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT \
+authentication provider configured.`,
+    );
+  });
 
-//   test(`'group' cannot have provider`, () => {
-//     validationTest(
-//       groupsWithProviderAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found \
-// 'iam' assigned`,
-//     );
-//   });
+  test(`'group' cannot have provider`, () => {
+    validationTest(
+      groupsWithProviderAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'groups' strategy only supports 'userPools' and 'oidc' providers, but found \
+'iam' assigned`,
+    );
+  });
 
-//   test(`'owner' has invalid IAM provider`, () => {
-//     validationTest(
-//       ownerWithIAMAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'owner' strategy only supports 'userPools' (default) and \
-// 'oidc' providers, but found 'iam' assigned.`,
-//     );
-//   });
+  test(`'owner' has invalid IAM provider`, () => {
+    validationTest(
+      ownerWithIAMAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'owner' strategy only supports 'userPools' (default) and \
+'oidc' providers, but found 'iam' assigned.`,
+    );
+  });
 
-//   test(`'public' has invalid 'userPools' provider`, () => {
-//     validationTest(
-//       publicUserPoolsAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'public' strategy only supports 'apiKey' (default) and 'iam' providers, but \
-// found 'userPools' assigned.`,
-//     );
-//   });
+  test(`'public' has invalid 'userPools' provider`, () => {
+    validationTest(
+      publicUserPoolsAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'public' strategy only supports 'apiKey' (default) and 'iam' providers, but \
+found 'userPools' assigned.`,
+    );
+  });
 
-//   test(`'private' has invalid 'apiKey' provider`, () => {
-//     validationTest(
-//       privateWithApiKeyAuthDirective,
-//       userPoolsDefaultConfig,
-//       `@auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, but \
-// found 'apiKey' assigned.`,
-//     );
-//   });
-// });
+  test(`'private' has invalid 'apiKey' provider`, () => {
+    validationTest(
+      privateWithApiKeyAuthDirective,
+      userPoolsDefaultConfig,
+      `@auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, but \
+found 'apiKey' assigned.`,
+    );
+  });
+});
 
 describe('schema generation directive tests', () => {
   const transformTest = (authDirective, authConfig, expectedDirectiveNames?: string[] | undefined) => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -1,0 +1,229 @@
+import { parse } from 'graphql';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { AppSyncAuthConfiguration, GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { ResourceConstants } from 'graphql-transformer-common';
+import { getField, getObjectType } from './test-helpers';
+
+test('auth transformer validation happy case', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const validSchema = `
+    type Post @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      title: String!
+      createdAt: String
+      updatedAt: String
+    }`;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
+    'AMAZON_COGNITO_USER_POOLS',
+  );
+});
+
+test('ownerfield with subscriptions', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const validSchema = `
+    type Post @model @auth(rules: [
+        {allow: owner, ownerField: "postOwner"}
+    ]){
+      id: ID!
+      title: String
+      postOwner: String
+    }`;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  // expect 'postOwner' as an argument for subscription operations
+  expect(out.schema).toContain('onCreatePost(postOwner: String)');
+  expect(out.schema).toContain('onUpdatePost(postOwner: String)');
+  expect(out.schema).toContain('onDeletePost(postOwner: String)');
+
+  // expect logic in the resolvers to check for postOwner args as an allowed owner
+  expect(out.pipelineFunctions['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
+  );
+  expect(out.pipelineFunctions['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
+  );
+  expect(out.pipelineFunctions['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
+  );
+});
+
+test('multiple owner rules with subscriptions', () => {
+  const validSchema = `
+        type Post @model
+            @auth(rules: [
+              { allow: owner },
+              { allow: owner, ownerField: "editor", operations: [read, update] }
+            ])
+        {
+            id: ID!
+            title: String
+            owner: String
+            editor: String
+        }`;
+
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  // expect 'owner' and 'editors' as arguments for subscription operations
+  expect(out.schema).toContain('onCreatePost(owner: String, editor: String)');
+  expect(out.schema).toContain('onUpdatePost(owner: String, editor: String)');
+  expect(out.schema).toContain('onDeletePost(owner: String, editor: String)');
+
+  // expect logic in the resolvers to check for owner args as an allowedOwner
+  expect(out.pipelineFunctions['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
+  );
+  expect(out.pipelineFunctions['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
+  );
+  expect(out.pipelineFunctions['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
+  );
+
+  // expect logic in the resolvers to check for editor args as an allowedOwner
+  expect(out.pipelineFunctions['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
+  );
+  expect(out.pipelineFunctions['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
+  );
+  expect(out.pipelineFunctions['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
+    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
+  );
+});
+
+test('implicit owner fields get added to the type', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const validSchema = `
+  type Post @model
+            @auth(rules: [
+                {allow: owner, ownerField: "postOwner"}
+                { allow: owner, ownerField: "customOwner", identityClaim: "sub"}
+            ])
+        {
+            id: ID!
+            title: String
+        }
+  `;
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const schema = parse(out.schema);
+  const postType = getObjectType(schema, 'Post');
+  expect(postType).toBeDefined();
+
+  const postOwnerField = getField(postType, 'postOwner');
+  expect(postOwnerField).toBeDefined();
+  expect((postOwnerField as any).type.name.value).toEqual('String');
+
+  const customOwner = getField(postType, 'customOwner');
+  expect(customOwner).toBeDefined();
+  expect((customOwner as any).type.name.value).toEqual('String');
+});
+
+test('implicit owner fields from field level auth get added to the type', () => {
+  const validSchema = `
+        type Post @model
+        {
+            id: ID
+            title: String
+            protectedField: String @auth(rules: [
+                {allow: owner, ownerField: "postOwner"}
+                { allow: owner, ownerField: "customOwner", identityClaim: "sub"}
+            ])
+        }`;
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  const postType = getObjectType(schema, 'Post');
+  expect(postType).toBeDefined();
+
+  const postOwnerField = getField(postType, 'postOwner');
+  expect(postOwnerField).toBeDefined();
+  expect((postOwnerField as any).type.name.value).toEqual('String');
+
+  const customOwner = getField(postType, 'customOwner');
+  expect(customOwner).toBeDefined();
+  expect((customOwner as any).type.name.value).toEqual('String');
+});

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -1,0 +1,92 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+import { AppSyncAuthConfiguration, GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+
+test('auth logic is enabled on owner/static rules in es request', () => {
+  const validSchema = `
+        type Comment @model
+            @searchable
+            @auth(rules: [
+                { allow: owner }
+                { allow: groups, groups: ["writer"]}
+            ])
+        {
+            id: ID!
+            content: String
+        }
+    `;
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new SearchableModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  // expect response resolver to contain auth logic for owner rule
+  expect(out).toBeDefined();
+  expect(out.pipelineFunctions['Query.searchComments.auth.1.req.vtl']).toContain(
+    '"terms":       [$util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), "___xamznone____"))],',
+  );
+  // expect response resolver to contain auth logic for group rule
+  expect(out.pipelineFunctions['Query.searchComments.auth.1.req.vtl']).toContain(
+    '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"writer"}] )',
+  );
+});
+
+test('auth logic is enabled for iam/apiKey auth rules', () => {
+  const validSchema = `
+        type Post @model
+            @searchable
+            @auth(rules: [
+                { allow: public, provider: apiKey } # api key is allowed
+                { allow: private, provider: iam } # auth roles are allowed
+            ]) {
+            id: ID!
+            content: String
+            secret: String @auth(rules: [{ allow: private, provider: iam }]) # only auth role can do crud on this
+        }
+    `;
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [
+      {
+        authenticationType: 'API_KEY',
+        apiKeyConfig: {
+          description: 'E2E Test API Key',
+          apiKeyExpirationDays: 300,
+        },
+      },
+      {
+        authenticationType: 'AWS_IAM',
+      },
+    ],
+  };
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [
+      new ModelTransformer(),
+      new SearchableModelTransformer(),
+      new AuthTransformer({
+        authConfig,
+        addAwsIamAuthInOutputSchema: false,
+      }),
+    ],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain('SearchablePostConnection @aws_api_key @aws_iam');
+});

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/test-helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/test-helpers.ts
@@ -1,0 +1,10 @@
+import { ObjectTypeDefinitionNode, FieldDefinitionNode, DocumentNode, Kind } from 'graphql';
+
+export const getObjectType = (doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined => {
+  return doc.definitions.find(def => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as
+    | ObjectTypeDefinitionNode
+    | undefined;
+};
+export const getField = (obj: ObjectTypeDefinitionNode, fieldName: string): FieldDefinitionNode | void => {
+  return obj.fields?.find(f => f.name.value === fieldName);
+};

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -261,6 +261,9 @@ Static group authorization should perform as expected.`,
           case QueryFieldType.LIST:
             this.protectListResolver(context, def, query.typeName, query.fieldName, acm);
             break;
+          case QueryFieldType.SYNC:
+            // protect sync query
+            break;
           default:
             throw new TransformerContractError('Unkown query field type');
         }
@@ -421,6 +424,23 @@ Static group authorization should perform as expected.`,
       MappingTemplate.s3MappingTemplateFromString(authExpression, `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`),
     );
   };
+  protectSyncResolver = (
+    ctx: TransformerContextProvider,
+    def: ObjectTypeDefinitionNode,
+    typeName: string,
+    fieldName: string,
+    acm: AccessControlMatrix,
+  ): void => {
+    if (ctx.isProjectUsingDataStore()) {
+      const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
+      const roleDefinitions = acm.getRolesPerOperation('read').map(r => this.roleMap.get(r)!);
+      const authExpression = generateAuthExpressionForQueries(this.configuredAuthProviders, roleDefinitions, def.fields ?? []);
+      resolver.addToSlot(
+        'auth',
+        MappingTemplate.s3MappingTemplateFromString(authExpression, `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`),
+      );
+    }
+  };
   protectSearchResolver = (
     ctx: TransformerContextProvider,
     def: ObjectTypeDefinitionNode,
@@ -436,6 +456,17 @@ Static group authorization should perform as expected.`,
       MappingTemplate.s3MappingTemplateFromString(authExpression, `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`),
     );
   };
+  /*
+  Field Resovler can protect the following
+  - model fields
+  - relational fields (hasOne, hasMany, belongsTo)
+  - fields on an operation (query/mutation)
+  - protection on predictions/function/no directive
+  Order of precendence
+  - resolver in api host (ex. @function, @predictions)
+  - resolver in resolver manager (ex. @hasOne, @hasMany @belongsTo)
+  - no resolver creates a blank non-pipeline resolver will return the source field
+  */
   protectFieldResolver = (
     ctx: TransformerContextProvider,
     def: ObjectTypeDefinitionNode,
@@ -471,8 +502,8 @@ Static group authorization should perform as expected.`,
       );
     } else {
       const fieldAuthExpression = generateAuthExpressionForField(this.configuredAuthProviders, roleDefinitions, def.fields ?? []);
-      const subsEnabled = this.modelDirectiveConfig.get(typeName)!.subscriptions.level === 'on';
-      const fieldResponse = generateFieldAuthResponse('Mutation', fieldName, hasModelDirective ? subsEnabled : false);
+      const subsEnabled = hasModelDirective ? this.modelDirectiveConfig.get(typeName)!.subscriptions.level === 'on' : false;
+      const fieldResponse = generateFieldAuthResponse('Mutation', fieldName, subsEnabled);
       if (!ctx.api.host.hasDataSource('NONE')) {
         ctx.api.host.addNoneDataSource('NONE');
       }
@@ -518,7 +549,7 @@ Static group authorization should perform as expected.`,
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
     const fields = acm.getResources();
     const updateDeleteRoles = [...new Set([...acm.getRolesPerOperation('update'), ...acm.getRolesPerOperation('delete')])];
-    // protect fields to be updated and fields that can't be set to null
+    // protect fields to be updated and fields that can't be set to null (partial delete on fields)
     const totalRoles = updateDeleteRoles.map(role => {
       const allowedFields = fields.filter(resource => acm.isAllowed(role, resource, 'update'));
       const nullAllowedFileds = fields.filter(resource => acm.isAllowed(role, resource, 'delete'));
@@ -864,7 +895,6 @@ Static group authorization should perform as expected.`,
 
   /**
    * TODO: Change Resource Ref Object/Field Functions to work with roles
-   * Currently we need FieldToResourceRef to have deny by default behavior for IAM Policy
    */
   private addTypeToResourceReferences(typeName: string, rules: AuthRule[]): void {
     const iamPublicRulesExist = rules.some(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -262,7 +262,7 @@ Static group authorization should perform as expected.`,
             this.protectListResolver(context, def, query.typeName, query.fieldName, acm);
             break;
           case QueryFieldType.SYNC:
-            // protect sync query
+            this.protectSyncResolver(context, def, query.typeName, query.fieldName, acm);
             break;
           default:
             throw new TransformerContractError('Unkown query field type');

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -90,7 +90,7 @@ export const generateAuthExpressionForField = (
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (provider.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, provider.hasAdminUIEnabled));
+    totalAuthExpressions.push(iamExpression(iamRoles, provider.hasAdminUIEnabled, provider.adminUserPoolID));
   }
   if (provider.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -31,6 +31,9 @@ import {
   MANAGE_ROLE,
 } from '../utils';
 
+// note in the resolver that operation is protected by auth
+export const setHasAuthExpression: Expression = qref(methodCall(ref('ctx.stash.put'), ref('hasAuth'), bool(true)));
+
 // since the keySet returns a set we can convert it to a list by converting to json and parsing back as a list
 export const getInputFields = (): Expression => {
   return set(ref('inputFields'), methodCall(ref('util.parseJson'), methodCall(ref('util.toJson'), ref('ctx.args.input.keySet()'))));

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
@@ -20,7 +20,7 @@ import {
   or,
   printBlock,
 } from 'graphql-mapping-template';
-import { getOwnerClaim, getIdentityClaimExp, getInputFields, addAllowedFieldsIfElse, emptyPayload } from './helpers';
+import { getOwnerClaim, getIdentityClaimExp, getInputFields, addAllowedFieldsIfElse, emptyPayload, setHasAuthExpression } from './helpers';
 import {
   ADMIN_ROLE,
   API_KEY_AUTH_TYPE,
@@ -218,6 +218,7 @@ export const generateAuthExpressionForCreate = (
     iamRoles,
   } = splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [
+    setHasAuthExpression,
     getInputFields(),
     set(ref(IS_AUTHORIZED_FLAG), bool(false)),
     set(ref(ALLOWED_FIELDS), list([])),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
@@ -60,7 +60,7 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
  * @param roles
  * @returns
  */
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false) => {
+const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false, adminUserPoolID?: string) => {
   const iamCheck = (claim: string, exp: Expression) =>
     iff(equals(methodCall(ref('ctx.identity.get'), str('cognitoIdentityAuthType')), str(claim)), exp);
   const expression = new Array<Expression>();
@@ -69,8 +69,8 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean 
     expression.push(
       iff(
         or([
-          methodCall(ref('ctx.identity.userArn.contains'), str(ADMIN_ROLE)),
-          methodCall(ref('ctx.identity.userArn.contains'), str(MANAGE_ROLE)),
+          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID!}${ADMIN_ROLE}`)),
+          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID!}${MANAGE_ROLE}`)),
         ]),
         raw('#return($util.toJson({})'),
       ),
@@ -226,7 +226,7 @@ export const generateAuthExpressionForCreate = (
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
@@ -52,7 +52,7 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
  * @param roles
  * @returns
  */
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false) => {
+const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false, adminUserPoolID?: string) => {
   const iamCheck = (claim: string, exp: Expression) =>
     iff(equals(methodCall(ref('ctx.identity.get'), str('cognitoIdentityAuthType')), str(claim)), exp);
   const expression = new Array<Expression>();
@@ -61,8 +61,8 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean 
     expression.push(
       iff(
         or([
-          methodCall(ref('ctx.identity.userArn.contains'), str(ADMIN_ROLE)),
-          methodCall(ref('ctx.identity.userArn.contains'), str(MANAGE_ROLE)),
+          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${ADMIN_ROLE}`)),
+          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${MANAGE_ROLE}`)),
         ]),
         raw('#return($util.toJson({})'),
       ),
@@ -165,7 +165,7 @@ export const geneateAuthExpressionForDelete = (
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
@@ -17,7 +17,7 @@ import {
   not,
   nul,
 } from 'graphql-mapping-template';
-import { emptyPayload, getIdentityClaimExp, getOwnerClaim } from './helpers';
+import { emptyPayload, getIdentityClaimExp, getOwnerClaim, setHasAuthExpression } from './helpers';
 import {
   ADMIN_ROLE,
   API_KEY_AUTH_TYPE,
@@ -160,7 +160,7 @@ export const geneateAuthExpressionForDelete = (
   fields: ReadonlyArray<FieldDefinitionNode>,
 ) => {
   const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles } = splitRoles(roles);
-  const totalAuthExpressions: Array<Expression> = [set(ref(IS_AUTHORIZED_FLAG), bool(false))];
+  const totalAuthExpressions: Array<Expression> = [setHasAuthExpression, set(ref(IS_AUTHORIZED_FLAG), bool(false))];
   if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -38,7 +38,7 @@ import {
   NULL_ALLOWED_FIELDS,
   DENIED_FIELDS,
 } from '../utils';
-import { getIdentityClaimExp, responseCheckForErrors, getOwnerClaim, getInputFields } from './helpers';
+import { getIdentityClaimExp, responseCheckForErrors, getOwnerClaim, getInputFields, setHasAuthExpression } from './helpers';
 
 /**
  * There is only one role for ApiKey we can use the first index
@@ -258,6 +258,7 @@ export const generateAuthExpressionForUpdate = (
 ) => {
   const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles } = splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [
+    setHasAuthExpression,
     responseCheckForErrors(),
     getInputFields(),
     set(ref(IS_AUTHORIZED_FLAG), bool(false)),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -61,7 +61,7 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
   return iff(equals(ref('util.authType()'), str(API_KEY_AUTH_TYPE)), compoundExpression(expression));
 };
 
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false) => {
+const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false, adminUserPoolID?: string) => {
   const iamCheck = (claim: string, exp: Expression) =>
     iff(equals(methodCall(ref('ctx.identity.get'), str('cognitoIdentityAuthType')), str(claim)), exp);
   const expression = new Array<Expression>();
@@ -70,8 +70,8 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean 
     expression.push(
       iff(
         or([
-          methodCall(ref('ctx.identity.userArn.contains'), str(ADMIN_ROLE)),
-          methodCall(ref('ctx.identity.userArn.contains'), str(MANAGE_ROLE)),
+          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${ADMIN_ROLE}`)),
+          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${MANAGE_ROLE}`)),
         ]),
         raw('#return($util.toJson({})'),
       ),
@@ -269,7 +269,7 @@ export const generateAuthExpressionForUpdate = (
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -18,7 +18,7 @@ import {
   raw,
   set,
 } from 'graphql-mapping-template';
-import { getIdentityClaimExp, getOwnerClaim, apiKeyExpression, iamExpression, emptyPayload } from './helpers';
+import { getIdentityClaimExp, getOwnerClaim, apiKeyExpression, iamExpression, emptyPayload, setHasAuthExpression } from './helpers';
 import {
   COGNITO_AUTH_TYPE,
   OIDC_AUTH_TYPE,
@@ -144,7 +144,7 @@ export const generateAuthExpressionForQueries = (
   querySource: QuerySource = 'dynamodb',
 ): string => {
   const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles } = splitRoles(roles);
-  const totalAuthExpressions: Array<Expression> = [set(ref(IS_AUTHORIZED_FLAG), bool(false))];
+  const totalAuthExpressions: Array<Expression> = [setHasAuthExpression, set(ref(IS_AUTHORIZED_FLAG), bool(false))];
   if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -138,20 +138,20 @@ const generateAuthFilter = (
 };
 
 export const generateAuthExpressionForQueries = (
-  provider: ConfiguredAuthProviders,
+  providers: ConfiguredAuthProviders,
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
   querySource: QuerySource = 'dynamodb',
 ): string => {
   const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles } = splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [set(ref(IS_AUTHORIZED_FLAG), bool(false))];
-  if (provider.hasApiKey) {
+  if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
-  if (provider.hasIAM) {
-    iamExpression(iamRoles, provider.hasAdminUIEnabled);
+  if (providers.hasIAM) {
+    iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID);
   }
-  if (provider.hasUserPools) {
+  if (providers.hasUserPools) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
@@ -162,7 +162,7 @@ export const generateAuthExpressionForQueries = (
       ),
     );
   }
-  if (provider.hasOIDC) {
+  if (providers.hasOIDC) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(OIDC_AUTH_TYPE)),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -44,7 +44,7 @@ export const generateAuthExpressionForSubscriptions = (providers: ConfiguredAuth
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
   }
   if (providers.hasUserPools)
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -57,11 +57,13 @@ export interface ConfiguredAuthProviders {
   hasOIDC: boolean;
   hasIAM: boolean;
   hasAdminUIEnabled: boolean;
+  adminUserPoolID?: string;
 }
 
 export interface AuthTransformerConfig {
   authConfig: AppSyncAuthConfiguration;
   addAwsIamAuthInOutputSchema: boolean;
+  adminUserPoolID?: string;
 }
 
 export const authDirectiveDefinition = `

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -140,6 +140,7 @@ export const getConfiguredAuthProviders = (config: AuthTransformerConfig): Confi
     default: getAuthProvider(config.authConfig.defaultAuthentication.authenticationType),
     onlyDefaultAuthProviderConfigured: config.authConfig.additionalAuthenticationProviders.length === 0,
     hasAdminUIEnabled: hasIAM && config.addAwsIamAuthInOutputSchema,
+    adminUserPoolID: config.adminUserPoolID!,
     hasApiKey: providers.some(p => p === 'API_KEY'),
     hasUserPools: providers.some(p => p === 'AMAZON_COGNITO_USER_POOLS'),
     hasOIDC: providers.some(p => p === 'OPENID_CONNECT'),

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -3920,11 +3920,32 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $filter = $filterExpression )
+  #end
+#end
 {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+  \\"filter\\":   #if( $filter )
+$util.toJson($filter)
   #else
 null
   #end,
@@ -7469,11 +7490,32 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $filter = $filterExpression )
+  #end
+#end
 {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+  \\"filter\\":   #if( $filter )
+$util.toJson($filter)
   #else
 null
   #end,
@@ -11018,11 +11060,32 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = [{
+  \\"and\\":   [$filter, $ctx.args.filter]
+}] )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterEpression.expressionValues.size() == 0 )
+      $util.qr($filterEpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $filter = $filterExpression )
+  #end
+#end
 {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $context.args.filter )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+  \\"filter\\":   #if( $filter )
+$util.toJson($filter)
   #else
 null
   #end,

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -8053,7 +8053,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -8186,7 +8186,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -12414,7 +12414,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -12485,7 +12485,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -12595,7 +12595,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -12759,7 +12759,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -14707,7 +14707,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -14839,7 +14839,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -14949,7 +14949,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -15059,7 +15059,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,
@@ -15169,7 +15169,7 @@ false
 true
     #end,
       \\"filter\\":     #if( $filter )
-$util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))
+$util.toJson($filter)
     #else
 null
     #end,

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -206,7 +206,7 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
       ifElse(equals(ref('context.args.sortDirection'), str('ASC')), bool(true), bool(false)),
       bool(true),
     ),
-    filter: ifElse(ref('filter'), ref('util.toJson(util.transform.toDynamoDBFilterExpression($ctx.args.filter))'), nul()),
+    filter: ifElse(ref('filter'), ref('util.toJson($filter)'), nul()),
     limit: ref('limit'),
     nextToken: ifElse(ref('context.args.nextToken'), ref('util.toJson($context.args.nextToken)'), nul()),
   } as any;

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -17,7 +17,7 @@ export function doAdminTokensExist(appId: string): boolean {
   return !!stateManager.getAmplifyAdminConfigEntry(appId);
 }
 
-export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: boolean; region: string }> {
+export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: boolean; region: string; userPoolID: string }> {
   if (!appId) {
     throw `Failed to check if Admin UI is enabled: appId is undefined`;
   }
@@ -25,7 +25,7 @@ export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: bo
   if (appState.appId && appState.region && appState.region !== 'us-east-1') {
     appState = await getAdminAppState(appId, appState.region);
   }
-  return { isAdminApp: !!appState.appId, region: appState.region };
+  return { isAdminApp: !!appState.appId, region: appState.region, userPoolID: JSON.parse(appState.loginAuthConfig).aws_user_pools_id };
 }
 
 export async function getTempCredsWithAdminTokens(context: $TSContext, appId: string): Promise<AwsSdkConfig> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- `@auth` on sync query (conflict resolution)
- updated unit tests
- add has auth flag for deny by default with `@model`s that don't have `@auth`
- pass admin ui userpool id down into the resolver if admin ui is enabled

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.