### PR TITLE
fix(graphql-model-transformer): use hasAuth flag when sandbox mode is disabled

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -14,7 +14,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -136,7 +138,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -226,7 +230,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -393,7 +399,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -584,7 +592,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -738,7 +748,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -750,7 +762,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -762,7 +776,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -790,7 +806,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -912,7 +930,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1002,7 +1022,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1169,7 +1191,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -1360,7 +1384,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -1416,7 +1442,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1428,7 +1456,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1440,7 +1470,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1468,7 +1500,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1590,7 +1624,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1680,7 +1716,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1847,7 +1885,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -2038,7 +2078,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -2250,7 +2292,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -2262,7 +2306,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -2274,7 +2320,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -2521,7 +2569,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2628,7 +2678,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2716,7 +2768,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2868,7 +2922,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -3066,7 +3122,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
@@ -3340,7 +3398,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -3352,7 +3412,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -3364,7 +3426,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -3392,7 +3456,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.addContentToCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.addContentToCategory.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3525,7 +3591,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createBlog.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -3631,7 +3699,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3756,7 +3826,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3874,7 +3946,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTodo.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -3969,7 +4043,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteBlog.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -4037,7 +4113,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteContentFromCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteContentFromCategory.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4118,7 +4196,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4197,7 +4277,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4276,7 +4358,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTodo.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -4353,7 +4437,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateBlog.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -4502,7 +4588,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateItem.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4670,7 +4758,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4831,7 +4921,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTodo.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -5029,7 +5121,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.getBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getBlog.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -5076,7 +5170,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getItem.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -5130,7 +5226,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -5184,7 +5282,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTodo.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -5427,7 +5527,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.listBlogs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listBlogs.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -5788,7 +5890,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Query.listItems.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listItems.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.orderId) && !$util.isNull($ctx.args.sortDirection) )
@@ -5952,7 +6056,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
@@ -6324,7 +6430,9 @@ $util.toJson($QueryRequest)",
 #end
 $util.toJson($ctx.result)",
   "Subscription.onCreateBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateBlog.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6336,7 +6444,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateContentCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateContentCategory.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6348,7 +6458,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateItem.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6360,7 +6472,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6372,7 +6486,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTodo.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6384,7 +6500,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteBlog.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6396,7 +6514,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteContentCategory.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteContentCategory.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6408,7 +6528,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteItem.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6420,7 +6542,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6432,7 +6556,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTodo.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6444,7 +6570,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateBlog.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateBlog.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6456,7 +6584,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateItem.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6468,7 +6598,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -6480,7 +6612,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTodo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTodo.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -14,7 +14,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -128,7 +130,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -216,7 +220,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -375,7 +381,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -429,7 +437,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
