### PR TITLE
fix(amplify-provider-awscloudformation): add if/else for warning message in sandbox mode

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/sandbox-mode-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/sandbox-mode-helpers.ts
@@ -4,8 +4,7 @@ import { hasApiKey } from './api-key-helpers';
 import { printer } from 'amplify-prompts';
 
 export async function showSandboxModePrompts(context: $TSContext): Promise<any> {
-  if (hasApiKey()) return showGlobalSandboxModeWarning();
-  else {
+  if (!hasApiKey()) {
     printer.info(
       `
 ⚠️  WARNING: Global Sandbox Mode has been enabled, which requires a valid API key. If


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds the sandbox mode warning to an if/else statement.
- If the sandbox mode is enabled in the GraphQL schema AND the user has an API Key configured, the sandbox mode warning message is displayed on `amplify api gql-compile`.
- Otherwise, the CLI will recommend adding auth to models if it is missing on any types.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
Tested locally with `amplify-dev` local binary.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
