### PR TITLE
fix: Custom policies works with `amplify status -v`

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/customPoliciesUtils.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/customPoliciesUtils.test.ts
@@ -1,31 +1,120 @@
-import {createDefaultCustomPoliciesFile} from '../customPoliciesUtils'
+import { createDefaultCustomPoliciesFile, generateCustomPoliciesInTemplate } from '../customPoliciesUtils';
+import { printer } from 'amplify-prompts';
 import { JSONUtilities } from '..';
-import { pathManager, PathConstants } from '../state-manager';
+import { pathManager, PathConstants, stateManager } from '../state-manager';
 import path from 'path';
+import { Template, Fn } from 'cloudform-types';
 
 describe('Custom policies util test', () => {
+  const testCategoryName = 'function';
+  const testResourceName = 'functionTest';
+  const expectedFilePath = path.join(
+    __dirname,
+    'testFiles',
+    'custom-policies-test',
+    testCategoryName,
+    testResourceName,
+    PathConstants.CustomPoliciesFilename,
+  );
+  jest.spyOn(pathManager, 'getCustomPoliciesPath').mockReturnValue(expectedFilePath);
+  stateManager.getCustomPolicies = jest.fn();
+  printer.warn = jest.fn();
+  test('Write default custom policy file to the specified resource name', () => {
+    createDefaultCustomPoliciesFile(testCategoryName, testResourceName);
 
-    jest.mock('../state-manager');
+    const data = JSONUtilities.readJson(expectedFilePath);
 
-    const testCategoryName = 'function';
-    const testResourceName = 'functionTest';
-    const expectedFilePath = path.join(__dirname, 'testFiles', 'custom-policies-test', testCategoryName, testResourceName, PathConstants.CustomPoliciesFilename);
-    jest.spyOn(pathManager, 'getCustomPoliciesPath').mockReturnValue(expectedFilePath);
+    expect(data).toMatchObject([
+      {
+        Action: [],
+        Resource: [],
+      },
+    ]);
+  });
 
-    beforeEach(jest.clearAllMocks);
+  test('test generateCustomPoliciesInTemplate with lambda function with no effect', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([
+      {
+        Action: ['s3:access'],
+        Resource: ['arn:aws:s3:::*'],
+      },
+    ]);
+    const template = generateCustomPoliciesInTemplate({}, 'lambdaResourceName', 'Lambda', 'function');
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Version).toEqual('2012-10-17');
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Statement[0].Action).toEqual(['s3:access']);
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Statement[0].Resource).toEqual(['arn:aws:s3:::*']);
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Statement[0].Effect).toEqual('Allow');
+  });
 
-    test('Write default custom policy file to the specified resource name', () => {
+  test('test generateCustomPoliciesInTemplate with lambda function with Deny effect', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([
+      {
+        Action: ['s3:access'],
+        Resource: ['arn:aws:s3:::*'],
+        Effect: 'Deny',
+      },
+    ]);
+    const template = generateCustomPoliciesInTemplate({}, 'lambdaResourceName', 'Lambda', 'function');
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Version).toEqual('2012-10-17');
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Statement[0].Action).toEqual(['s3:access']);
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Statement[0].Resource).toEqual(['arn:aws:s3:::*']);
+    expect(template.Resources?.CustomLambdaExecutionPolicy.Properties?.PolicyDocument.Statement[0].Effect).toEqual('Deny');
+  });
 
