### PR TITLE
fix: require @primaryKey sort fields to be non-nullable

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
@@ -148,6 +148,10 @@ function validate(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerCont
       );
     }
 
+    if (!isNonNullType(sortField.type)) {
+      throw new InvalidDirectiveError(`The primary key on type '${object.name.value}' must reference non-null fields.`);
+    }
+
     config.sortKey.push(sortField);
   }
 }


### PR DESCRIPTION
#### Description of changes
This commit ensures that `@primaryKey` sort key fields are non-nullable.

#### Description of how you validated changes
Manual and unit tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
