### PR TITLE
chore(amplify-prompts): prompts typo fix

### DIFF
--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -56,7 +56,7 @@ export type ResourceName = string;
 
 export type IContextPrint = {
   /**
-   * @deprecated Use printer.info from amplify-prommpts instead
+   * @deprecated Use printer.info from amplify-prompts instead
    */
   info: (message: string) => void;
   /**
@@ -72,7 +72,7 @@ export type IContextPrint = {
    */
   error: (message: string) => void;
   /**
-   * @deprecated Use printer.success from amplify-prommpts instead
+   * @deprecated Use printer.success from amplify-prompts instead
    */
   success: (message: string) => void;
   /**

--- a/packages/amplify-prompts/src/demo/demo.ts
+++ b/packages/amplify-prompts/src/demo/demo.ts
@@ -2,11 +2,11 @@ import { printer } from '../printer';
 import { prompter } from '../prompter';
 import { alphanumeric, and, integer, minLength } from '../validators';
 
-const printResult = (result: any) => console.log(`Prommpt result was [${result}]`);
+const printResult = (result: any) => console.log(`Prompt result was [${result}]`);
 const printTypeofResult = (result: any) => console.log(`Response type was [${typeof result}]`);
 
 /**
- * The following is meant to be a runnable example of functionality offered by amplify-prommpts
+ * The following is meant to be a runnable example of functionality offered by amplify-prompts
  * Run `yarn demo` to see it in action
  */
 const demo = async () => {
@@ -76,7 +76,7 @@ const demo = async () => {
 
   // pick
   printer.blankLine();
-  printer.info('prommpter.pick is used to select one or more items fromm a selection set');
+  printer.info('prompter.pick is used to select one or more items fromm a selection set');
   printer.info('It supports autocomplete of choices automatically');
   const choices1 = ['red', 'yellow', 'green', 'orange', 'purple'];
   printResult(await prompter.pick('Pick your favorite Skittle color', choices1));


### PR DESCRIPTION
Correct typos in amplify prompts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
