### PR TITLE
fix(amplify-appsync-simulator): none data source type definition and add test

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/__helpers__/appsync-client.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/__helpers__/appsync-client.ts
@@ -1,0 +1,104 @@
+/**
+ * AppSync GraphQL client for testing AmplifyAppSyncSimulator
+ */
+
+import * as http from 'http';
+import type { GraphQLError } from 'graphql';
+import { AmplifyAppSyncSimulator, AmplifyAppSyncSimulatorAuthenticationType } from '../../';
+import jwt from 'jsonwebtoken';
+
+/**
+ * Minimal gql tag just for syntax highlighting and Prettier while writing client GraphQL queries
+ */
+export const gql = (chunks: TemplateStringsArray, ...variables: unknown[]): string =>
+  chunks
+    .reduce((accumulator, chunk, index) => `${accumulator}${chunk}${index in variables ? variables[index] : ''}`, '')
+    .replace(/^\s+|\s$/g, '');
+
+interface AppSyncSimulatorAuthentication {
+  type: AmplifyAppSyncSimulatorAuthenticationType;
+}
+
+interface AppSyncSimulatorIAMAuthentication extends AppSyncSimulatorAuthentication {
+  type: AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM;
+}
+
+interface AppSyncSimulatorApiKeyAuthentication extends AppSyncSimulatorAuthentication {
+  type: AmplifyAppSyncSimulatorAuthenticationType.API_KEY;
+  apiKey: string;
+}
+
+interface AppSyncSimulatorCognitoKeyAuthentication extends AppSyncSimulatorAuthentication {
+  type: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS;
+  username: string;
+  groups?: readonly string[];
+}
+
+export async function appSyncClient<ResponseDataType = unknown, VarsType = Record<string, unknown>>({
+  appSync,
+  query,
+  variables,
+  auth,
+}: {
+  appSync: AmplifyAppSyncSimulator;
+  query: string;
+  variables?: VarsType;
+  auth?: AppSyncSimulatorIAMAuthentication | AppSyncSimulatorApiKeyAuthentication | AppSyncSimulatorCognitoKeyAuthentication;
+}): Promise<ResponseDataType> {
+  const headers: http.OutgoingHttpHeaders = {
+    'Content-Type': 'application/json',
+  };
+  switch (auth?.type) {
+    case AmplifyAppSyncSimulatorAuthenticationType.API_KEY:
+      headers['x-api-key'] = auth.apiKey;
+      break;
+
+    case AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS:
+      headers.Authorization = jwt.sign(
+        {
+          username: auth.username,
+          'cognito:groups': auth.groups ?? [],
+        },
+        'mockSecret',
+        { issuer: `https://cognito-idp.mock-region.amazonaws.com/mockUserPool` },
+      );
+      break;
+
+    case AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM:
+    default:
+      // doing just enough to cheat amplify-appsync-simulator/src/utils/auth-helpers/current-auth-mode.ts
+      headers.Authorization = 'AWS4-HMAC-SHA256-mock-signature';
+  }
+
+  return await new Promise((resolve, reject) => {
+    const httpRequest = http.request(
+      appSync.url,
+      {
+        host: 'localhost',
+        path: '/graphql',
+        method: 'POST',
+        headers,
+      },
+      result => {
+        let data = '';
+        result
+          .setEncoding('utf-8')
+          .on('data', (chunk: string) => {
+            data += chunk;
+          })
+          .once('end', () => {
+            if (!result.headers['content-type']?.toLowerCase().includes('application/json')) {
+              return reject(new Error(`AppSync GraphQL result failed: ${data}`));
+            }
+            const body: { data: ResponseDataType; errors?: readonly GraphQLError[] } = JSON.parse(data);
+            if (body.errors?.length) {
+              return reject(new Error(`GraphQL request error(s): ${JSON.stringify(body.errors)}`));
+            }
+            resolve(body.data);
+          })
+          .once('error', err => reject(err));
+      },
+    );
+    httpRequest.end(JSON.stringify({ query, variables }));
+  });
+}

--- a/packages/amplify-appsync-simulator/src/__tests__/__helpers__/appsync-client.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/__helpers__/appsync-client.ts
@@ -66,8 +66,8 @@ export async function appSyncClient<ResponseDataType = unknown, VarsType = Recor
 
     case AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM:
     default:
-      // doing just enough to cheat amplify-appsync-simulator/src/utils/auth-helpers/current-auth-mode.ts
-      headers.Authorization = 'AWS4-HMAC-SHA256-mock-signature';
+      // doing just enough to cheat amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
+      headers.Authorization = `AWS4-HMAC-SHA256 Credential=${appSync.appSyncConfig.authAccessKeyId}/2021-12-12`;
   }
 
   return await new Promise((resolve, reject) => {

--- a/packages/amplify-appsync-simulator/src/__tests__/data-loader/none.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/data-loader/none.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'fs';
+import { gql, appSyncClient } from '../__helpers__/appsync-client';
+import { AmplifyAppSyncSimulator, AmplifyAppSyncSimulatorAuthenticationType, RESOLVER_KIND } from '../../';
+
+describe('None data source', () => {
+  const appSync = new AmplifyAppSyncSimulator();
+  const onInboxMock = jest.fn();
+  let onInboxMockSubscription;
+
+  beforeAll(async () => {
+    appSync.init({
+      appSync: {
+        name: 'local-appsync',
+        defaultAuthenticationType: {
+          authenticationType: AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM,
+        },
+        additionalAuthenticationProviders: [
+          {
+            authenticationType: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
+            cognitoUserPoolConfig: {},
+          },
+        ],
+      },
+      schema: {
+        content: readFileSync(require.resolve('./test-schema.graphql'), 'utf8'),
+      },
+      dataSources: [
+        {
+          type: 'NONE',
+          name: 'noneDataSource',
+        },
+      ],
+      resolvers: [
+        {
+          fieldName: 'page',
+          typeName: 'Mutation',
+          kind: RESOLVER_KIND.UNIT,
+          dataSourceName: 'noneDataSource',
+          // from example at https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-local-resolvers.html
+          requestMappingTemplate: `
+          {
+            "version": "2017-02-28",
+            "payload": {
+              "body": $util.toJson($context.arguments.body),
+              "from": $util.toJson($context.identity.username),
+              "to":  $util.toJson($context.arguments.to),
+              "sentAt": "$util.time.nowISO8601()"
+            }
+          }
+          `,
+          responseMappingTemplate: `$util.toJson($ctx.result)`,
+        },
+      ],
+    });
+    await appSync.start();
+    onInboxMockSubscription = await appSync.pubsub.subscribe('inbox', onInboxMock);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(async () => {
+    await appSync.pubsub.unsubscribe(onInboxMockSubscription);
+    await appSync.stop();
+  });
+
+  test('`page` should trigger `inbox` subscription with given parameters', async () => {
+    const { page } = await appSyncClient<{ page: unknown }>({
+      appSync,
+      auth: {
+        type: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
+        username: 'mockUser',
+        groups: ['testGroup'],
+      },
+      query: gql`
+        mutation Page {
+          page(to: "Nadia", body: "Hello, World!") {
+            body
+            to
+            from
+            sentAt
+          }
+        }
+      `,
+    });
+    expect(page).toMatchObject({
+      body: 'Hello, World!',
+      from: 'mockUser',
+      sentAt: expect.any(String),
+      to: 'Nadia',
+    });
+
+    // give pubsub some time to deliver message
+    await new Promise(resolve => setTimeout(resolve, 500));
+    expect(onInboxMock).toHaveBeenCalledTimes(1);
+    expect(onInboxMock).toHaveBeenCalledWith(page);
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/data-loader/test-schema.graphql
+++ b/packages/amplify-appsync-simulator/src/__tests__/data-loader/test-schema.graphql
@@ -1,0 +1,26 @@
+# based on https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-local-resolvers.html
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+type Subscription {
+  inbox(to: String!): Page @aws_subscribe(mutations: ["page"])
+}
+
+type Mutation {
+  page(body: String!, to: String!): Page! @aws_cognito_user_pools(cognito_groups: ["testGroup"])
+}
+
+type Page @aws_cognito_user_pools(cognito_groups: ["testGroup"]) {
+  from: String!
+  to: String!
+  body: String!
+  sentAt: AWSDateTime!
+}
+
+type Query {
+  me: String
+}

--- a/packages/amplify-appsync-simulator/src/data-loader/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/index.ts
@@ -3,10 +3,14 @@ import { NoneDataLoader } from './none';
 import { LambdaDataLoader } from './lambda';
 import { OpenSearchDataLoader } from './opensearch';
 
+import { AppSyncSimulatorDataSourceConfig, AppSyncSimulatorDataSourceType } from '../type-definition';
 export interface AmplifyAppSyncSimulatorDataLoader {
   load(payload: any, extraData?: any): Promise<object | null>;
 }
-const DATA_LOADER_MAP = new Map();
+const DATA_LOADER_MAP = new Map<
+  AppSyncSimulatorDataSourceType,
+  new (config?: AppSyncSimulatorDataSourceConfig) => AmplifyAppSyncSimulatorDataLoader
+>();
 export function getDataLoader(sourceType) {
   if (DATA_LOADER_MAP.has(sourceType)) {
     return DATA_LOADER_MAP.get(sourceType);
@@ -14,23 +18,23 @@ export function getDataLoader(sourceType) {
   throw new Error(`Unsupported data source type ${sourceType}`);
 }
 
-export function addDataLoader(sourceType, loader) {
+export function addDataLoader(
+  sourceType: AppSyncSimulatorDataSourceType,
+  loader: new (config?: AppSyncSimulatorDataSourceConfig) => AmplifyAppSyncSimulatorDataLoader,
+) {
   if (DATA_LOADER_MAP.has(sourceType)) {
     throw new Error(`Data loader for source ${sourceType} is already registered`);
   }
   DATA_LOADER_MAP.set(sourceType, loader);
 }
 
-export function removeDataLoader(sourceType: string) {
-  if (DATA_LOADER_MAP.has(sourceType)) {
-    const loader = DATA_LOADER_MAP.get(sourceType);
-    return DATA_LOADER_MAP.delete(sourceType);
-    return loader;
-  }
+export function removeDataLoader(sourceType: AppSyncSimulatorDataSourceType) {
+  return DATA_LOADER_MAP.delete(sourceType);
 }
 
 // add known data sources
-addDataLoader('AMAZON_DYNAMODB', DynamoDBDataLoader);
-addDataLoader('NONE', NoneDataLoader);
-addDataLoader('AWS_LAMBDA', LambdaDataLoader);
-addDataLoader('AMAZON_ELASTICSEARCH', OpenSearchDataLoader);
+// @ts-expect-error Type 'AppSyncSimulatorDataSourceConfig' is not assignable to type 'DynamoDBLoaderConfig'
+addDataLoader(AppSyncSimulatorDataSourceType.DynamoDB, DynamoDBDataLoader);
+addDataLoader(AppSyncSimulatorDataSourceType.None, NoneDataLoader);
+addDataLoader(AppSyncSimulatorDataSourceType.Lambda, LambdaDataLoader);
+addDataLoader(AppSyncSimulatorDataSourceType.OpenSearch, OpenSearchDataLoader);

--- a/packages/amplify-appsync-simulator/src/type-definition.ts
+++ b/packages/amplify-appsync-simulator/src/type-definition.ts
@@ -45,12 +45,20 @@ export interface AppSyncSimulatorUnitResolver extends AppSyncSimulatorUnitResolv
 export interface AppSyncSimulatorPipelineResolver extends AppSyncSimulatorUnitResolverConfig {
   functions: string[];
 }
+
+export const enum AppSyncSimulatorDataSourceType {
+  DynamoDB = 'AMAZON_DYNAMODB',
+  Lambda = 'AWS_LAMBDA',
+  OpenSearch = 'AMAZON_ELASTICSEARCH',
+  None = 'NONE',
+}
+
 export interface AppSyncSimulatorDataSourceBaseConfig {
   name: string;
-  type: string;
+  type: AppSyncSimulatorDataSourceType | `${AppSyncSimulatorDataSourceType}`;
 }
 export interface AppSyncSimulatorDataSourceDDBConfig extends AppSyncSimulatorDataSourceBaseConfig {
-  type: 'AMAZON_DYNAMODB';
+  type: AppSyncSimulatorDataSourceType.DynamoDB | `${AppSyncSimulatorDataSourceType.DynamoDB}`;
   config: {
     endpoint: string;
     region?: string;
@@ -60,10 +68,10 @@ export interface AppSyncSimulatorDataSourceDDBConfig extends AppSyncSimulatorDat
   };
 }
 export interface AppSyncSimulatorDataSourceNoneConfig extends AppSyncSimulatorDataSourceBaseConfig {
-  type: 'None';
+  type: AppSyncSimulatorDataSourceType.None | `${AppSyncSimulatorDataSourceType.None}`;
 }
 export interface AppSyncSimulatorDataSourceLambdaConfig extends AppSyncSimulatorDataSourceBaseConfig {
-  type: 'AWS_LAMBDA';
+  type: AppSyncSimulatorDataSourceType.Lambda | `${AppSyncSimulatorDataSourceType.Lambda}`;
   invoke: Function;
 }
 export type AppSyncSimulatorDataSourceConfig =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR fixes type definition for NONE data source - in type definition we were expecting `None` string while in the actual implementation it was `NONE` string.

To fix that error an enum was added and used internally, and string (produced from enum by TS 4.1) is also allowed externally.

Added test covers touched functionality and a little bit more (see codecov comment below).

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are or added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