-        createDefaultCustomPoliciesFile(testCategoryName, testResourceName);
-      
-        const data = JSONUtilities.readJson(expectedFilePath);
-      
-        expect(data).toMatchObject([
-            {
-                Action: [],
-                Resource: []
-            }
-        ]);
+  test('test generateCustomPoliciesInTemplate with lambda function with Deny effect', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([
+      {
+        Action: ['s3:access'],
+        Resource: ['arn:aws:s3:::*'],
+      },
+    ]);
 
-    })
-})
+    const apiTemplate = {
+      Resources: {
+        TaskDefinition: {
+          Properties: {
+            TaskRoleArn: {
+              'Fn::GetAtt': ['mockRoleName'],
+            },
+          },
+        },
+      },
+    } as unknown as Template;
+    const template = generateCustomPoliciesInTemplate(apiTemplate, 'apiResourceName', 'ElasticContainer', 'api');
+    expect(template.Resources?.CustomExecutionPolicyForContainer.Properties?.PolicyDocument.Version).toEqual('2012-10-17');
+    expect(template.Resources?.CustomExecutionPolicyForContainer.Properties?.PolicyDocument.Statement[0].Action).toEqual(['s3:access']);
+    expect(template.Resources?.CustomExecutionPolicyForContainer.Properties?.PolicyDocument.Statement[0].Resource).toEqual([
+      'arn:aws:s3:::*',
+    ]);
+    expect(template.Resources?.CustomExecutionPolicyForContainer.Properties?.PolicyDocument.Statement[0].Effect).toEqual('Allow');
+    expect(template.Resources?.CustomExecutionPolicyForContainer.Properties?.Roles).toEqual([Fn.Ref('mockRoleName')]);
+  });
+
+  test('test generateCustomPoliciesInTemplate with lambda function with bad policy', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([
+      {
+        Action: ['s3:access'],
+        Resource: ['arbsd'],
+      },
+    ]);
+    try {
+      generateCustomPoliciesInTemplate({}, 'lambdaResourceName', 'Lambda', 'function');
+    } catch (ex) {
+      expect(ex).toBeDefined();
+      expect(ex.message).toContain('Invalid custom IAM policy for lambdaResourceName. Incorrect "Resource": arbsd');
+    }
+  });
+
+  test('test generateCustomPoliciesInTemplate with lambda function with * in resource', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([
+      {
+        Action: ['s3:access'],
+        Resource: ['*'],
+      },
+    ]);
+    generateCustomPoliciesInTemplate({}, 'lambdaResourceName', 'Lambda', 'function');
+    expect(printer.warn).toBeCalledWith(
+      `Warning: You've specified "*" as the "Resource" in lambdaResourceName's custom IAM policy.\n This will grant lambdaResourceName the ability to perform s3:access on ALL resources in this AWS Account.`,
+    );
+  });
+});

--- a/packages/amplify-cli-core/src/__tests__/customPoliciesUtils.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/customPoliciesUtils.test.ts
@@ -117,4 +117,23 @@ describe('Custom policies util test', () => {
       `Warning: You've specified "*" as the "Resource" in lambdaResourceName's custom IAM policy.\n This will grant lambdaResourceName the ability to perform s3:access on ALL resources in this AWS Account.`,
     );
   });
+
+  test('test generateCustomPoliciesInTemplate with lambda function default policy', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([
+      {
+        Action: [],
+        Resource: [],
+      },
+    ]);
+    const template = generateCustomPoliciesInTemplate({}, 'lambdaResourceName', 'Lambda', 'function');
+
+    expect(template.Resources?.CustomLambdaExecutionPolicy).toBeUndefined();
+  });
+
+  test('test generateCustomPoliciesInTemplate with lambda function with empty array', () => {
+    (stateManager.getCustomPolicies as jest.Mock).mockReturnValueOnce([]);
+    const template = generateCustomPoliciesInTemplate({}, 'lambdaResourceName', 'Lambda', 'function');
+
+    expect(template.Resources?.CustomLambdaExecutionPolicy).toBeUndefined();
+  });
 });

--- a/packages/amplify-cli-core/src/customPoliciesUtils.ts
+++ b/packages/amplify-cli-core/src/customPoliciesUtils.ts
@@ -149,12 +149,11 @@ function validateCustomPolicies(data: CustomIAMPolicies, categoryName: string, r
   }
 }
 
