### PR TITLE
(fix) s3 add with no-auth resource should succeed

### DIFF
--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-auth-api.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-auth-api.ts
@@ -1,6 +1,6 @@
-import { $TSAny, $TSContext} from "amplify-cli-core";
-import { printer } from "amplify-prompts";
-import { AmplifyCategories } from "amplify-cli-core";
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { printer } from 'amplify-prompts';
+import { AmplifyCategories } from 'amplify-cli-core';
 
 /* This file contains all functions interacting with AUTH category */
 
@@ -11,27 +11,35 @@ import { AmplifyCategories } from "amplify-cli-core";
  * @param context  used to fetch all auth resources used by storage(S3)
  * @returns Name of the auth resource used by S3
  */
-export  async function getAuthResourceARN( context : $TSContext ) : Promise<string> {
-    let authResources = (await context.amplify.getResourceStatus('auth')).allResources;
-    authResources = authResources.filter((resource: $TSAny) => resource.service === 'Cognito');
-    if (authResources.length === 0) {
-      throw new Error('No auth resource found. Please add it using amplify add auth');
-    }
-    return authResources[0].resourceName as string;
+export async function getAuthResourceARN(context: $TSContext): Promise<string> {
+  let authResources = (await context.amplify.getResourceStatus('auth')).allResources;
+  authResources = authResources.filter((resource: $TSAny) => resource.service === 'Cognito');
+  if (authResources.length === 0) {
+    throw new Error('No auth resource found. Please add it using amplify add auth');
+  }
+  return authResources[0].resourceName as string;
 }
 /**
  * Migrate all Auth resources used by Storage(S3) for Override feature.
  * @param context - used to fetch auth resources and to migrate auth resources for override-feature.
  */
-export async function migrateAuthDependencyResource( context : $TSContext ) {
-    const authResourceName = await getAuthResourceARN(context);
+export async function migrateAuthDependencyResource(context: $TSContext) {
+  let authResourceName = undefined;
+  try {
+    authResourceName = await getAuthResourceARN(context);
+  } catch (error) {
+    //No auth resources to migrate - new project
+    return;
+  }
+  if (authResourceName) {
     try {
-      await context.amplify.invokePluginMethod(context,
-                                               AmplifyCategories.AUTH, undefined,
-                                               'migrateAuthResource',
-                                               [context, authResourceName ]);
+      await context.amplify.invokePluginMethod(context, AmplifyCategories.AUTH, undefined, 'migrateAuthResource', [
+        context,
+        authResourceName,
+      ]);
     } catch (error) {
       printer.error(error as string);
       throw error;
     }
+  }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
migration changes introduced regression for add storage without auth scenario. 
when migrating Auth dependency, we now return success if there is no auth resource.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
amplify-dev init
amplify-dev add storage
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [* ] PR description included
- [* ] `yarn test` passes
- [ *] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ *] Relevant documentation is changed or added (and PR referenced)
- [* ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
