### PR TITLE
geo category check for unsupported regions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1018,7 +1018,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/geo-remove.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   geo-update-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1026,7 +1026,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/geo-update.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   geo-add-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1034,7 +1034,7 @@ jobs:
     steps: *ref_5
     environment:
       TEST_SUITE: src/__tests__/geo-add.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   hostingPROD-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_1
@@ -1755,7 +1755,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/geo-remove.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
     steps: *ref_6
   geo-update-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1765,7 +1765,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/geo-update.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
     steps: *ref_6
   geo-add-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -1775,7 +1775,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
       TEST_SUITE: src/__tests__/geo-add.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
     steps: *ref_6
   hostingPROD-amplify_e2e_tests_pkg_linux:
     working_directory: ~/repo
@@ -2612,36 +2612,30 @@ workflows:
           filters: *ref_10
           requires:
             - migration-api-connection-migration-amplify_e2e_tests
-      - geo-remove-amplify_e2e_tests:
-          context: *ref_8
-          post-steps: *ref_9
-          filters: *ref_10
-          requires:
-            - schema-auth-11-amplify_e2e_tests
       - feature-flags-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - import_s3_1-amplify_e2e_tests
+            - schema-auth-11-amplify_e2e_tests
       - schema-versioned-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - schema-auth-7-amplify_e2e_tests
+            - import_s3_1-amplify_e2e_tests
       - plugin-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - schema-auth-3-amplify_e2e_tests
+            - schema-auth-7-amplify_e2e_tests
       - hooks-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - geo-remove-amplify_e2e_tests
+            - schema-auth-3-amplify_e2e_tests
       - auth_6-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -2684,7 +2678,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-model-amplify_e2e_tests
-      - geo-update-amplify_e2e_tests:
+      - geo-remove-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2713,7 +2707,7 @@ workflows:
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - geo-update-amplify_e2e_tests
+            - geo-remove-amplify_e2e_tests
       - api_4-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -2756,7 +2750,7 @@ workflows:
           filters: *ref_10
           requires:
             - schema-function-amplify_e2e_tests
-      - geo-add-amplify_e2e_tests:
+      - geo-update-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
@@ -2785,7 +2779,7 @@ workflows:
           post-steps: *ref_9
           filters: *ref_10
           requires:
-            - geo-add-amplify_e2e_tests
+            - geo-update-amplify_e2e_tests
       - schema-auth-2-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -2822,30 +2816,36 @@ workflows:
           filters: *ref_10
           requires:
             - function_4-amplify_e2e_tests
-      - hostingPROD-amplify_e2e_tests:
+      - geo-add-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - env-amplify_e2e_tests
-      - amplify-app-amplify_e2e_tests:
+      - hostingPROD-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - api_3-amplify_e2e_tests
-      - init-amplify_e2e_tests:
+      - amplify-app-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - layer-amplify_e2e_tests
-      - pull-amplify_e2e_tests:
+      - init-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
           filters: *ref_10
           requires:
             - auth_5-amplify_e2e_tests
+      - pull-amplify_e2e_tests:
+          context: *ref_8
+          post-steps: *ref_9
+          filters: *ref_10
+          requires:
+            - geo-add-amplify_e2e_tests
       - function_5-amplify_e2e_tests:
           context: *ref_8
           post-steps: *ref_9
@@ -3120,36 +3120,30 @@ workflows:
           filters: *ref_13
           requires:
             - migration-api-connection-migration-amplify_e2e_tests_pkg_linux
-      - geo-remove-amplify_e2e_tests_pkg_linux:
-          context: *ref_11
-          post-steps: *ref_12
-          filters: *ref_13
-          requires:
-            - schema-auth-11-amplify_e2e_tests_pkg_linux
       - feature-flags-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - import_s3_1-amplify_e2e_tests_pkg_linux
+            - schema-auth-11-amplify_e2e_tests_pkg_linux
       - schema-versioned-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - schema-auth-7-amplify_e2e_tests_pkg_linux
