### PR TITLE
ci: remove per-job cleanup

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -288,8 +288,8 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
+      # - clean_e2e_resources:
+      #     os: << parameters.os >>
   amplify_migration_tests_v4:
     <<: *defaults
     steps:
@@ -767,8 +767,8 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
           filters:
             branches:
               only:
@@ -805,8 +805,8 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
       - amplify_migration_tests_v4:
           context:
             - amplify-ecr-image-pull
@@ -821,8 +821,8 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
       - amplify_migration_tests_v4_30_0:
           context:
             - amplify-ecr-image-pull
@@ -837,8 +837,8 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
       - amplify_migration_tests_non_multi_env_layers:
           context:
             - amplify-ecr-image-pull
@@ -853,8 +853,8 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
       - amplify_migration_tests_multi_env_layers:
           context:
             - amplify-ecr-image-pull
@@ -869,8 +869,8 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
       - amplify_console_integration_tests:
           context:
             - amplify-ecr-image-pull
@@ -878,8 +878,8 @@ workflows:
             - cleanup-resources
             - console-e2e-test
             - e2e-test-context
-          post-steps:
-            - run: *clean_e2e_resources
+          # post-steps:
+          #   - run: *clean_e2e_resources
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,8 +357,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
   amplify_migration_tests_v4:
     working_directory: ~/repo
     parameters:
@@ -5978,8 +5976,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/api_4.test.ts
       CLI_REGION: us-east-2
@@ -6015,8 +6011,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_6.test.ts
       CLI_REGION: us-west-2
@@ -6052,8 +6046,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_7.test.ts
       CLI_REGION: eu-west-2
@@ -6089,8 +6081,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_8.test.ts
       CLI_REGION: eu-central-1
@@ -6126,8 +6116,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/configure-project.test.ts
       CLI_REGION: ap-northeast-1
@@ -6163,8 +6151,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/container-hosting.test.ts
       CLI_REGION: ap-southeast-1
@@ -6200,8 +6186,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/frontend_config_drift.test.ts
       CLI_REGION: ap-southeast-2
@@ -6237,8 +6221,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_5.test.ts
       CLI_REGION: us-east-2
@@ -6274,8 +6256,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_6.test.ts
       CLI_REGION: us-west-2
@@ -6311,8 +6291,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_7.test.ts
       CLI_REGION: eu-west-2
@@ -6348,8 +6326,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_8.test.ts
       CLI_REGION: eu-central-1
@@ -6385,8 +6361,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_9.test.ts
       CLI_REGION: ap-northeast-1
@@ -6422,8 +6396,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/hooks.test.ts
       CLI_REGION: ap-southeast-1
@@ -6459,8 +6431,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts
       CLI_REGION: ap-southeast-2
@@ -6496,8 +6466,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_auth_3.test.ts
       CLI_REGION: us-east-2
@@ -6533,8 +6501,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_dynamodb_2.test.ts
       CLI_REGION: us-west-2
@@ -6570,8 +6536,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_s3_2.test.ts
       CLI_REGION: eu-west-2
@@ -6607,8 +6571,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/layer-1.test.ts
       CLI_REGION: eu-central-1
@@ -6644,8 +6606,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/layer-2.test.ts
       CLI_REGION: ap-northeast-1
@@ -6681,8 +6641,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/layer-3.test.ts
       CLI_REGION: ap-southeast-1
@@ -6718,8 +6676,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/layer-4.test.ts
       CLI_REGION: ap-southeast-2
@@ -6755,8 +6711,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/migration/api.connection.migration2.test.ts
       CLI_REGION: us-east-2
@@ -6792,8 +6746,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/migration/node.function.test.ts
       CLI_REGION: us-west-2
@@ -6829,8 +6781,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/pull.test.ts
       CLI_REGION: eu-west-2
@@ -6866,8 +6816,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/s3-sse.test.ts
       CLI_REGION: eu-central-1
@@ -6903,8 +6851,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-12.test.ts
       CLI_REGION: ap-northeast-1
@@ -6940,8 +6886,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-13.test.ts
       CLI_REGION: ap-southeast-1
@@ -6977,8 +6921,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-function-1.test.ts
       CLI_REGION: ap-southeast-2
@@ -7014,8 +6956,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-function-2.test.ts
       CLI_REGION: us-east-2
@@ -7051,8 +6991,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts
       CLI_REGION: us-west-2
@@ -7088,8 +7026,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/storage-1.test.ts
       CLI_REGION: eu-west-2
@@ -7125,8 +7061,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/storage-2.test.ts
       CLI_REGION: eu-central-1
@@ -7162,8 +7096,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/storage-3.test.ts
       CLI_REGION: ap-northeast-1
@@ -7199,8 +7131,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/plugin.test.ts
       CLI_REGION: ap-southeast-1
@@ -7236,8 +7166,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/init-special-case.test.ts
       CLI_REGION: ap-southeast-2
