### PR TITLE
fix: improve trigger update error handling

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import _ from 'lodash';
-import { JSONUtilities, $TSAny } from 'amplify-cli-core';
+import { exitOnNextTick, JSONUtilities, $TSAny } from 'amplify-cli-core';
 import Separator from 'inquirer/lib/objects/separator';
 
 // keep in sync with ServiceName in amplify-category-function, but probably it will not change
@@ -193,10 +193,12 @@ export const updateTrigger = async triggerOptions => {
 
       await cleanFunctions(key, values, category, context, targetPath);
     }
-    context.print.success('Successfully updated the Lambda function locally');
+    context.print.success('Successfully updated the Cognito trigger locally');
     return null;
-  } catch (e) {
-    throw new Error('Unable to update lambda function');
+  } catch (err: $TSAny) {
+    context.print.error(`Error updating the Cognito trigger: ${err.message}`);
+    await context.usageData.emitError(err);
+    exitOnNextTick(1);
   }
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Update error handling for failed trigger updates to include helpful message with clear direction
- Updates & standardizes naming of resource in success and error messages
- `e` -> `err`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

ref #8280

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
