### PR TITLE
fix: parameters file path and updates cloud backend with build

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -102,7 +102,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
     const backendDir = pathManager.getBackendDirPath();
     const overrideDir = path.join(backendDir, this._category, this.resourceName);
     const isBuild = await buildOverrideDir(backendDir, overrideDir).catch(error => {
-      printer.warn(`Skipping build as ${error.message}`);
+      printer.debug(`Skipping build as ${error.message}`);
       return false;
     });
     if (isBuild) {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -175,7 +175,7 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
     const backendDir = pathManager.getBackendDirPath();
     const overrideDir = path.join(backendDir, this._category, this._resourceName);
     const isBuild = await buildOverrideDir(backendDir, overrideDir).catch(error => {
-      printer.warn(`Skipping build as ${error.message}`);
+      printer.debug(`Skipping build as ${error.message}`);
       return false;
     });
     if (isBuild) {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.js
@@ -38,9 +38,7 @@ async function updateConfigOnEnvInit(context, category, service) {
 
   const providerPlugin = context.amplify.getPluginInstance(context, provider);
   // previously selected answers
-  const currentAuthName = await getAuthResourceName(context);
-  const cliState = new AuthInputState(currentAuthName);
-  const resourceParams = await cliState.loadResourceParameters(context, cliState.getCLIInputPayload());
+  const resourceParams = providerPlugin.loadResourceParameters(context, 'auth', service);
   // ask only env specific questions
   let currentEnvSpecificValues = context.amplify.loadEnvResourceParameters(context, category, service);
 

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
@@ -171,7 +171,7 @@ export class DDBStackTransform {
     const overrideFilePath = pathManager.getResourceDirectoryPath(undefined, 'storage', this._resourceName);
 
     const isBuild = await buildOverrideDir(backendDir, overrideFilePath).catch(error => {
-      printer.warn(`Skipping build as ${error.message}`);
+      printer.debug(`Skipping build as ${error.message}`);
       return false;
     });
     // skip if packageManager or override.ts not found

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -167,7 +167,7 @@ export class AmplifyS3ResourceStackTransform {
     const backendDir = pathManager.getBackendDirPath();
     const overrideFilePath = pathManager.getResourceDirectoryPath(undefined, AmplifyCategories.STORAGE, this.resourceName);
     const isBuild = await buildOverrideDir(backendDir, overrideFilePath).catch(error => {
-      printer.warn(`Skipping build as ${error.message}`);
+      printer.debug(`Skipping build as ${error.message}`);
       return false;
     });
     //Skip if packageManager or override.ts not found

--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -21,6 +21,8 @@ export const PathConstants = {
   CurrentCloudBackendDirName: '#current-cloud-backend',
   HooksDirName: 'hooks',
 
+  // resource level
+  BuildDirName: 'build',
   // 2nd Level
   OverrideDirName: 'overrides',
   ProviderName: 'awscloudformation',
@@ -41,7 +43,6 @@ export const PathConstants = {
   HooksShellSampleFileName: 'post-push.sh.sample',
   HooksJsSampleFileName: 'pre-push.js.sample',
   HooksReadmeFileName: 'hooks-readme.md',
-  OverrideFileName: 'override.ts',
 
   LocalEnvFileName: 'local-env-info.json',
   LocalAWSInfoFileName: 'local-aws-info.json',
@@ -52,10 +53,11 @@ export const PathConstants = {
   CLIJSONFileNameGlob: 'cli*.json',
   CLIJsonWithEnvironmentFileName: (env: string) => `cli.${env}.json`,
 
+  CLIInputsJsonFileName: 'cli-inputs.json',
+
   CfnFileName: (resourceName: string) => `${resourceName}-awscloudformation-template.json`,
 
   CustomPoliciesFilename: 'custom-policies.json',
-  cliInputsFileName: 'cli-inputs.json',
 };
 
 export class PathManager {
@@ -91,16 +93,6 @@ export class PathManager {
 
   getBackendDirPath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName]);
-
-  getCliInputsPath = (projectPath: string, category: string, resourceName: string): string => {
-    return this.constructPath(projectPath, [
-      PathConstants.AmplifyDirName,
-      PathConstants.BackendDirName,
-      category,
-      resourceName,
-      PathConstants.cliInputsFileName,
-    ]);
-  };
 
   getCurrentCloudBackendDirPath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName]);
@@ -142,11 +134,29 @@ export class PathManager {
   getResourceDirectoryPath = (projectPath: string | undefined, category: string, resourceName: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, category, resourceName]);
 
-  getResourceParametersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
-    path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), 'build', PathConstants.ParametersJsonFileName);
+  getResourceInputsJsonFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
+    path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.CLIInputsJsonFileName);
 
-  getResourceCfnTemplatePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
-    path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), 'build', PathConstants.CfnFileName(resourceName));
+  getResourceParametersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string => {
+    let isBuildParametersjson: boolean = false;
+    const resourceDirPath = this.getResourceDirectoryPath(projectPath, category, resourceName);
+    if (!fs.existsSync(path.join(resourceDirPath, PathConstants.ParametersJsonFileName))) {
+      isBuildParametersjson = true;
+    }
+    const basePath = isBuildParametersjson ? path.join(resourceDirPath, PathConstants.BuildDirName) : resourceDirPath;
+    return path.join(basePath, PathConstants.ParametersJsonFileName);
+  };
+
+  getResourceCfnTemplatePath = (
+    projectPath: string | undefined,
+    category: string,
+    resourceName: string,
+    buildDirectory = false,
+  ): string => {
+    const resourceDirPath = this.getResourceDirectoryPath(projectPath, category, resourceName);
+    const basePath = buildDirectory ? path.join(resourceDirPath, PathConstants.BuildDirName) : resourceDirPath;
+    return path.join(basePath, PathConstants.CfnFileName(resourceName));
+  };
 
   getReadMeFilePath = (projectPath?: string): string =>
     this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.ReadMeFileName]);
