### PR TITLE
chore: updating deprecated codegen feature flags to true for existing projects

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -593,31 +593,31 @@ export class FeatureFlags {
       {
         name: 'useAppSyncModelgenPlugin',
         type: 'boolean',
-        defaultValueForExistingProjects: false,
+        defaultValueForExistingProjects: true,
         defaultValueForNewProjects: true,
       },
       {
         name: 'useDocsGeneratorPlugin',
         type: 'boolean',
-        defaultValueForExistingProjects: false,
+        defaultValueForExistingProjects: true,
         defaultValueForNewProjects: true,
       },
       {
         name: 'useTypesGeneratorPlugin',
         type: 'boolean',
-        defaultValueForExistingProjects: false,
+        defaultValueForExistingProjects: true,
         defaultValueForNewProjects: true,
       },
       {
         name: 'cleanGeneratedModelsDirectory',
         type: 'boolean',
-        defaultValueForExistingProjects: false,
+        defaultValueForExistingProjects: true,
         defaultValueForNewProjects: true,
       },
       {
         name: 'retainCaseStyle',
         type: 'boolean',
-        defaultValueForExistingProjects: false,
+        defaultValueForExistingProjects: true,
         defaultValueForNewProjects: true,
       },
       {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Updating deprecated codegen feature flags to true for existing projects. We are electing to begin defaulting customers into this new behavior before removing the feature flag entirely, to gather any issues or feedback which may arise while customers still have a release valve.

Documentation update PR is available here https://github.com/aws-amplify/docs/pull/3678

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

N/A - just config changes. The existing 'use this field for new project' flags have been released for several months now.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
