### PR TITLE
fix: auth on getting related model name and searchablevNext e2e

### DIFF
--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -75,6 +75,12 @@ export class ModelResourceIDs {
   static ModelConnectionTypeName(typeName: string): string {
     return `Model${typeName}Connection`;
   }
+  static IsModelConnectionType(typeName: string): boolean {
+    return /^Model.*Connection$/.test(typeName);
+  }
+  static GetModelFromConnectionType(typeName: string): string {
+    return /(?<=Model)(.*)(?=Connection)/.exec(typeName)[0];
+  }
   static ModelDeleteInputObjectName(typeName: string): string {
     return graphqlName('Delete' + toUpper(typeName) + 'Input');
   }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
@@ -84,7 +84,7 @@ const USERNAME1 = 'user1@test.com';
 const USERNAME2 = 'user2@test.com';
 const USERNAME3 = 'user3@test.com';
 const TMP_PASSWORD = 'Password123!';
-const REAL_PASSWORD = 'password';
+const REAL_PASSWORD = 'Password1234!';
 const WRITER_GROUP_NAME = 'writer';
 const ADMIN_GROUP_NAME = 'admin';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- add connection type util functions
- change get model object for relational directives to use output schema

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
