### PR TITLE
fix(graphql-model-transformer): remove unnecessary warnings for resolver config per type

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -171,7 +171,9 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
 
     // todo: get model configuration with default values and store it in the map
     const typeName = definition.name.value;
-    SyncUtils.validateResolverConfigForType(ctx, typeName);
+    if (ctx.isProjectUsingDataStore()) {
+      SyncUtils.validateResolverConfigForType(ctx, typeName);
+    }
     const directiveWrapped: DirectiveWrapper = new DirectiveWrapper(directive);
     const options = directiveWrapped.getArguments({
       queries: {


### PR DESCRIPTION
#### Description of changes
- validate resolver config per type only if project data store is enabled

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
