### PR TITLE
fix: prevent infinite loop

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
@@ -212,7 +212,8 @@ export function getResourcesToBeCreated(amplifyMeta, currentAmplifyMeta, categor
           (!amplifyMeta[dependsOnCategory][dependsOnResourcename]?.lastPushTimeStamp ||
             !currentAmplifyMeta[dependsOnCategory] ||
             !currentAmplifyMeta[dependsOnCategory][dependsOnResourcename]) &&
-          amplifyMeta[dependsOnCategory][dependsOnResourcename].serviceType !== 'imported'
+          amplifyMeta[dependsOnCategory][dependsOnResourcename].serviceType !== 'imported' &&
+          !resources.includes(amplifyMeta[dependsOnCategory][dependsOnResourcename])
         ) {
           resources.push(amplifyMeta[dependsOnCategory][dependsOnResourcename]);
         }


### PR DESCRIPTION
#### Description of changes

The loop in `getResourcesToBeCreated()` pushes items into the array that it is iterating over. However, there was no check for cycles, meaning that circular dependencies pushes resources into the array until an out of memory error occurs. This commit adds a check to prevent adding the same item to the array more than once.

#### Issue #, if available

Closes #8517

#### Description of how you validated changes

Ran the failing command in the linked issue against the customer's project.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
