### PR TITLE
ci: remove retries as they cause windows to hang

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1030,25 +1030,25 @@ commands:
             equal: [*windows-e2e-executor, << parameters.os >>]
           steps:
             - run:
-              name: Run E2e Tests
-              command: |
-                source .circleci/local_publish_helpers.sh
-                source $BASH_ENV
-                amplify version
-                runE2eTest
-              no_output_timeout: 90m
+                name: Run E2e Tests
+                command: |
+                  source .circleci/local_publish_helpers.sh
+                  source $BASH_ENV
+                  amplify version
+                  runE2eTest
+                no_output_timeout: 90m
       - when:
           condition:
             equal: [*linux-e2e-executor, << parameters.os >>]
           steps:
             - run:
-              name: Run E2e Tests
-              command: |
-                source .circleci/local_publish_helpers.sh
-                source $BASH_ENV
-                amplify version
-                retry runE2eTest
-              no_output_timeout: 90m
+                name: Run E2e Tests
+                command: |
+                  source .circleci/local_publish_helpers.sh
+                  source $BASH_ENV
+                  amplify version
+                  retry runE2eTest
+                no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: 'Scan And Cleanup E2E Test Artifacts'
     parameters:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1026,29 +1026,29 @@ commands:
         default: linux-e2e-executor
     steps:
       - when:
-        condition:
-          equal: [*windows-e2e-executor, << parameters.os >>]
-        steps:
-          - run:
-            name: Run E2e Tests
-            command: |
-              source .circleci/local_publish_helpers.sh
-              source $BASH_ENV
-              amplify version
-              runE2eTest
-            no_output_timeout: 90m
+          condition:
+            equal: [*windows-e2e-executor, << parameters.os >>]
+          steps:
+            - run:
+              name: Run E2e Tests
+              command: |
+                source .circleci/local_publish_helpers.sh
+                source $BASH_ENV
+                amplify version
+                runE2eTest
+              no_output_timeout: 90m
       - when:
-        condition:
-          equal: [*linux-e2e-executor, << parameters.os >>]
-        steps:
-          - run:
-            name: Run E2e Tests
-            command: |
-              source .circleci/local_publish_helpers.sh
-              source $BASH_ENV
-              amplify version
-              retry runE2eTest
-            no_output_timeout: 90m
+          condition:
+            equal: [*linux-e2e-executor, << parameters.os >>]
+          steps:
+            - run:
+              name: Run E2e Tests
+              command: |
+                source .circleci/local_publish_helpers.sh
+                source $BASH_ENV
+                amplify version
+                retry runE2eTest
+              no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: 'Scan And Cleanup E2E Test Artifacts'
     parameters:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1025,14 +1025,30 @@ commands:
         type: executor
         default: linux-e2e-executor
     steps:
-      - run:
-          name: Run E2e Tests
-          command: |
-            source .circleci/local_publish_helpers.sh
-            source $BASH_ENV
-            amplify version
-            retry runE2eTest
-          no_output_timeout: 90m
+      - when:
+        condition:
+          equal: [*windows-e2e-executor, << parameters.os >>]
+        steps:
+          - run:
+            name: Run E2e Tests
+            command: |
+              source .circleci/local_publish_helpers.sh
+              source $BASH_ENV
+              amplify version
+              runE2eTest
+            no_output_timeout: 90m
+      - when:
+        condition:
+          equal: [*linux-e2e-executor, << parameters.os >>]
+        steps:
+          - run:
+            name: Run E2e Tests
+            command: |
+              source .circleci/local_publish_helpers.sh
+              source $BASH_ENV
+              amplify version
+              retry runE2eTest
+            no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: 'Scan And Cleanup E2E Test Artifacts'
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15983,14 +15983,14 @@ commands:
                   AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
               - << parameters.os >>
           steps:
-            - run: null
-              name: Run E2e Tests
-              command: |
-                source .circleci/local_publish_helpers.sh
-                source $BASH_ENV
-                amplify version
-                runE2eTest
-              no_output_timeout: 90m
+            - run:
+                name: Run E2e Tests
+                command: |
+                  source .circleci/local_publish_helpers.sh
+                  source $BASH_ENV
+                  amplify version
+                  runE2eTest
+                no_output_timeout: 90m
       - when:
           condition:
             equal:
@@ -16004,14 +16004,14 @@ commands:
                   AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
               - << parameters.os >>
           steps:
-            - run: null
-              name: Run E2e Tests
-              command: |
-                source .circleci/local_publish_helpers.sh
-                source $BASH_ENV
-                amplify version
-                retry runE2eTest
-              no_output_timeout: 90m
+            - run:
+                name: Run E2e Tests
+                command: |
+                  source .circleci/local_publish_helpers.sh
+                  source $BASH_ENV
+                  amplify version
+                  retry runE2eTest
+                no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: Scan And Cleanup E2E Test Artifacts
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15970,14 +15970,48 @@ commands:
         type: executor
         default: linux-e2e-executor
     steps:
-      - run:
-          name: Run E2e Tests
-          command: |
-            source .circleci/local_publish_helpers.sh
-            source $BASH_ENV
-            amplify version
-            retry runE2eTest
-          no_output_timeout: 90m
+      - when: null
+        condition:
+          equal:
+            - machine:
+                image: windows-server-2019-vs2019:stable
+                resource_class: windows.large
+                shell: bash.exe
+              working_directory: ~/repo
+              environment:
+                AMPLIFY_DIR: C:/home/circleci/repo/out
+                AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
+            - << parameters.os >>
+        steps:
+          - run: null
+            name: Run E2e Tests
+            command: |
+              source .circleci/local_publish_helpers.sh
+              source $BASH_ENV
+              amplify version
+              runE2eTest
+            no_output_timeout: 90m
+      - when: null
+        condition:
+          equal:
+            - docker:
+                - image: >-
+                    public.ecr.aws/a6e6w2n0/amplify-cli-e2e-base-image-repo-public:latest
+              working_directory: ~/repo
+              resource_class: large
+              environment:
+                AMPLIFY_DIR: /home/circleci/repo/out
+                AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+            - << parameters.os >>
+        steps:
+          - run: null
+            name: Run E2e Tests
+            command: |
+              source .circleci/local_publish_helpers.sh
+              source $BASH_ENV
+              amplify version
+              retry runE2eTest
+            no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: Scan And Cleanup E2E Test Artifacts
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15970,48 +15970,48 @@ commands:
         type: executor
         default: linux-e2e-executor
     steps:
-      - when: null
-        condition:
-          equal:
-            - machine:
-                image: windows-server-2019-vs2019:stable
-                resource_class: windows.large
-                shell: bash.exe
-              working_directory: ~/repo
-              environment:
-                AMPLIFY_DIR: C:/home/circleci/repo/out
-                AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
-            - << parameters.os >>
-        steps:
-          - run: null
-            name: Run E2e Tests
-            command: |
-              source .circleci/local_publish_helpers.sh
-              source $BASH_ENV
-              amplify version
-              runE2eTest
-            no_output_timeout: 90m
-      - when: null
-        condition:
-          equal:
-            - docker:
-                - image: >-
-                    public.ecr.aws/a6e6w2n0/amplify-cli-e2e-base-image-repo-public:latest
-              working_directory: ~/repo
-              resource_class: large
-              environment:
-                AMPLIFY_DIR: /home/circleci/repo/out
-                AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
-            - << parameters.os >>
-        steps:
-          - run: null
-            name: Run E2e Tests
-            command: |
-              source .circleci/local_publish_helpers.sh
-              source $BASH_ENV
-              amplify version
-              retry runE2eTest
-            no_output_timeout: 90m
+      - when:
+          condition:
+            equal:
+              - machine:
+                  image: windows-server-2019-vs2019:stable
+                  resource_class: windows.large
+                  shell: bash.exe
+                working_directory: ~/repo
+                environment:
+                  AMPLIFY_DIR: C:/home/circleci/repo/out
+                  AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
+              - << parameters.os >>
+          steps:
+            - run: null
+              name: Run E2e Tests
+              command: |
+                source .circleci/local_publish_helpers.sh
+                source $BASH_ENV
+                amplify version
+                runE2eTest
+              no_output_timeout: 90m
+      - when:
+          condition:
+            equal:
+              - docker:
+                  - image: >-
+                      public.ecr.aws/a6e6w2n0/amplify-cli-e2e-base-image-repo-public:latest
+                working_directory: ~/repo
+                resource_class: large
+                environment:
+                  AMPLIFY_DIR: /home/circleci/repo/out
+                  AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
+              - << parameters.os >>
+          steps:
+            - run: null
+              name: Run E2e Tests
+              command: |
+                source .circleci/local_publish_helpers.sh
+                source $BASH_ENV
+                amplify version
+                retry runE2eTest
+              no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: Scan And Cleanup E2E Test Artifacts
     parameters:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Windows tests crash after success due to incompatibility with the retry bash script. This commit removes the retry wrapper around windows test runs.

#### Description of how you validated changes

Ran this against a "retry with ssh" on circleci

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