+            - import_s3_1-amplify_e2e_tests_pkg_linux
       - plugin-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - schema-auth-3-amplify_e2e_tests_pkg_linux
+            - schema-auth-7-amplify_e2e_tests_pkg_linux
       - hooks-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - geo-remove-amplify_e2e_tests_pkg_linux
+            - schema-auth-3-amplify_e2e_tests_pkg_linux
       - auth_6-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
@@ -3196,7 +3190,7 @@ workflows:
           filters: *ref_13
           requires:
             - schema-model-amplify_e2e_tests_pkg_linux
-      - geo-update-amplify_e2e_tests_pkg_linux:
+      - geo-remove-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3225,7 +3219,7 @@ workflows:
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - geo-update-amplify_e2e_tests_pkg_linux
+            - geo-remove-amplify_e2e_tests_pkg_linux
       - api_4-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
@@ -3272,7 +3266,7 @@ workflows:
           filters: *ref_13
           requires:
             - schema-function-amplify_e2e_tests_pkg_linux
-      - geo-add-amplify_e2e_tests_pkg_linux:
+      - geo-update-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
@@ -3301,7 +3295,7 @@ workflows:
           post-steps: *ref_12
           filters: *ref_13
           requires:
-            - geo-add-amplify_e2e_tests_pkg_linux
+            - geo-update-amplify_e2e_tests_pkg_linux
       - schema-auth-2-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
@@ -3342,30 +3336,36 @@ workflows:
           filters: *ref_13
           requires:
             - function_4-amplify_e2e_tests_pkg_linux
-      - hostingPROD-amplify_e2e_tests_pkg_linux:
+      - geo-add-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - env-amplify_e2e_tests_pkg_linux
-      - amplify-app-amplify_e2e_tests_pkg_linux:
+      - hostingPROD-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - api_3-amplify_e2e_tests_pkg_linux
-      - init-amplify_e2e_tests_pkg_linux:
+      - amplify-app-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - layer-amplify_e2e_tests_pkg_linux
-      - pull-amplify_e2e_tests_pkg_linux:
+      - init-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12
           filters: *ref_13
           requires:
             - auth_5-amplify_e2e_tests_pkg_linux
+      - pull-amplify_e2e_tests_pkg_linux:
+          context: *ref_11
+          post-steps: *ref_12
+          filters: *ref_13
+          requires:
+            - geo-add-amplify_e2e_tests_pkg_linux
       - function_5-amplify_e2e_tests_pkg_linux:
           context: *ref_11
           post-steps: *ref_12

--- a/packages/amplify-category-geo/src/__tests__/commands/geo/add.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/commands/geo/add.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext, stateManager, $TSObject } from 'amplify-cli-core';
 import { addResource } from '../../../provider-controllers/index';
 import { ServiceName } from '../../../service-utils/constants';
 import { run } from '../../../commands/geo/add';
@@ -13,6 +13,10 @@ jest.mock('../../../provider-controllers/index');
 describe('add command tests', () => {
     const provider = 'awscloudformation';
     let mockContext: $TSContext;
+    // construct mock amplify meta
+    const mockAmplifyMeta: $TSObject = {
+        providers: {}
+    };
         
     beforeEach(() => {
         jest.clearAllMocks();
@@ -23,6 +27,10 @@ describe('add command tests', () => {
             },
             amplify: {}
         } as unknown) as $TSContext;
+        mockAmplifyMeta.providers[provider] = {
+            Region: 'us-west-2'
+        };
+        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
     });
 
     it('add resource workflow is invoked for map service', async() => {
@@ -45,5 +53,16 @@ describe('add command tests', () => {
         await run(mockContext);
 
         expect(mockAddResource).toHaveBeenCalledWith(mockContext, service);
+    });
+
+    it('add resource workflow is not invoked for unsupported region', async() => {
+        mockAmplifyMeta.providers[provider] = {
+            Region: 'eu-west-2'
+        };
+        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
+
+        await run(mockContext);
+
+        expect(mockAddResource).toBeCalledTimes(0);
     });
 });

--- a/packages/amplify-category-geo/src/__tests__/commands/geo/remove.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/commands/geo/remove.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext, stateManager, $TSObject } from 'amplify-cli-core';
 import { removeResource } from '../../../provider-controllers';
 import { ServiceName } from '../../../service-utils/constants';
 import { run } from '../../../commands/geo/remove';
