### PR TITLE
fix: sub "_" with hash in resource logical ID in transformer v2

### DIFF
--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -23,7 +23,8 @@
     "scripts": {
         "build": "tsc",
         "watch": "tsc -w",
-        "clean": "rimraf ./lib"
+        "clean": "rimraf ./lib",
+        "test": "jest"
     },
     "dependencies": {
         "@aws-amplify/graphql-transformer-interfaces": "1.10.0",

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
@@ -16,6 +16,7 @@ describe('addResolver', () => {
       new InlineTemplate('testTemplate'),
       new InlineTemplate('testTemplate'),
       undefined,
+      undefined,
       ['testPipelineConfig'],
       stack,
     );
@@ -28,6 +29,7 @@ describe('addResolver', () => {
       'test_field',
       new InlineTemplate('testTemplate'),
       new InlineTemplate('testTemplate'),
+      undefined,
       undefined,
       ['testPipelineConfig'],
       stack,

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
@@ -4,10 +4,6 @@ import { App } from '@aws-cdk/core';
 import { InlineTemplate } from '../cdk-compat/template-asset';
 import { TransformerRootStack } from '../cdk-compat/root-stack';
 
-// jest.mock('../graphql-api');
-
-// const GraphqlApi_mock = GraphQLApi as jest.MockedClass<typeof GraphQLApi>;
-
 describe('addResolver', () => {
   const app = new App();
   const stack = new TransformerRootStack(app, 'test-root-stack');

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
@@ -1,0 +1,41 @@
+import { DefaultTransformHost } from '../transform-host';
+import { GraphQLApi, TransformerAPIProps } from '../graphql-api';
+import { App } from '@aws-cdk/core';
+import { InlineTemplate } from '../cdk-compat/template-asset';
+import { TransformerRootStack } from '../cdk-compat/root-stack';
+
+// jest.mock('../graphql-api');
+
+// const GraphqlApi_mock = GraphQLApi as jest.MockedClass<typeof GraphQLApi>;
+
+describe('addResolver', () => {
+  const app = new App();
+  const stack = new TransformerRootStack(app, 'test-root-stack');
+  const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+
+  it('generates resolver name with hash for non-alphanumeric type names', () => {
+    const cfnResolver = transformHost.addResolver(
+      'test_type',
+      'testField',
+      new InlineTemplate('testTemplate'),
+      new InlineTemplate('testTemplate'),
+      undefined,
+      ['testPipelineConfig'],
+      stack,
+    );
+    expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+  });
+
+  it('generates resolver name with hash for non-alphanumeric field names', () => {
+    const cfnResolver = transformHost.addResolver(
+      'testType',
+      'test_field',
+      new InlineTemplate('testTemplate'),
+      new InlineTemplate('testTemplate'),
+      undefined,
+      ['testPipelineConfig'],
+      stack,
+    );
+    expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -17,7 +17,7 @@ import { CfnFunction, Code, Function, IFunction, ILayerVersion, Runtime } from '
 import { AppSyncFunctionConfiguration } from './appsync-function';
 import { IRole } from '@aws-cdk/aws-iam';
 import { InlineTemplate, S3MappingFunctionCode } from './cdk-compat/template-asset';
-import { toCamelCase } from 'graphql-transformer-common';
+import { resourceName, toCamelCase } from 'graphql-transformer-common';
 import { GraphQLApi } from './graphql-api';
 
 export interface DefaultTransformHostOptions {
@@ -143,7 +143,8 @@ export class DefaultTransformHost implements TransformHostProvider {
 
     const requestTemplateLocation = requestMappingTemplate.bind(this.api);
     const responseTemplateLocation = responseMappingTemplate.bind(this.api);
-    const resolverName = toCamelCase([typeName, fieldName, 'Resolver']);
+    const resolverName = toCamelCase([resourceName(typeName), resourceName(fieldName), 'Resolver']);
+
     if (dataSourceName) {
       const dataSource = this.dataSources.get(dataSourceName);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Replaces "_" in resolver logical IDs with a short hash to avoid resource name conflicts cause by removing the "_" altogether
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
