### PR TITLE
fix(graphql-model-transformer): override resource logical id to fix v1 to v2 transformer migration

### DIFF
--- a/packages/amplify-e2e-tests/schemas/transformer_migration/basic-model-v1.graphql
+++ b/packages/amplify-e2e-tests/schemas/transformer_migration/basic-model-v1.graphql
@@ -1,0 +1,19 @@
+type Post @model {
+  id: ID!
+  title: String!
+}
+
+type Customer @model @key(fields: ["email"]) @key(name: "byUsername", fields: ["username"], queryField: "byUsername") {
+  email: String!
+  username: String
+}
+
+type Test @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn" }) {
+  id: ID!
+  title: String!
+}
+
+type Rename @model(queries: { get: "rename" }, mutations: { create: "makeRename" }, subscriptions: null) {
+  id: ID!
+  title: String!
+}

--- a/packages/amplify-e2e-tests/schemas/transformer_migration/basic-model-v2.graphql
+++ b/packages/amplify-e2e-tests/schemas/transformer_migration/basic-model-v2.graphql
@@ -1,0 +1,19 @@
+type Post @model @auth(rules: [{ allow: public }]) {
+  id: ID!
+  title: String!
+}
+
+type Customer @model @auth(rules: [{ allow: public }]) {
+  email: String! @primaryKey
+  username: String @index(name: "byUsername", queryField: "byUsername")
+}
+
+type Test @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn" }) @auth(rules: [{ allow: public }]) {
+  id: ID!
+  title: String!
+}
+
+type Rename @model(queries: { get: "rename" }, mutations: { create: "makeRename" }, subscriptions: null) @auth(rules: [{ allow: public }]) {
+  id: ID!
+  title: String!
+}