@@ -18,6 +18,10 @@ jest.mock('../../../provider-controllers');
 describe('remove command tests', () => {
     const provider = 'awscloudformation';
     let mockContext: $TSContext;
+    // construct mock amplify meta
+    const mockAmplifyMeta: $TSObject = {
+        providers: {}
+    };
     
     beforeEach(() => {
         jest.clearAllMocks();
@@ -28,6 +32,10 @@ describe('remove command tests', () => {
             },
             amplify: {}
         } as unknown) as $TSContext;
+        mockAmplifyMeta.providers[provider] = {
+            Region: 'us-west-2'
+        };
+        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
     });
 
     it('remove resource workflow is invoked for map service', async() => {
@@ -50,5 +58,16 @@ describe('remove command tests', () => {
         await run(mockContext);
 
         expect(mockRemoveResource).toHaveBeenCalledWith(mockContext, service);
+    });
+
+    it('remove resource workflow is not invoked for unsupported region', async() => {
+        mockAmplifyMeta.providers[provider] = {
+            Region: 'eu-west-2'
+        };
+        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
+
+        await run(mockContext);
+
+        expect(mockRemoveResource).toBeCalledTimes(0);
     });
 });

--- a/packages/amplify-category-geo/src/__tests__/commands/geo/update.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/commands/geo/update.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext, stateManager, $TSObject } from 'amplify-cli-core';
 import { updateResource } from '../../../provider-controllers/index';
 import { ServiceName } from '../../../service-utils/constants';
 import { run } from '../../../commands/geo/update';
