### PR TITLE
fix: #8254 invalid url is shown for branches with slash

### DIFF
--- a/packages/amplify-console-hosting/utils/table-utils.js
+++ b/packages/amplify-console-hosting/utils/table-utils.js
@@ -19,9 +19,10 @@ async function generateTableContentForApp(context, appId) {
         .promise();
 
       for (const branch of branches) {
-        const { branchName } = branch;
+        const { branchName, displayName } = branch;
+        const validDisplayName = displayName || branchName;
         domainMap[branchName] = [];
-        domainMap[branchName].push(`https://${branchName}.${appId}.amplifyapp.com`);
+        domainMap[branchName].push(`https://${validDisplayName}.${appId}.amplifyapp.com`);
       }
     } while (nextToken != null);
 


### PR DESCRIPTION
#### Description of changes

Hosting URL will be correctly displayed when branch name has slashes in it.

#### Issue #, if available

fixes: #8254 

#### Description of how you validated changes

Manual testing as it requires specific project setup 
 
#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)
- [X] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
