### PR TITLE
fix(graphql-transformer-core): add default api name when generating stack

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -241,7 +241,10 @@ export class GraphQLTransform {
 
     const rootStack = stackManager.rootStack;
     const authorizationConfig = adoptAuthModes(stackManager, this.authConfig);
-    const apiName = stackManager.addParameter('AppSyncApiName', { type: 'String' }).valueAsString;
+    const apiName = stackManager.addParameter('AppSyncApiName', {
+      default: 'AppSyncSimpleTransform',
+      type: 'String',
+    }).valueAsString;
     const envName = stackManager.getParameter('env');
     assert(envName);
     const api = new GraphQLApi(rootStack, 'GraphQLAPI', {


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
When porting over some tests for the next version of transformers, a test was failing because the default value for this template was missing. This adds the default value for the API name.



#### Description of how you validated changes
Working on the `amplify-mock-utils` test highlighted that this value was missing. The tests to verify this will be a in a different PR.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.