### PR TITLE
Correcting the "pro-tip" to use "push" instead of "publish"

### DIFF
--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -200,6 +200,6 @@ function printWelcomeMessage(context: $TSContext) {
   );
   context.print.info('');
   context.print.success('Pro tip:');
-  context.print.info('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything');
+  context.print.info('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything');
   context.print.info('');
 }

--- a/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
@@ -40,7 +40,7 @@ export function addEnvironment(cwd: string, settings: any): Promise<void> {
     spawn(getCLIPath(), ['env', 'add', '--providers', JSON.stringify(settings.providersParam)], { cwd, stripColors: true })
       .wait('Enter a name for the environment')
       .sendLine(settings.envName)
-      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
+      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -80,7 +80,7 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
         .sendLine(s.profileName);
     }
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
       if (err) {
         reject(err);
       } else {

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -119,7 +119,7 @@ export function initProjectForPinpoint(cwd: string): Promise<void> {
 
     singleSelect(chain, settings.region, amplifyRegions);
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
       if (!err) {
         resolve();
       } else {

--- a/packages/amplify-e2e-tests/src/environment/env.ts
+++ b/packages/amplify-e2e-tests/src/environment/env.ts
@@ -200,7 +200,7 @@ export function addEnvironmentHostedUI(cwd: string, settings: { envName: string 
       .sendLine(APPLE_KEY_ID)
       .wait('Enter your Private Key for your OAuth flow:')
       .sendLine(APPLE_PRIVATE_KEY)
-      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
+      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-e2e-tests/src/init-special-cases/index.ts
@@ -87,7 +87,7 @@ async function initWorkflow(cwd: string, settings: { accessKeyId: string; secret
 
     singleSelect(chain, settings.region, amplifyRegions);
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
       if (!err) {
         resolve();
       } else {

--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -55,7 +55,7 @@ export function initJSProjectWithProfileOldDX(cwd: string, settings: Object, tes
       .sendCarriageReturn()
       .wait('Please choose the profile you want to use')
       .sendLine(s.profileName)
-      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
+      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -55,7 +55,7 @@ export function initJSProjectWithProfileOldDX(cwd: string, settings: Object, tes
       .sendCarriageReturn()
       .wait('Please choose the profile you want to use')
       .sendLine(s.profileName)
-      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
+      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Correcting the "pro-tip" to use "push" instead of "publish" when customers first initialize a project.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