@@ -7273,8 +7201,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
       CLI_REGION: us-east-2
@@ -7310,8 +7236,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/amplify-configure.test.ts
       CLI_REGION: us-west-2
@@ -7347,8 +7271,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/init.test.ts
       CLI_REGION: eu-west-2
@@ -7384,8 +7306,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/tags.test.ts
       CLI_REGION: eu-central-1
@@ -7421,8 +7341,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/notifications.test.ts
       CLI_REGION: ap-northeast-1
@@ -7458,8 +7376,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-versioned.test.ts
       CLI_REGION: ap-southeast-1
@@ -7495,8 +7411,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts
       CLI_REGION: ap-southeast-2
@@ -7532,8 +7446,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/interactions.test.ts
       CLI_REGION: us-west-2
@@ -7569,8 +7481,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-predictions.test.ts
       CLI_REGION: us-west-2
@@ -7606,8 +7516,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/amplify-app.test.ts
       CLI_REGION: eu-west-2
@@ -7643,8 +7551,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/hosting.test.ts
       CLI_REGION: eu-central-1
@@ -7680,8 +7586,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/analytics.test.ts
       CLI_REGION: ap-northeast-1
@@ -7717,8 +7621,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/feature-flags.test.ts
       CLI_REGION: ap-southeast-1
@@ -7754,8 +7656,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts
       CLI_REGION: ap-southeast-2
@@ -7791,8 +7691,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/containers-api.test.ts
       CLI_REGION: us-east-2
@@ -7828,8 +7726,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/predictions.test.ts
       CLI_REGION: us-west-2
@@ -7865,8 +7761,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/hostingPROD.test.ts
       CLI_REGION: eu-west-2
@@ -7902,8 +7796,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/geo-add.test.ts
       CLI_REGION: ap-southeast-1
@@ -7939,8 +7831,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/geo-update.test.ts
       CLI_REGION: ap-southeast-2
@@ -7976,8 +7866,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/geo-remove.test.ts
       CLI_REGION: us-east-2
@@ -8013,8 +7901,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-10.test.ts
       CLI_REGION: ap-southeast-2
@@ -8050,8 +7936,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-key.test.ts
       CLI_REGION: us-east-2
@@ -8087,8 +7971,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_1.test.ts
       CLI_REGION: us-west-2
@@ -8124,8 +8006,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_5.test.ts
       CLI_REGION: eu-west-2
@@ -8161,8 +8041,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_3.test.ts
       CLI_REGION: eu-central-1
@@ -8198,8 +8076,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts
       CLI_REGION: ap-northeast-1
@@ -8235,8 +8111,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-3.test.ts
       CLI_REGION: ap-southeast-1
@@ -8272,8 +8146,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/delete.test.ts
       CLI_REGION: ap-southeast-2
@@ -8309,8 +8181,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_2.test.ts
       CLI_REGION: us-east-2
@@ -8346,8 +8216,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_3.test.ts
       CLI_REGION: us-west-2
@@ -8383,8 +8251,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
       CLI_REGION: eu-west-2
@@ -8420,8 +8286,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_4.test.ts
       CLI_REGION: eu-central-1
@@ -8457,8 +8321,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-7.test.ts
       CLI_REGION: ap-northeast-1
@@ -8494,8 +8356,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-8.test.ts
       CLI_REGION: ap-southeast-1
@@ -8531,8 +8391,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-searchable.test.ts
       CLI_REGION: ap-southeast-2
@@ -8568,8 +8426,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-4.test.ts
       CLI_REGION: us-east-2
@@ -8605,8 +8461,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/api_3.test.ts
       CLI_REGION: us-west-2
@@ -8642,8 +8496,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_auth_1.test.ts
       CLI_REGION: eu-west-2
@@ -8679,8 +8531,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_auth_2.test.ts
       CLI_REGION: eu-central-1
@@ -8716,8 +8566,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_s3_1.test.ts
       CLI_REGION: ap-northeast-1
@@ -8754,8 +8602,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
       CLI_REGION: ap-southeast-1
@@ -8792,8 +8638,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
       CLI_REGION: ap-southeast-2
@@ -8829,8 +8673,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-rollback-2.test.ts
       CLI_REGION: us-east-2
@@ -8866,8 +8708,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/env.test.ts
       CLI_REGION: us-west-2
@@ -8903,8 +8743,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/auth_2.test.ts
       CLI_REGION: eu-west-2
@@ -8941,8 +8779,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-9.test.ts
       CLI_REGION: eu-central-1
@@ -8978,8 +8814,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-11.test.ts
       CLI_REGION: ap-northeast-1
@@ -9015,8 +8849,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
       CLI_REGION: ap-southeast-1
@@ -9053,8 +8885,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_1.test.ts
       CLI_REGION: ap-southeast-2
@@ -9090,8 +8920,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-1.test.ts
       CLI_REGION: us-east-2
@@ -9127,8 +8955,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/function_4.test.ts
       CLI_REGION: us-west-2
