### PR TITLE
fix(amplify-nodejs-function-runtime-provider): catch yarn 2 error on lambda build

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -60,6 +60,8 @@ function runPackageManager(cwd: string, buildType?: BuildType, scriptName?: stri
   } catch (error) {
     if ((error as any).code === 'ENOENT') {
       throw new Error(`Packaging lambda function failed. Could not find ${packageManager} executable in the PATH.`);
+    } else if (error.stdout?.includes('YN0050: The --production option is deprecated')) {
+      throw new Error(`Packaging lambda function failed. Yarn 2 is not supported. Use Yarn 1.x and push again.`);
     } else {
       throw new Error(`Packaging lambda function failed with the error \n${error.message}`);
     }


### PR DESCRIPTION


#### Description of changes

Displays a graceful error when a user attempts to push up a lambda with Yarn 2 and directs them to use Yarn 1.

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/7883

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
