### PR TITLE
Transformer auto migration

### DIFF
--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -52,6 +52,8 @@
         "@aws-cdk/custom-resources": "~1.119.0",
         "@aws-cdk/cx-api": "~1.119.0",
         "@aws-cdk/region-info": "~1.119.0",
+        "amplify-cli-core": "1.28.0",
+        "amplify-prompts": "1.1.2",
         "change-case": "^4.1.1",
         "constructs": "^3.3.125",
         "deep-diff": "^1.0.2",

--- a/packages/amplify-graphql-transformer-core/src/migration/migrate.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrate.ts
@@ -1,0 +1,27 @@
+import { parse, print, visit } from 'graphql'
+import { migrateKeys } from './migrators/key'
+import { migrateAuth } from './migrators/auth'
+import { migrateConnection } from './migrators/connection'
+import { readSchemaDocuments, getResourceDir } from './utils'
+import { DocumentNode } from 'graphql/language';
+
+
+function migrateGraphQLSchema(schema: string, authMode: string, massSchema: DocumentNode): string {
+  let output = parse(schema)
+  visit(output, {
+    ObjectTypeDefinition: {
+      enter(node) {
+        migrateKeys(node);
+        migrateAuth(node, authMode);
+        migrateConnection(node, massSchema);
+        return node;
+      }
+    }
+  });
+
+  return print(output);
+}
+
+export function migrateToV2Transformer(): void {
+  const schemaDocuments = readSchemaDocuments(getResourceDir());
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrate.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrate.ts
@@ -1,10 +1,28 @@
+import * as fs from 'fs-extra';
 import { parse, print, visit } from 'graphql'
 import { migrateKeys } from './migrators/key'
 import { migrateAuth } from './migrators/auth'
 import { migrateConnection } from './migrators/connection'
-import { readSchemaDocuments, getResourceDir } from './utils'
+import {
+  backupSchema,
+  getDefaultAuthFromContext,
+  readSchemaDocuments,
+  readSingleFileSchema,
+  replaceFile,
+  SchemaDocument,
+  undoAllSchemaMigration,
+} from './utils';
 import { DocumentNode } from 'graphql/language';
+import { prompter, printer } from 'amplify-prompts';
+import path from 'path';
+import { $TSContext, exitOnNextTick, FeatureFlags, pathManager, stateManager } from 'amplify-cli-core';
 
+const cliToMigratorAuthMap: Map<string, string> = new Map<string, string>([
+  ['API_KEY', 'apiKey'],
+  ['AWS_IAM', 'iam'],
+  ['AMAZON_COGNITO_USER_POOLS', 'userPools'],
+  ['OPENID_CONNECT', 'oidc']
+]);
 
 function migrateGraphQLSchema(schema: string, authMode: string, massSchema: DocumentNode): string {
   let output = parse(schema)
@@ -22,6 +40,105 @@ function migrateGraphQLSchema(schema: string, authMode: string, massSchema: Docu
   return print(output);
 }
 
-export function migrateToV2Transformer(): void {
-  const schemaDocuments = readSchemaDocuments(getResourceDir());
+async function askMigration(singleFileExists: boolean, directoryExists: boolean): Promise<boolean> {
+  await printer.info(`About to begin schema migration, found valid target(s) for migration:\n${singleFileExists ? 'schema.graphql\n' : ''}${directoryExists ? 'schema directory\n' : ''}\n`);
+  await printer.info('If you confirm migration, you will receive no further prompts and all migration will be completed. The CLI will exit after migration and will not push your resources to give you time to review.');
+  await printer.warn('If you are using @auth, we strongly recommend spending extra time reviewing your auth rules after migration to ensure they\'re accurate');
+  return await prompter.confirmContinue("About to start migrating to V2 transformer, are you ready to continue?");
+}
+
+async function runMigration(schemas: SchemaDocument[], authMode: string): Promise<void> {
+  let fullSchema: string;
+  let schemaList: string[] = new Array(schemas.length);
+  let backupSchemaPromiseArray: Promise<void>[] = [];
+  schemas.forEach((doc, idx) => {
+    schemaList[idx] = doc.schema;
+    backupSchemaPromiseArray.push(backupSchema(doc.filePath));
+  });
+  for (let promise of backupSchemaPromiseArray) {
+    await promise;
+  }
+
+  fullSchema = schemaList.join('\n');
+  let fullSchemaNode = parse(fullSchema);
+  let writeNewPromiseArray: Promise<void>[] = [];
+  schemas.forEach(doc => {
+    const newSchema = migrateGraphQLSchema(doc.schema, authMode, fullSchemaNode);
+    writeNewPromiseArray.push(replaceFile(newSchema, doc.filePath));
+  });
+
+  for (let promise of writeNewPromiseArray) {
+    await promise;
+  }
+}
+
+export async function updateTransformerVersion(env: string): Promise<void> {
+  const projectPath = pathManager.findProjectRoot() ?? process.cwd();
+  let envCLI: boolean = true;
+  let cliJSON: any;
+  try {
+    cliJSON = stateManager.getCLIJSON(projectPath, env);
+  }
+  catch (e) {
+    if (e.message.includes("File at path:") && e.message.includes("does not exist")) {
+      envCLI = false;
+      cliJSON = stateManager.getCLIJSON(projectPath);
+    }
+    else {
+      throw e;
+    }
+  }
+  if (!cliJSON.features) {
+    cliJSON.features = {};
+  }
+  if (!cliJSON.features.graphqltransformer) {
+    cliJSON.features.graphqltransformer = {}
+  }
+  cliJSON.features.graphqltransformer.useexperimentalpipelinedtransformer = true;
+
+  if (envCLI) {
+    stateManager.setCLIJSON(projectPath, cliJSON, env);
+  }
+  else {
+    stateManager.setCLIJSON(projectPath, cliJSON);
+  }
+  await FeatureFlags.reloadValues();
+}
+
+export async function migrateToV2Transformer(resourceDir: string, context: $TSContext): Promise<boolean> {
+  const { envName } = context.amplify.getEnvInfo();
+  const defaultAuth = await getDefaultAuthFromContext();
+  const authMode = cliToMigratorAuthMap.get(defaultAuth);
+  if (!authMode) {
+    throw Error(`Unidentified authorization mode for API found: ${defaultAuth}`);
+  }
+  const schemaFilePath = path.join(resourceDir, 'schema.graphql');
+  const schemaDirectoryPath = path.join(resourceDir, 'schema');
+  const schemaFileExists = await fs.existsSync(schemaFilePath);
+  const schemaDirectoryExists = await fs.existsSync(schemaDirectoryPath);
+
+  if (schemaFileExists || schemaDirectoryExists) {
+    let migrateCheck = await askMigration(schemaFileExists, schemaDirectoryExists);
+    if (!migrateCheck) {
+      await printer.info("Skipping schema migration, did not receive confirmation.");
+      return false;
+    }
+  }
+  try {
+    if (schemaFileExists) {
+      await runMigration(await readSingleFileSchema(schemaFilePath), authMode);
+    }
+    if (schemaDirectoryExists) {
+      await runMigration(await readSchemaDocuments(schemaDirectoryPath), authMode);
+    }
+    await updateTransformerVersion(envName);
+    await printer.info("Successfully migrated schema(s), please review them to ensure they've been properly migrated before running 'amplify push'. Pay extra care with any auth rules to ensure your data remains secured.");
+    exitOnNextTick(0);
+  }
+  catch (error) {
+    await printer.error("Encountered an error while migrating schema to V2 transformer, reverting to old schemas");
+    await undoAllSchemaMigration(resourceDir);
+    throw error;
+  }
+  return true;
 }

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/defaultAuth.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/defaultAuth.ts
@@ -1,0 +1,56 @@
+import { getAuthRules, hasAuthDirectives, addAuthRuleToNode } from '.'
+import { createAuthRule } from '../generators'
+
+const defaultAuthModeMap: Map<string, string> = new Map<string, string>([
+  ['apiKey', 'public'],
+  ['iam', 'private'],
+  ['userPools', 'private'],
+  ['oidc', 'private']
+]);
+
+function getDefaultAuthRule(authMode: any, rules: any) {
+  const parsedRules = rules.map((rule: any) => ({
+    provider: rule.fields.find((r: any) => r.name.value === 'provider'),
+    strategy: rule.fields.find((r: any) => r.name.value === 'allow')
+  })).map((r: any) => ({
+    strategy: r.strategy.value.value,
+    provider: r.provider?.value?.value
+  }));
+
+  const foundRules = parsedRules.filter((r: any) => r.strategy === defaultAuthModeMap.get(authMode));
+  if (foundRules.length === 0) {
+    return null;
+  }
+
+  if (authMode === "iam" && foundRules.filter((r: any) => r.provider === 'iam').length !== 0) {
+    return foundRules.find((r: any) => r.provider === 'iam');
+  } else if (authMode === 'iam') {
+    return null;
+  }
+
+  if (foundRules.filter((r: any) => r.provider === undefined || r.provider === authMode).length !== 0) {
+    return foundRules.find((r: any) => r.provider === undefined || r.provider === authMode);
+  }
+
+  return null;
+}
+
+export function migrateDefaultAuthMode(node: any, defaultAuthMode: any) {
+  if (defaultAuthMode === 'iam') {
+    return;
+  }
+
+  if (!hasAuthDirectives(node)) {
+    const authRule = createAuthRule(defaultAuthModeMap.get(defaultAuthMode), defaultAuthMode);
+    addAuthRuleToNode(node, authRule);
+    return;
+  }
+
+  const authRules = getAuthRules(node);
+
+  // if rule with default auth mode exist, then don't mess with it otherwise add it
+  const defaultAuthRule = getDefaultAuthRule(defaultAuthMode, authRules);
+  if (!defaultAuthRule) {
+    addAuthRuleToNode(node, createAuthRule(defaultAuthModeMap.get(defaultAuthMode), defaultAuthMode));
+  }
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/fieldAuth.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/fieldAuth.ts
@@ -1,0 +1,21 @@
+import { addAuthRuleToNode, getAuthRules, hasAuthDirectives } from "."
+
+function hasFieldAuthRules(node: any) {
+  return getFieldsWithAuthRules(node).length !== 0
+}
+
+function getFieldsWithAuthRules(node: any) {
+  return node.fields.filter((f: any) => hasAuthDirectives(f))
+}
+
+export function migrateFieldAuth(node: any) {
+  if (!hasFieldAuthRules(node)) {
+    return;
+  }
+
+  const fieldWithAuthRules = getFieldsWithAuthRules(node)
+  fieldWithAuthRules
+    .map((f: any) => getAuthRules(f))
+    .flat()
+    .forEach((rule: any) => addAuthRuleToNode(node, rule));
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/index.ts
@@ -1,0 +1,102 @@
+import { isModelType } from '../model';
+import { migrateDefaultAuthMode } from './defaultAuth';
+import { migrateFieldAuth } from './fieldAuth';
+import { migrateOwnerAuth } from './ownerAuth';
+import { createArgumentNode, createAuthRule, createDirectiveNode, createListValueNode } from '../generators';
+
+export function hasAuthDirectives(node: any) {
+  return node.directives.some((dir: any) => dir.name.value === 'auth');
+}
+
+export function getAuthRules(node: any) {
+  return node.directives.find((dir: any) => dir.name.value === 'auth').arguments[0].value.values;
+}
+
+export function setAuthRules(node: any, rules: any) {
+  node.directives.find((dir: any) => dir.name.value === 'auth').arguments[0].value.values = rules;
+}
+
+export function addAuthRuleToNode(node: any, rule: any) {
+  if (!hasAuthDirectives(node)) {
+    const authDirArgs = createArgumentNode('rules', createListValueNode([rule]));
+    const authDir = createDirectiveNode('auth', [authDirArgs]);
+    node.directives.push(authDir);
+  } else {
+    const authRules = getAuthRules(node);
+    if (authRules) {
+      authRules.push(rule);
+    }
+  }
+}
+
+function getAuthStrategy(rule: any) {
+  return rule.fields.find((f: any) => f.name.value === 'allow').value.value
+}
+
+function getAuthOperations(rule: any) {
+  return rule.fields.find((f: any) => f.name.value === 'operations')
+    ?.value.values.map((op: any) => op.value)
+    ?? ["create", "read", "update", "delete"]
+}
+
+export const defaultProviderMap: Map<string, string> = new Map<string, string>([
+  ['public', 'apiKey'],
+  ['private', 'userPools'],
+  ['owner', 'userPools'],
+  ['groups', 'userPools']
+]);
+
+function getAuthProvider(rule: any) {
+  return rule.fields.find((f: any) => f.name.value === 'provider')
+    ?.value.value
+    ?? defaultProviderMap.get(getAuthStrategy(rule));
+}
+
+function getAuthRuleWithSameScopeIndex(rules: any[], rule: any) {
+  let sameRule;
+  rules.forEach((r, index) => {
+    if (getAuthStrategy(r) === getAuthStrategy(rule) && getAuthProvider(r) === getAuthProvider(rule)) {
+      sameRule = index
+    }
+  })
+  return sameRule
+}
+
+function mergeOperations(a: any, b: any) {
+  const aOps = getAuthOperations(a)
+  const bOps = getAuthOperations(b)
+
+  const operationsUnion = new Set([aOps, bOps].flat())
+
+  return Array.from(operationsUnion)
+}
+
+function mergeAuthRules(node: any, rules: any[]) {
+  const newRules = rules.reduce((result, rule) => {
+    const existingRuleIndex = getAuthRuleWithSameScopeIndex(result, rule);
+    if (existingRuleIndex !== undefined) {
+      result[existingRuleIndex] = createAuthRule(getAuthStrategy(rule), getAuthProvider(rule), mergeOperations(result[existingRuleIndex], rule));
+    } else {
+      result.push(rule);
+    }
+    return result;
+  }, [])
+
+  setAuthRules(node, newRules.map((r: any) => createAuthRule(getAuthStrategy(r), getAuthProvider(r), getAuthOperations(r))));
+}
+
+export function migrateAuth(node: any, defaultAuthMode: any) {
+  if (!isModelType(node)) {
+    return;
+  }
+
+  migrateFieldAuth(node);
+
+  if (hasAuthDirectives(node)) {
+    migrateOwnerAuth(node, defaultAuthMode);
+  }
+
+  migrateDefaultAuthMode(node, defaultAuthMode);
+
+  mergeAuthRules(node, getAuthRules(node));
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/ownerAuth.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/auth/ownerAuth.ts
@@ -1,0 +1,64 @@
+import { getAuthRules } from '.'
+import { createAuthRule } from '../generators'
+
+function getPrivateAuthRule(rules: any, provider: any) {
+  return rules.find((rule: any) => {
+    const foundStrategy = rule.fields.find((f: any) => f.name.value === "allow").value.value
+    const foundProvider = rule.fields.find((f: any) => f.name.value === "provider")?.value?.value
+
+    if (foundStrategy !== 'private') {
+      return false
+    }
+
+    if (provider === "userPools" && (foundProvider === undefined || foundProvider === "userPools")) {
+      return true
+    } else if (provider === "iam" && foundProvider === "iam") {
+      return true
+    }
+    return false
+  })
+}
+
+function getOwnerAuthRules(rules: any) {
+  return rules.filter((rule: any) => rule.fields.find((f: any) => f.name.value === 'allow').value.value === 'owner')
+}
+
+export function migrateOwnerAuth(node: any, defaultAuthMode: any) {
+  const authRules = getAuthRules(node)
+
+  // check if owner-based auth exist and if operations allow everything.
+  const deniedOperations = new Set()
+  const ownerRules = getOwnerAuthRules(authRules)
+  if (ownerRules.length !== 0) {
+    ownerRules.forEach((rule: any) => {
+      const operationsIndex = rule.fields.findIndex((f: any) => f.name.value === 'operations')
+
+      if (operationsIndex === -1) {
+        deniedOperations.add('update')
+        deniedOperations.add('read')
+        deniedOperations.add('delete')
+      } else {
+        // remember denied operations
+        rule.fields[operationsIndex].value.values.map((op: any) => op.value).forEach((op: any) => deniedOperations.add(op))
+
+        // maintain full CRUD access for owners
+        rule.fields.splice(operationsIndex, 1)
+      }
+    })
+
+    // convert owner auth from deny-others to allow-only basis
+    // remove create because it's not a denied operation
+    deniedOperations.delete('create')
+
+    const explicitPrivateAllowRule = {
+      strategy: 'private',
+      provider: defaultAuthMode === "iam" ? "iam" : "userPools",
+      operations: ['create', 'read', 'update', 'delete'].filter(x => !deniedOperations.has(x))
+    }
+
+    const privateRule = getPrivateAuthRule(authRules, explicitPrivateAllowRule.provider)
+    if (!privateRule) {
+      authRules.push(createAuthRule(explicitPrivateAllowRule.strategy, explicitPrivateAllowRule.provider, explicitPrivateAllowRule.operations))
+    }
+  }
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/generators/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/generators/index.ts
@@ -1,0 +1,45 @@
+import { parseValue } from "graphql"
+import { defaultProviderMap } from "../auth"
+
+export function createNameNode(name: any) {
+    return {
+        kind: 'Name',
+        value: name
+    };
+}
+
+export function createDirectiveNode(name: any, args: any) {
+    return {
+        kind: 'Directive',
+        name: createNameNode(name),
+        arguments: args
+    };
+}
+
+export function createArgumentNode(name: any, value: any) {
+    return {
+        kind: 'Argument',
+        name: createNameNode(name),
+        value: value
+    };
+}
+
+export function createListValueNode(values: any) {
+    return {
+        kind: 'ListValue',
+        values: values
+    };
+}
+
+export function createAuthRule(strategy: any, provider: any, operations?: any) {
+    let rule = `{allow: ${strategy}`;
+    if (provider && provider !== defaultProviderMap.get(strategy)) {
+        rule += `, provider: ${provider}`;
+    }
+
+    if (operations && operations.length !== 4) {
+        rule += `, operations: [${operations.join(', ')}]`;
+    }
+    rule += '}';
+    return parseValue(rule);
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/key/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/key/index.ts
@@ -1,0 +1,69 @@
+import { createArgumentNode, createDirectiveNode } from "../generators";
+
+export function isPrimaryKey(directive: any) {
+    if (directive.name.value === 'key'
+        && directive.arguments.find((a: any) => a.name.value === "fields")
+        && !directive.arguments.find((a: any) => a.name.value === "name")) {
+        return true;
+    }
+    return false;
+}
+
+export function migratePrimaryKey(node: any, directive: any) {
+    let fields = directive.arguments.find((i: any) => i.name.value === "fields");
+    const fieldIndex = node.fields.findIndex((field: any) => field.name.value === fields.value.values[0].value);
+    let args: any[] = [];
+    if (fields.value.values.length !== 1) {
+        args = [createArgumentNode('sortKeyFields', {
+                ...fields.value,
+                values: fields.value.values.slice(1)
+            }
+        )];
+    }
+    node.fields[fieldIndex].directives.push(createDirectiveNode('primaryKey', args));
+}
+
+export function isSecondaryKey(directive: any) {
+    if (directive.name.value === 'key'
+        && directive.arguments.find((a: any) => a.name.value === "fields")
+        && directive.arguments.find((a: any) => a.name.value === "name")) {
+        return true;
+    }
+    return false;
+}
+
+export function migrateSecondaryKey(node: any, directive: any) {
+    let fields = directive.arguments.find((i: any) => i.name.value === "fields");
+    const fieldIndex = node.fields.findIndex((field: any) => field.name.value === fields.value.values[0].value);
+    let args = directive.arguments.filter((i: any) => i.name.value !== "fields");
+    if (fields.value.values.length !== 1) {
+        args = [...args, createArgumentNode(
+            'sortKeyFields', {
+                ...fields.value,
+                values: fields.value.values.slice(1)
+            },
+        )];
+    }
+    node.fields[fieldIndex].directives.push(createDirectiveNode('index', args));
+}
+
+export function migrateKeys(node: any) {
+    const dirs = node.directives;
+    if (!dirs) {
+        return;
+    }
+    let keys = [];
+    for (const dir of dirs) {
+        if (dir.name.value === 'key') {
+            keys.push(dir);
+        }
+    }
+    node.directives = dirs.filter((dir: any) => dir.name.value !== "key");
+    for (const index of keys) {
+        if (isPrimaryKey(index)) {
+            migratePrimaryKey(node, index);
+        } else if (isSecondaryKey(index)) {
+            migrateSecondaryKey(node, index);
+        }
+    }
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/migrators/model/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/migrators/model/index.ts
@@ -1,0 +1,6 @@
+export function isModelType(node: any) {
+    if (node.directives.find((dir: any) => dir.name.value === 'model')) {
+        return true;
+    }
+    return false;
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/utils.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs-extra';
+
+export type SchemaDocument = {
+  schema: string;
+  filePath: string;
+}
+
+export function getResourceDir(): string {
+  return '';
+}
+
+/**
+ * Copies the schema to the same location with extension .bkp
+ * @param schemaPath
+ */
+export async function backupSchema(schemaPath: string): Promise<void> {
+  await fs.copyFile(schemaPath, `${schemaPath}.bkp`);
+}
+
+export async function readSchemaDocuments(schemaDirectoryPath: string): Promise<SchemaDocument[]> {
+  const files = await fs.readdir(schemaDirectoryPath);
+  let schemaDocuments: Array<SchemaDocument> = [];
+  for (const fileName of files) {
+    if (!fileName.endsWith(".graphql")) {
+      continue;
+    }
+
+    const fullPath = `${schemaDirectoryPath}/${fileName}`;
+    const stats = await fs.lstat(fullPath);
+    if (stats.isDirectory()) {
+      const childDocs = await readSchemaDocuments(fullPath);
+      schemaDocuments = schemaDocuments.concat(childDocs);
+    } else if (stats.isFile()) {
+      const schemaDoc = await fs.readFile(fullPath);
+      schemaDocuments.push({ schema: schemaDoc.toString(), filePath: fullPath });
+    }
+  }
+  return schemaDocuments;
+}

--- a/packages/amplify-graphql-transformer-core/src/migration/utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/migration/utils.ts
@@ -1,12 +1,9 @@
 import * as fs from 'fs-extra';
+import { stateManager } from 'amplify-cli-core';
 
 export type SchemaDocument = {
   schema: string;
   filePath: string;
-}
-
-export function getResourceDir(): string {
-  return '';
 }
 
 /**
@@ -15,6 +12,19 @@ export function getResourceDir(): string {
  */
 export async function backupSchema(schemaPath: string): Promise<void> {
   await fs.copyFile(schemaPath, `${schemaPath}.bkp`);
+}
+
+export async function readSingleFileSchema(schemaPath: string): Promise<SchemaDocument[]> {
+  let schema: string = (await fs.readFile(schemaPath)).toString();
+  return [{ schema: schema, filePath: schemaPath }];
+}
+
+export async function replaceFile(newSchema: string, filePath: string): Promise<void> {
+  await fs.writeFile(filePath, newSchema, {encoding: 'utf-8', flag: 'w'});
+}
+
+export function removeBkpExtension(path: string): string {
+  return path.slice(0, path.length - 4);
 }
 
 export async function readSchemaDocuments(schemaDirectoryPath: string): Promise<SchemaDocument[]> {
@@ -36,4 +46,32 @@ export async function readSchemaDocuments(schemaDirectoryPath: string): Promise<
     }
   }
   return schemaDocuments;
+}
+
+export async function undoAllSchemaMigration(resourceDir: string): Promise<void> {
+  const files = await fs.readdir(resourceDir);
+  for (const fileName of files) {
+    if (!fileName.endsWith(".bkp")) {
+      continue;
+    }
+
+    const fullPath = `${resourceDir}/${fileName}`;
+    const stats = await fs.lstat(fullPath);
+    if (stats.isDirectory()) {
+      await undoAllSchemaMigration(fullPath);
+    } else if (stats.isFile()) {
+      fs.moveSync(fullPath, removeBkpExtension(fullPath), { overwrite: true });
+      fs.removeSync(fullPath);
+    }
+  }
+}
+
+export async function getDefaultAuthFromContext(): Promise<string> {
+  const backendConfig = stateManager.getBackendConfig();
+  if (Object.keys(backendConfig.api).length < 1) {
+    return "AMAZON_COGNITO_USER_POOLS"
+  }
+  // Only support one API, so grab the ID
+  const firstAPIID = Object.keys(backendConfig.api)[0];
+  return backendConfig.api[firstAPIID].output.authConfig.defaultAuthentication.authenticationType;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds in an auto-migrator that will run when schema is transformed, this can be triggered on a `amplify api gql-compile` or an `amplify push`. It will update the feature flag to the V2 transformer and it will write any old schema files to the same path but with a .bkp extension

As this is meant for migrating existing projects, it won't work if you initialize an amplify project and try to migrate before pushing your API.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Executed manually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
