### PR TITLE
fix(amplify-frontend-javascript): geo region default

### DIFF
--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -169,11 +169,11 @@ function getAWSExportsObject(resources) {
         };
         break;
       case 'Map':
-        geoConfig.region = serviceResourceMapping[service][0].output.Region;
+        geoConfig.region = serviceResourceMapping[service][0].output.Region || projectRegion;
         geoConfig.maps = getMapConfig(serviceResourceMapping[service]);
         break;
       case 'PlaceIndex':
-        geoConfig.region = serviceResourceMapping[service][0].output.Region;
+        geoConfig.region = serviceResourceMapping[service][0].output.Region || projectRegion;
         geoConfig.search_indices = getPlaceIndexConfig(serviceResourceMapping[service]);
         break;
       default:
@@ -592,4 +592,4 @@ function getPlaceIndexConfig(placeIndexResources) {
   return placeIndexConfig;
 }
 
-module.exports = { createAWSExports, createAmplifyConfig, deleteAmplifyConfig };
+module.exports = { createAWSExports, createAmplifyConfig, deleteAmplifyConfig, getAWSExportsObject };

--- a/packages/amplify-frontend-javascript/tests/__snapshots__/frontend-config-creator.test.js.snap
+++ b/packages/amplify-frontend-javascript/tests/__snapshots__/frontend-config-creator.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate maps and search configuration generates correct configuration for maps and search geo resources with Region as CFN output 1`] = `
+Object {
+  "aws_project_region": "eu-west-2",
+  "geo": Object {
+    "amazon_location_service": Object {
+      "maps": Object {
+        "default": "defaultMap12345",
+        "items": Object {
+          "defaultMap12345": Object {
+            "style": "VectorEsriStreets",
+          },
+          "map12345": Object {
+            "style": "VectorEsriStreets",
+          },
+        },
+      },
+      "region": "eu-west-1",
+      "search_indices": Object {
+        "default": "defaultIndex12345",
+        "items": Array [
+          "index12345",
+          "defaultIndex12345",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`generate maps and search configuration generates correct configuration for maps and search geo resources without Region CFN output 1`] = `
+Object {
+  "aws_project_region": "us-west-2",
+  "geo": Object {
+    "amazon_location_service": Object {
+      "maps": Object {
+        "default": "defaultMap12345",
+        "items": Object {
+          "defaultMap12345": Object {
+            "style": "VectorEsriStreets",
+          },
+          "map12345": Object {
+            "style": "VectorEsriStreets",
+          },
+        },
+      },
+      "region": "us-west-2",
+      "search_indices": Object {
+        "default": "defaultIndex12345",
+        "items": Array [
+          "index12345",
+          "defaultIndex12345",
+        ],
+      },
+    },
+  },
+}
+`;

--- a/packages/amplify-frontend-javascript/tests/frontend-config-creator.test.js
+++ b/packages/amplify-frontend-javascript/tests/frontend-config-creator.test.js
@@ -1,0 +1,91 @@
+const configCreator = require("../lib/frontend-config-creator");
+jest.mock('amplify-cli-core');
+
+const mapServiceName = 'Map';
+const placeIndexServiceName = 'PlaceIndex';
+
+describe('generate maps and search configuration', () => {
+
+    function constructMapMeta(mapName, mapStyle, isDefault, region) {
+        return {
+            service: mapServiceName,
+            output: {
+                Style: mapStyle,
+                Name: mapName,
+                Region: region
+            },
+            isDefault: isDefault
+        };
+    }
+
+    function constructPlaceIndexMeta(indexName, isDefault, region) {
+        return {
+            service: placeIndexServiceName,
+            output: {
+                Name: indexName,
+                Region: region
+            },
+            isDefault: isDefault
+        };
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('generates correct configuration for maps and search geo resources without Region CFN output', () => {
+        const projectRegion = 'us-west-2';
+        const mockGeoResources = {
+            serviceResourceMapping: {
+                Map: [
+                    constructMapMeta('map12345', 'VectorEsriStreets', false),
+                    constructMapMeta('defaultMap12345', 'VectorEsriStreets', true)
+                ],
+                PlaceIndex: [
+                    constructPlaceIndexMeta('index12345', false),
+                    constructPlaceIndexMeta('defaultIndex12345', true)
+                ]
+            },
+            metadata: {
+                Region: projectRegion
+            }
+        };
+        const generatedConfig = configCreator.getAWSExportsObject(mockGeoResources);
+        expect(generatedConfig.geo.amazon_location_service.region).toEqual(projectRegion);
+        expect(generatedConfig).toMatchSnapshot();
+    });
+
+    it('does not add any geo configuration if no maps or search is added', () => {
+        const mockGeoResources = {
+            serviceResourceMapping: {},
+            metadata: {
+                Region: 'us-west-2'
+            }
+        };
+        const generatedConfig = configCreator.getAWSExportsObject(mockGeoResources);
+        expect(generatedConfig.geo).toBeUndefined();
+    });
+
+    it('generates correct configuration for maps and search geo resources with Region as CFN output', () => {
+        const resourceRegion = 'eu-west-1';
+        const projectRegion = 'eu-west-2';
+        const mockGeoResources = {
+            serviceResourceMapping: {
+                Map: [
+                    constructMapMeta('map12345', 'VectorEsriStreets', false, resourceRegion),
+                    constructMapMeta('defaultMap12345', 'VectorEsriStreets', true, resourceRegion)
+                ],
+                PlaceIndex: [
+                    constructPlaceIndexMeta('index12345', false, resourceRegion),
+                    constructPlaceIndexMeta('defaultIndex12345', true, resourceRegion)
+                ]
+            },
+            metadata: {
+                Region: projectRegion
+            }
+        };
+        const generatedConfig = configCreator.getAWSExportsObject(mockGeoResources);
+        expect(generatedConfig.geo.amazon_location_service.region).toEqual(resourceRegion);
+        expect(generatedConfig).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The Geo resources created before CLI `v6.3.1` do not have the `Region` CFN output. Instead, the project region is used in `aws-exports` file. The Geo resources created post CLI `v6.3.1` however, have `Region` output which is used in `aws-exports`.  This change fixes the issue https://github.com/aws-amplify/amplify-cli/issues/8538 where a customer upgrades the CLI version to `v6.3.1` with some Geo resources already present in the project. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-cli/issues/8538

#### Description of how you validated changes
Unit testing; JS sample app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
