### PR TITLE
fix: pinpoint feature flag read

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-pinpoint.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-pinpoint.js
@@ -3,31 +3,8 @@ const { FeatureFlags } = require('amplify-cli-core');
 const proxyAgent = require('proxy-agent');
 const configurationManager = require('../configuration-manager');
 const { formUserAgentParam } = require('./user-agent');
-const latestPinpointRegions = FeatureFlags.getNumber('latestRegionSupport.pinpoint');
 
 const defaultPinpointRegion = 'us-east-1';
-const serviceRegionMap = {
-  'us-east-1': 'us-east-1',
-  'us-east-2': 'us-east-1',
-  'sa-east-1': 'us-east-1',
-  'ca-central-1': latestPinpointRegions >= 1 ? 'ca-central-1' : 'us-east-1',
-  'us-west-1': 'us-west-2',
-  'us-west-2': 'us-west-2',
-  'cn-north-1': 'us-west-2',
-  'cn-northwest-1': 'us-west-2',
-  'ap-south-1': latestPinpointRegions >= 1 ? 'ap-south-1' : 'us-west-2',
-  'ap-northeast-3': 'us-west-2',
-  'ap-northeast-2': latestPinpointRegions >= 1 ? 'ap-northeast-2' : 'us-west-2',
-  'ap-southeast-1': latestPinpointRegions >= 1 ? 'ap-southeast-1' : 'us-west-2',
-  'ap-southeast-2': latestPinpointRegions >= 1 ? 'ap-southeast-2' : 'us-west-2',
-  'ap-northeast-1': latestPinpointRegions >= 1 ? 'ap-northeast-1' : 'us-west-2',
-  'eu-central-1': 'eu-central-1',
-  'eu-north-1': 'eu-central-1',
-  'eu-west-1': 'eu-west-1',
-  'eu-west-2': latestPinpointRegions >= 1 ? 'eu-west-2' : 'eu-west-1',
-  'eu-west-3': 'eu-west-1',
-  'me-south-1': 'ap-south-1',
-};
 
 async function getConfiguredPinpointClient(context, category, action, envName) {
   let cred = {};
@@ -62,6 +39,7 @@ async function getConfiguredPinpointClient(context, category, action, envName) {
 }
 
 function mapServiceRegion(region) {
+  const serviceRegionMap = getPinpointRegionMapping();
   if (serviceRegionMap[region]) {
     return serviceRegionMap[region];
   }
@@ -69,7 +47,30 @@ function mapServiceRegion(region) {
 }
 
 function getPinpointRegionMapping() {
-  return serviceRegionMap;
+  const latestPinpointRegions = FeatureFlags.getNumber('latestRegionSupport.pinpoint');
+
+  return {
+    'us-east-1': 'us-east-1',
+    'us-east-2': 'us-east-1',
+    'sa-east-1': 'us-east-1',
+    'ca-central-1': latestPinpointRegions >= 1 ? 'ca-central-1' : 'us-east-1',
+    'us-west-1': 'us-west-2',
+    'us-west-2': 'us-west-2',
+    'cn-north-1': 'us-west-2',
+    'cn-northwest-1': 'us-west-2',
+    'ap-south-1': latestPinpointRegions >= 1 ? 'ap-south-1' : 'us-west-2',
+    'ap-northeast-3': 'us-west-2',
+    'ap-northeast-2': latestPinpointRegions >= 1 ? 'ap-northeast-2' : 'us-west-2',
+    'ap-southeast-1': latestPinpointRegions >= 1 ? 'ap-southeast-1' : 'us-west-2',
+    'ap-southeast-2': latestPinpointRegions >= 1 ? 'ap-southeast-2' : 'us-west-2',
+    'ap-northeast-1': latestPinpointRegions >= 1 ? 'ap-northeast-1' : 'us-west-2',
+    'eu-central-1': 'eu-central-1',
+    'eu-north-1': 'eu-central-1',
+    'eu-west-1': 'eu-west-1',
+    'eu-west-2': latestPinpointRegions >= 1 ? 'eu-west-2' : 'eu-west-1',
+    'eu-west-3': 'eu-west-1',
+    'me-south-1': 'ap-south-1',
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
#### Description of changes

Encapsulate region map reading into a function to make sure external tooling (codegen, etc) can still load the awscloudformation package without failure.

#### Issue #, if available

N/A

#### Description of how you validated changes

Manual testing against codegen by @sundersc 

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
