### PR TITLE
fix: e2e test for generating custom policies

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/cfn-pre-processor.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/cfn-pre-processor.test.ts
@@ -18,14 +18,6 @@ const cfnTemplate = {
 } as unknown as Template;
 const templateFormat = CFNTemplateFormat.JSON;
 
-const customPolicies: CustomIAMPolicies = [
-  {
-    Action: ['test:test'],
-    Effect: 'Allow',
-    Resource: ['arn:aws:s3:us-east-2:012345678910:testResource'],
-  },
-];
-
 readCFNTemplate_mock.mockResolvedValue({
   templateFormat,
   cfnTemplate,
@@ -40,7 +32,6 @@ const resourcePath = 'api/resourceName/cfn-template-name.json';
 
 pathManager_mock.getBackendDirPath.mockReturnValue(backendPath);
 pathManager_mock.getResourceDirectoryPath.mockReturnValue(backendPath);
-stateManager_mock.getCustomPolicies.mockReturnValue(customPolicies);
 stateManager_mock.getLocalEnvInfo.mockReturnValue({ envName: 'test' });
 
 describe('preProcessCFNTemplate', () => {
@@ -64,5 +55,31 @@ describe('preProcessCFNTemplate', () => {
   it('writes to root build directory if path is not within backend dir', async () => {
     const newPath = await preProcessCFNTemplate(path.join('/something/else', resourcePath));
     expect(newPath).toMatchInlineSnapshot(`"/project/amplify/backend/awscloudformation/build/cfn-template-name.json"`);
+  });
+
+  it('test writeCustonPolicies with Lambda function', () => {
+    writeCustomPoliciesToCFNTemplate('testLambdaResourceName', 'Lambda', '../dummypath', 'function');
+    expect(pathManager_mock.getResourceDirectoryPath).toBeCalledWith(undefined, 'function', 'testLambdaResourceName');
+    expect(readCFNTemplate_mock).toBeCalled();
+  });
+
+  it('test writeCustonPolicies with LambdaLayer function', () => {
+    writeCustomPoliciesToCFNTemplate('testLambdaResourceName', 'LambdaLayer', '../dummypath', 'function');
+    expect(pathManager_mock.getResourceDirectoryPath).not.toBeCalled();
+    expect(readCFNTemplate_mock).not.toBeCalled();
+  });
+
+  it('test writeCustonPolicies with Containers Api', () => {
+    writeCustomPoliciesToCFNTemplate('testApiResourceName', 'ElasticContainer', '../dummypath', 'api');
+    expect(pathManager_mock.getResourceDirectoryPath).toBeCalledWith(undefined, 'api', 'testApiResourceName');
+    expect(readCFNTemplate_mock).toBeCalled();
+  });
+
+  it('test writeCustonPolicies with Appsync', () => {
+    pathManager_mock.getResourceDirectoryPath.mockClear();
+    readCFNTemplate_mock.mockClear();
+    writeCustomPoliciesToCFNTemplate('testApiResourceName', 'AppSync', '../dummypath', 'api');
+    expect(pathManager_mock.getResourceDirectoryPath).not.toBeCalled();
+    expect(readCFNTemplate_mock).not.toBeCalled();
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
+++ b/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
@@ -26,7 +26,7 @@ export async function preProcessCFNTemplate(filePath: string): Promise<string> {
 
 //get data from custom polcies file and write custom policies to CFN template
 export async function writeCustomPoliciesToCFNTemplate(resourceName: string, service: string, cfnFile: string, category: string) {
-  if (category !== 'api' && service !== 'ElasticContainer' && category !== 'function' && service !== 'Lambda') {
+  if (!(category === 'api' && service === 'ElasticContainer') && !(category === 'function' && service === 'Lambda')) {
     return;
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
