### PR TITLE
fix: update auth vnext validation to use private for oidc

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -561,6 +561,18 @@ describe('schema generation directive tests', () => {
     expectMultiple(tagType, expectedDirectiveNames);
   });
 
+  test('OIDC works with private', () => {
+    const cognitoUserPoolAndOidcAuthRules =
+      '@auth(rules: [ { allow: private, provider: oidc, operations: [read] } { allow: owner, ownerField: "editors" } { allow: groups, groupsField: "groups"} ])';
+    const authConfig = withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS', 'OPENID_CONNECT']);
+
+    (authConfig.additionalAuthenticationProviders[1] as AppSyncAuthConfigurationOIDCEntry).openIDConnectConfig = {
+      name: 'Test Provider',
+      issuerUrl: 'https://abc.def/',
+    };
+    transformTest(cognitoUserPoolAndOidcAuthRules, authConfig, [userPoolsDirectiveName, openIdDirectiveName]);
+  });
+
   test(`Nested types without @model getting directives applied (cognito default, api key additional)`, () => {
     const schema = getSchemaWithNonModelField(privateAndPublicDirective);
     const transformer = getTransformer(withAuthModes(userPoolsDefaultConfig, ['API_KEY']));

--- a/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
@@ -42,7 +42,7 @@ found '${rule.provider}' assigned.`,
   // Private
   //
   if (rule.allow === 'private') {
-    if (rule.provider !== null && rule.provider !== 'userPools' && rule.provider !== 'iam') {
+    if (rule.provider !== null && rule.provider !== 'userPools' && rule.provider !== 'iam' && rule.provider !== 'oidc') {
       throw new InvalidDirectiveError(
         `@auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, but \
 found '${rule.provider}' assigned.`,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- update validation to allow private to work for oidc
- updated unit test to verify

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