@@ -167,8 +177,8 @@ export class PathManager {
 
   getDotAWSDirPath = (): string => path.normalize(path.join(homedir(), PathConstants.DotAWSDirName));
 
-  getCustomPoliciesPath  = (category: string, resourceName: string): string =>
-  path.join(this.getResourceDirectoryPath(undefined, category, resourceName), PathConstants.CustomPoliciesFilename);
+  getCustomPoliciesPath = (category: string, resourceName: string): string =>
+    path.join(this.getResourceDirectoryPath(undefined, category, resourceName), PathConstants.CustomPoliciesFilename);
 
   getAWSCredentialsFilePath = (): string => path.normalize(path.join(this.getDotAWSDirPath(), PathConstants.AWSCredentials));
 
@@ -214,7 +224,7 @@ export class PathManager {
       PathConstants.AmplifyDirName,
       PathConstants.BackendDirName,
       PathConstants.ProviderName,
-      PathConstants.CfnStacksBuildDirName,
+      PathConstants.BuildDirName,
     ]);
   };
 
@@ -223,7 +233,7 @@ export class PathManager {
       PathConstants.AmplifyDirName,
       PathConstants.CurrentCloudBackendDirName,
       PathConstants.ProviderName,
-      PathConstants.CfnStacksBuildDirName,
+      PathConstants.BuildDirName,
     ]);
   };
 

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -2,12 +2,11 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import _ from 'lodash';
 import { PathConstants, pathManager } from './pathManager';
-import { $TSMeta, $TSTeamProviderInfo, $TSAny, DeploymentSecrets, HooksConfig } from '..';
+import { $TSMeta, $TSTeamProviderInfo, $TSAny, DeploymentSecrets, HooksConfig, $TSObject } from '..';
 import { JSONUtilities } from '../jsonUtilities';
 import { SecretFileMode } from '../cliConstants';
 import { HydrateTags, ReadTags, Tag } from '../tags';
 import { CustomIAMPolicies } from '../customPoliciesUtils';
-
 
 export type GetOptions<T> = {
   throwIfNotExist?: boolean;
@@ -80,9 +79,9 @@ export class StateManager {
 
   getCustomPolicies = (categoryName: string, resourceName: string): CustomIAMPolicies | undefined => {
     const filePath = pathManager.getCustomPoliciesPath(categoryName, resourceName);
-    try{
+    try {
       return JSONUtilities.readJson<CustomIAMPolicies>(filePath);
-    } catch(err) {
+    } catch (err) {
       return undefined;
     }
   };
@@ -142,6 +141,21 @@ export class StateManager {
     options?: GetOptions<$TSAny>,
   ): $TSAny => {
     const filePath = pathManager.getResourceParametersFilePath(projectPath, category, resourceName);
+    const mergedOptions = {
+      throwIfNotExist: true,
+      ...options,
+    };
+
+    return this.getData<$TSAny>(filePath, mergedOptions);
+  };
+
+  getResourceInputsJson = (
+    projectPath: string | undefined,
+    category: string,
+    resourceName: string,
+    options?: GetOptions<$TSAny>,
+  ): $TSAny => {
+    const filePath = pathManager.getResourceInputsJsonFilePath(projectPath, category, resourceName);
     const mergedOptions = {
       throwIfNotExist: true,
       ...options,
@@ -274,6 +288,12 @@ export class StateManager {
     JSONUtilities.writeJson(filePath, parameters);
   };
 
+  setResourceInputsJson = (projectPath: string | undefined, category: string, resourceName: string, inputs: $TSObject): void => {
+    const filePath = pathManager.getResourceInputsJsonFilePath(projectPath, category, resourceName);
+
+    JSONUtilities.writeJson(filePath, inputs);
+  };
+
   cliJSONFileExists = (projectPath: string, env?: string): boolean => {
     try {
       return fs.existsSync(pathManager.getCLIJSONFilePath(projectPath, env));
@@ -379,5 +399,3 @@ export class StateManager {
 }
 
 export const stateManager = new StateManager();
-
-

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -49,7 +49,7 @@ export class AmplifyRootStackTransform {
     const backendDir = pathManager.getBackendDirPath();
     const overrideFilePath = path.join(backendDir, this._resourceName);
     const isBuild = await buildOverrideDir(backendDir, overrideFilePath).catch(error => {
-      amplifyPrinter.printer.warn(`Skipping build as ${error.message}`);
+      amplifyPrinter.printer.debug(`Skipping build as ${error.message}`);
       return false;
     });
     // skip if packageManager or override.ts not found

--- a/packages/amplify-provider-awscloudformation/src/utils/archiver.js
+++ b/packages/amplify-provider-awscloudformation/src/utils/archiver.js
@@ -25,6 +25,14 @@ function run(folder, zipFilePath, ignorePattern = DEFAULT_IGNORE_PATTERN, extraF
       cwd: folder,
       dot: true,
     });
+    zip.glob('storage/*/build/**', {
+      cwd: folder,
+      dot: true,
+    });
+    zip.glob('auth/*/build/**', {
+      cwd: folder,
+      dot: true,
+    });
     zip.glob('**', {
       cwd: folder,
       ignore: ignorePattern,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Updates path reading of parameters.json based on if build folder is present or not
- updates build folder in current cloud backend
- removes printer logs when build files not found during CFN transformation

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
-Tested manually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
