### PR TITLE
fix(graphql-relational-schema-transformer): fix the case of table nam…

### DIFF
--- a/packages/graphql-relational-schema-transformer/src/RelationalDBResolverGenerator.ts
+++ b/packages/graphql-relational-schema-transformer/src/RelationalDBResolverGenerator.ts
@@ -391,8 +391,7 @@ export class RelationalDBResolverGenerator {
    * @returns string with the sql statement
    */
   private generateSelectStatement(type: string): string {
-    const tableName = this.getTableName(type);
-    return `SELECT * FROM ${tableName}`;
+    return `SELECT * FROM ${type}`;
   }
 
   /**
@@ -408,9 +407,9 @@ export class RelationalDBResolverGenerator {
     const hasToAppendOperationInput = ![GRAPHQL_RESOLVER_OPERATION.Get, GRAPHQL_RESOLVER_OPERATION.Delete].includes(operationType);
     const operationInput = hasToAppendOperationInput ? `${operationType}${tableName}Input.` : '';
     if (this.isPrimaryKeyAStringType(type)) {
-      return `SELECT * FROM ${tableName} WHERE ${primaryKey}=\'$ctx.args.${operationInput}${primaryKey}\'`;
+      return `SELECT * FROM ${type} WHERE ${primaryKey}=\'$ctx.args.${operationInput}${primaryKey}\'`;
     }
-    return `SELECT * FROM ${tableName} WHERE ${primaryKey}=$ctx.args.${operationInput}${primaryKey}`;
+    return `SELECT * FROM ${type} WHERE ${primaryKey}=$ctx.args.${operationInput}${primaryKey}`;
   }
 
   /**
@@ -420,8 +419,7 @@ export class RelationalDBResolverGenerator {
    * @returns string with the sql statement
    */
   private generateInsertStatement(type: string): string {
-    const tableName = this.getTableName(type);
-    return `INSERT INTO ${tableName} $colStr VALUES $valStr`;
+    return `INSERT INTO ${type} $colStr VALUES $valStr`;
   }
 
   /**


### PR DESCRIPTION
Fix the case of table names in rds SQL statements
Should not upper case the capital letter for the table names.
The case of table names is totally correct for UPDATE and DELETE SQL statements, but wrong for INSERT and SELECT SQL statements.


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
