### PR TITLE
feat: add admin roles which have admin control over a graphql api

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -8,7 +8,7 @@ import { EOL } from 'os';
 import { modifiedApi } from './resources/modified-api-index';
 
 export function getSchemaPath(schemaName: string): string {
-  return `${__dirname}/../../../amplify-e2e-tests/schemas/${schemaName}`;
+  return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);
 }
 
 export function apiGqlCompile(cwd: string, testingWithLatestCodebase: boolean = false) {

--- a/packages/amplify-e2e-tests/schemas/iam_simple_model.graphql
+++ b/packages/amplify-e2e-tests/schemas/iam_simple_model.graphql
@@ -1,0 +1,5 @@
+type Todo @model @auth(rules: [{ allow: private, provider: iam }]) {
+  id: ID!
+  name: String!
+  description: String
+}

--- a/packages/amplify-e2e-tests/src/__tests__/function_9.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_9.test.ts
@@ -1,39 +1,32 @@
 import {
   addApiWithoutSchema,
   addApi,
-  addAuthWithDefault,
   addDDBWithTrigger,
   addFunction,
-  addS3StorageWithSettings,
   addSimpleDDB,
-  AddStorageSettings,
   amplifyPush,
   amplifyPushAuth,
-  amplifyPushForce,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
   getBackendAmplifyMeta,
-  getFunctionSrcNode,
   getProjectMeta,
   initJSProjectWithProfile,
   invokeFunction,
-  overrideFunctionSrcNode,
   addNodeDependencies,
   readJsonFile,
   updateFunction,
   overrideFunctionCodeNode,
   getBackendConfig,
   addFeatureFlag,
-  addAuthWithGroupsAndAdminAPI,
-  getFunction,
-  loadFunctionTestFile,
   updateApiSchema,
   createRandomName,
 } from 'amplify-e2e-core';
 import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';
+
+const GraphQLTransformerLatestVersion = 2;
 
 describe('nodejs', () => {
   describe('amplify add function with additional permissions', () => {
@@ -222,6 +215,66 @@ describe('nodejs', () => {
       await addApi(projRoot, {
         IAM: {},
       });
+      const beforeMeta = getBackendConfig(projRoot);
+      const apiName = Object.keys(beforeMeta.api)[0];
+      await addFunction(
+        projRoot,
+        {
+          name: fnName,
+          functionTemplate: 'Hello World',
+          additionalPermissions: {
+            permissions: ['api'],
+            choices: ['api'],
+            resources: [apiName],
+            operations: ['Mutation'],
+          },
+        },
+        'nodejs',
+      );
+      // Pin aws-appsync to 4.0.3 until https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/647 is fixed.
+      addNodeDependencies(projRoot, fnName, ['aws-appsync@4.0.3', 'isomorphic-fetch', 'graphql-tag']);
+      overrideFunctionCodeNode(projRoot, fnName, 'mutation-appsync.js');
+      await amplifyPush(projRoot);
+      const meta = getProjectMeta(projRoot);
+      const { Region: region, Name: functionName } = Object.keys(meta.function).map(key => meta.function[key])[0].output;
+      const lambdaCFN = readJsonFile(
+        path.join(projRoot, 'amplify', 'backend', 'function', fnName, `${fnName}-cloudformation-template.json`),
+      );
+      const urlKey = Object.keys(lambdaCFN.Resources.LambdaFunction.Properties.Environment.Variables).filter(value =>
+        value.endsWith('GRAPHQLAPIENDPOINTOUTPUT'),
+      )[0];
+      const payloadObj = { urlKey, mutation: createTodo, variables: { input: { name: 'todo', description: 'sampleDesc' } } };
+      const fnResponse = await invokeFunction(functionName, JSON.stringify(payloadObj), region);
+
+      expect(fnResponse.StatusCode).toBe(200);
+      expect(fnResponse.Payload).toBeDefined();
+      const gqlResponse = JSON.parse(fnResponse.Payload as string);
+
+      expect(gqlResponse.data).toBeDefined();
+      expect(gqlResponse.data.createTodo.name).toEqual('todo');
+      expect(gqlResponse.data.createTodo.description).toEqual('sampleDesc');
+    });
+
+    it('should be able to query AppSync with minimal permissions with featureFlag for function and vNext GraphQL API', async () => {
+      const appName = 'functiongqlvnext';
+      const random = Math.floor(Math.random() * 10000);
+      const fnName = `apienvvar${random}`;
+      const createTodo = `
+        mutation CreateTodo($input: CreateTodoInput!) {
+          createTodo(input: $input) {
+            id
+            name
+            description
+            createdAt
+            updatedAt
+          }
+        }`;
+      await initJSProjectWithProfile(projRoot, { name: appName });
+      addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', GraphQLTransformerLatestVersion);
+      await addApi(projRoot, {
+        IAM: {},
+      });
+      updateApiSchema(projRoot, appName, 'iam_simple_model.graphql');
       const beforeMeta = getBackendConfig(projRoot);
       const apiName = Object.keys(beforeMeta.api)[0];
       await addFunction(

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test simple model with AdminUI enabled should add IAM policy only for fields that have explicit IAM auth 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $inputFields = $util.parseJson($util.toJson($ctx.args.input.keySet())) )
+#set( $isAuthorized = false )
+#set( $allowedFields = [] )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #set( $adminRoles = [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"] )
+  #foreach( $adminRole in $adminRoles )
+    #if( $ctx.identity.userArn.contains($adminRole) )
+      #return($util.toJson({}))
+    #end
+  #end
+$util.unauthorized()
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+
+#end
+#if( !$isAuthorized && $allowedFields.isEmpty() )
+$util.unauthorized()
+#end
+#if( !$isAuthorized )
+  #set( $deniedFields = $util.list.copyAndRemoveAll($inputFields, $allowedFields) )
+  #if( $deniedFields.size() > 0 )
+    $util.error(\\"Unauthorized on \${deniedFields}\\", \\"Unauthorized\\")
+  #end
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`Test simple model with AdminUI enabled should add IAM policy only for fields that have explicit IAM auth 2`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+#set( $inputFields = $util.parseJson($util.toJson($ctx.args.input.keySet())) )
+#set( $isAuthorized = false )
+#set( $allowedFields = [] )
+#set( $nullAllowedFields = [] )
+#set( $deniedFields = {} )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #set( $adminRoles = [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"] )
+  #foreach( $adminRole in $adminRoles )
+    #if( $ctx.identity.userArn.contains($adminRole) )
+      #return($util.toJson({}))
+    #end
+  #end
+$util.unauthorized()
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+
+#end
+#if( !$isAuthorized && $allowedFields.isEmpty() && $nullAllowedFields.isEmpty() )
+$util.unauthorized()
+#end
+#if( !$isAuthorized )
+  #foreach( $entry in $util.map.copyAndRetainAllKeys($ctx.args.input, $inputFields).entrySet() )
+    #if( $util.isNull($entry.value) && !$nullAllowedFields.contains($entry.key) )
+      $util.qr($deniedFields.put($entry.key, \\"\\"))
+    #end
+  #end
+  #foreach( $deniedField in $util.list.copyAndRemoveAll($inputFields, $allowedFields) )
+    $util.qr($deniedFields.put($deniedField, \\"\\"))
+  #end
+#end
+#if( $deniedFields.keySet().size() > 0 )
+  $util.error(\\"Unauthorized on \${deniedFields.keySet()}\\", \\"Unauthorized\\")
+#end
+$util.toJson({})
+## [End] Authorization Steps. **"
+`;
+
+exports[`Test simple model with AdminUI enabled should add IAM policy only for fields that have explicit IAM auth 3`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #set( $adminRoles = [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"] )
+  #foreach( $adminRole in $adminRoles )
+    #if( $ctx.identity.userArn.contains($adminRole) )
+      #return($util.toJson({}))
+    #end
+  #end
+$util.unauthorized()
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+
+#end
+#if( !$isAuthorized )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/custom-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/custom-auth.test.ts
@@ -24,13 +24,7 @@ test('happy case with lambda auth mode as default auth mode', () => {
   }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -61,17 +55,14 @@ test('happy case with lambda auth mode as additional auth mode', () => {
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
-  expect(out.rootStack!.Resources![ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AdditionalAuthenticationProviders[0].AuthenticationType).toEqual('AWS_LAMBDA');
+  expect(
+    out.rootStack!.Resources![ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AdditionalAuthenticationProviders[0]
+      .AuthenticationType,
+  ).toEqual('AWS_LAMBDA');
 });
 
 test('allow: custom defaults provider to function', () => {
@@ -94,13 +85,7 @@ test('allow: custom defaults provider to function', () => {
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -123,13 +108,7 @@ test('allow: custom error out when there is no lambda auth mode defined', () => 
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   expect(() => transformer.transform(validSchema)).toThrowError(
     `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`,
@@ -156,13 +135,7 @@ test('allow: custom and provider: iam error out for invalid combination', () => 
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   expect(() => transformer.transform(validSchema)).toThrowError(
     `@auth directive with 'custom' strategy only supports 'function' (default) provider, but found 'iam' assigned.`,
@@ -189,13 +162,7 @@ test('allow: non-custom and provider: function error out for invalid combination
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   expect(() => transformer.transform(validSchema)).toThrowError(
     `@auth directive with 'public' strategy only supports 'apiKey' (default) and 'iam' providers, but found 'function' assigned.`,

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -25,13 +25,7 @@ test('subscriptions are only generated if the respective mutation operation exis
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   // expect to generate subscription resolvers for create and update only
@@ -59,13 +53,7 @@ test('per-field @auth without @model', () => {
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -20,13 +20,7 @@ test('happy case with static groups', () => {
   }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -53,13 +47,7 @@ test('happy case with dynamic groups', () => {
     `;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -85,13 +73,7 @@ test('validation on @auth on a non-@model type', () => {
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   expect(() => transformer.transform(invalidSchema)).toThrowError('Types annotated with @auth must also be annotated with @model.');
 });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -166,13 +166,7 @@ const getRecursiveSchemaWithDiffModesOnParentType = (authDir1: string, authDir2:
 const getTransformer = (authConfig: AppSyncAuthConfiguration) =>
   new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
 
 const getObjectType = (doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -22,13 +22,7 @@ test('auth transformer validation happy case', () => {
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -85,13 +79,7 @@ test('ownerfield with subscriptions', () => {
     }`;
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -135,13 +123,7 @@ test('multiple owner rules with subscriptions', () => {
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -183,13 +165,7 @@ test('implicit owner fields get added to the type', () => {
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const validSchema = `
   type Post @model
@@ -237,13 +213,7 @@ test('implicit owner fields from field level auth get added to the type', () => 
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -46,14 +46,7 @@ test('auth logic is enabled on owner/static rules in es request', () => {
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new SearchableModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new SearchableModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   // expect response resolver to contain auth logic for owner rule
@@ -100,14 +93,7 @@ test('auth logic is enabled for iam/apiKey auth rules', () => {
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new SearchableModelTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new SearchableModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -113,7 +113,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   private authPolicyResources = new Set<string>();
   private unauthPolicyResources = new Set<string>();
 
-  constructor(config: AuthTransformerConfig = { addAwsIamAuthInOutputSchema: false }) {
+  constructor(config: AuthTransformerConfig = { adminRoles: [] }) {
     super('amplify-auth-transformer', authDirectiveDefinition);
     this.config = config;
     this.modelDirectiveConfig = new Map();
@@ -845,7 +845,7 @@ Static group authorization should perform as expected.`,
     for (let role of roles) {
       providers.add(this.roleMap.get(role)!.provider);
     }
-    if (this.configuredAuthProviders.hasAdminUIEnabled) {
+    if (this.configuredAuthProviders.hasAdminRolesEnabled) {
       providers.add('iam');
     }
     return Array.from(providers);
@@ -965,7 +965,9 @@ Static group authorization should perform as expected.`,
    * @returns boolean
    */
   private shouldAddDefaultServiceDirective(): boolean {
-    return this.configuredAuthProviders.hasAdminUIEnabled && this.config.authConfig.defaultAuthentication.authenticationType !== 'AWS_IAM';
+    return (
+      this.configuredAuthProviders.hasAdminRolesEnabled && this.config.authConfig.defaultAuthentication.authenticationType !== 'AWS_IAM'
+    );
   }
   /*
   IAM Helpers
@@ -976,7 +978,7 @@ Static group authorization should perform as expected.`,
       // Sanity check to make sure we're not generating invalid policies, where no resources are defined.
       if (this.authPolicyResources.size === 0) {
         // When AdminUI is enabled, IAM auth is added but it does not need any policies to be generated
-        if (!this.configuredAuthProviders.hasAdminUIEnabled) {
+        if (!this.configuredAuthProviders.hasAdminRolesEnabled) {
           throw new TransformerContractError('AuthRole policies should be generated, but no resources were added.');
         }
       } else {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -32,7 +32,15 @@ import {
   IS_AUTHORIZED_FLAG,
   API_KEY_AUTH_TYPE,
 } from '../utils';
-import { getOwnerClaim, generateStaticRoleExpression, apiKeyExpression, iamExpression, emptyPayload, lambdaExpression, getIdentityClaimExp } from './helpers';
+import {
+  getOwnerClaim,
+  generateStaticRoleExpression,
+  apiKeyExpression,
+  iamExpression,
+  emptyPayload,
+  lambdaExpression,
+  getIdentityClaimExp,
+} from './helpers';
 
 // Field Read VTL Functions
 const generateDynamicAuthReadExpression = (roles: Array<RoleDefinition>, fields: ReadonlyArray<FieldDefinitionNode>) => {
@@ -89,7 +97,8 @@ export const generateAuthExpressionForField = (
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ): string => {
-  const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, iamRoles, apiKeyRoles, lambdaRoles } = splitRoles(roles);
+  const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, iamRoles, apiKeyRoles, lambdaRoles } =
+    splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [set(ref(IS_AUTHORIZED_FLAG), bool(false))];
   if (provider.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
@@ -98,14 +107,14 @@ export const generateAuthExpressionForField = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (provider.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, provider.hasAdminUIEnabled, provider.adminUserPoolID));
+    totalAuthExpressions.push(iamExpression(iamRoles, provider.hasAdminRolesEnabled, provider.adminRoles));
   }
   if (provider.hasUserPools) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
         compoundExpression([
-          ...generateStaticRoleExpression(cogntoStaticRoles),
+          ...generateStaticRoleExpression(cognitoStaticRoles),
           ...generateDynamicAuthReadExpression(cognitoDynamicRoles, fields),
         ]),
       ),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -17,7 +17,6 @@ import {
   forEach,
   list,
   equals,
-  or,
 } from 'graphql-mapping-template';
 import { NONE_VALUE } from 'graphql-transformer-common';
 import {
@@ -27,9 +26,7 @@ import {
   ALLOWED_FIELDS,
   API_KEY_AUTH_TYPE,
   LAMBDA_AUTH_TYPE,
-  ADMIN_ROLE,
   IAM_AUTH_TYPE,
-  MANAGE_ROLE,
 } from '../utils';
 
 // note in the resolver that operation is protected by auth
@@ -112,35 +109,38 @@ export const apiKeyExpression = (roles: Array<RoleDefinition>) => {
     equals(ref('util.authType()'), str(API_KEY_AUTH_TYPE)),
     compoundExpression([...(roles.length > 0 ? [set(ref(IS_AUTHORIZED_FLAG), bool(true))] : [])]),
   );
-}
+};
 
 export const lambdaExpression = (roles: Array<RoleDefinition>) => {
   return iff(
     equals(ref('util.authType()'), str(LAMBDA_AUTH_TYPE)),
     compoundExpression([...(roles.length > 0 ? [set(ref(IS_AUTHORIZED_FLAG), bool(true))] : [])]),
   );
-}
+};
 
-export const iamExpression = (roles: Array<RoleDefinition>, adminuiEnabled: boolean = false, adminUserPoolID?: string) => {
+export const iamExpression = (roles: Array<RoleDefinition>, adminRolesEnabled: boolean, adminRoles: Array<string> = []) => {
   const expression = new Array<Expression>();
-  // allow if using admin ui
-  if (adminuiEnabled) {
-    expression.push(
-      iff(
-        or([
-          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${ADMIN_ROLE}`)),
-          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${MANAGE_ROLE}`)),
-        ]),
-        raw('#return($util.toJson({})'),
-      ),
-    );
+  // allow if using an admin role
+  if (adminRolesEnabled) {
+    expression.push(iamAdminRoleCheckExpression(adminRoles));
   }
   if (roles.length > 0) {
     for (let role of roles) {
       expression.push(iff(not(ref(IS_AUTHORIZED_FLAG)), iamCheck(role.claim!, set(ref(IS_AUTHORIZED_FLAG), bool(true)))));
     }
+  } else {
+    expression.push(ref('util.unauthorized()'));
   }
   return iff(equals(ref('util.authType()'), str(IAM_AUTH_TYPE)), compoundExpression(expression));
+};
+
+export const iamAdminRoleCheckExpression = (adminRoles: Array<string>): Expression => {
+  return compoundExpression([
+    set(ref('adminRoles'), raw(JSON.stringify(adminRoles))),
+    forEach(/*for */ ref('adminRole'), /* in */ ref('adminRoles'), [
+      iff(methodCall(ref('ctx.identity.userArn.contains'), ref('adminRole')), raw('#return($util.toJson({}))')),
+    ]),
+  ]);
 };
 
 // Get Request for Update and Delete

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
@@ -11,15 +11,13 @@ import {
   set,
   str,
   methodCall,
-  or,
   forEach,
   list,
   not,
   nul,
 } from 'graphql-mapping-template';
-import { emptyPayload, getIdentityClaimExp, getOwnerClaim, iamCheck, setHasAuthExpression } from './helpers';
+import { emptyPayload, getIdentityClaimExp, getOwnerClaim, iamAdminRoleCheckExpression, iamCheck, setHasAuthExpression } from './helpers';
 import {
-  ADMIN_ROLE,
   API_KEY_AUTH_TYPE,
   COGNITO_AUTH_TYPE,
   LAMBDA_AUTH_TYPE,
@@ -27,7 +25,6 @@ import {
   fieldIsList,
   IAM_AUTH_TYPE,
   IS_AUTHORIZED_FLAG,
-  MANAGE_ROLE,
   OIDC_AUTH_TYPE,
   RoleDefinition,
   splitRoles,
@@ -52,19 +49,11 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
  * @param roles
  * @returns
  */
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false, adminUserPoolID?: string) => {
+const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boolean = false, adminRoles: Array<string> = []) => {
   const expression = new Array<Expression>();
-  // allow if using admin ui
-  if (hasAdminUIEnabled) {
-    expression.push(
-      iff(
-        or([
-          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${ADMIN_ROLE}`)),
-          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${MANAGE_ROLE}`)),
-        ]),
-        raw('#return($util.toJson({})'),
-      ),
-    );
+  // allow if using an admin role
+  if (hasAdminRolesEnabled) {
+    expression.push(iamAdminRoleCheckExpression(adminRoles));
   }
   if (roles.length > 0) {
     for (let role of roles) {
@@ -81,7 +70,7 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean 
  * @param roles
  * @returns Expression | null
  */
- const lambdaExpression = (roles: Array<RoleDefinition>) => {
+const lambdaExpression = (roles: Array<RoleDefinition>) => {
   const expression = new Array<Expression>();
   if (roles.length === 0) {
     return iff(equals(ref('util.authType()'), str(LAMBDA_AUTH_TYPE)), ref('util.unauthorized()'));
@@ -172,13 +161,14 @@ export const geneateAuthExpressionForDelete = (
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ) => {
-  const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } = splitRoles(roles);
+  const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } =
+    splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [setHasAuthExpression, set(ref(IS_AUTHORIZED_FLAG), bool(false))];
   if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
   }
   if (providers.hasLambda) {
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
@@ -188,7 +178,7 @@ export const geneateAuthExpressionForDelete = (
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
         compoundExpression([
-          ...generateStaticRoleExpression(cogntoStaticRoles),
+          ...generateStaticRoleExpression(cognitoStaticRoles),
           ...dynamicGroupRoleExpression(cognitoDynamicRoles, fields),
         ]),
       ),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -23,13 +23,11 @@ import {
   or,
 } from 'graphql-mapping-template';
 import {
-  ADMIN_ROLE,
   API_KEY_AUTH_TYPE,
   COGNITO_AUTH_TYPE,
   LAMBDA_AUTH_TYPE,
   ConfiguredAuthProviders,
   IAM_AUTH_TYPE,
-  MANAGE_ROLE,
   OIDC_AUTH_TYPE,
   RoleDefinition,
   splitRoles,
@@ -39,7 +37,15 @@ import {
   NULL_ALLOWED_FIELDS,
   DENIED_FIELDS,
 } from '../utils';
-import { getIdentityClaimExp, responseCheckForErrors, getOwnerClaim, getInputFields, setHasAuthExpression, iamCheck } from './helpers';
+import {
+  getIdentityClaimExp,
+  responseCheckForErrors,
+  getOwnerClaim,
+  getInputFields,
+  setHasAuthExpression,
+  iamCheck,
+  iamAdminRoleCheckExpression,
+} from './helpers';
 
 /**
  * There is only one role for ApiKey we can use the first index
@@ -67,7 +73,7 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
  * @param roles
  * @returns Expression | null
  */
- const lambdaExpression = (roles: Array<RoleDefinition>) => {
+const lambdaExpression = (roles: Array<RoleDefinition>) => {
   const expression = new Array<Expression>();
   if (roles.length === 0) {
     return iff(equals(ref('util.authType()'), str(LAMBDA_AUTH_TYPE)), ref('util.unauthorized()'));
@@ -83,19 +89,11 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
   return iff(equals(ref('util.authType()'), str(LAMBDA_AUTH_TYPE)), compoundExpression(expression));
 };
 
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminUIEnabled: boolean = false, adminUserPoolID?: string) => {
+const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boolean = false, adminRoles: Array<string> = []) => {
   const expression = new Array<Expression>();
-  // allow if using admin ui
-  if (hasAdminUIEnabled) {
-    expression.push(
-      iff(
-        or([
-          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${ADMIN_ROLE}`)),
-          methodCall(ref('ctx.identity.userArn.contains'), str(`${adminUserPoolID}${MANAGE_ROLE}`)),
-        ]),
-        raw('#return($util.toJson({})'),
-      ),
-    );
+  // allow if using an admin role
+  if (hasAdminRolesEnabled) {
+    expression.push(iamAdminRoleCheckExpression(adminRoles));
   }
   if (roles.length > 0) {
     for (let role of roles) {
@@ -276,7 +274,8 @@ export const generateAuthExpressionForUpdate = (
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ) => {
-  const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } = splitRoles(roles);
+  const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } =
+    splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [
     setHasAuthExpression,
     responseCheckForErrors(),
@@ -293,14 +292,14 @@ export const generateAuthExpressionForUpdate = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
         compoundExpression([
-          ...generateStaticRoleExpression(cogntoStaticRoles),
+          ...generateStaticRoleExpression(cognitoStaticRoles),
           ...dynamicGroupRoleExpression(cognitoDynamicRoles, fields),
         ]),
       ),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -20,7 +20,15 @@ import {
   ifElse,
   nul,
 } from 'graphql-mapping-template';
-import { getIdentityClaimExp, getOwnerClaim, apiKeyExpression, iamExpression, lambdaExpression, emptyPayload, setHasAuthExpression } from './helpers';
+import {
+  getIdentityClaimExp,
+  getOwnerClaim,
+  apiKeyExpression,
+  iamExpression,
+  lambdaExpression,
+  emptyPayload,
+  setHasAuthExpression,
+} from './helpers';
 import {
   COGNITO_AUTH_TYPE,
   OIDC_AUTH_TYPE,
@@ -248,7 +256,8 @@ export const generateAuthExpressionForQueries = (
   primaryFields: Array<string>,
   isIndexQuery = false,
 ): string => {
-  const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } = splitRoles(roles);
+  const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } =
+    splitRoles(roles);
   const getNonPrimaryFieldRoles = (roles: RoleDefinition[]) => roles.filter(roles => !primaryFields.includes(roles.entity));
   const totalAuthExpressions: Array<Expression> = [
     setHasAuthExpression,
@@ -262,14 +271,14 @@ export const generateAuthExpressionForQueries = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
         compoundExpression([
-          ...generateStaticRoleExpression(cogntoStaticRoles),
+          ...generateStaticRoleExpression(cognitoStaticRoles),
           ...generateAuthFilter(getNonPrimaryFieldRoles(cognitoDynamicRoles), fields),
           ...generateAuthOnModelQueryExpression(cognitoDynamicRoles, primaryFields, isIndexQuery),
         ]),
@@ -303,7 +312,8 @@ export const generateAuthExpressionForRelationQuery = (
   fields: ReadonlyArray<FieldDefinitionNode>,
   primaryFieldMap: RelationalPrimaryMapConfig,
 ) => {
-  const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } = splitRoles(roles);
+  const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } =
+    splitRoles(roles);
   const getNonPrimaryFieldRoles = (roles: RoleDefinition[]) => roles.filter(roles => !primaryFieldMap.has(roles.entity));
   const totalAuthExpressions: Array<Expression> = [
     setHasAuthExpression,
@@ -317,14 +327,14 @@ export const generateAuthExpressionForRelationQuery = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
         compoundExpression([
-          ...generateStaticRoleExpression(cogntoStaticRoles),
+          ...generateStaticRoleExpression(cognitoStaticRoles),
           ...generateAuthFilter(getNonPrimaryFieldRoles(cognitoDynamicRoles), fields),
           ...generateAuthOnRelationalModelQueryExpression(cognitoDynamicRoles, primaryFieldMap),
         ]),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -45,7 +45,8 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
 };
 
 export const generateAuthExpressionForSubscriptions = (providers: ConfiguredAuthProviders, roles: Array<RoleDefinition>): string => {
-  const { cogntoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, iamRoles, apiKeyRoles, lambdaRoles } = splitRoles(roles);
+  const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, iamRoles, apiKeyRoles, lambdaRoles } =
+    splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [setHasAuthExpression, set(ref(IS_AUTHORIZED_FLAG), bool(false))];
   if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
@@ -54,13 +55,13 @@ export const generateAuthExpressionForSubscriptions = (providers: ConfiguredAuth
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminUIEnabled, providers.adminUserPoolID));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
   }
   if (providers.hasUserPools)
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
-        compoundExpression([...generateStaticRoleExpression(cogntoStaticRoles), ...dynamicRoleExpression(cognitoDynamicRoles)]),
+        compoundExpression([...generateStaticRoleExpression(cognitoStaticRoles), ...dynamicRoleExpression(cognitoDynamicRoles)]),
       ),
     );
   if (providers.hasOIDC)

--- a/packages/amplify-graphql-auth-transformer/src/utils/constants.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/constants.ts
@@ -27,9 +27,6 @@ export const IS_AUTHORIZED_FLAG = 'isAuthorized';
 export const ALLOWED_FIELDS = 'allowedFields';
 export const NULL_ALLOWED_FIELDS = 'nullAllowedFields';
 export const DENIED_FIELDS = 'deniedFields';
-// Admin Roles
-export const ADMIN_ROLE = '_Full-access/CognitoIdentityCredentials';
-export const MANAGE_ROLE = '_Manage-only/CognitoIdentityCredentials';
 // resolver
 export const NONE_DS = 'NONE_DS';
 // relational directives

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -13,7 +13,7 @@ export interface SearchableConfig {
 }
 
 export interface RolesByProvider {
-  cogntoStaticRoles: Array<RoleDefinition>;
+  cognitoStaticRoles: Array<RoleDefinition>;
   cognitoDynamicRoles: Array<RoleDefinition>;
   oidcStaticRoles: Array<RoleDefinition>;
   oidcDynamicRoles: Array<RoleDefinition>;
@@ -58,14 +58,14 @@ export interface ConfiguredAuthProviders {
   hasOIDC: boolean;
   hasIAM: boolean;
   hasLambda: boolean;
-  hasAdminUIEnabled: boolean;
+  hasAdminRolesEnabled: boolean;
+  adminRoles: Array<string>;
   adminUserPoolID?: string;
 }
 
 export interface AuthTransformerConfig {
-  addAwsIamAuthInOutputSchema: boolean;
+  adminRoles?: Array<string>;
   authConfig?: AppSyncAuthConfiguration;
-  adminUserPoolID?: string;
 }
 
 export const authDirectiveDefinition = `

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -12,7 +12,7 @@ export * from './iam';
 
 export const splitRoles = (roles: Array<RoleDefinition>): RolesByProvider => {
   return {
-    cogntoStaticRoles: roles.filter(r => r.static && r.provider === 'userPools'),
+    cognitoStaticRoles: roles.filter(r => r.static && r.provider === 'userPools'),
     cognitoDynamicRoles: roles.filter(r => !r.static && r.provider === 'userPools'),
     oidcStaticRoles: roles.filter(r => r.static && r.provider === 'oidc'),
     oidcDynamicRoles: roles.filter(r => !r.static && r.provider === 'oidc'),
@@ -100,8 +100,8 @@ export const getConfiguredAuthProviders = (config: AuthTransformerConfig): Confi
   const configuredProviders: ConfiguredAuthProviders = {
     default: getAuthProvider(config.authConfig.defaultAuthentication.authenticationType),
     onlyDefaultAuthProviderConfigured: config.authConfig.additionalAuthenticationProviders.length === 0,
-    hasAdminUIEnabled: hasIAM && config.addAwsIamAuthInOutputSchema,
-    adminUserPoolID: config.adminUserPoolID!,
+    hasAdminRolesEnabled: hasIAM && config.adminRoles.length > 0,
+    adminRoles: config.adminRoles,
     hasApiKey: providers.some(p => p === 'API_KEY'),
     hasUserPools: providers.some(p => p === 'AMAZON_COGNITO_USER_POOLS'),
     hasOIDC: providers.some(p => p === 'OPENID_CONNECT'),

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
@@ -298,7 +298,7 @@ function createTransformer() {
     },
     additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }],
   };
-  const authTransformer = new AuthTransformer({ authConfig, addAwsIamAuthInOutputSchema: false });
+  const authTransformer = new AuthTransformer();
   const modelTransformer = new ModelTransformer();
   const indexTransformer = new IndexTransformer();
   const hasOneTransformer = new HasOneTransformer();

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/relational-auth.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/relational-auth.test.ts
@@ -40,14 +40,7 @@ test('per-field auth on relational field', () => {
   };
   const transformer = new GraphQLTransform({
     authConfig,
-    transformers: [
-      new ModelTransformer(),
-      new HasManyTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new HasManyTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -141,10 +134,7 @@ const getTransformer = (authConfig: AppSyncAuthConfiguration) => {
       new IndexTransformer(),
       new HasManyTransformer(),
       new BelongsToTransformer(),
-      new AuthTransformer({
-        authConfig,
-        addAwsIamAuthInOutputSchema: false,
-      }),
+      new AuthTransformer(),
     ],
   });
 };

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -27,15 +27,14 @@ import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-tran
 import { DefaultValueTransformer } from '@aws-amplify/graphql-default-value-transformer';
 import { destructiveUpdatesFlag, ProviderName as providerName } from '../constants';
 import { hashDirectory } from '../upload-appsync-files';
-import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from './utils';
+import { getAdminRoles, mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from './utils';
 import { loadProject as readTransformerConfiguration } from './transform-config';
 import { getSanityCheckRules, loadProject } from 'graphql-transformer-core';
 import { Template } from '@aws-amplify/graphql-transformer-core/lib/config/project-config';
 import { AmplifyCLIFeatureFlagAdapter } from '../utils/amplify-cli-feature-flag-adapter';
-import { JSONUtilities, stateManager, $TSContext } from 'amplify-cli-core';
+import { JSONUtilities, $TSContext } from 'amplify-cli-core';
 import { searchablePushChecks } from '../transform-graphql-schema';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { isAmplifyAdminApp } from '../utils/admin-helpers';
 import {
   showGlobalSandboxModeWarning,
   showSandboxModePrompts,
@@ -77,23 +76,11 @@ function getTransformerFactory(
     // TODO: Build dependency mechanism into transformers. Auth runs last
     // so any resolvers that need to be protected will already be created.
 
-    let adminUserPoolID: string;
-    try {
-      const amplifyMeta = stateManager.getMeta();
-      const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
-      const res = await isAmplifyAdminApp(appId);
-      adminUserPoolID = res.userPoolID;
-    } catch (err) {
-      console.info('App not deployed yet.');
-    }
-
     const modelTransformer = new ModelTransformer();
     const indexTransformer = new IndexTransformer();
     const hasOneTransformer = new HasOneTransformer();
     const authTransformer = new AuthTransformer({
-      authConfig: options?.authConfig,
-      addAwsIamAuthInOutputSchema: !!adminUserPoolID,
-      adminUserPoolID,
+      adminRoles: options.authAdminIAMRoles ?? [],
     });
     const transformerList: TransformerPluginProvider[] = [
       modelTransformer,
@@ -186,6 +173,7 @@ function getTransformerFactory(
 }
 
 export async function transformGraphQLSchema(context, options) {
+  let resourceName: string;
   const backEndDir = context.amplify.pathManager.getBackendDirPath();
   const flags = context.parameters.options;
   if (flags['no-gql-override']) {
@@ -238,7 +226,8 @@ export async function transformGraphQLSchema(context, options) {
       if (resource.providerPlugin !== providerName) {
         return;
       }
-      const { category, resourceName } = resource;
+      const { category } = resource;
+      resourceName = resource.resourceName;
       const cloudBackendRootDir = context.amplify.pathManager.getCurrentCloudBackendDirPath();
       /* eslint-disable */
       previouslyDeployedBackendDir = path.normalize(path.join(cloudBackendRootDir, category, resourceName));
@@ -277,6 +266,8 @@ export async function transformGraphQLSchema(context, options) {
     }
   }
 
+  // for auth check which functions have access to the api
+  const adminRoles = await getAdminRoles(context, resourceName);
   // for the predictions directive get storage config
   const s3Resource = s3ResourceAlreadyExists(context);
   const storageConfig = s3Resource ? getBucketName(context, s3Resource, backEndDir) : undefined;
@@ -346,7 +337,12 @@ export async function transformGraphQLSchema(context, options) {
     buildParameters,
     projectDirectory: resourceDir,
     transformersFactory: transformerListFactory,
-    transformersFactoryArgs: { addSearchableTransformer: searchableTransformerFlag, storageConfig, authConfig },
+    transformersFactoryArgs: {
+      addSearchableTransformer: searchableTransformerFlag,
+      storageConfig,
+      authConfig,
+      authAdminIAMRoles: adminRoles,
+    },
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
     minify: options.minify,
@@ -441,6 +437,7 @@ type TransformerFactoryArgs = {
   addSearchableTransformer: boolean;
   authConfig: any;
   storageConfig?: any;
+  authAdminIAMRoles?: Array<string>;
 };
 export type ProjectOptions<T> = {
   buildParameters: {

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -2,13 +2,18 @@ import fs from 'fs-extra';
 import * as path from 'path';
 import { TransformerProjectConfig, DeploymentResources } from '@aws-amplify/graphql-transformer-core';
 import rimraf from 'rimraf';
-import { JSONUtilities } from 'amplify-cli-core';
+import { ProviderName as providerName } from '../constants';
+import { $TSContext, JSONUtilities, stateManager } from 'amplify-cli-core';
 import { CloudFormation, Template, Fn } from 'cloudform';
 import { Diff, diff as getDiffs } from 'deep-diff';
 import { ResourceConstants } from 'graphql-transformer-common';
+import { pullAllBy } from 'lodash';
+import { isAmplifyAdminApp } from '../utils/admin-helpers';
 
 const ROOT_STACK_FILE_NAME = 'cloudformation-template.json';
 const PARAMETERS_FILE_NAME = 'parameters.json';
+const AMPLIFY_ADMIN_ROLE = '_Full-access/CognitoIdentityCredentials';
+const AMPLIFY_MANAGE_ROLE = '_Manage-only/CognitoIdentityCredentials';
 export interface DiffableProject {
   stacks: {
     [stackName: string]: Template;
@@ -23,6 +28,31 @@ export interface GQLDiff {
   next: DiffableProject;
   current: DiffableProject;
 }
+
+export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string): Promise<Array<string>> => {
+  const currentEnv = ctx.amplify.getEnvInfo().envName;
+  const adminRoles = new Array<string>();
+  //admin ui roles
+  try {
+    const amplifyMeta = stateManager.getMeta();
+    const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
+    const res = await isAmplifyAdminApp(appId);
+    if (res.userPoolID) {
+      adminRoles.push(`${res.userPoolID}${AMPLIFY_ADMIN_ROLE}`, `${res.userPoolID}${AMPLIFY_MANAGE_ROLE}`);
+    }
+  } catch (err) {
+    console.info('App not deployed yet.');
+    // no need to error if not admin ui app
+  }
+
+  // lambda functions which have access to the api
+  const { allResources, resourcesToBeDeleted } = await ctx.amplify.getResourceStatus('function');
+  const resources = pullAllBy(allResources, resourcesToBeDeleted, 'resourceName')
+    .filter((r: any) => r.dependsOn.some(d => d.resourceName === apiResourceName))
+    .map((r: any) => `${r.resourceName}-${currentEnv}`);
+  adminRoles.push(...resources);
+  return adminRoles;
+};
 
 export const getGQLDiff = (currentBackendDir: string, cloudBackendDir: string): GQLDiff => {
   const currentBuildDir = path.join(currentBackendDir, 'build');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
@@ -221,10 +221,7 @@ describe('@model with @auth', () => {
         new PrimaryKeyTransformer(),
         new IndexTransformer(),
         new HasOneTransformer(),
-        new AuthTransformer({
-          authConfig,
-          addAwsIamAuthInOutputSchema: false,
-        }),
+        new AuthTransformer(),
       ],
     });
     const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2.e2e.test.ts
@@ -90,12 +90,7 @@ beforeAll(async () => {
       },
       additionalAuthenticationProviders: [],
     },
-    transformers: [
-      new ModelTransformer(),
-      new PrimaryKeyTransformer(),
-      new IndexTransformer(),
-      new AuthTransformer({ addAwsIamAuthInOutputSchema: false }),
-    ],
+    transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
   const finishedStack = await deploy(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthV2Transformer.e2e.test.ts
@@ -295,9 +295,7 @@ beforeAll(async () => {
       new PrimaryKeyTransformer(),
       new HasOneTransformer(),
       new HasManyTransformer(),
-      new AuthTransformer({
-        addAwsIamAuthInOutputSchema: false,
-      }),
+      new AuthTransformer(),
     ],
   });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthV2Function.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthV2Function.e2e.test.ts
@@ -107,13 +107,7 @@ beforeAll(async () => {
         },
       ],
     },
-    transformers: [
-      new ModelTransformer(),
-      new FunctionTransformer(),
-      new AuthTransformer({
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new FunctionTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
@@ -178,12 +178,7 @@ beforeAll(async () => {
       },
       additionalAuthenticationProviders: [],
     },
-    transformers: [
-      new ModelTransformer(),
-      new AuthTransformer({
-        addAwsIamAuthInOutputSchema: false,
-      }),
-    ],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
   USER_POOL_ID = userPoolResponse.UserPool.Id;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
@@ -127,7 +127,7 @@ type Course @model {
       },
       additionalAuthenticationProviders: [],
     };
-    const authTransformer = new AuthTransformer({ authConfig, addAwsIamAuthInOutputSchema: false });
+    const authTransformer = new AuthTransformer();
     const modelTransformer = new ModelTransformer();
     const indexTransformer = new IndexTransformer();
     const hasOneTransformer = new HasOneTransformer();

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2.e2e.test.ts
@@ -116,7 +116,7 @@ beforeAll(async () => {
     const modelTransformer = new ModelTransformer();
     const indexTransformer = new IndexTransformer();
     const hasOneTransformer = new HasOneTransformer();
-    const authTransformer = new AuthTransformer({ addAwsIamAuthInOutputSchema: false });
+    const authTransformer = new AuthTransformer();
     const transformer = new GraphQLTransform({
       authConfig: {
         defaultAuthentication: {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
@@ -167,7 +167,7 @@ beforeAll(async () => {
         },
       ],
     },
-    transformers: [new ModelTransformer(), new SearchableModelTransformer(), new AuthTransformer({ addAwsIamAuthInOutputSchema: false })],
+    transformers: [new ModelTransformer(), new SearchableModelTransformer(), new AuthTransformer()],
   });
   const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
   USER_POOL_ID = userPoolResponse.UserPool.Id;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
@@ -222,7 +222,7 @@ beforeAll(async () => {
         },
       ],
     },
-    transformers: [new ModelTransformer(), new AuthTransformer({ addAwsIamAuthInOutputSchema: false })],
+    transformers: [new ModelTransformer(), new AuthTransformer()],
   });
 
   try {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- extend admin ui role check to work with functions which have access to graphql apis
- updated unit/e2e
- change the options for the auth transformer class to only require an admin role list to determine if the iam directives should added on a `@model`

#### Description of how you validated changes
- unit/e2e

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
