### PR TITLE
build: run circleci validator on split-e2e-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify amplify-dev",
     "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
     "setup-dev-win": "yarn dev-build && yarn link-win && yarn link-aa-win",
-    "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
+    "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml && circleci config validate",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
     "pkg-install": "cd pkg && cp ../yarn.lock ./ && yarn --production",
     "pkg-prune": "cd pkg && rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify amplify-dev",
     "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
     "setup-dev-win": "yarn dev-build && yarn link-win && yarn link-aa-win",
-    "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml && circleci config validate",
+    "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
     "pkg-install": "cd pkg && cp ../yarn.lock ./ && yarn --production",
     "pkg-prune": "cd pkg && rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md",

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -448,6 +448,7 @@ function saveConfig(config: CircleCIConfig): void {
   const output = ['# auto generated file. Edit config.base.yaml if you want to change', yaml.dump(config, { noRefs: true })];
   fs.writeFileSync(configFile, output.join('\n'));
 }
+
 function verifyConfig() {
   try {
     execa.commandSync('which circleci');

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -3,6 +3,7 @@ import * as glob from 'glob';
 import { join } from 'path';
 import * as fs from 'fs-extra';
 import { supportedRegions } from '../packages/amplify-category-geo/src/constants';
+import * as execa from 'execa';
 
 const CONCURRENCY = 25;
 // Some our e2e tests are known to fail when run on windows hosts
@@ -447,6 +448,23 @@ function saveConfig(config: CircleCIConfig): void {
   const output = ['# auto generated file. Edit config.base.yaml if you want to change', yaml.dump(config, { noRefs: true })];
   fs.writeFileSync(configFile, output.join('\n'));
 }
+function verifyConfig() {
+  try {
+    execa.commandSync('which circleci');
+  } catch {
+    console.error(
+      'Please install circleci cli to validate your circle config. Installation information can be found at https://circleci.com/docs/2.0/local-cli/',
+    );
+    process.exit(1);
+  }
+  try {
+    execa.commandSync('circleci config validate');
+  } catch {
+    console.error(`"circleci config validate" command failed. Please check your .circleci/config.yml validity`);
+    process.exit(1);
+  }
+}
+
 function main(): void {
   const config = loadConfig();
   const splitNodeTests = splitTests(
@@ -471,5 +489,6 @@ function main(): void {
     CONCURRENCY,
   );
   saveConfig(splitGqlTests);
+  verifyConfig();
 }
 main();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This adds another step to `yarn run split-e2e-tests` using the [CircleCi CLI](https://circleci.com/docs/2.0/local-cli/) to [validate the generated build.yml](https://support.circleci.com/hc/en-us/articles/360006735753-Validating-your-CircleCI-Configuration).

The CircleCI CLI must be installed (eg `brew install circleci`). 

This will notify us before attempting to use invalid CircleCI configuration.

#### Description of how you validated changes

- ran `yarn run split-e2e-tests` on valid and invalid configs

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
