### PR TITLE
Add pre-push hook to verify region support

### DIFF
--- a/packages/amplify-category-geo/amplify-plugin.json
+++ b/packages/amplify-category-geo/amplify-plugin.json
@@ -12,5 +12,5 @@
     "commandAliases":{
         "configure": "update"
     },
-    "eventHandlers": []
+    "eventHandlers": ["PrePush"]
 }

--- a/packages/amplify-category-geo/src/__tests__/commands/geo/remove.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/commands/geo/remove.test.ts
@@ -59,15 +59,4 @@ describe('remove command tests', () => {
 
         expect(mockRemoveResource).toHaveBeenCalledWith(mockContext, service);
     });
-
-    it('remove resource workflow is not invoked for unsupported region', async() => {
-        mockAmplifyMeta.providers[provider] = {
-            Region: 'eu-west-2'
-        };
-        stateManager.getMeta = jest.fn().mockReturnValue(mockAmplifyMeta);
-
-        await run(mockContext);
-
-        expect(mockRemoveResource).toBeCalledTimes(0);
-    });
 });

--- a/packages/amplify-category-geo/src/commands/geo/remove.ts
+++ b/packages/amplify-category-geo/src/commands/geo/remove.ts
@@ -4,17 +4,12 @@ import { supportedServices } from '../../supportedServices';
 import { $TSAny, $TSContext } from 'amplify-cli-core';
 import { removeResource } from '../../provider-controllers';
 import { printer } from 'amplify-prompts';
-import { verifySupportedRegion } from '../../service-utils/resourceUtils';
 
 export const name = 'remove';
 
 export const run = async(context: $TSContext) => {
   const { amplify } = context;
   try {
-    if(!verifySupportedRegion()) {
-      return;
-    }
-
     const result: {service: string, providerName: string} = await amplify.serviceSelectionPrompt(context, category, supportedServices, chooseServiceMessageRemove);
 
     if (result.providerName !== provider) {

--- a/packages/amplify-category-geo/src/index.ts
+++ b/packages/amplify-category-geo/src/index.ts
@@ -1,11 +1,11 @@
-import { $TSContext, $TSObject, stateManager } from 'amplify-cli-core';
+import { $TSContext, $TSObject, stateManager, exitOnNextTick, $TSAny } from 'amplify-cli-core';
 import { category } from './constants';
 import * as addCommand from './commands/geo/add';
 import * as updateCommand from './commands/geo/update';
 import * as removeCommand from './commands/geo/remove';
 import * as consoleCommand from './commands/geo/console';
 import * as helpCommand from './commands/geo/help';
-import { getServicePermissionPolicies } from './service-utils/resourceUtils';
+import { getServicePermissionPolicies, verifySupportedRegion, checkAnyGeoResourceExists } from './service-utils/resourceUtils';
 import { ServiceName } from './service-utils/constants';
 import { printer } from 'amplify-prompts';
 
@@ -32,9 +32,19 @@ export const executeAmplifyCommand = async (context: $TSContext) => {
     }
 };
 
-export const handleAmplifyEvent = (context: $TSContext, args: $TSObject) => {
-    printer.info(`${category} handleAmplifyEvent to be implemented`);
-    printer.info(`Received event args ${args}`);
+export const handleAmplifyEvent = async (context: $TSContext, args: $TSAny) => {
+  switch (args.event) {
+    case 'PrePush':
+      if((await checkAnyGeoResourceExists()) && !verifySupportedRegion()) {
+        const errMessage = 'Failed to create Geo resources';
+        await context.usageData.emitError(new Error(errMessage));
+        printer.info('Remove Geo resources using "amplify remove geo" and retry "amplify push"');
+        exitOnNextTick(1);
+      }
+      break;
+    default:
+      break;
+  }
 };
 
 export const getPermissionPolicies = (context: $TSContext, resourceOpsMapping: $TSObject) => {

--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -219,8 +219,16 @@ export const getServicePermissionPolicies = (
 export const verifySupportedRegion = (): boolean => {
   const currentRegion = stateManager.getMeta()?.providers[provider]?.Region;
   if(!supportedRegions.includes(currentRegion)) {
-    printer.error(`Geo category is not supported in your region: ${currentRegion}`);
+    printer.error(`Geo category is not supported in the region: [${currentRegion}]`);
     return false;
   }
   return true;
 };
+
+/**
+ * Check if any Geo resource exists
+ */
+ export const checkAnyGeoResourceExists = async (): Promise<boolean> => {
+  const geoMeta = stateManager.getMeta()?.[category];
+  return geoMeta && Object.keys(geoMeta) && Object.keys(geoMeta).length > 0;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds a pre-push event handler to check if current region is supported when Geo resources are present. 
Useful when using multi-environment setup to fail fast if region is not supported. 
`remove geo` workflow should work in unsupported region for dev to be able to remove Geo resources if he wants to. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested with sample app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
