### PR TITLE
test: dont run geo e2e tests on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11447,7 +11447,6 @@ workflows:
             parameters:
               os:
                 - linux
-                - windows
       - schema-iterative-update-1-amplify_e2e_tests_pkg:
           context:
             - amplify-ecr-image-pull
@@ -12508,7 +12507,6 @@ workflows:
             parameters:
               os:
                 - linux
-                - windows
       - auth_5-amplify_e2e_tests_pkg:
           context:
             - amplify-ecr-image-pull
@@ -12709,7 +12707,6 @@ workflows:
             parameters:
               os:
                 - linux
-                - windows
       - function_3-amplify_e2e_tests_pkg:
           context:
             - amplify-ecr-image-pull

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -36,6 +36,9 @@ const WINDOWS_TEST_FAILURES = [
   'function_6-amplify_e2e_tests',
   'function_5-amplify_e2e_tests',
   'function_7-amplify_e2e_tests',
+  'geo-add-amplify_e2e_tests',
+  'geo-update-amplify_e2e_tests',
+  'geo-remove-amplify_e2e_tests',
   'hosting-amplify_e2e_tests',
   'hostingPROD-amplify_e2e_tests',
   'import_auth_1-amplify_e2e_tests',
@@ -278,7 +281,7 @@ function splitTests(
         ...newJob.environment,
         AMPLIFY_DIR: '/home/circleci/repo/packages/amplify-cli/bin',
         AMPLIFY_PATH: '/home/circleci/repo/packages/amplify-cli/bin/amplify',
-      }
+      };
     }
     return { ...acc, [newJobName]: newJob };
   }, {});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removing geo tests from windows e2e tests due to some failures

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
