### PR TITLE
fix: function comments to use os.EOL constant

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { EOL } from 'os';
 import path from 'path';
 import { categoryName, topLevelCommentPrefix, topLevelCommentSuffix } from '../../../constants';
 import _ from 'lodash';
@@ -16,7 +17,7 @@ export const tryUpdateTopLevelComment = (resourceDirPath: string, envVars: strin
   updateTopLevelComment(sourceFilePath, newComment);
 };
 
-const createTopLevelComment = (envVars: string[]) => `${topLevelCommentPrefix}${envVars.sort().join('\n\t')}${topLevelCommentSuffix}`;
+const createTopLevelComment = (envVars: string[]) => `${topLevelCommentPrefix}${envVars.sort().join(`${EOL}\t`)}${topLevelCommentSuffix}`;
 
 const updateTopLevelComment = (filePath, newComment) => {
   const commentRegex = new RegExp(`${_.escapeRegExp(topLevelCommentPrefix)}[a-zA-Z0-9\\-\\s._=]+${_.escapeRegExp(topLevelCommentSuffix)}`);
@@ -52,9 +53,9 @@ export const tryPrependSecretsUsageExample = async (functionName: string, secret
   await fs.writeFile(sourceFilePath, fileContent);
 };
 
-const secretsUsageHeader = '/*\nUse the following code to retrieve configured secrets from SSM:';
+const secretsUsageHeader = `/*${EOL}Use the following code to retrieve configured secrets from SSM:`;
 
-const secretsUsageFooter = "Parameters will be of the form { Name: 'secretName', Value: 'secretValue', ... }[]\n*/\n";
+const secretsUsageFooter = `Parameters will be of the form { Name: 'secretName', Value: 'secretValue', ... }[]${EOL}*/${EOL}`;
 
 const secretsUsageTemplate = (secretNames: string[]) =>
   `${secretsUsageHeader}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Small fix to replace usage of `\n` with `os.EOL` in function's comments to improve experience on Windows.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

ref #8177 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
