### PR TITLE
fix(graphql): correct api key typo on auto apply auth mode

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -119,7 +119,7 @@ async function handleValidGraphQLAuthError(context: $TSContext, message: string)
       await addGraphQLAuthRequirement(context, 'OPENID_CONNECT')
       return true;
     } else if (message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`) {
-      await addGraphQLAuthRequirement(context, 'AWS_KEY');
+      await addGraphQLAuthRequirement(context, 'API_KEY');
       return true;
     } else if (message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`) {
       await addGraphQLAuthRequirement(context, 'AWS_LAMBDA');


### PR DESCRIPTION
#### Description of changes
Correct API_KEY typo on auto apply auth mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
