### PR TITLE
feat(graphql-elasticsearch-transformer): Add option to resume sync with particular key

### DIFF
--- a/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
+++ b/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
@@ -72,7 +72,9 @@ def import_dynamodb_items_to_es(table_name, aws_secret, aws_access, aws_token, a
         reports.append(record)
         if partSize >= 100:
           send_to_eslambda(reports, lambda_f)
-      if 'LastEvaluatedKey' not in response:
+      if 'LastEvaluatedKey' in response:
+        logger.info('Last Evaluated Key: %s', response['LastEvaluatedKey'])
+      else:
         break
   if partSize > 0:
     send_to_eslambda(reports, lambda_f)


### PR DESCRIPTION
#### Description of changes

`ddb_to_es.py` allows us to perform full sync between DynamoDB and OpenSearch, [as documented in Amplify Docs](https://docs.amplify.aws/cli/graphql-transformer/searchable/#backfill-your-opensearch-index-from-your-dynamodb-table):

```sh
python3 ddb_to_es.py \
  --rn 'us-west-2' \
  --tn 'Post-XXXX-dev' \
  --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \
  --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350'
```

In some cases, we want to resume the sync from a certain point. (e.g. after the sync has stopped for some reason)
This PR enables us to provide the starting key to the script.

```diff
 python3 ddb_to_es.py \
   --rn 'us-west-2' \
   --tn 'Post-XXXX-dev' \
   --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \
   --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350'
+  --lek 'bb6f5516-332a-11ec-8d3d-0242ac130003'
```

#### Description of how you validated changes

Tested the expected behavior running the script both from local Mac & EC2 instance (Amazon Linux)

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.