@@ -9164,8 +8990,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-model.test.ts
       CLI_REGION: eu-west-2
@@ -9201,8 +9025,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts
       CLI_REGION: eu-central-1
@@ -9238,8 +9060,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-connection.test.ts
       CLI_REGION: ap-northeast-1
@@ -9275,8 +9095,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-6.test.ts
       CLI_REGION: ap-southeast-1
@@ -9312,8 +9130,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts
       CLI_REGION: ap-southeast-2
@@ -9349,8 +9165,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-2.test.ts
       CLI_REGION: us-east-2
@@ -9386,8 +9200,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/api_1.test.ts
       CLI_REGION: us-west-2
@@ -9424,8 +9236,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-auth-5.test.ts
       CLI_REGION: eu-west-2
@@ -9461,8 +9271,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/api_2.test.ts
       CLI_REGION: eu-central-1
@@ -9499,8 +9307,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/api_5.test.ts
       CLI_REGION: ap-northeast-1
@@ -9536,8 +9342,6 @@ jobs:
           path: packages/amplify-e2e-tests/
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
-      - clean_e2e_resources:
-          os: << parameters.os >>
     environment:
       TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
       CLI_REGION: ap-southeast-1
@@ -10545,14 +10349,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
       - amplify_migration_tests_v4:
           context:
             - amplify-ecr-image-pull
@@ -10567,14 +10363,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
       - amplify_migration_tests_v4_30_0:
           context:
             - amplify-ecr-image-pull
@@ -10589,14 +10377,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
       - amplify_migration_tests_non_multi_env_layers:
           context:
             - amplify-ecr-image-pull
@@ -10611,14 +10391,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
       - amplify_migration_tests_multi_env_layers:
           context:
             - amplify-ecr-image-pull
@@ -10633,14 +10405,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - build
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
       - amplify_console_integration_tests:
           context:
             - amplify-ecr-image-pull
@@ -10648,14 +10412,6 @@ workflows:
             - cleanup-resources
             - console-e2e-test
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11141,14 +10897,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11167,14 +10915,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11193,14 +10933,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11219,14 +10951,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11245,14 +10969,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11271,14 +10987,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11297,14 +11005,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11323,14 +11023,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11349,14 +11041,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11375,14 +11059,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11401,14 +11077,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11427,14 +11095,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11453,14 +11113,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11479,14 +11131,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11505,14 +11149,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11531,14 +11167,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11557,14 +11185,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11583,14 +11203,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11609,14 +11221,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11635,14 +11239,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11661,14 +11257,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11687,14 +11275,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11713,14 +11293,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11739,14 +11311,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11765,14 +11329,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11791,14 +11347,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11817,14 +11365,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11843,14 +11383,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11869,14 +11401,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11895,14 +11419,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11921,14 +11437,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11947,14 +11455,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11973,14 +11473,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -11999,14 +11491,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12025,14 +11509,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12051,14 +11527,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12077,14 +11545,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12103,14 +11563,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12129,14 +11581,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12155,14 +11599,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12181,14 +11617,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12207,14 +11635,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12233,14 +11653,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12259,14 +11671,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12285,14 +11689,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12311,14 +11707,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12337,14 +11725,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12363,14 +11743,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12389,14 +11761,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12415,14 +11779,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12441,14 +11797,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12467,14 +11815,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12493,14 +11833,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12519,14 +11851,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12545,14 +11869,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12571,14 +11887,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12597,14 +11905,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12623,14 +11923,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12649,14 +11941,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12675,14 +11959,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12701,14 +11977,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12727,14 +11995,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12753,14 +12013,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12779,14 +12031,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12805,14 +12049,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12831,14 +12067,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12857,14 +12085,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12883,14 +12103,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12909,14 +12121,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12935,14 +12139,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12961,14 +12157,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -12987,14 +12175,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13013,14 +12193,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13039,14 +12211,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13065,14 +12229,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13091,14 +12247,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13117,14 +12265,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13143,14 +12283,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13169,14 +12301,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13195,14 +12319,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13221,14 +12337,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13247,14 +12355,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13273,14 +12373,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13299,14 +12391,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13325,14 +12409,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13351,14 +12427,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13377,14 +12445,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13403,14 +12463,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13429,14 +12481,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13455,14 +12499,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13481,14 +12517,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13507,14 +12535,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13533,14 +12553,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13559,14 +12571,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13585,14 +12589,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13611,14 +12607,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:
@@ -13637,14 +12625,6 @@ workflows:
             - cleanup-resources
             - e2e-auth-credentials
             - e2e-test-context
-          post-steps:
-            - run:
-                name: Cleanup resources
-                command: |
-                  pwd
-                  cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-                working_directory: ~/repo
           filters:
             branches:
               only:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Remove per-job cleanup for now because it was resulting in throttling errors. Also there is an issue where if the parent account is used to run a test it will attempt to clean up resources in all of the child accounts
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
