### PR TITLE
fix(graphql-relational-schema-transformer): has-many transformer update filter/condition inputs

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -509,6 +509,23 @@ test('has many with implicit index and fields and a user-defined primary key', (
   expect(commentUpdateInput.fields.find((f: any) => f.name.value === 'id')).toBeDefined();
   expect(commentUpdateInput.fields.find((f: any) => f.name.value === 'content')).toBeDefined();
   expect(commentUpdateInput.fields.find((f: any) => f.name.value === 'postCommentsId')).toBeDefined();
+
+  const commentType = schema.definitions.find((def: any) => def.name && def.name.value === 'Comment') as any;
+  expect(commentType).toBeDefined();
+
+  const postCommentsField = commentType.fields.find((f: any) => f.name.value === 'postCommentsId');
+  expect(postCommentsField).toBeDefined();
+
+  const commentFilterInput = schema.definitions.find((def: any) => def.name && def.name.value === 'ModelCommentFilterInput') as any;
+  expect(commentFilterInput).toBeDefined();
+  expect(commentFilterInput.fields.find((f: any) => f.name.value === 'id')).toBeDefined();
+  expect(commentFilterInput.fields.find((f: any) => f.name.value === 'content')).toBeDefined();
+  expect(commentFilterInput.fields.find((f: any) => f.name.value === 'postCommentsId')).toBeDefined();
+
+  const commentConditionInput = schema.definitions.find((def: any) => def.name && def.name.value === 'ModelCommentConditionInput') as any;
+  expect(commentConditionInput).toBeDefined();
+  expect(commentConditionInput.fields.find((f: any) => f.name.value === 'content')).toBeDefined();
+  expect(commentConditionInput.fields.find((f: any) => f.name.value === 'postCommentsId')).toBeDefined();
 });
 
 test('the limit of 100 is used by default', () => {


### PR DESCRIPTION
#### Description of changes
- adds GSI index link field in the related type for has many directive
- adds GSI index field to Filter and Condition Inputs
- updates hasMany directive with the GSI index name

#### Description of how you validated changes
- tested local android datastore application before and after changes
- tested local iOS datastore application before and after changes
- tested local javascript datastore application before and after changes
- tested local flutter datastore application before and after changes
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
