### PR TITLE
test: fix post-test account cleanup

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -494,7 +494,7 @@ export const cleanup = async () => {
     accs = await Promise.all(accs);
   } catch (e) {
     console.error(e);
-    console.log('Error assuming role in child account. Using parent AWS account.');
+    console.log('Error assuming child account role. This could be because the script is already running from within a child account. Running on current AWS account only.');
     accs = [
       {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR fixes an issue where only the parent aws account gets cleaned upon completion of the e2e test suite.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manually ran `yarn clean-e2e-resources` and confirmed it was assuming roles appropriately.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