@@ -13,6 +13,10 @@ jest.mock('../../../provider-controllers/index');
 describe('update command tests', () => {
     const provider = 'awscloudformation';
     let mockContext: $TSContext;
+    // construct mock amplify meta
+    const mockAmplifyMeta: $TSObject = {
+        providers: {}
+    };
     
     beforeEach(() => {
         jest.clearAllMocks();
@@ -23,6 +27,10 @@ describe('update command tests', () => {
             },
             amplify: {}
         } as unknown) as $TSContext;
+        mockAmplifyMeta.providers[provider] = {
+            Region: 'us-west-2'
+        };
+        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
     });
 
     it('update resource workflow is invoked for map service', async() => {
@@ -45,5 +53,16 @@ describe('update command tests', () => {
         await run(mockContext);
 
         expect(mockUpdateResource).toHaveBeenCalledWith(mockContext, service);
+    });
+
+    it('update resource workflow is not invoked for unsupported region', async() => {
+        mockAmplifyMeta.providers[provider] = {
+            Region: 'eu-west-2'
+        };
+        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
+
+        await run(mockContext);
+
+        expect(mockUpdateResource).toBeCalledTimes(0);
     });
 });

--- a/packages/amplify-category-geo/src/commands/geo/add.ts
+++ b/packages/amplify-category-geo/src/commands/geo/add.ts
@@ -1,16 +1,21 @@
-import { chooseServiceMessageAdd, previewBanner, provider } from '../../service-utils/constants';
-import { category } from '../../constants';
+import { chooseServiceMessageAdd, provider } from '../../service-utils/constants';
+import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
-import { $TSAny, $TSContext } from 'amplify-cli-core';
-import { addResource } from '../../provider-controllers';
+import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
+import { addResource, unsupportedRegionError } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
 
 export const name = 'add';
 
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
-
   try {
+    const region = stateManager.getMeta()?.providers[provider]?.Region;
+    if(!supportedRegions.includes(region)) {
+      printer.error(unsupportedRegionError(region));
+      return;
+    }
+
     const result: {service: string, providerName: string} = await amplify.serviceSelectionPrompt(context, category, supportedServices, chooseServiceMessageAdd);
 
     if (result.providerName !== provider) {

--- a/packages/amplify-category-geo/src/commands/geo/add.ts
+++ b/packages/amplify-category-geo/src/commands/geo/add.ts
@@ -1,18 +1,17 @@
 import { chooseServiceMessageAdd, provider } from '../../service-utils/constants';
-import { category, supportedRegions } from '../../constants';
+import { category } from '../../constants';
 import { supportedServices } from '../../supportedServices';
-import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
-import { addResource, unsupportedRegionMessage } from '../../provider-controllers';
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { addResource } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
+import { verifySupportedRegion } from '../../service-utils/resourceUtils';
 
 export const name = 'add';
 
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
   try {
-    const region = stateManager.getMeta()?.providers[provider]?.Region;
-    if(!supportedRegions.includes(region)) {
-      printer.error(unsupportedRegionMessage(region));
+    if(!verifySupportedRegion()) {
       return;
     }
 

--- a/packages/amplify-category-geo/src/commands/geo/add.ts
+++ b/packages/amplify-category-geo/src/commands/geo/add.ts
@@ -2,7 +2,7 @@ import { chooseServiceMessageAdd, provider } from '../../service-utils/constants
 import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
 import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
-import { addResource, unsupportedRegionError } from '../../provider-controllers';
+import { addResource, unsupportedRegionMessage } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
 
 export const name = 'add';
@@ -12,7 +12,7 @@ export const run = async(context: $TSContext) => {
   try {
     const region = stateManager.getMeta()?.providers[provider]?.Region;
     if(!supportedRegions.includes(region)) {
-      printer.error(unsupportedRegionError(region));
+      printer.error(unsupportedRegionMessage(region));
       return;
     }
 

--- a/packages/amplify-category-geo/src/commands/geo/console.ts
+++ b/packages/amplify-category-geo/src/commands/geo/console.ts
@@ -1,6 +1,6 @@
-import { $TSContext } from 'amplify-cli-core';
-import { openConsole } from '../../provider-controllers';
-import { category } from '../../constants';
+import { $TSContext, stateManager } from 'amplify-cli-core';
+import { openConsole, unsupportedRegionError } from '../../provider-controllers';
+import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
 import { provider } from '../../service-utils/constants';
 import { printer } from 'amplify-prompts';
@@ -9,11 +9,18 @@ export const name = 'console';
 
 export const run = async (context: $TSContext) => {
   const { amplify } = context;
+  const region = stateManager.getMeta()?.providers[provider]?.Region;
+  if(!supportedRegions.includes(region)) {
+    printer.error(unsupportedRegionError(region));
+    return;
+  }
+
   const result: {service: string, providerName: string} = await amplify.serviceSelectionPrompt(context, category, supportedServices);
 
   if (result.providerName !== provider) {
     printer.error(`Provider ${result.providerName} not configured for this category`);
     return;
   }
+
   return openConsole(result.service);
 };

--- a/packages/amplify-category-geo/src/commands/geo/console.ts
+++ b/packages/amplify-category-geo/src/commands/geo/console.ts
@@ -1,17 +1,16 @@
-import { $TSContext, stateManager } from 'amplify-cli-core';
-import { openConsole, unsupportedRegionMessage } from '../../provider-controllers';
-import { category, supportedRegions } from '../../constants';
+import { $TSContext } from 'amplify-cli-core';
+import { openConsole } from '../../provider-controllers';
+import { category } from '../../constants';
 import { supportedServices } from '../../supportedServices';
 import { provider } from '../../service-utils/constants';
 import { printer } from 'amplify-prompts';
+import { verifySupportedRegion } from '../../service-utils/resourceUtils';
 
 export const name = 'console';
 
 export const run = async (context: $TSContext) => {
   const { amplify } = context;
-  const region = stateManager.getMeta()?.providers[provider]?.Region;
-  if(!supportedRegions.includes(region)) {
-    printer.error(unsupportedRegionMessage(region));
+  if(!verifySupportedRegion()) {
     return;
   }
 

--- a/packages/amplify-category-geo/src/commands/geo/console.ts
+++ b/packages/amplify-category-geo/src/commands/geo/console.ts
@@ -1,5 +1,5 @@
 import { $TSContext, stateManager } from 'amplify-cli-core';
-import { openConsole, unsupportedRegionError } from '../../provider-controllers';
+import { openConsole, unsupportedRegionMessage } from '../../provider-controllers';
 import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
 import { provider } from '../../service-utils/constants';
@@ -11,7 +11,7 @@ export const run = async (context: $TSContext) => {
   const { amplify } = context;
   const region = stateManager.getMeta()?.providers[provider]?.Region;
   if(!supportedRegions.includes(region)) {
-    printer.error(unsupportedRegionError(region));
+    printer.error(unsupportedRegionMessage(region));
     return;
   }
 

--- a/packages/amplify-category-geo/src/commands/geo/remove.ts
+++ b/packages/amplify-category-geo/src/commands/geo/remove.ts
@@ -1,8 +1,8 @@
 import { chooseServiceMessageRemove, provider } from '../../service-utils/constants';
-import { category } from '../../constants';
+import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
-import { $TSAny, $TSContext } from 'amplify-cli-core';
-import { removeResource } from '../../provider-controllers';
+import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
+import { removeResource, unsupportedRegionError } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
 
 export const name = 'remove';
@@ -10,6 +10,12 @@ export const name = 'remove';
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
   try {
+    const region = stateManager.getMeta()?.providers[provider]?.Region;
+    if(!supportedRegions.includes(region)) {
+      printer.error(unsupportedRegionError(region));
+      return;
+    }
+
     const result: {service: string, providerName: string} = await amplify.serviceSelectionPrompt(context, category, supportedServices, chooseServiceMessageRemove);
 
     if (result.providerName !== provider) {

--- a/packages/amplify-category-geo/src/commands/geo/remove.ts
+++ b/packages/amplify-category-geo/src/commands/geo/remove.ts
@@ -1,18 +1,17 @@
 import { chooseServiceMessageRemove, provider } from '../../service-utils/constants';
-import { category, supportedRegions } from '../../constants';
+import { category } from '../../constants';
 import { supportedServices } from '../../supportedServices';
-import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
-import { removeResource, unsupportedRegionMessage } from '../../provider-controllers';
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { removeResource } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
+import { verifySupportedRegion } from '../../service-utils/resourceUtils';
 
 export const name = 'remove';
 
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
   try {
-    const region = stateManager.getMeta()?.providers[provider]?.Region;
-    if(!supportedRegions.includes(region)) {
-      printer.error(unsupportedRegionMessage(region));
+    if(!verifySupportedRegion()) {
       return;
     }
 

--- a/packages/amplify-category-geo/src/commands/geo/remove.ts
+++ b/packages/amplify-category-geo/src/commands/geo/remove.ts
@@ -2,7 +2,7 @@ import { chooseServiceMessageRemove, provider } from '../../service-utils/consta
 import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
 import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
-import { removeResource, unsupportedRegionError } from '../../provider-controllers';
+import { removeResource, unsupportedRegionMessage } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
 
 export const name = 'remove';
@@ -12,7 +12,7 @@ export const run = async(context: $TSContext) => {
   try {
     const region = stateManager.getMeta()?.providers[provider]?.Region;
     if(!supportedRegions.includes(region)) {
-      printer.error(unsupportedRegionError(region));
+      printer.error(unsupportedRegionMessage(region));
       return;
     }
 

--- a/packages/amplify-category-geo/src/commands/geo/update.ts
+++ b/packages/amplify-category-geo/src/commands/geo/update.ts
@@ -2,7 +2,7 @@ import { chooseServiceMessageUpdate, provider } from '../../service-utils/consta
 import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
 import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
-import { updateResource, unsupportedRegionError } from '../../provider-controllers';
+import { updateResource, unsupportedRegionMessage } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
 
 export const name = 'update';
@@ -12,7 +12,7 @@ export const run = async(context: $TSContext) => {
   try {
     const region = stateManager.getMeta()?.providers[provider]?.Region;
     if(!supportedRegions.includes(region)) {
-      printer.error(unsupportedRegionError(region));
+      printer.error(unsupportedRegionMessage(region));
       return;
     }
 

--- a/packages/amplify-category-geo/src/commands/geo/update.ts
+++ b/packages/amplify-category-geo/src/commands/geo/update.ts
@@ -1,8 +1,8 @@
 import { chooseServiceMessageUpdate, provider } from '../../service-utils/constants';
-import { category } from '../../constants';
+import { category, supportedRegions } from '../../constants';
 import { supportedServices } from '../../supportedServices';
-import { $TSAny, $TSContext } from 'amplify-cli-core';
-import { updateResource } from '../../provider-controllers';
+import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
+import { updateResource, unsupportedRegionError } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
 
 export const name = 'update';
@@ -10,6 +10,12 @@ export const name = 'update';
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
   try {
+    const region = stateManager.getMeta()?.providers[provider]?.Region;
+    if(!supportedRegions.includes(region)) {
+      printer.error(unsupportedRegionError(region));
+      return;
+    }
+
     const result: {service: string, providerName: string} = await amplify.serviceSelectionPrompt(context, category, supportedServices, chooseServiceMessageUpdate);
 
     if (result.providerName !== provider) {

--- a/packages/amplify-category-geo/src/commands/geo/update.ts
+++ b/packages/amplify-category-geo/src/commands/geo/update.ts
@@ -1,18 +1,17 @@
 import { chooseServiceMessageUpdate, provider } from '../../service-utils/constants';
-import { category, supportedRegions } from '../../constants';
+import { category } from '../../constants';
 import { supportedServices } from '../../supportedServices';
-import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
-import { updateResource, unsupportedRegionMessage } from '../../provider-controllers';
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { updateResource } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
+import { verifySupportedRegion } from '../../service-utils/resourceUtils';
 
 export const name = 'update';
 
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
   try {
-    const region = stateManager.getMeta()?.providers[provider]?.Region;
-    if(!supportedRegions.includes(region)) {
-      printer.error(unsupportedRegionMessage(region));
+    if(!verifySupportedRegion()) {
       return;
     }
 

--- a/packages/amplify-category-geo/src/constants.ts
+++ b/packages/amplify-category-geo/src/constants.ts
@@ -1,1 +1,14 @@
 export const category = 'geo';
+
+// https://aws.amazon.com/location/faqs/#:~:text=Amazon%20Location%20Service%20is%20available,Asia%20Pacific%20(Tokyo)%20regions
+export const supportedRegions = [
+    'us-east-1',
+    'us-east-2',
+    'us-west-2',
+    'ap-southeast-1',
+    'ap-southeast-2',
+    'ap-northeast-1',
+    'eu-central-1',
+    'eu-west-1',
+    'eu-north-1'
+];

--- a/packages/amplify-category-geo/src/provider-controllers/index.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/index.ts
@@ -121,7 +121,3 @@ const badServiceError = (service: string) => {
 export const insufficientInfoForUpdateError = (service: ServiceName) => {
   new Error(`Insufficient information to update ${getServiceFriendlyName(service)}. Please re-try and provide all inputs.`);
 }
-
-export const unsupportedRegionMessage = (region: string): string => {
-  return `Geo category is not supported in your region: ${region}`
-};

--- a/packages/amplify-category-geo/src/provider-controllers/index.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/index.ts
@@ -121,3 +121,7 @@ const badServiceError = (service: string) => {
 export const insufficientInfoForUpdateError = (service: ServiceName) => {
   new Error(`Insufficient information to update ${getServiceFriendlyName(service)}. Please re-try and provide all inputs.`);
 }
+
+export const unsupportedRegionError = (region: string): string => {
+  return `Geo category is not supported in your region: ${region}`;
+}

--- a/packages/amplify-category-geo/src/provider-controllers/index.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/index.ts
@@ -122,6 +122,6 @@ export const insufficientInfoForUpdateError = (service: ServiceName) => {
   new Error(`Insufficient information to update ${getServiceFriendlyName(service)}. Please re-try and provide all inputs.`);
 }
 
-export const unsupportedRegionError = (region: string): string => {
-  return `Geo category is not supported in your region: ${region}`;
-}
+export const unsupportedRegionMessage = (region: string): string => {
+  return `Geo category is not supported in your region: ${region}`
+};

--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -1,9 +1,9 @@
 import { JSONUtilities, pathManager, $TSObject, stateManager, $TSContext } from 'amplify-cli-core';
-import { category } from '../constants';
+import { category, supportedRegions } from '../constants';
 import path from 'path';
 import _ from 'lodash';
 import { BaseStack } from '../service-stacks/baseStack';
-import { parametersFileName, ServiceName } from './constants';
+import { parametersFileName, ServiceName, provider } from './constants';
 import { PricingPlan, ResourceParameters, AccessType } from './resourceParams';
 import os from 'os';
 import { getMapIamPolicies } from './mapUtils';
@@ -215,3 +215,12 @@ export const getServicePermissionPolicies = (
   }
   return {policy: [], attributes: []};
 }
+
+export const verifySupportedRegion = (): boolean => {
+  const currentRegion = stateManager.getMeta()?.providers[provider]?.Region;
+  if(!supportedRegions.includes(currentRegion)) {
+    printer.error(`Geo category is not supported in your region: ${currentRegion}`);
+    return false;
+  }
+  return true;
+};

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -2,6 +2,8 @@ import * as yaml from 'js-yaml';
 import * as glob from 'glob';
 import { join } from 'path';
 import * as fs from 'fs-extra';
+import { supportedRegions } from '../packages/amplify-category-geo/src/constants';
+
 const CONCURRENCY = 4;
 // Ensure to update packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts is also updated this gets updated
 const AWS_REGIONS_TO_RUN_TESTS = [
@@ -305,9 +307,7 @@ function getRequiredJob(jobNames: string[], index: number, concurrency: number =
  */
 function getSupportedRegions(suite: string): string[] {
   if (suite.startsWith('src/__tests__/geo')) {
-    return AWS_REGIONS_TO_RUN_TESTS.filter(function(value, index, arr){ 
-      return value !== 'eu-west-2';
-    });
+    return AWS_REGIONS_TO_RUN_TESTS.filter(region => supportedRegions.includes(region));
   }
   return AWS_REGIONS_TO_RUN_TESTS;
 }

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -166,7 +166,8 @@ function splitTests(
   const testSuites = getTestFiles(jobRootDir);
 
   const newJobs = testSuites.reduce((acc, suite, index) => {
-    const testRegion = AWS_REGIONS_TO_RUN_TESTS[index % AWS_REGIONS_TO_RUN_TESTS.length];
+    const supportedRegions = getSupportedRegions(suite);
+    const testRegion = supportedRegions[index % supportedRegions.length];
     const newJob = {
       ...job,
       environment: {
@@ -296,6 +297,19 @@ function getRequiredJob(jobNames: string[], index: number, concurrency: number =
     const prevIndex = (mult - 1) * concurrency + mod;
     return jobNames[prevIndex];
   }
+}
+
+/**
+ * Helper function to filter unsupported regions for certain category tests
+ * @returns list of supported regions
+ */
+function getSupportedRegions(suite: string): string[] {
+  if (suite.startsWith('src/__tests__/geo')) {
+    return AWS_REGIONS_TO_RUN_TESTS.filter(function(value, index, arr){ 
+      return value !== 'eu-west-2';
+    });
+  }
+  return AWS_REGIONS_TO_RUN_TESTS;
 }
 
 function loadConfig(): CircleCIConfig {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Check if the Amplify project's region is supported by Amazon Location Service before allowing add/update/remove of Geo resources. 
[service region support doc](https://aws.amazon.com/location/faqs/#:~:text=Amazon%20Location%20Service%20is%20available,Asia%20Pacific%20(Tokyo)%20regions).

Modify the `split-e2e-tests` script to handle unsupported regions during region assignment.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
