### PR TITLE
feat: add mock context to python shim

### DIFF
--- a/packages/amplify-python-function-runtime-provider/shim/shim.py
+++ b/packages/amplify-python-function-runtime-provider/shim/shim.py
@@ -26,6 +26,15 @@ def main(argv):
   lambdaInput = json.loads(sys.stdin.readline().rstrip())
   event = json.loads(lambdaInput["event"]) # event is already serialized by the platform so need to turn it into a dict here before invoking
   context = lambdaInput["context"]
+  if not context:
+    class ContextShim:
+      def __init__(self):
+        self.function_name = handlerName
+        self.memory_limit_in_mb = 128
+        self.invoked_function_arn = "UNDEFINED"
+        self.aws_request_id = "UNDEFINED"
+    context = ContextShim()
+
   
   # execute lambda and return result on stdout
   print('\n') # since we rely on the last line being the result, make sure the handler didn't already write something to the line


### PR DESCRIPTION
Shamelessly borrowed the defaults from https://github.com/awslabs/aws-lambda-powertools-python/blob/29497d47d63b2e795c2a9d81eaca3985dfe8f071/aws_lambda_powertools/logging/lambda_context.py\#L4

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds context information (if it was not provided already) to lambda functions when amplify mock is run
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue aws-amplify/amplify-category-api#156

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

performed steps in issue, with modified code. Issue appeared to be resolved.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [x] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)
- [X] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
