### PR TITLE
fix: add schema directives for sync operation when conflict resolution is enabled

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/conflict-resolution.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/conflict-resolution.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test multi auth model with conflict resolution 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #if( !$isAuthorized )
+    #if( $ctx.identity.userArn == $ctx.stash.authRole )
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $authFilter = [{
+  \\"owner\\": {
+      \\"eq\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
+  }
+}] )
+    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`test single auth model is enabled with conflict resolution 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $authFilter = [{
+  \\"owner\\": {
+      \\"eq\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
+  }
+}] )
+    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -1,4 +1,4 @@
-import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import _ from 'lodash';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/conflict-resolution.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/conflict-resolution.test.ts
@@ -1,0 +1,70 @@
+import { AuthTransformer } from '../graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { GraphQLTransform, ConflictHandlerType } from '@aws-amplify/graphql-transformer-core';
+import _ from 'lodash';
+
+test('test single auth model is enabled with conflict resolution', () => {
+  const validSchema = `
+    type Post @model @auth(rules: [{ allow: owner}]) {
+      id: ID!
+      title: String!
+      createdAt: String
+      updatedAt: String
+    }`;
+  const transformer = new GraphQLTransform({
+    authConfig: {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [],
+    },
+    transformConfig: {
+      ResolverConfig: {
+        project: {
+          ConflictDetection: 'VERSION',
+          ConflictHandler: ConflictHandlerType.AUTOMERGE,
+        },
+      },
+    },
+    transformers: [new ModelTransformer(), new AuthTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain(
+    `syncPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String, lastSync: AWSTimestamp): ModelPostConnection`,
+  );
+  expect(out.pipelineFunctions['Query.syncPosts.auth.1.req.vtl']).toMatchSnapshot();
+});
+
+test('test multi auth model with conflict resolution', () => {
+  const validSchema = `
+    type Post @model @auth(rules: [{ allow: owner }, { allow: private, provider: iam }]) {
+      id: ID!
+      title: String!
+      createdAt: String
+      updatedAt: String
+    }`;
+  const transformer = new GraphQLTransform({
+    authConfig: {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }],
+    },
+    transformConfig: {
+      ResolverConfig: {
+        project: {
+          ConflictDetection: 'VERSION',
+          ConflictHandler: ConflictHandlerType.AUTOMERGE,
+        },
+      },
+    },
+    transformers: [new ModelTransformer(), new AuthTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.schema).toContain(
+    `syncPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String, lastSync: AWSTimestamp): ModelPostConnection @aws_iam @aws_cognito_user_pools`,
+  );
+  expect(out.pipelineFunctions['Query.syncPosts.auth.1.req.vtl']).toMatchSnapshot();
+});

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -1,4 +1,4 @@
-import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -1,4 +1,4 @@
-import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -1,4 +1,4 @@
-import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { AppSyncAuthConfiguration, AppSyncAuthConfigurationOIDCEntry, AppSyncAuthMode } from '@aws-amplify/graphql-transformer-interfaces';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -1,5 +1,5 @@
 import { parse } from 'graphql';
-import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -1,4 +1,4 @@
-import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -112,7 +112,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   private authPolicyResources = new Set<string>();
   private unauthPolicyResources = new Set<string>();
 
-  constructor(config: AuthTransformerConfig) {
+  constructor(config: AuthTransformerConfig = { addAwsIamAuthInOutputSchema: false }) {
     super('amplify-auth-transformer', authDirectiveDefinition);
     this.config = config;
     this.modelDirectiveConfig = new Map();
@@ -370,9 +370,10 @@ Static group authorization should perform as expected.`,
         this.addOperationToResourceReferences(typeName, operationName, acm.getRoles());
       }
     };
-    // default model operations TODO: protect sync queries once supported
+    // default model operations
     addServiceDirective(ctx.output.getQueryTypeName()!, 'read', modelConfig?.queries?.get);
     addServiceDirective(ctx.output.getQueryTypeName()!, 'read', modelConfig?.queries?.list);
+    addServiceDirective(ctx.output.getQueryTypeName()!, 'read', modelConfig?.queries?.sync);
     addServiceDirective(ctx.output.getMutationTypeName()!, 'create', modelConfig?.mutations?.create);
     addServiceDirective(ctx.output.getMutationTypeName()!, 'update', modelConfig?.mutations?.update);
     addServiceDirective(ctx.output.getMutationTypeName()!, 'delete', modelConfig?.mutations?.delete);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- updated import path for `@auth` in unit tests
- add service directives for sync operations when conflict resolution is enabled
- change constructor to accept `addAwsIamAuthInOutputSchema` as false 
  - authConfig is also optional since we are using the authConfig provided by the transformer core
- updated unit tests on conflict resolution

#### Description of how you validated changes
- unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
