### PR TITLE
revert: temporarily setup new apps with old pluralization

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -519,7 +519,7 @@ export class FeatureFlags {
         name: 'improvePluralization',
         type: 'boolean',
         defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: true,
+        defaultValueForNewProjects: false,
       },
       {
         name: 'validateTypeNameReservedWords',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Updates to our pluralization have resulted in customer issues  as described in https://github.com/aws-amplify/amplify-cli/issues/8350.

This pull request switches the cli to use the old pluralization scheme by default for new apps until any underlying problems can be addressed.

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/8350

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Ran all unit tests
- Pushed new api with two models. One called wish and one called wishes. No errors.

Cloud e2e: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/3119/workflows/dc448064-0287-4ff5-8158-c107889951b2

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
