### PR TITLE
Fix geo e2e tests

### DIFF
--- a/packages/amplify-e2e-core/src/categories/geo.ts
+++ b/packages/amplify-e2e-core/src/categories/geo.ts
@@ -114,6 +114,8 @@ export function updateMapWithDefault(cwd: string): Promise<void> {
       .wait('Who can access this Map?')
       .send(KEY_DOWN_ARROW)
       .sendCarriageReturn()
+      .wait(defaultMapQuestion)
+      .sendConfirmYes()
       .run((err: Error) => {
         if (!err) {
           resolve();
@@ -165,6 +167,8 @@ export function updatePlaceIndexWithDefault(cwd: string): Promise<void> {
       .wait('Who can access this Search Index?')
       .send(KEY_DOWN_ARROW)
       .sendCarriageReturn()
+      .wait(defaultSearchIndexQuestion)
+      .sendConfirmYes()
       .run((err: Error) => {
         if (!err) {
           resolve();
@@ -307,9 +311,12 @@ export function getGeoJSConfiguration(awsExports: any): any {
   return awsExports.geo.amazon_location_service;
 }
 
-export function generateTwoResourceIdsInOrder(): string[] {
+export function generateResourceIdsInOrder(count: number): string[] {
   const resourceIdArr: string[] = [];
-  resourceIdArr.push(generateRandomShortId());
-  resourceIdArr.push(generateRandomShortId());
+  while (count > 0) {
+    resourceIdArr.push(generateRandomShortId());
+    resourceIdArr.push(generateRandomShortId());
+    count--;
+  }
   return resourceIdArr.sort();
 }

--- a/packages/amplify-e2e-tests/src/__tests__/geo-remove.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/geo-remove.test.ts
@@ -13,8 +13,7 @@ import {
   removePlaceIndex,
   removeFirstDefaultMap,
   removeFirstDefaultPlaceIndex,
-  generateRandomShortId,
-  generateTwoResourceIdsInOrder,
+  generateResourceIdsInOrder,
   getGeoJSConfiguration
 } from 'amplify-e2e-core';
 import { existsSync } from 'fs';
@@ -69,12 +68,13 @@ describe('amplify geo remove', () => {
     expect(awsExport.geo).toBeUndefined();
   });
 
-  it('init a project with default auth config and two map resources, then remove the default map', async () => {
-    const [map1Id, map2Id] = generateTwoResourceIdsInOrder();
+  it('init a project with default auth config and multiple map resources, then remove the default map', async () => {
+    const [map1Id, map2Id, map3Id] = generateResourceIdsInOrder(3);
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await addMapWithDefault(projRoot, { resourceName: map1Id, isFirstGeoResource: true });
-    await addMapWithDefault(projRoot, { resourceName: map2Id, isAdditional: true, isDefault: false })
+    await addMapWithDefault(projRoot, { resourceName: map2Id, isAdditional: true, isDefault: false });
+    await addMapWithDefault(projRoot, { resourceName: map3Id, isAdditional: true, isDefault: false });
     await amplifyPushWithoutCodegen(projRoot);
     const oldMeta = getProjectMeta(projRoot);
     expect(oldMeta.geo[map1Id].isDefault).toBe(true);
@@ -95,12 +95,13 @@ describe('amplify geo remove', () => {
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });
 
-  it('init a project with default auth config and two index resources, then remove the default index', async () => {
-    const [index1Id, index2Id] = generateTwoResourceIdsInOrder();
+  it('init a project with default auth config and multiple index resources, then remove the default index', async () => {
+    const [index1Id, index2Id, index3Id] = generateResourceIdsInOrder(3);
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await addPlaceIndexWithDefault(projRoot, { resourceName: index1Id, isFirstGeoResource: true });
-    await addPlaceIndexWithDefault(projRoot, { resourceName: index2Id, isAdditional: true, isDefault: false })
+    await addPlaceIndexWithDefault(projRoot, { resourceName: index2Id, isAdditional: true, isDefault: false });
+    await addPlaceIndexWithDefault(projRoot, { resourceName: index3Id, isAdditional: true, isDefault: false });
     await amplifyPushWithoutCodegen(projRoot);
     const oldMeta = getProjectMeta(projRoot);
     expect(oldMeta.geo[index1Id].isDefault).toBe(true);
@@ -114,7 +115,7 @@ describe('amplify geo remove', () => {
     expect(newMeta.geo[index1Id]).toBeUndefined();
     expect(newMeta.geo[index2Id].isDefault).toBe(true);
     const awsExport: any = getAWSExports(projRoot).default;
-    expect(getGeoJSConfiguration(awsExport).search_indices.items).toEqual([index2Name]);
+    expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(index2Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.default).toEqual(index2Name);
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });

--- a/packages/amplify-e2e-tests/src/__tests__/geo-update.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/geo-update.test.ts
@@ -14,7 +14,7 @@ import {
   updatePlaceIndexWithDefault,
   updateSecondMapAsDefault,
   updateSecondPlaceIndexAsDefault,
-  generateTwoResourceIdsInOrder,
+  generateResourceIdsInOrder,
   getGeoJSConfiguration
 } from 'amplify-e2e-core';
 import { existsSync } from 'fs';
@@ -36,19 +36,20 @@ describe('amplify geo update', () => {
   });
 
   it('init a project with default auth config, add the map resource and update the auth config', async () => {
+    const [map1Id, map2Id] = generateResourceIdsInOrder(2);
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
-    await addMapWithDefault(projRoot, { isFirstGeoResource: true });
+    await addMapWithDefault(projRoot, { resourceName: map1Id, isFirstGeoResource: true });
+    await addMapWithDefault(projRoot, { resourceName: map2Id, isAdditional: true, isDefault: false });
     await updateMapWithDefault(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
 
     const meta = getProjectMeta(projRoot);
-    const geoMeta = Object.keys(meta.geo).filter(key => meta.geo[key].service === 'Map').map(key => meta.geo[key])[0]
-    const mapName = geoMeta.output.Name;
+    const mapName = meta.geo[map1Id].output.Name;
     const region = meta.providers.awscloudformation.Region;
     const map = await getMap(mapName, region);
     expect(map.MapName).toBeDefined();
-    expect(geoMeta.accessType).toBe('AuthorizedAndGuestUsers');
+    expect(meta.geo[map1Id].accessType).toBe('AuthorizedAndGuestUsers');
     const awsExport: any = getAWSExports(projRoot).default;
     expect(getGeoJSConfiguration(awsExport).maps.items[mapName]).toBeDefined();
     expect(getGeoJSConfiguration(awsExport).maps.default).toEqual(mapName);
@@ -56,19 +57,20 @@ describe('amplify geo update', () => {
   });
 
   it('init a project with default auth config, add the place index resource and update the auth config', async () => {
+    const [index1Id, index2Id] = generateResourceIdsInOrder(2);
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
-    await addPlaceIndexWithDefault(projRoot, { isFirstGeoResource: true });
+    await addPlaceIndexWithDefault(projRoot, { resourceName: index1Id, isFirstGeoResource: true });
+    await addPlaceIndexWithDefault(projRoot, { resourceName: index2Id, isAdditional: true, isDefault: false });
     await updatePlaceIndexWithDefault(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
 
     const meta = getProjectMeta(projRoot);
-    const geoMeta = Object.keys(meta.geo).filter(key => meta.geo[key].service === 'PlaceIndex').map(key => meta.geo[key])[0]
-    const placeIndexName = geoMeta.output.Name;
+    const placeIndexName = meta.geo[index1Id].output.Name;
     const region = meta.providers.awscloudformation.Region;
     const placeIndex = await getPlaceIndex(placeIndexName, region);
     expect(placeIndex.IndexName).toBeDefined();
-    expect(geoMeta.accessType).toBe('AuthorizedAndGuestUsers');
+    expect(meta.geo[index1Id].accessType).toBe('AuthorizedAndGuestUsers');
     const awsExport: any = getAWSExports(projRoot).default;
     expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(placeIndexName);
     expect(getGeoJSConfiguration(awsExport).search_indices.default).toEqual(placeIndexName);
@@ -76,11 +78,12 @@ describe('amplify geo update', () => {
   });
 
   it('init a project with default auth config, add multiple map resources and update the default map', async () => {
-    const [map1Id, map2Id] = generateTwoResourceIdsInOrder();
+    const [map1Id, map2Id, map3Id] = generateResourceIdsInOrder(3);
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await addMapWithDefault(projRoot, { resourceName: map1Id, isFirstGeoResource: true });
     await addMapWithDefault(projRoot, { resourceName: map2Id, isAdditional: true, isDefault: false });
+    await addMapWithDefault(projRoot, { resourceName: map3Id, isAdditional: true, isDefault: false });
     await updateSecondMapAsDefault(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
 
@@ -105,11 +108,12 @@ describe('amplify geo update', () => {
   });
 
   it('init a project with default auth config, add multiple place index resources and update the default index', async () => {
-    const [index1Id, index2Id] = generateTwoResourceIdsInOrder();
+    const [index1Id, index2Id, index3Id] = generateResourceIdsInOrder(3);
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await addPlaceIndexWithDefault(projRoot, { resourceName: index1Id, isFirstGeoResource: true });
     await addPlaceIndexWithDefault(projRoot, { resourceName: index2Id, isAdditional: true, isDefault: false });
+    await addPlaceIndexWithDefault(projRoot, { resourceName: index3Id, isAdditional: true, isDefault: false });
     await updateSecondPlaceIndexAsDefault(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Address some of the failing e2e tests for Geo.
`amplify-prompts` automatically makes the selection for the user when there is only one choice in the selection set. 
This could interfere with the `nspawn` process chain of commands defined in the e2e test setup.
We are avoiding such cases by having multiple geo resources in the e2e tests. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran e2e tests locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