@@ -593,7 +603,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -605,7 +617,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -617,7 +631,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -645,7 +661,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -752,7 +770,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -840,7 +860,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -992,7 +1014,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -1046,7 +1070,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.email) && !$util.isNull($ctx.args.sortDirection) )
@@ -1164,7 +1190,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1176,7 +1204,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1188,7 +1218,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1216,7 +1248,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1322,7 +1356,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1409,7 +1445,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1560,7 +1598,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -1613,7 +1653,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
@@ -1688,7 +1730,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1700,7 +1744,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1712,7 +1758,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1740,7 +1788,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1847,7 +1897,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1935,7 +1987,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2087,7 +2141,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -2141,7 +2197,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.status) && !$util.isNull($ctx.args.sortDirection) )
@@ -2259,7 +2317,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -2271,7 +2331,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -2283,7 +2345,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -2311,7 +2375,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2418,7 +2484,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2508,7 +2576,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.testCreate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.testCreate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2615,7 +2685,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.testDelete.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.testDelete.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2703,7 +2775,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.testUpdate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.testUpdate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2864,7 +2938,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3016,7 +3092,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -3069,7 +3147,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
@@ -3144,7 +3224,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.testGet.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.testGet.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -3198,7 +3280,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.testList.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.testList.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
@@ -3316,7 +3400,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -3328,7 +3414,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -3340,7 +3428,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -3368,7 +3458,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3474,7 +3566,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3563,7 +3657,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.testCreate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.testCreate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3670,7 +3766,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.testDelete.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.testDelete.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3758,7 +3856,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.testUpdate.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.testUpdate.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3919,7 +4019,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4070,7 +4172,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -4123,7 +4227,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
@@ -4198,7 +4304,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.testGet.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.testGet.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -4252,7 +4360,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.testList.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.testList.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
@@ -4370,7 +4480,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4382,7 +4494,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4394,7 +4508,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -597,7 +597,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -703,7 +705,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -809,7 +813,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createEmail.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -915,7 +921,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -1021,7 +1029,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createRequire.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -1127,7 +1137,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -1233,7 +1245,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -1339,7 +1353,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.customCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customCreatePost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -1434,7 +1450,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.customDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -1511,7 +1529,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.customUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customUpdatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -1651,7 +1671,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -1719,7 +1741,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -1787,7 +1811,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -1855,7 +1881,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -1924,7 +1952,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -1992,7 +2022,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -2060,7 +2092,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -2137,7 +2171,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -2286,7 +2322,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -2435,7 +2473,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateEmail.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -2584,7 +2624,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -2734,7 +2776,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateRequire.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -2883,7 +2927,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -3032,7 +3078,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -3172,7 +3220,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.customGetPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3219,7 +3269,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.customListPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.customListPost.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3275,7 +3327,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.getAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3322,7 +3376,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3369,7 +3425,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getEmail.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3416,7 +3474,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getEntity.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getEntity.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3463,7 +3523,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3510,7 +3572,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getRequire.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3557,7 +3621,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3604,7 +3670,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getUser.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -3651,7 +3719,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3707,7 +3777,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3763,7 +3835,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listEmails.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3819,7 +3893,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3875,7 +3951,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listRequires.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3931,7 +4009,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -3987,7 +4067,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -4043,7 +4125,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.syncPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
@@ -4088,7 +4172,9 @@ null
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4100,7 +4186,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4112,7 +4200,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4124,7 +4214,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4136,7 +4228,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4148,7 +4242,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4160,7 +4256,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4172,7 +4270,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4184,7 +4284,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4196,7 +4298,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4208,7 +4312,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4220,7 +4326,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4232,7 +4340,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4244,7 +4354,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4256,7 +4368,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4268,7 +4382,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4280,7 +4396,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4292,7 +4410,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4304,7 +4424,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4316,7 +4438,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4328,7 +4452,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -4356,7 +4482,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -4462,7 +4590,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -4568,7 +4698,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createEmail.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -4674,7 +4806,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -4780,7 +4914,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createRequire.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -4886,7 +5022,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -4992,7 +5130,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -5098,7 +5238,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.customCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customCreatePost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -5193,7 +5335,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.customDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5270,7 +5414,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.customUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customUpdatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -5410,7 +5556,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5478,7 +5626,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5546,7 +5696,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5614,7 +5766,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5683,7 +5837,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5751,7 +5907,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5819,7 +5977,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -5896,7 +6056,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6045,7 +6207,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6194,7 +6358,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateEmail.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6343,7 +6509,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6493,7 +6661,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateRequire.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6642,7 +6812,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6791,7 +6963,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -6931,7 +7105,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.customGetPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -6978,7 +7154,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.customListPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.customListPost.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7034,7 +7212,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.getAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7081,7 +7261,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7128,7 +7310,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getEmail.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7175,7 +7359,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getEntity.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getEntity.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7222,7 +7408,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7269,7 +7457,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getRequire.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7316,7 +7506,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7363,7 +7555,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getUser.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -7410,7 +7604,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7466,7 +7662,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7522,7 +7720,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listEmails.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7578,7 +7778,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7634,7 +7836,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listRequires.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7690,7 +7894,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7746,7 +7952,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -7802,7 +8010,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.syncPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
@@ -7847,7 +8057,9 @@ null
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7859,7 +8071,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7871,7 +8085,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7883,7 +8099,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7895,7 +8113,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7907,7 +8127,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7919,7 +8141,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7931,7 +8155,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7943,7 +8169,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7955,7 +8183,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7967,7 +8197,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7979,7 +8211,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -7991,7 +8225,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8003,7 +8239,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8015,7 +8253,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8027,7 +8267,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8039,7 +8281,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8051,7 +8295,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8063,7 +8309,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8075,7 +8323,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8087,7 +8337,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -8115,7 +8367,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8221,7 +8475,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8327,7 +8583,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createEmail.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8433,7 +8691,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8539,7 +8799,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createRequire.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8645,7 +8907,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8751,7 +9015,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8857,7 +9123,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.customCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customCreatePost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8952,7 +9220,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.customDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customDeletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9029,7 +9299,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.customUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.customUpdatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -9169,7 +9441,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9237,7 +9511,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9305,7 +9581,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteEmail.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9373,7 +9651,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9442,7 +9722,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteRequire.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9510,7 +9792,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9578,7 +9862,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9655,7 +9941,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -9804,7 +10092,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -9953,7 +10243,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateEmail.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10102,7 +10394,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10252,7 +10546,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateRequire.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10401,7 +10697,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10550,7 +10848,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10690,7 +10990,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.customGetPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.customGetPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -10737,7 +11039,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.customListPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.customListPost.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -10793,7 +11097,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.getAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -10840,7 +11146,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -10887,7 +11195,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getEmail.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -10934,7 +11244,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getEntity.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getEntity.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -10981,7 +11293,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -11028,7 +11342,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getRequire.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -11075,7 +11391,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -11122,7 +11440,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getUser.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -11169,7 +11489,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11225,7 +11547,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11281,7 +11605,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listEmails.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listEmails.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11337,7 +11663,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11393,7 +11721,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listRequires.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listRequires.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11449,7 +11779,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11505,7 +11837,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -11561,7 +11895,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.syncPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
@@ -11606,7 +11942,9 @@ null
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11618,7 +11956,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11630,7 +11970,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11642,7 +11984,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11654,7 +11998,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11666,7 +12012,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11678,7 +12026,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11690,7 +12040,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11702,7 +12054,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11714,7 +12068,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11726,7 +12082,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11738,7 +12096,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11750,7 +12110,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11762,7 +12124,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11774,7 +12138,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11786,7 +12152,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11798,7 +12166,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateEmail.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateEmail.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11810,7 +12180,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11822,7 +12194,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateRequire.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateRequire.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11834,7 +12208,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -11846,7 +12222,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -8218,7 +8218,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -8336,7 +8338,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createComment.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8442,7 +8446,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createFriendship.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8548,7 +8554,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createParent.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8654,7 +8662,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -8771,7 +8781,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPostAuthor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8877,7 +8889,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPostEditor.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -8983,7 +8997,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPostModel.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -9089,7 +9105,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -9195,7 +9213,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9320,7 +9340,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9445,7 +9467,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9579,7 +9603,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9658,7 +9684,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteComment.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9726,7 +9754,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteFriendship.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9794,7 +9824,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteParent.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -9862,7 +9894,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -9940,7 +9974,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePostAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -10008,7 +10044,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePostEditor.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -10076,7 +10114,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePostModel.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -10144,7 +10184,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -10212,7 +10254,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10291,7 +10335,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10370,7 +10416,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deleteUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deleteUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10471,7 +10519,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateChild.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -10632,7 +10682,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateComment.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10781,7 +10833,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateFriendship.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -10930,7 +10984,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateParent.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -11079,7 +11135,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -11239,7 +11297,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePostAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -11388,7 +11448,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePostEditor.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -11537,7 +11599,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePostModel.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -11686,7 +11750,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -11835,7 +11901,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateTest1.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -12003,7 +12071,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUser.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -12171,7 +12241,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updateUserModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -12920,7 +12992,9 @@ $util.unauthorized()
   #end
 #end",
   "Query.getChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getChild.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -12974,7 +13048,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getComment.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -13021,7 +13097,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getFriendship.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -13068,7 +13146,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getParent.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -13115,7 +13195,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPost.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -13168,7 +13250,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getPostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPostAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -13215,7 +13299,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getPostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPostModel.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -13262,7 +13348,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -13309,7 +13397,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getTest1.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -13363,7 +13453,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getUser.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -13417,7 +13509,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.getUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getUserModel.preAuth.1.req.vtl": "## [Start] Set the primary key. **
 $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