--- a/packages/amplify-e2e-tests/src/GraphQLClient.ts
+++ b/packages/amplify-e2e-tests/src/GraphQLClient.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+export interface GraphQLLocation {
+  line: number;
+  column: number;
+}
+export interface GraphQLError {
+  message: string;
+  locations: GraphQLLocation[];
+  path: string[];
+}
+export interface GraphQLResponse {
+  data: any;
+  errors: GraphQLError[];
+}
+export class GraphQLClient {
+  constructor(private url: string, private headers: any) {}
+
+  async query(query: string, variables: any = {}): Promise<GraphQLResponse> {
+    const axRes = await axios.post<GraphQLResponse>(
+      this.url,
+      {
+        query,
+        variables,
+      },
+      { headers: this.headers },
+    );
+    return axRes.data;
+  }
+}

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/model-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/model-migration.test.ts
@@ -1,0 +1,272 @@
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  amplifyPushUpdate,
+  addFeatureFlag,
+  createRandomName,
+  addAuthWithDefault,
+} from 'amplify-e2e-core';
+import { addApiWithoutSchema, updateApiSchema, getProjectMeta } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+(global as any).fetch = require('node-fetch');
+
+describe('transformer model migration test', () => {
+  let projRoot: string;
+  let projectName: string;
+
+  beforeEach(async () => {
+    projectName = createRandomName();
+    projRoot = await createNewProjectDir(createRandomName());
+    await initJSProjectWithProfile(projRoot, { name: projectName });
+    await addAuthWithDefault(projRoot, {});
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('migration of model key queries timestamps should succeed', async () => {
+    const modelSchemaV1 = 'transformer_migration/basic-model-v1.graphql';
+    const modelSchemaV2 = 'transformer_migration/basic-model-v2.graphql';
+
+    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await updateApiSchema(projRoot, projectName, modelSchemaV1);
+    await amplifyPush(projRoot);
+
+    let appSyncClient = getAppSyncClientFromProj(projRoot);
+
+    let createPostMutation = /* GraphQL */ `
+      mutation CreatePost {
+        createPost(input: { title: "Created in V1" }) {
+          id
+        }
+      }
+    `;
+
+    let createPostResult = await appSyncClient.mutate({
+      mutation: gql(createPostMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createPostResult.errors).toBeUndefined();
+    expect(createPostResult.data).toBeDefined();
+
+    let createCustomerMutation = /* GraphQL */ `
+      mutation CreateCustomer {
+        createCustomer(input: { email: "v1@test.com" }) {
+          email
+        }
+      }
+    `;
+
+    let createCustomerResult = await appSyncClient.mutate({
+      mutation: gql(createCustomerMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createCustomerResult.errors).toBeUndefined();
+    expect(createCustomerResult.data).toBeDefined();
+
+    let createTestMutation = /* GraphQL */ `
+      mutation CreateTest {
+        createTest(input: { title: "Created in V1" }) {
+          id
+        }
+      }
+    `;
+
+    let createTestResult = await appSyncClient.mutate({
+      mutation: gql(createTestMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createTestResult.errors).toBeUndefined();
+    expect(createTestResult.data).toBeDefined();
+
+    let createRenameMutation = /* GraphQL */ `
+      mutation CreateRename {
+        makeRename(input: { title: "Created in V1" }) {
+          id
+        }
+      }
+    `;
+
+    let createRenameResult = await appSyncClient.mutate({
+      mutation: gql(createRenameMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createRenameResult.errors).toBeUndefined();
+    expect(createRenameResult.data).toBeDefined();
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 2);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', true);
+
+    await updateApiSchema(projRoot, projectName, modelSchemaV2);
+    await amplifyPushUpdate(projRoot);
+
+    appSyncClient = getAppSyncClientFromProj(projRoot);
+
+    createPostMutation = /* GraphQL */ `
+      mutation CreatePost {
+        createPost(input: { title: "Created in V2" }) {
+          id
+        }
+      }
+    `;
+
+    createPostResult = await appSyncClient.mutate({
+      mutation: gql(createPostMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createPostResult.errors).toBeUndefined();
+    expect(createPostResult.data).toBeDefined();
+
+    createCustomerMutation = /* GraphQL */ `
+      mutation CreateCustomer {
+        createCustomer(input: { email: "v2@test.com" }) {
+          email
+        }
+      }
+    `;
+
+    createCustomerResult = await appSyncClient.mutate({
+      mutation: gql(createCustomerMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createCustomerResult.errors).toBeUndefined();
+    expect(createCustomerResult.data).toBeDefined();
+
+    createTestMutation = /* GraphQL */ `
+      mutation CreateTest {
+        createTest(input: { title: "Created in V2" }) {
+          id
+        }
+      }
+    `;
+
+    createTestResult = await appSyncClient.mutate({
+      mutation: gql(createTestMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createTestResult.errors).toBeUndefined();
+    expect(createTestResult.data).toBeDefined();
+
+    createRenameMutation = /* GraphQL */ `
+      mutation CreateRename {
+        makeRename(input: { title: "Created in V2" }) {
+          id
+        }
+      }
+    `;
+
+    createRenameResult = await appSyncClient.mutate({
+      mutation: gql(createRenameMutation),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(createRenameResult.errors).toBeUndefined();
+    expect(createRenameResult.data).toBeDefined();
+
+    const postsQuery = /* GraphQL */ `
+      query ListPosts {
+        listPosts {
+          items {
+            id
+            title
+          }
+        }
+      }
+    `;
+
+    let queryResult = await appSyncClient.query({
+      query: gql(postsQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(queryResult.errors).toBeUndefined();
+    expect(queryResult.data).toBeDefined();
+    expect((queryResult.data as any).listPosts.items.length).toEqual(2);
+
+    const customersQuery = /* GraphQL */ `
+      query ListCustomers {
+        listCustomers {
+          items {
+            email
+          }
+        }
+      }
+    `;
+
+    queryResult = await appSyncClient.query({
+      query: gql(customersQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(queryResult.errors).toBeUndefined();
+    expect(queryResult.data).toBeDefined();
+    expect((queryResult.data as any).listCustomers.items.length).toEqual(2);
+
+    const testsQuery = /* GraphQL */ `
+      query ListTests {
+        listTests {
+          items {
+            id
+            title
+          }
+        }
+      }
+    `;
+
+    queryResult = await appSyncClient.query({
+      query: gql(testsQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(queryResult.errors).toBeUndefined();
+    expect(queryResult.data).toBeDefined();
+    expect((queryResult.data as any).listTests.items.length).toEqual(2);
+
+    const renamesQuery = /* GraphQL */ `
+      query GetRename {
+        rename (id: "${(createRenameResult.data as any).makeRename.id}") {
+          id
+          title
+        }
+      }
+    `;
+
+    queryResult = await appSyncClient.query({
+      query: gql(renamesQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(queryResult.errors).toBeUndefined();
+    expect(queryResult.data).toBeDefined();
+  });
+
+  const getAppSyncClientFromProj = (projRoot: string) => {
+    const meta = getProjectMeta(projRoot);
+    const region = meta['providers']['awscloudformation']['Region'] as string;
+    const { output } = meta.api[projectName];
+    const url = output.GraphQLAPIEndpointOutput as string;
+    const apiKey = output.GraphQLAPIKeyOutput as string;
+
+    return new AWSAppSyncClient({
+      url,
+      region,
+      disableOffline: true,
+      auth: {
+        type: AUTH_TYPE.API_KEY,
+        apiKey,
+      },
+    });
+  };
+});

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -66,7 +66,15 @@ import {
 } from 'graphql';
 import { SubscriptionLevel, ModelDirectiveConfiguration } from '@aws-amplify/graphql-model-transformer';
 import { AccessControlMatrix } from './accesscontrol';
-import { getBaseType, makeDirective, makeField, makeNamedType, ResourceConstants, ModelResourceIDs } from 'graphql-transformer-common';
+import {
+  getBaseType,
+  makeDirective,
+  makeField,
+  makeNamedType,
+  ResourceConstants,
+  ModelResourceIDs,
+  ResolverResourceIDs,
+} from 'graphql-transformer-common';
 import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
 import {
@@ -649,6 +657,7 @@ Static group authorization should perform as expected.`,
         new TransformerResolver(
           typeName,
           fieldName,
+          ResolverResourceIDs.ResolverResourceID(typeName, fieldName),
           MappingTemplate.s3MappingTemplateFromString(fieldAuthExpression, `${typeName}.${fieldName}.req.vtl`),
           MappingTemplate.s3MappingTemplateFromString(fieldResponse, `${typeName}.${fieldName}.res.vtl`),
           ['init'],

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -23,6 +23,7 @@ import {
 } from 'graphql-transformer-common';
 import { RELATIONAL_DIRECTIVES } from './constants';
 import { RelationalPrimaryMapConfig, RoleDefinition, SearchableConfig } from './definitions';
+import md5 from 'md5';
 
 export const collectFieldNames = (object: ObjectTypeDefinitionNode): Array<string> => {
   return object.fields!.map((field: FieldDefinitionNode) => field.name.value);
@@ -47,9 +48,9 @@ export const getModelConfig = (directive: DirectiveNode, typeName: string, isDat
     },
     subscriptions: {
       level: SubscriptionLevel.on,
-      onCreate: [toCamelCase(['onCreate', typeName])],
-      onDelete: [toCamelCase(['onDelete', typeName])],
-      onUpdate: [toCamelCase(['onUpdate', typeName])],
+      onCreate: [ensureValidSubscriptionName(toCamelCase(['onCreate', typeName]))],
+      onDelete: [ensureValidSubscriptionName(toCamelCase(['onDelete', typeName]))],
+      onUpdate: [ensureValidSubscriptionName(toCamelCase(['onUpdate', typeName]))],
     },
     timestamps: {
       createdAt: 'createdAt',
@@ -334,4 +335,10 @@ export const getSubscriptionFieldNames = (
   }
 
   return fields;
+};
+
+const ensureValidSubscriptionName = (name: string): string => {
+  if (name.length <= 50) return name;
+
+  return name.slice(0, 45) + md5(name).slice(0, 5);
 };

--- a/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
+++ b/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
@@ -167,6 +167,7 @@ export class FunctionTransformer extends TransformerPluginBase {
               `${config.resolverTypeName}.${config.resolverFieldName}.res.vtl`,
             ),
             undefined,
+            undefined,
             [],
             stack,
           );

--- a/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
@@ -119,7 +119,7 @@ test('it generates the expected resources', () => {
     }),
   );
   cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 5));
-  expect(stack.Resources!.commentContentResolver).toBeTruthy();
+  expect(stack.Resources!.CommentcontentResolver).toBeTruthy();
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::Resolver', {
       ApiId: { Ref: anything() },
@@ -137,7 +137,7 @@ test('it generates the expected resources', () => {
       },
     }),
   );
-  expect(stack.Resources!.commentContent2Resolver).toBeTruthy();
+  expect(stack.Resources!.Commentcontent2Resolver).toBeTruthy();
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::Resolver', {
       ApiId: { Ref: anything() },
@@ -155,7 +155,7 @@ test('it generates the expected resources', () => {
       },
     }),
   );
-  expect(stack.Resources!.commentMoreResolver).toBeTruthy();
+  expect(stack.Resources!.CommentmoreResolver).toBeTruthy();
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::Resolver', {
       ApiId: { Ref: anything() },
@@ -173,7 +173,7 @@ test('it generates the expected resources', () => {
       },
     }),
   );
-  expect(stack.Resources!.commentEvenMoreResolver).toBeTruthy();
+  expect(stack.Resources!.CommentevenMoreResolver).toBeTruthy();
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::Resolver', {
       ApiId: { Ref: anything() },
@@ -191,7 +191,7 @@ test('it generates the expected resources', () => {
       },
     }),
   );
-  expect(stack.Resources!.commentStillMoreResolver).toBeTruthy();
+  expect(stack.Resources!.CommentstillMoreResolver).toBeTruthy();
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::Resolver', {
       ApiId: { Ref: anything() },
@@ -257,13 +257,13 @@ test('URL params happy path', () => {
   const stack = out.stacks.HttpDirectiveStack;
   cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 1));
   cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 7));
-  expect(stack.Resources!.commentComplexResolver).toBeTruthy();
-  expect(stack.Resources!.commentComplexAgainResolver).toBeTruthy();
-  expect(stack.Resources!.commentComplexPostResolver).toBeTruthy();
-  expect(stack.Resources!.commentComplexPutResolver).toBeTruthy();
-  expect(stack.Resources!.commentDeleterResolver).toBeTruthy();
-  expect(stack.Resources!.commentComplexGetResolver).toBeTruthy();
-  expect(stack.Resources!.commentComplexGet2Resolver).toBeTruthy();
+  expect(stack.Resources!.CommentcomplexResolver).toBeTruthy();
+  expect(stack.Resources!.CommentcomplexAgainResolver).toBeTruthy();
+  expect(stack.Resources!.CommentcomplexPostResolver).toBeTruthy();
+  expect(stack.Resources!.CommentcomplexPutResolver).toBeTruthy();
+  expect(stack.Resources!.CommentdeleterResolver).toBeTruthy();
+  expect(stack.Resources!.CommentcomplexGetResolver).toBeTruthy();
+  expect(stack.Resources!.CommentcomplexGet2Resolver).toBeTruthy();
 });
 
 test('it throws an error when missing protocol in URL argument', () => {
@@ -297,7 +297,7 @@ test('env on the URI path', () => {
   expect(out.stacks).toBeDefined();
   parse(out.schema);
   const stack = out.stacks.HttpDirectiveStack;
-  const reqTemplate = stack.Resources!.commentContentResolver.Properties.RequestMappingTemplate;
+  const reqTemplate = stack.Resources!.CommentcontentResolver.Properties.RequestMappingTemplate;
   expect(reqTemplate['Fn::Sub']).toBeTruthy();
   expect(reqTemplate['Fn::Sub'][0]).toMatch('"resourcePath": "/ping${env}"');
   expect(reqTemplate['Fn::Sub'][1].env.Ref).toBeTruthy();
@@ -412,7 +412,7 @@ test('aws_region on the URI path', () => {
   expect(out.stacks).toBeDefined();
   parse(out.schema);
   const stack = out.stacks.HttpDirectiveStack;
-  const reqTemplate = stack.Resources!.commentContentResolver.Properties.RequestMappingTemplate;
+  const reqTemplate = stack.Resources!.CommentcontentResolver.Properties.RequestMappingTemplate;
   expect(reqTemplate['Fn::Sub']).toBeTruthy();
   expect(reqTemplate['Fn::Sub'][0]).toMatch('"resourcePath": "/ping${aws_region}"');
   expect(reqTemplate['Fn::Sub'][1].aws_region.Ref).toBeTruthy();

--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -290,6 +290,7 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
       ),
       `${config.resolverTypeName}.${config.resolverFieldName}.res.vtl`,
     ),
+    undefined,
     dataSourceId,
     undefined,
     stack,
@@ -302,7 +303,7 @@ function replaceEnvAndRegion(env: cdk.CfnParameter, region: string, value: strin
   } = {};
 
   if (value.includes('${env}')) {
-    vars.env = (env as unknown) as string;
+    vars.env = env as unknown as string;
   }
 
   if (value.includes('${aws_region}')) {

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -39,6 +39,7 @@ import {
   getBaseType,
   graphqlName,
   ModelResourceIDs,
+  ResolverResourceIDs,
   ResourceConstants,
   toCamelCase,
 } from 'graphql-transformer-common';
@@ -439,6 +440,7 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
   const resolver = ctx.resolvers.generateQueryResolver(
     queryTypeName,
     queryField,
+    ResolverResourceIDs.ResolverResourceID(queryTypeName, queryField),
     dataSource as DataSourceProvider,
     MappingTemplate.s3MappingTemplateFromString(
       print(

--- a/packages/amplify-graphql-model-transformer/src/wrappers/object-definition-wrapper.ts
+++ b/packages/amplify-graphql-model-transformer/src/wrappers/object-definition-wrapper.ts
@@ -1,5 +1,5 @@
+import { DirectiveWrapper } from '@aws-amplify/graphql-transformer-core';
 import {
-  ArgumentNode,
   DirectiveNode,
   DocumentNode,
   EnumTypeDefinitionNode,
@@ -11,13 +11,10 @@ import {
   ListTypeNode,
   Location,
   NamedTypeNode,
-  NameNode,
   NonNullTypeNode,
   ObjectTypeDefinitionNode,
   StringValueNode,
   TypeNode,
-  valueFromASTUntyped,
-  ValueNode,
 } from 'graphql';
 import {
   DEFAULT_SCALARS,
@@ -28,53 +25,6 @@ import {
   unwrapNonNull,
   withNamedNodeNamed,
 } from 'graphql-transformer-common';
-
-// Todo: to be moved to core later. context.output.getObject would return wrapper type so its easier to manipulate
-// objects
-
-export class ArgumentWrapper {
-  public readonly name: NameNode;
-  public readonly value: ValueNode;
-  constructor(argument: ArgumentNode) {
-    this.name = argument.name;
-    this.value = argument.value;
-  }
-  serialize = (): ArgumentNode => {
-    return {
-      kind: 'Argument',
-      name: this.name,
-      value: this.value,
-    };
-  };
-}
-
-export class DirectiveWrapper {
-  private arguments: ArgumentWrapper[] = [];
-  private name: NameNode;
-  private location?: Location;
-  constructor(node: DirectiveNode) {
-    this.name = node.name;
-    this.arguments = (node.arguments || []).map(arg => new ArgumentWrapper(arg));
-    this.location = this.location;
-  }
-  public serialize = (): DirectiveNode => {
-    return {
-      kind: 'Directive',
-      name: this.name,
-      arguments: this.arguments.map(arg => arg.serialize()),
-    };
-  };
-  public getArguments = <T>(defaultValue: Required<T>): Required<T> => {
-    const argValues = this.arguments.reduce(
-      (acc: Record<string, any>, arg: ArgumentWrapper) => ({
-        ...acc,
-        [arg.name.value]: valueFromASTUntyped(arg.value),
-      }),
-      {},
-    );
-    return Object.assign(defaultValue, argValues);
-  };
-}
 
 export class GenericFieldWrapper {
   protected type: TypeNode;

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -295,6 +295,638 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "QueryconvertTextToSpeechResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "convertTextToSpeech",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "QueryidentifyLabelsResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "identifyLabels",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "QueryidentifyTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "identifyText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "QueryspeakTranslatedIdentifiedTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "speakTranslatedIdentifiedText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "QueryspeakTranslatedLabelTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "speakTranslatedLabelText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "QueryspeakTranslatedTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "speakTranslatedText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "QuerytranslateTextResolver": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "FieldName": "translateText",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": Object {
+          "Fn::Join": Array [
+            "
+",
+            Array [
+              Object {
+                "Fn::If": Array [
+                  "HasEnvironmentParameter",
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
+                      Object {
+                        "env": Object {
+                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                        },
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
+                      Object {
+                        "hash": Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              "$util.qr($ctx.stash.put(\\"isList\\", false))
+{}",
+            ],
+          ],
+        },
+        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
+#if( $ctx.stash.get(\\"isList\\") )
+  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
+  $util.toJson($result)
+#else
+  $util.toJson($ctx.result)
+#end",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
     "RekognitionDataSourceC6790FED": Object {
       "Properties": Object {
         "ApiId": Object {
@@ -722,638 +1354,6 @@ $utils.error($ctx.result.body)
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "queryConvertTextToSpeechResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "convertTextToSpeech",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "queryIdentifyLabelsResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "identifyLabels",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "queryIdentifyTextResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "identifyText",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "querySpeakTranslatedIdentifiedTextResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "speakTranslatedIdentifiedText",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A",
-                "FunctionId",
-              ],
-            },
-            Object {
-              "Fn::GetAtt": Array [
-                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
-                "FunctionId",
-              ],
-            },
-            Object {
-              "Fn::GetAtt": Array [
-                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "querySpeakTranslatedLabelTextResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "speakTranslatedLabelText",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61",
-                "FunctionId",
-              ],
-            },
-            Object {
-              "Fn::GetAtt": Array [
-                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
-                "FunctionId",
-              ],
-            },
-            Object {
-              "Fn::GetAtt": Array [
-                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "querySpeakTranslatedTextResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "speakTranslatedText",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
-                "FunctionId",
-              ],
-            },
-            Object {
-              "Fn::GetAtt": Array [
-                "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "queryTranslateTextResolver": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-        },
-        "FieldName": "translateText",
-        "Kind": "PIPELINE",
-        "PipelineConfig": Object {
-          "Functions": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9",
-                "FunctionId",
-              ],
-            },
-          ],
-        },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "
-",
-            Array [
-              Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}-\${env}\\"))",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
-                        },
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                  Object {
-                    "Fn::Sub": Array [
-                      "$util.qr($ctx.stash.put(\\"s3Bucket\\", \\"myStorage\${hash}\\"))",
-                      Object {
-                        "hash": Object {
-                          "Fn::Select": Array [
-                            3,
-                            Object {
-                              "Fn::Split": Array [
-                                "-",
-                                Object {
-                                  "Ref": "AWS::StackName",
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                ],
-              },
-              "$util.qr($ctx.stash.put(\\"isList\\", false))
-{}",
-            ],
-          ],
-        },
-        "ResponseMappingTemplate": "## If the result is a list return the result as a list **
-#if( $ctx.stash.get(\\"isList\\") )
-  #set( $result = $ctx.result.split(\\"[ ,]+\\") )
-  $util.toJson($result)
-#else
-  $util.toJson($ctx.result)
-#end",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
     },
     "translateTextAccess74D3AE90": Object {
       "Properties": Object {

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -384,6 +384,7 @@ function createResolver(
       ),
     ),
     undefined,
+    undefined,
     pipelineFunctions,
     stack,
   );

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -279,8 +279,8 @@ test('bidirectional has many query case', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect((out.stacks as any).User.Resources.postAuthorResolver).toBeTruthy();
-  expect((out.stacks as any).Post.Resources.userPostsResolver).toBeTruthy();
+  expect((out.stacks as any).User.Resources.PostauthorResolver).toBeTruthy();
+  expect((out.stacks as any).Post.Resources.UserpostsResolver).toBeTruthy();
 
   const userType = schema.definitions.find((def: any) => def.name && def.name.value === 'User') as any;
   expect(userType).toBeDefined();
@@ -327,7 +327,7 @@ test('has many query with a composite sort key', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect((out.stacks as any).Test1.Resources.testOtherPartsResolver).toBeTruthy();
+  expect((out.stacks as any).Test1.Resources.TestotherPartsResolver).toBeTruthy();
 
   const testObjType = schema.definitions.find((def: any) => def.name && def.name.value === 'Test') as any;
   expect(testObjType).toBeDefined();

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -37,6 +37,7 @@ import {
   attributeTypeFromScalar,
   ModelResourceIDs,
   NONE_VALUE,
+  ResolverResourceIDs,
   ResourceConstants,
   toCamelCase,
 } from 'graphql-transformer-common';
@@ -86,6 +87,7 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
   const resolver = ctx.resolvers.generateQueryResolver(
     object.name.value,
     field.name.value,
+    ResolverResourceIDs.ResolverResourceID(object.name.value, field.name.value),
     dataSource as any,
     MappingTemplate.s3MappingTemplateFromString(
       print(
@@ -223,6 +225,7 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
   const resolver = ctx.resolvers.generateQueryResolver(
     object.name.value,
     field.name.value,
+    ResolverResourceIDs.ResolverResourceID(object.name.value, field.name.value),
     dataSource as any,
     MappingTemplate.s3MappingTemplateFromString(
       print(

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -26,6 +26,7 @@ import {
   graphqlName,
   plurality,
   toUpper,
+  ResolverResourceIDs,
 } from 'graphql-transformer-common';
 import { createParametersStack as createParametersInStack } from './cdk/create-cfnParameters';
 import { requestTemplate, responseTemplate, sandboxMappingTemplate } from './generate-resolver-vtl';
@@ -134,6 +135,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
       const resolver = context.resolvers.generateQueryResolver(
         typeName,
         def.fieldName,
+        ResolverResourceIDs.ResolverResourceID(typeName, def.fieldName),
         datasource as DataSourceProvider,
         MappingTemplate.s3MappingTemplateFromString(
           requestTemplate(attributeName, getNonKeywordFields(def.node), false, type, keyFields),

--- a/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts
@@ -60,6 +60,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -68,6 +69,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -76,6 +78,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -84,6 +87,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -92,6 +96,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -100,6 +105,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -108,6 +114,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -116,6 +123,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 
@@ -124,6 +132,7 @@ export abstract class TransformerModelBase extends TransformerPluginBase impleme
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -32,6 +32,7 @@ export class ResolverManager implements TransformerResolversManagerProvider {
   generateQueryResolver = (
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     dataSource: DataSourceProvider,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
@@ -39,6 +40,7 @@ export class ResolverManager implements TransformerResolversManagerProvider {
     return new TransformerResolver(
       typeName,
       fieldName,
+      resolverLogicalId,
       requestMappingTemplate,
       responseMappingTemplate,
       ['init', 'preAuth', 'auth', 'postAuth', 'preDataLoad'],
@@ -50,6 +52,7 @@ export class ResolverManager implements TransformerResolversManagerProvider {
   generateMutationResolver = (
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     dataSource: DataSourceProvider,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
@@ -57,6 +60,7 @@ export class ResolverManager implements TransformerResolversManagerProvider {
     return new TransformerResolver(
       typeName,
       fieldName,
+      resolverLogicalId,
       requestMappingTemplate,
       responseMappingTemplate,
       ['init', 'preAuth', 'auth', 'postAuth', 'preUpdate'],
@@ -68,12 +72,14 @@ export class ResolverManager implements TransformerResolversManagerProvider {
   generateSubscriptionResolver = (
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
   ): TransformerResolver => {
     return new TransformerResolver(
       typeName,
       fieldName,
+      resolverLogicalId,
       requestMappingTemplate,
       responseMappingTemplate,
       ['init', 'preAuth', 'auth', 'postAuth', 'preSubscribe'],
@@ -122,6 +128,7 @@ export class TransformerResolver implements TransformerResolverProvider {
   constructor(
     private typeName: string,
     private fieldName: string,
+    private resolverLogicalId: string,
     private requestMappingTemplate: MappingTemplateProvider,
     private responseMappingTemplate: MappingTemplateProvider,
     private requestSlots: string[],
@@ -130,6 +137,7 @@ export class TransformerResolver implements TransformerResolverProvider {
   ) {
     assert(typeName, 'typeName is required');
     assert(fieldName, 'fieldName is required');
+    assert(resolverLogicalId, 'resolverLogicalId is required');
     assert(requestMappingTemplate, 'requestMappingTemplate is required');
     assert(responseMappingTemplate, 'responseMappingTemplate is required');
     this.slotNames = new Set([...requestSlots, ...responseSlots]);
@@ -273,6 +281,7 @@ export class TransformerResolver implements TransformerResolverProvider {
       this.fieldName,
       MappingTemplate.inlineTemplateFromString(initResolver),
       MappingTemplate.inlineTemplateFromString('$util.toJson($ctx.prev.result)'),
+      this.resolverLogicalId,
       undefined,
       [...requestFns, dataSourceProviderFn, ...responseFns].map(fn => fn.functionId),
       stack,

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,7 +1,6 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
-import { merge } from 'lodash';
 
-class ArgumentWrapper {
+export class ArgumentWrapper {
   public readonly name: NameNode;
   public readonly value: ValueNode;
   constructor(argument: ArgumentNode) {
@@ -41,6 +40,6 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    return merge(defaultValue, argValues);
+    return Object.assign(defaultValue, argValues);
   };
 }

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -53,6 +53,7 @@ export interface TransformHostProvider {
     fieldName: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
+    resolverLogicalId?: string,
     dataSourceName?: string,
     pipelineConfig?: string[],
     stack?: Stack,

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -24,6 +24,7 @@ export interface TransformerResolversManagerProvider {
   generateQueryResolver: (
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     dataSource: DataSourceProvider,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
@@ -32,6 +33,7 @@ export interface TransformerResolversManagerProvider {
   generateMutationResolver: (
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     dataSource: DataSourceProvider,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
@@ -40,6 +42,7 @@ export interface TransformerResolversManagerProvider {
   generateSubscriptionResolver: (
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
   ) => TransformerResolverProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-model-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-model-provider.ts
@@ -26,6 +26,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateListResolver: (
@@ -33,6 +34,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateCreateResolver: (
@@ -40,6 +42,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateUpdateResolver: (
@@ -47,6 +50,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateDeleteResolver: (
@@ -54,6 +58,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateOnCreateResolver?: (
@@ -61,6 +66,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateOnUpdateResolver?: (
@@ -68,6 +74,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateOnDeleteResolver?: (
@@ -75,6 +82,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
   generateSyncResolver?: (
@@ -82,6 +90,7 @@ export interface TransformerModelProvider extends TransformerPluginProvider {
     type: ObjectTypeDefinitionNode,
     typeName: string,
     fieldName: string,
+    resolverLogicalId: string,
     directive?: DirectiveDefinitionNode,
   ) => TransformerResolverProvider;
 


### PR DESCRIPTION
#### Description of changes
- sets resolver and data source logical IDs as V1 to allow proper migration
- adds migration test for @model
- fixes auth resolver lookup when queries are renamed

#### Description of how you validated changes
- `yarn test` passes
- manual testing
- e2e migration for @model with key timestamps and queries override from v1 to v2 passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
