### PR TITLE
style: 💄 Use compact status table

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-view.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-view.ts
@@ -32,5 +32,5 @@ export function viewEnvInfo() {
 export function viewSummaryTable(resourceStateData) {
   const tableOptions = getSummaryTableData(resourceStateData);
   const { table } = print;
-  table(tableOptions, { format: 'lean' });
+  table(tableOptions);
 }


### PR DESCRIPTION
Removes the line in the `amplify status` command

✅ Closes: #8185

#### Description of changes

Removes the optional `format` on the status table which in turn applies the compact styling (i.e. no lines)

#### Issue 

https://github.com/aws-amplify/amplify-cli/issues/8185

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Run `amplify status` before the change includes the lines in the table like so 

![image](https://user-images.githubusercontent.com/13058008/135756614-54631bb3-befa-4020-97e4-06f0fa25c7b7.png)

Run `amplify status` after the change no longer includes the lines

![image](https://user-images.githubusercontent.com/13058008/135756918-a483a30e-6aea-432b-86a0-16b81e21b0a0.png)

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