@@ -13471,7 +13565,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listChildren.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listChildren.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
@@ -13589,7 +13685,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listComments.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listComments.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -13645,7 +13743,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listFriendships.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listFriendships.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -13701,7 +13801,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listParents.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listParents.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -13757,7 +13859,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listPostAuthors.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPostAuthors.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -13813,7 +13917,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listPostModels.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPostModels.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -13869,7 +13975,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( !$util.isNull($ctx.args.sortDirection) )
@@ -13944,7 +14052,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listTest1s.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTest1s.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
@@ -14108,7 +14218,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listTests.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listTests.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -14164,7 +14276,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listUserModels.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listUserModels.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
@@ -14282,7 +14396,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Query.listUsers.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listUsers.preAuth.1.req.vtl": "## [Start] Set query expression for key **
 #if( $util.isNull($ctx.args.id) && !$util.isNull($ctx.args.sortDirection) )
@@ -14446,7 +14562,9 @@ $util.toJson($ListRequest)
 #end
 ## [End] ResponseTemplate. **",
   "Subscription.onCreateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14458,7 +14576,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14470,7 +14590,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateFriendship.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14482,7 +14604,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateParent.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14494,7 +14618,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14506,7 +14632,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePostAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14518,7 +14646,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePostEditor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14530,7 +14660,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePostModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14542,7 +14674,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14554,7 +14688,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateTest1.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14566,7 +14702,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14578,7 +14716,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onCreateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreateUserModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14590,7 +14730,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14602,7 +14744,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14614,7 +14758,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteFriendship.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14626,7 +14772,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteParent.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14638,7 +14786,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14650,7 +14800,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePostAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14662,7 +14814,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePostEditor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14674,7 +14828,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePostModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14686,7 +14842,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14698,7 +14856,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteTest1.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14710,7 +14870,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14722,7 +14884,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeleteUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeleteUserModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14734,7 +14898,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateChild.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14746,7 +14912,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateComment.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateComment.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14758,7 +14926,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateFriendship.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14770,7 +14940,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateParent.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14782,7 +14954,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14794,7 +14968,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePostAuthor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14806,7 +14982,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePostEditor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePostEditor.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14818,7 +14996,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePostModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14830,7 +15010,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14842,7 +15024,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateTest1.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateTest1.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14854,7 +15038,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUser.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -14866,7 +15052,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdateUserModel.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -605,7 +605,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.createPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 ## Begin - key condition **
@@ -700,7 +702,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Mutation.deletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $DeleteRequest = {
@@ -777,7 +781,9 @@ $util.toJson({
 })
 ## [End] Initialization default values. **",
   "Mutation.updatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
@@ -917,7 +923,9 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 ## [End] ResponseTemplate. **",
   "Query.getPost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
@@ -964,7 +972,9 @@ $util.unauthorized()
 #end
 ## [End] Get Response template. **",
   "Query.listPosts.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
@@ -1125,7 +1135,9 @@ $util.toJson({
   \\"aggregateItems\\": $aggregateValues
 })",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onCreatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1137,7 +1149,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onDeletePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({
@@ -1149,7 +1163,9 @@ $util.toJson({
 $util.toJson(null)
 ## [End] Subscription Resonse template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
-$util.unauthorized()
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
 ## [End] Sandbox Mode Disabled. **",
   "Subscription.onUpdatePost.req.vtl": "## [Start] Subscription Request template. **
 $util.toJson({


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Makes sure that unauthorized is set when hasAuth flag is false.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.