-function resourceHasCustomPolicies(customPolicies: CustomIAMPolicies | undefined): boolean {
-  if (!customPolicies || customPolicies.length === 0) {
-    return false;
-  }
+function resourceHasCustomPolicies(customPolicies: CustomIAMPolicies): boolean {
+  const customPolicy = _.first(customPolicies);
 
-  if (customPolicies.length === 1 && customPolicies[0].Action?.length === 0 && customPolicies[0].Resource?.length === 0) {
+  // if either there are no custom policies in the array or the defined policy is the default
+  if (!customPolicy || (customPolicy && customPolicy.Action.length === 0 && customPolicy.Resource.length == 0)) {
     return false;
   }
 

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -8,7 +8,6 @@ import { SecretFileMode } from '../cliConstants';
 import { HydrateTags, ReadTags, Tag } from '../tags';
 import { CustomIAMPolicies } from '../customPoliciesUtils';
 
-
 export type GetOptions<T> = {
   throwIfNotExist?: boolean;
   preserveComments?: boolean;
@@ -78,13 +77,9 @@ export class StateManager {
     return this.getData<$TSTeamProviderInfo>(filePath, mergedOptions);
   };
 
-  getCustomPolicies = (categoryName: string, resourceName: string): CustomIAMPolicies | undefined => {
+  getCustomPolicies = (categoryName: string, resourceName: string): CustomIAMPolicies => {
     const filePath = pathManager.getCustomPoliciesPath(categoryName, resourceName);
-    try{
-      return JSONUtilities.readJson<CustomIAMPolicies>(filePath);
-    } catch(err) {
-      return undefined;
-    }
+    return JSONUtilities.readJson<CustomIAMPolicies>(filePath, { throwIfNotExist: false }) || [];
   };
 
   localEnvInfoExists = (projectPath?: string): boolean => this.doesExist(pathManager.getLocalEnvFilePath, projectPath);
@@ -379,5 +374,3 @@ export class StateManager {
 }
 
 export const stateManager = new StateManager();
-
-

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-diff.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-diff.ts
@@ -1,87 +1,86 @@
-
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as glob from 'glob';
 import chalk from 'chalk';
 import * as cfnDiff from '@aws-cdk/cloudformation-diff';
 import { print } from './print';
-import { pathManager, readCFNTemplate } from 'amplify-cli-core';
+import { generateCustomPoliciesInTemplate, pathManager, readCFNTemplate } from 'amplify-cli-core';
 import { Template } from 'cloudform-types';
 import { getResourceService } from './resource-status-data';
 
 const CategoryProviders = {
-    CLOUDFORMATION : "cloudformation",
-}
+  CLOUDFORMATION: 'cloudformation',
+};
 
 export interface StackMutationInfo {
-  label : String;
-  consoleStyle : chalk.Chalk;
-  icon : String;
+  label: String;
+  consoleStyle: chalk.Chalk;
+  icon: String;
 }
 //helper for summary styling
 export interface StackMutationType {
-  CREATE : StackMutationInfo,
-  UPDATE : StackMutationInfo,
-  DELETE : StackMutationInfo,
-  IMPORT : StackMutationInfo,
-  UNLINK : StackMutationInfo,
-  NOCHANGE : StackMutationInfo,
+  CREATE: StackMutationInfo;
+  UPDATE: StackMutationInfo;
+  DELETE: StackMutationInfo;
+  IMPORT: StackMutationInfo;
+  UNLINK: StackMutationInfo;
+  NOCHANGE: StackMutationInfo;
 }
 //helper map from mutation-type to ux styling
-export const stackMutationType :  StackMutationType = {
-    CREATE : {
-      label : "Create",
-      consoleStyle : chalk.green.bold,
-      icon : "[+]"
-    },
-    UPDATE : {
-      label : "Update",
-      consoleStyle : chalk.yellow.bold,
-      icon : "[~]"
-    },
+export const stackMutationType: StackMutationType = {
+  CREATE: {
+    label: 'Create',
+    consoleStyle: chalk.green.bold,
+    icon: '[+]',
+  },
+  UPDATE: {
+    label: 'Update',
+    consoleStyle: chalk.yellow.bold,
+    icon: '[~]',
+  },
 
-    DELETE : {
-      label: "Delete",
-      consoleStyle : chalk.red.bold,
-      icon : "[-]"
-    },
+  DELETE: {
+    label: 'Delete',
+    consoleStyle: chalk.red.bold,
+    icon: '[-]',
+  },
 
-    IMPORT : {
-      label: "Import",
-      consoleStyle : chalk.blue.bold,
-      icon : `[\u21E9]`
-    },
+  IMPORT: {
+    label: 'Import',
+    consoleStyle: chalk.blue.bold,
+    icon: `[\u21E9]`,
+  },
 
-    UNLINK : {
-      label : "Unlink",
-      consoleStyle : chalk.red.bold,
-      icon : `[\u2BFB]`
-    },
-    NOCHANGE : {
-      label : "No Change",
-      consoleStyle : chalk.grey,
-      icon : `[ ]`
-    }
-}
+  UNLINK: {
+    label: 'Unlink',
+    consoleStyle: chalk.red.bold,
+    icon: `[\u2BFB]`,
+  },
+  NOCHANGE: {
+    label: 'No Change',
+    consoleStyle: chalk.grey,
+    icon: `[ ]`,
+  },
+};
 
 //helper to capitalize string
-export function capitalize(str: string) : string {
+export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
 
 //Console text styling for resource details section
-const resourceDetailSectionStyle = chalk.bgRgb(15, 100, 204)
+const resourceDetailSectionStyle = chalk.bgRgb(15, 100, 204);
 
 //IResourcePaths: Interface for (build/prebuild) paths to local and cloud CFN files
 interface IResourcePaths {
-    localPreBuildCfnFile : string;
-    cloudPreBuildCfnFile : string;
-    localBuildCfnFile : string;
-    cloudBuildCfnFile : string;
+  localPreBuildCfnFile: string;
+  cloudPreBuildCfnFile: string;
+  localBuildCfnFile: string;
+  cloudBuildCfnFile: string;
 }
 
-export function globCFNFilePath( fileFolder : string ){
-  if (fs.existsSync( fileFolder )) {
+export function globCFNFilePath(fileFolder: string) {
+  if (fs.existsSync(fileFolder)) {
     const globOptions: glob.IOptions = {
       absolute: false,
       cwd: fileFolder,
@@ -97,165 +96,173 @@ export function globCFNFilePath( fileFolder : string ){
   throw new Error(`No CloudFormation template found in ${fileFolder}`);
 }
 
-
 export class ResourceDiff {
-    resourceName: string;
-    category : string;
-    provider : string;
-    service: string;
-    resourceFiles : IResourcePaths;
-    localBackendDir : string;
-    cloudBackendDir : string;
-    localTemplate : Template;
-    cloudTemplate : Template;
-    mutationInfo : StackMutationInfo;
+  resourceName: string;
+  category: string;
+  provider: string;
+  service: string;
+  resourceFiles: IResourcePaths;
+  localBackendDir: string;
+  cloudBackendDir: string;
+  localTemplate: Template;
+  cloudTemplate: Template;
+  mutationInfo: StackMutationInfo;
 
-    constructor( category: string, resourceName : string, provider : string, mutationInfo: StackMutationInfo ){
-        this.localBackendDir = pathManager.getBackendDirPath();
-        this.cloudBackendDir = pathManager.getCurrentCloudBackendDirPath();
-        this.resourceName = resourceName;
-        this.category = category;
-        this.provider = this.normalizeProviderForFileNames(provider);
-        this.service = getResourceService(category, resourceName);
-        this.localTemplate = {}; //requires file-access, hence loaded from async methods
-        this.cloudTemplate = {}; //requires file-access, hence loaded from async methods
-        this.mutationInfo = mutationInfo;
-        //Resource Path state
-        const localResourceAbsolutePathFolder = path.normalize(path.join(this.localBackendDir, category, resourceName));
-        const cloudResourceAbsolutePathFolder = path.normalize(path.join(this.cloudBackendDir, category, resourceName));
-        this.resourceFiles = {
-            //Paths using glob for Cfn file and Build file
-            localPreBuildCfnFile : this.safeGlobCFNFilePath(localResourceAbsolutePathFolder),
-            cloudPreBuildCfnFile : this.safeGlobCFNFilePath(cloudResourceAbsolutePathFolder),
-            //Build folder exists for services like GraphQL api which have an additional build step to generate CFN.
-            localBuildCfnFile : this.safeGlobCFNFilePath(path.normalize(path.join(localResourceAbsolutePathFolder, 'build'))),
-            cloudBuildCfnFile : this.safeGlobCFNFilePath(path.normalize(path.join(cloudResourceAbsolutePathFolder, 'build'))),
-          }
+  constructor(category: string, resourceName: string, provider: string, mutationInfo: StackMutationInfo) {
+    this.localBackendDir = pathManager.getBackendDirPath();
+    this.cloudBackendDir = pathManager.getCurrentCloudBackendDirPath();
+    this.resourceName = resourceName;
+    this.category = category;
+    this.provider = this.normalizeProviderForFileNames(provider);
+    this.service = getResourceService(category, resourceName);
+    this.localTemplate = {}; //requires file-access, hence loaded from async methods
+    this.cloudTemplate = {}; //requires file-access, hence loaded from async methods
+    this.mutationInfo = mutationInfo;
+    //Resource Path state
+    const localResourceAbsolutePathFolder = path.normalize(path.join(this.localBackendDir, category, resourceName));
+    const cloudResourceAbsolutePathFolder = path.normalize(path.join(this.cloudBackendDir, category, resourceName));
+    this.resourceFiles = {
+      //Paths using glob for Cfn file and Build file
+      localPreBuildCfnFile: this.safeGlobCFNFilePath(localResourceAbsolutePathFolder),
+      cloudPreBuildCfnFile: this.safeGlobCFNFilePath(cloudResourceAbsolutePathFolder),
+      //Build folder exists for services like GraphQL api which have an additional build step to generate CFN.
+      localBuildCfnFile: this.safeGlobCFNFilePath(path.normalize(path.join(localResourceAbsolutePathFolder, 'build'))),
+      cloudBuildCfnFile: this.safeGlobCFNFilePath(path.normalize(path.join(cloudResourceAbsolutePathFolder, 'build'))),
+    };
+  }
+
+  //API :View: Print the resource detail status for the given mutation (Create/Update/Delete)
+  public printResourceDetailStatus = async (mutationInfo: StackMutationInfo) => {
+    const header = `${mutationInfo.consoleStyle(mutationInfo.label)}`;
+    const diff = await this.calculateCfnDiff();
+    print.info(`${resourceDetailSectionStyle(`[\u27A5] Resource Stack: ${capitalize(this.category)}/${this.resourceName}`)} : ${header}`);
+    const diffCount = this.printStackDiff(diff, process.stdout);
+    if (diffCount === 0) {
+      console.log('No changes  ');
+    }
+  };
+
+  //API :Data: Calculate the difference in cloudformation templates between local and cloud templates
+  public calculateCfnDiff = async (): Promise<cfnDiff.TemplateDiff> => {
+    const resourceTemplatePaths = await this.getCfnResourceFilePaths();
+    //set the member template objects
+    this.localTemplate = await this.safeReadCFNTemplate(resourceTemplatePaths.localTemplatePath);
+    this.localTemplate = generateCustomPoliciesInTemplate(this.localTemplate, this.resourceName, this.service, this.category);
+    this.cloudTemplate = await this.safeReadCFNTemplate(resourceTemplatePaths.cloudTemplatePath);
+
+    //Note!! :- special handling to support multi-env. Currently in multi-env, when new env is created,
+    //we do *Not* delete the cloud-backend folder. Hence this logic will always give no diff for new resources.
+    //TBD: REMOVE this once we delete cloud-backend folder for new envs
+    if (this.mutationInfo.label == stackMutationType.CREATE.label) {
+      this.cloudTemplate = {}; //Dont use the parent env's template
     }
 
-    //API :View: Print the resource detail status for the given mutation (Create/Update/Delete)
-    public printResourceDetailStatus = async ( mutationInfo : StackMutationInfo ) => {
-      const header = `${ mutationInfo.consoleStyle(mutationInfo.label)}`;
-      const diff = await this.calculateCfnDiff();
-      print.info(`${resourceDetailSectionStyle(`[\u27A5] Resource Stack: ${capitalize(this.category)}/${this.resourceName}`)} : ${header}`);
-      const diffCount = this.printStackDiff( diff, process.stdout );
-      if ( diffCount === 0 ){
-          console.log("No changes  ")
-      }
+    //calculate diff of graphs.
+    const diff: cfnDiff.TemplateDiff = cfnDiff.diffTemplate(this.cloudTemplate, this.localTemplate);
+    return diff;
+  };
+
+  //helper: wrapper around readCFNTemplate type to handle expressions.
+  private safeReadCFNTemplate = async (filePath: string) => {
+    try {
+      const templateResult = await readCFNTemplate(filePath);
+      return templateResult.cfnTemplate;
+    } catch (e) {
+      return {};
     }
+  };
 
-    //API :Data: Calculate the difference in cloudformation templates between local and cloud templates
-    public calculateCfnDiff = async () : Promise<cfnDiff.TemplateDiff>  => {
-      const resourceTemplatePaths = await this.getCfnResourceFilePaths();
-      //set the member template objects
-      this.localTemplate = await this.safeReadCFNTemplate(resourceTemplatePaths.localTemplatePath);
-      this.cloudTemplate = await this.safeReadCFNTemplate(resourceTemplatePaths.cloudTemplatePath);
+  //helper: Select cloudformation file path from build folder or non build folder.
+  //TBD: Update this function to infer filepath based on the state of the resource.
+  private getCfnResourceFilePaths = async () => {
+    const resourceFilePaths = {
+      localTemplatePath: checkExist(this.resourceFiles.localBuildCfnFile)
+        ? this.resourceFiles.localBuildCfnFile
+        : this.resourceFiles.localPreBuildCfnFile,
+      cloudTemplatePath: checkExist(this.resourceFiles.cloudBuildCfnFile)
+        ? this.resourceFiles.cloudBuildCfnFile
+        : this.resourceFiles.cloudPreBuildCfnFile,
+    };
+    return resourceFilePaths;
+  };
 
-      //Note!! :- special handling to support multi-env. Currently in multi-env, when new env is created,
-      //we do *Not* delete the cloud-backend folder. Hence this logic will always give no diff for new resources.
-      //TBD: REMOVE this once we delete cloud-backend folder for new envs
-      if ( this.mutationInfo.label == stackMutationType.CREATE.label ){
-        this.cloudTemplate = {} ;//Dont use the parent env's template
-      }
-
-      //calculate diff of graphs.
-      const diff : cfnDiff.TemplateDiff = cfnDiff.diffTemplate(this.cloudTemplate, this.localTemplate );
-      return diff;
+  //helper: Get category provider from filename
+  private normalizeProviderForFileNames(provider: string): string {
+    //file-names are currently standardized around "cloudformation" not awscloudformation.
+    if (provider === 'awscloudformation') {
+      return CategoryProviders.CLOUDFORMATION;
+    } else {
+      return provider;
     }
+  }
 
-    //helper: wrapper around readCFNTemplate type to handle expressions.
-    private safeReadCFNTemplate = async(filePath : string ) => {
-      try {
-        const templateResult = await readCFNTemplate(filePath);
-        return templateResult.cfnTemplate;
-      } catch (e){
-        return {};
-      }
-    }
-
-    //helper: Select cloudformation file path from build folder or non build folder.
-    //TBD: Update this function to infer filepath based on the state of the resource.
-    private getCfnResourceFilePaths = async() => {
-      const resourceFilePaths = {
-        localTemplatePath : (checkExist(this.resourceFiles.localBuildCfnFile))?this.resourceFiles.localBuildCfnFile: this.resourceFiles.localPreBuildCfnFile ,
-        cloudTemplatePath : (checkExist(this.resourceFiles.cloudBuildCfnFile))?this.resourceFiles.cloudBuildCfnFile: this.resourceFiles.cloudPreBuildCfnFile
-      }
-      return resourceFilePaths;
-    }
-
-    //helper: Get category provider from filename
-    private normalizeProviderForFileNames(provider:string):string{
-      //file-names are currently standardized around "cloudformation" not awscloudformation.
-      if ( provider === "awscloudformation"){
-        return CategoryProviders.CLOUDFORMATION
-      } else {
-        return provider;
-      }
-    }
-
-    //helper: Convert cloudformation template diff data using CDK api
-    private printStackDiff = ( templateDiff : cfnDiff.TemplateDiff, stream?: cfnDiff.FormatStream ) =>{
-        // filter out 'AWS::CDK::Metadata' since info is not helpful and formatDifferences doesnt know how to format it.
-        if (templateDiff.resources ) {
-          templateDiff.resources = templateDiff.resources.filter(change => {
-            if (!change) { return true; }
-            if (change.newResourceType === 'AWS::CDK::Metadata') { return false; }
-            if (change.oldResourceType === 'AWS::CDK::Metadata') { return false; }
-            return true;
-          });
+  //helper: Convert cloudformation template diff data using CDK api
+  private printStackDiff = (templateDiff: cfnDiff.TemplateDiff, stream?: cfnDiff.FormatStream) => {
+    // filter out 'AWS::CDK::Metadata' since info is not helpful and formatDifferences doesnt know how to format it.
+    if (templateDiff.resources) {
+      templateDiff.resources = templateDiff.resources.filter(change => {
+        if (!change) {
+          return true;
         }
-        if (!templateDiff.isEmpty) {
-          cfnDiff.formatDifferences(stream || process.stderr, templateDiff);
+        if (change.newResourceType === 'AWS::CDK::Metadata') {
+          return false;
         }
-        return templateDiff.differenceCount;
+        if (change.oldResourceType === 'AWS::CDK::Metadata') {
+          return false;
+        }
+        return true;
+      });
     }
+    if (!templateDiff.isEmpty) {
+      cfnDiff.formatDifferences(stream || process.stderr, templateDiff);
+    }
+    return templateDiff.differenceCount;
+  };
 
-    //Search and return the path to cloudformation template in the given folder
-    private safeGlobCFNFilePath( fileFolder : string ){
-      try {
-        return globCFNFilePath(fileFolder);
-      } catch ( e ){
-        return "";
-      }
+  //Search and return the path to cloudformation template in the given folder
+  private safeGlobCFNFilePath(fileFolder: string) {
+    try {
+      return globCFNFilePath(fileFolder);
+    } catch (e) {
+      return '';
     }
+  }
 }
 
-function checkExist( filePath ){
-    const inputTypes = [ 'json', 'yaml', 'yml'] ; //check for existence of any one of the extensions.
-    for( let i = 0 ; i < inputTypes.length ; i++ ){
-      if ( fs.existsSync(`${filePath}.${inputTypes[i]}`) ){
-        return true;
-      }
+function checkExist(filePath) {
+  const inputTypes = ['json', 'yaml', 'yml']; //check for existence of any one of the extensions.
+  for (let i = 0; i < inputTypes.length; i++) {
+    if (fs.existsSync(`${filePath}.${inputTypes[i]}`)) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 //Interface to store template-diffs for C-D-U resource diffs
 export interface IResourceDiffCollection {
-  updatedDiff : ResourceDiff[]|[],
-  deletedDiff : ResourceDiff[]|[],
-  createdDiff : ResourceDiff[]|[]
+  updatedDiff: ResourceDiff[] | [];
+  deletedDiff: ResourceDiff[] | [];
+  createdDiff: ResourceDiff[] | [];
 }
 
 //Interface to store resource status for each category
 export interface ICategoryStatusCollection {
-  resourcesToBeCreated: any[],
-  resourcesToBeUpdated: any[],
-  resourcesToBeDeleted: any[],
-  resourcesToBeSynced: any[],
-  allResources:any[],
-  tagsUpdated: boolean
+  resourcesToBeCreated: any[];
+  resourcesToBeUpdated: any[];
+  resourcesToBeDeleted: any[];
+  resourcesToBeSynced: any[];
+  allResources: any[];
+  tagsUpdated: boolean;
 }
 
 //"CollateResourceDiffs" - Calculates the diffs for the list of resources provided.
 // note:- The mutationInfo may be used for styling in enhanced summary.
-export async function CollateResourceDiffs( resources , mutationInfo : StackMutationInfo  /* create/update/delete */ ){
-    const provider = CategoryProviders.CLOUDFORMATION;
-    let resourceDiffs : ResourceDiff[] = [];
-    for await (const resource of resources) {
-      resourceDiffs.push( new ResourceDiff( resource.category, resource.resourceName, provider, mutationInfo ) );
-    }
-    return resourceDiffs;
+export async function CollateResourceDiffs(resources, mutationInfo: StackMutationInfo /* create/update/delete */) {
+  const provider = CategoryProviders.CLOUDFORMATION;
+  let resourceDiffs: ResourceDiff[] = [];
+  for await (const resource of resources) {
+    resourceDiffs.push(new ResourceDiff(resource.category, resource.resourceName, provider, mutationInfo));
   }
-
-
+  return resourceDiffs;
+}

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-diff.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-diff.ts
@@ -204,10 +204,7 @@ export class ResourceDiff {
         if (!change) {
           return true;
         }
-        if (change.newResourceType === 'AWS::CDK::Metadata') {
-          return false;
-        }
-        if (change.oldResourceType === 'AWS::CDK::Metadata') {
+        if (this.isResourceTypeCDKMetada(change.newResourceType) || this.isResourceTypeCDKMetada(change.oldResourceType)) {
           return false;
         }
         return true;
@@ -226,6 +223,10 @@ export class ResourceDiff {
     } catch (e) {
       return '';
     }
+  }
+
+  private isResourceTypeCDKMetada(resourceType: string | undefined): boolean {
+    return resourceType === 'AWS::CDK::Metadata';
   }
 }
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/cfn-pre-processor.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/cfn-pre-processor.test.ts
@@ -13,17 +13,18 @@ const prePushCfnTemplateModifier_mock = prePushCfnTemplateModifier as jest.Mocke
 const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
 const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
 
-const cfnTemplate = ({
+const cfnTemplate = {
   test: 'content',
-} as unknown) as Template;
+} as unknown as Template;
 const templateFormat = CFNTemplateFormat.JSON;
 
 const customPolicies: CustomIAMPolicies = [
   {
-    Action : ['test:test'],
-    Effect : 'Allow',
-    Resource : ['arn:aws:s3:us-east-2:012345678910:testResource']
-  }];
+    Action: ['test:test'],
+    Effect: 'Allow',
+    Resource: ['arn:aws:s3:us-east-2:012345678910:testResource'],
+  },
+];
 
 readCFNTemplate_mock.mockResolvedValue({
   templateFormat,
@@ -40,7 +41,7 @@ const resourcePath = 'api/resourceName/cfn-template-name.json';
 pathManager_mock.getBackendDirPath.mockReturnValue(backendPath);
 pathManager_mock.getResourceDirectoryPath.mockReturnValue(backendPath);
 stateManager_mock.getCustomPolicies.mockReturnValue(customPolicies);
-stateManager_mock.getLocalEnvInfo.mockReturnValue({envName:'test'});
+stateManager_mock.getLocalEnvInfo.mockReturnValue({ envName: 'test' });
 
 describe('preProcessCFNTemplate', () => {
   beforeEach(jest.clearAllMocks);
@@ -64,29 +65,4 @@ describe('preProcessCFNTemplate', () => {
     const newPath = await preProcessCFNTemplate(path.join('/something/else', resourcePath));
     expect(newPath).toMatchInlineSnapshot(`"/project/amplify/backend/awscloudformation/build/cfn-template-name.json"`);
   });
-
-  it('writes valid custom policies to cfn template', async () => {
-    const cfnTemplate = ({
-      Resources: {
-        LambdaExecutionRole: {
-          Type: 'AWS::IAM::Role'
-        }
-      },
-    } as unknown) as Template;
-
-    readCFNTemplate_mock.mockResolvedValueOnce({
-      templateFormat,
-      cfnTemplate,
-    });
-    
-    await writeCustomPoliciesToCFNTemplate('test', 'Lambda', 'cfn-template.json', 'test');
-    
-    const templateWithCustomPolicies = writeCFNTemplate_mock.mock.calls[0][0] as any;
-
-    expect(templateWithCustomPolicies.Resources.CustomLambdaExecutionPolicy.Properties.PolicyDocument.Statement).toEqual([{
-      Action : ['test:test'],
-      Effect : 'Allow',
-      Resource : ['arn:aws:s3:us-east-2:012345678910:testResource']
-    }]);
-  })
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Generate custom policies in a template to compare with cloud template to make amplify status -v wo

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
