### PR TITLE
fix(amplify-category-auth): handle undefined aliasattributes

### DIFF
--- a/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
+++ b/packages/amplify-category-auth/resources/cloudformation-templates/auth-template.yml.ejs
@@ -1,4 +1,4 @@
-<% var autoVerifiedAttributes = props.autoVerifiedAttributes ? props.autoVerifiedAttributes.concat(props.aliasAttributes).filter((attr, i, aliasAttributeArray) => ['email', 'phone_number'].includes(attr) && aliasAttributeArray.indexOf(attr) === i) : [] %>
+<% var autoVerifiedAttributes = props.autoVerifiedAttributes ? props.autoVerifiedAttributes.concat(props.aliasAttributes ? props.aliasAttributes : []).filter((attr, i, aliasAttributeArray) => ['email', 'phone_number'].includes(attr) && aliasAttributeArray.indexOf(attr) === i) : [] %>
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:

--- a/packages/amplify-category-auth/src/commands/auth/update.js
+++ b/packages/amplify-category-auth/src/commands/auth/update.js
@@ -38,7 +38,7 @@ module.exports = {
           const authAttributes = JSON.parse(
             fs.readFileSync(pathManager.getResourceParametersFilePath(undefined, 'auth', services[i])).toString(),
           );
-          if (authAttributes.aliasAttributes.length > 0) {
+          if (authAttributes.aliasAttributes && authAttributes.aliasAttributes.length > 0) {
             const authUpdateWarning = await BannerMessage.getMessage('AMPLIFY_UPDATE_AUTH_ALIAS_ATTRIBUTES_WARNING');
             printer.warn(authUpdateWarning);
           }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`amplify update auth` is currently broken for CLI users that created auth before v5.2.0, because generated `parameters.json` file does not contain `aliasAttributes` key. This PR adds handling for the undefined alias attributes case, fixing `amplify update auth` for that case


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/8221


#### Description of how you validated changes

Created auth using v5.1.0
Updated auth using v6 (including this change)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.