### PR TITLE
test: update split script for new suites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2193,6 +2193,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/packages/amplify-cli/bin/amplify
       TEST_SUITE: src/__tests__/migration/api.key.migration4.test.ts
       CLI_REGION: eu-central-1
+      USE_PARENT_ACCOUNT: 1
   migration-api-key-migration5-amplify_e2e_tests:
     working_directory: ~/repo
     parameters:
@@ -2245,6 +2246,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/packages/amplify-cli/bin/amplify
       TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts
       CLI_REGION: ap-northeast-1
+      USE_PARENT_ACCOUNT: 1
   migration-node-function-amplify_e2e_tests:
     working_directory: ~/repo
     parameters:
@@ -5525,6 +5527,7 @@ jobs:
       AMPLIFY_PATH: /home/circleci/repo/packages/amplify-cli/bin/amplify
       TEST_SUITE: src/__tests__/migration/api.key.migration3.test.ts
       CLI_REGION: ap-northeast-1
+      USE_PARENT_ACCOUNT: 1
   function_1-amplify_e2e_tests:
     working_directory: ~/repo
     parameters:
@@ -7130,6 +7133,7 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration4.test.ts
       CLI_REGION: eu-central-1
+      USE_PARENT_ACCOUNT: 1
   migration-api-key-migration5-amplify_e2e_tests_pkg:
     parameters:
       os:
@@ -7165,6 +7169,7 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts
       CLI_REGION: ap-northeast-1
+      USE_PARENT_ACCOUNT: 1
   migration-node-function-amplify_e2e_tests_pkg:
     parameters:
       os:
@@ -9374,6 +9379,7 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/migration/api.key.migration3.test.ts
       CLI_REGION: ap-northeast-1
+      USE_PARENT_ACCOUNT: 1
   function_1-amplify_e2e_tests_pkg:
     parameters:
       os:
@@ -15234,7 +15240,6 @@ workflows:
             parameters:
               os:
                 - linux
-                - windows
       - schema-auth-13-amplify_e2e_tests_pkg:
           context:
             - amplify-ecr-image-pull
@@ -15507,7 +15512,6 @@ workflows:
             parameters:
               os:
                 - linux
-                - windows
       - schema-function-1-amplify_e2e_tests_pkg:
           context:
             - amplify-ecr-image-pull

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -69,6 +69,8 @@ const WINDOWS_TEST_FAILURES = [
   'migration-api-key-migration1-amplify_e2e_tests',
   'migration-api-key-migration2-amplify_e2e_tests',
   'migration-api-key-migration3-amplify_e2e_tests',
+  'migration-api-key-migration4-amplify_e2e_tests',
+  'migration-api-key-migration5-amplify_e2e_tests',
   'migration-node-function-amplify_e2e_tests',
   'notifications-amplify_e2e_tests',
   'predictions-amplify_e2e_tests',
@@ -134,6 +136,9 @@ const USE_PARENT_ACCOUNT = [
   'import_dynamodb_1-amplify_e2e_tests',
   'import_s3_1-amplify_e2e_tests',
   'migration-api-key-migration2-amplify_e2e_tests',
+  'migration-api-key-migration3-amplify_e2e_tests',
+  'migration-api-key-migration4-amplify_e2e_tests',
+  'migration-api-key-migration5-amplify_e2e_tests',
   'storage-amplify_e2e_tests',
 ];
 


### PR DESCRIPTION
#### Description of changes
migration-api-key-migration2 was recently split into multiple suites. The original suite was special cased in the split-e2e-tests.ts script. This commit updates the new suites to have the same special casing.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
