### PR TITLE
Reenable nightly workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,13 +211,6 @@ workflows:
       - setup
   nightly_console_integration_tests:
     when: << pipeline.parameters.nightly_console_integration_tests >>
-    triggers:
-      - schedule:
-          cron: 0 14 * * *
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build
       - publish_to_local_registry:
@@ -234,13 +227,6 @@ workflows:
             - publish_to_local_registry
   e2e_resource_cleanup:
     when: << pipeline.parameters.e2e_resource_cleanup >>
-    triggers:
-      - schedule:
-          cron: 45 0,12 * * *
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build
       - cleanup_resources:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Recently, we changed our `split-e2e-tests` script to dynamically run as part of circleci to reduce merge conflicts. This resulted in our scheduled jobs, `e2e_resource_cleanup` and `nightly_console_integration_tests` to stop running, because CircleCI does not yet support dynamic configurations _and_ scheduled jobs (see https://support.circleci.com/hc/en-us/articles/360060833331-Support-for-Scheduled-Workflows-in-Dynamic-Configs-Setup-Workflows).

This PR implements CCI's [suggested workaround](https://discuss.circleci.com/t/workaround-using-scheduled-workflows-with-dynamic-config/40344) to enable this behavior. It successfully restores our scheduled jobs by relying on a new `nightly-jobs` branch where scheduled jobs are configured and triggered. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

I tested this by temporarily pointing the `nightly-jobs` to trigger jobs against the change in this PR, and found that it successfully triggers the workflows we want:

* https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/3502/workflows/4b5e6dce-9e00-47a7-ae09-2e3b7a3a04e1
* https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/3503/workflows/2af70414-89c2-4ad4-96b6-9c365091c2e1

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
