### PR TITLE
ci: use powershell to run windows tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1031,11 +1031,10 @@ commands:
           steps:
             - run:
                 name: Run E2e Tests
+                shell: powershell.exe
                 command: |
-                  source .circleci/local_publish_helpers.sh
-                  source $BASH_ENV
-                  amplify version
-                  runE2eTest
+                  cd packages/amplify-e2e-tests
+                  yarn run e2e --detectOpenHandles --maxWorkers=3 $env:TEST_SUITE
                 no_output_timeout: 90m
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15985,11 +15985,12 @@ commands:
           steps:
             - run:
                 name: Run E2e Tests
-                command: |
-                  source .circleci/local_publish_helpers.sh
-                  source $BASH_ENV
-                  amplify version
-                  runE2eTest
+                shell: powershell.exe
+                command: >
+                  cd packages/amplify-e2e-tests
+
+                  yarn run e2e --detectOpenHandles --maxWorkers=3
+                  $env:TEST_SUITE
                 no_output_timeout: 90m
       - when:
           condition:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

I'm not sure what's wrong with windows bash yet, but in the meantime we should just use powershell which is how it worked before.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
