### PR TITLE
feat: allow optional idp arg into auth to allow provided auth role or authenticated identity

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/multi-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/multi-auth.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iam checks test that admin roles are added when functions have access to the graphql api 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $inputFields = $util.parseJson($util.toJson($ctx.args.input.keySet())) )
+#set( $isAuthorized = false )
+#set( $allowedFields = [] )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #set( $adminRoles = [\\"helloWorldFunction\\",\\"echoMessageFunction\\"] )
+  #foreach( $adminRole in $adminRoles )
+    #if( $ctx.identity.userArn.contains($adminRole) )
+      #return($util.toJson({}))
+    #end
+  #end
+  #if( $ctx.identity.userArn == $ctx.stash.authRole )
+    #set( $isAuthorized = true )
+  #end
+#end
+#if( !$isAuthorized && $allowedFields.isEmpty() )
+$util.unauthorized()
+#end
+#if( !$isAuthorized )
+  #set( $deniedFields = $util.list.copyAndRemoveAll($inputFields, $allowedFields) )
+  #if( $deniedFields.size() > 0 )
+    $util.error(\\"Unauthorized on \${deniedFields}\\", \\"Unauthorized\\")
+  #end
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -121,7 +121,11 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   private authPolicyResources = new Set<string>();
   private unauthPolicyResources = new Set<string>();
 
-  constructor(config: AuthTransformerConfig = { adminRoles: [] }) {
+  /**
+   *
+   * @param config settings to configure the auth transformer during transpilation
+   */
+  constructor(config: AuthTransformerConfig = {}) {
     super('amplify-auth-transformer', authDirectiveDefinition);
     this.config = config;
     this.modelDirectiveConfig = new Map();
@@ -135,7 +139,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
 
   before = (context: TransformerBeforeStepContextProvider): void => {
     // if there was no auth config in the props we add the authConfig from the context
-    this.config.authConfig = this.config.authConfig || context.authConfig;
+    this.config.authConfig = this.config.authConfig ?? context.authConfig;
     this.configuredAuthProviders = getConfiguredAuthProviders(this.config);
   };
 

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -93,23 +93,23 @@ const generateDynamicAuthReadExpression = (roles: Array<RoleDefinition>, fields:
 };
 
 export const generateAuthExpressionForField = (
-  provider: ConfiguredAuthProviders,
+  providers: ConfiguredAuthProviders,
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ): string => {
   const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, iamRoles, apiKeyRoles, lambdaRoles } =
     splitRoles(roles);
   const totalAuthExpressions: Array<Expression> = [set(ref(IS_AUTHORIZED_FLAG), bool(false))];
-  if (provider.hasApiKey) {
+  if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
-  if (provider.hasLambda) {
+  if (providers.hasLambda) {
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
-  if (provider.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, provider.hasAdminRolesEnabled, provider.adminRoles));
+  if (providers.hasIAM) {
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
-  if (provider.hasUserPools) {
+  if (providers.hasUserPools) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(COGNITO_AUTH_TYPE)),
@@ -120,7 +120,7 @@ export const generateAuthExpressionForField = (
       ),
     );
   }
-  if (provider.hasOIDC) {
+  if (providers.hasOIDC) {
     totalAuthExpressions.push(
       iff(
         equals(ref('util.authType()'), str(OIDC_AUTH_TYPE)),

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
@@ -49,7 +49,12 @@ const apiKeyExpression = (roles: Array<RoleDefinition>) => {
  * @param roles
  * @returns
  */
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boolean = false, adminRoles: Array<string> = []) => {
+const iamExpression = (
+  roles: Array<RoleDefinition>,
+  hasAdminRolesEnabled: boolean = false,
+  adminRoles: Array<string> = [],
+  identityPoolId?: string,
+) => {
   const expression = new Array<Expression>();
   // allow if using an admin role
   if (hasAdminRolesEnabled) {
@@ -57,7 +62,7 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boole
   }
   if (roles.length > 0) {
     for (let role of roles) {
-      expression.push(iamCheck(role.claim!, set(ref(IS_AUTHORIZED_FLAG), bool(true))));
+      expression.push(iamCheck(role.claim!, set(ref(IS_AUTHORIZED_FLAG), bool(true)), identityPoolId));
     }
   } else {
     expression.push(ref('util.unauthorized()'));
@@ -168,7 +173,7 @@ export const geneateAuthExpressionForDelete = (
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
   if (providers.hasLambda) {
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -89,7 +89,12 @@ const lambdaExpression = (roles: Array<RoleDefinition>) => {
   return iff(equals(ref('util.authType()'), str(LAMBDA_AUTH_TYPE)), compoundExpression(expression));
 };
 
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boolean = false, adminRoles: Array<string> = []) => {
+const iamExpression = (
+  roles: Array<RoleDefinition>,
+  hasAdminRolesEnabled: boolean = false,
+  adminRoles: Array<string> = [],
+  identityPoolId?: string,
+) => {
   const expression = new Array<Expression>();
   // allow if using an admin role
   if (hasAdminRolesEnabled) {
@@ -105,6 +110,7 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boole
               set(ref(`${ALLOWED_FIELDS}`), raw(JSON.stringify(role.allowedFields))),
               set(ref(`${NULL_ALLOWED_FIELDS}`), raw(JSON.stringify(role.nullAllowedFields))),
             ]),
+            identityPoolId,
           ),
         );
       } else {
@@ -292,7 +298,7 @@ export const generateAuthExpressionForUpdate = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -271,7 +271,7 @@ export const generateAuthExpressionForQueries = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(
@@ -327,7 +327,7 @@ export const generateAuthExpressionForRelationQuery = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/search.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/search.ts
@@ -69,7 +69,12 @@ const lambdaExpression = (roles: Array<RoleDefinition>): Expression => {
   return iff(equals(ref('util.authType()'), str(LAMBDA_AUTH_TYPE)), compoundExpression(expression));
 };
 
-const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boolean = false, adminRoles: Array<string> = []) => {
+const iamExpression = (
+  roles: Array<RoleDefinition>,
+  hasAdminRolesEnabled: boolean = false,
+  adminRoles: Array<string> = [],
+  identityPoolId?: string,
+) => {
   const expression = new Array<Expression>();
   // allow if using an admin role
   if (hasAdminRolesEnabled) {
@@ -85,7 +90,7 @@ const iamExpression = (roles: Array<RoleDefinition>, hasAdminRolesEnabled: boole
       } else {
         exp.push(set(ref(allowedAggFieldsList), ref(totalFields)));
       }
-      expression.push(iff(not(ref(IS_AUTHORIZED_FLAG)), iamCheck(role.claim!, compoundExpression(exp))));
+      expression.push(iff(not(ref(IS_AUTHORIZED_FLAG)), iamCheck(role.claim!, compoundExpression(exp), identityPoolId)));
     }
   }
   return iff(equals(ref('util.authType()'), str(IAM_AUTH_TYPE)), compoundExpression(expression));
@@ -248,7 +253,7 @@ export const generateAuthExpressionForSearchQueries = (
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
   if (providers.hasUserPools) {
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -55,7 +55,7 @@ export const generateAuthExpressionForSubscriptions = (providers: ConfiguredAuth
     totalAuthExpressions.push(lambdaExpression(lambdaRoles));
   }
   if (providers.hasIAM) {
-    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles));
+    totalAuthExpressions.push(iamExpression(iamRoles, providers.hasAdminRolesEnabled, providers.adminRoles, providers.identityPoolId));
   }
   if (providers.hasUserPools)
     totalAuthExpressions.push(

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -12,6 +12,15 @@ export interface SearchableConfig {
   };
 }
 
+export interface AuthTransformerConfig {
+  /** used mainly in the before step to pass the authConfig from the transformer core down to the directive */
+  authConfig?: AppSyncAuthConfiguration;
+  /** using the iam provider the resolvers checks will lets the roles in this list passthrough the acm */
+  adminRoles?: Array<string>;
+  /** when authorizing private/public @auth can also check authenticated/unauthenticated status for a given identityPoolId */
+  identityPoolId?: string;
+}
+
 export interface RolesByProvider {
   cognitoStaticRoles: Array<RoleDefinition>;
   cognitoDynamicRoles: Array<RoleDefinition>;
@@ -60,12 +69,7 @@ export interface ConfiguredAuthProviders {
   hasLambda: boolean;
   hasAdminRolesEnabled: boolean;
   adminRoles: Array<string>;
-  adminUserPoolID?: string;
-}
-
-export interface AuthTransformerConfig {
-  adminRoles?: Array<string>;
-  authConfig?: AppSyncAuthConfiguration;
+  identityPoolId?: string;
 }
 
 export const authDirectiveDefinition = `

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -100,8 +100,9 @@ export const getConfiguredAuthProviders = (config: AuthTransformerConfig): Confi
   const configuredProviders: ConfiguredAuthProviders = {
     default: getAuthProvider(config.authConfig.defaultAuthentication.authenticationType),
     onlyDefaultAuthProviderConfigured: config.authConfig.additionalAuthenticationProviders.length === 0,
-    hasAdminRolesEnabled: hasIAM && config.adminRoles.length > 0,
+    hasAdminRolesEnabled: hasIAM && config.adminRoles?.length > 0,
     adminRoles: config.adminRoles,
+    identityPoolId: config.identityPoolId,
     hasApiKey: providers.some(p => p === 'API_KEY'),
     hasUserPools: providers.some(p => p === 'AMAZON_COGNITO_USER_POOLS'),
     hasOIDC: providers.some(p => p === 'OPENID_CONNECT'),

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -26,7 +26,7 @@ import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-tran
 import { DefaultValueTransformer } from '@aws-amplify/graphql-default-value-transformer';
 import { destructiveUpdatesFlag, ProviderName as providerName } from '../constants';
 import { hashDirectory } from '../upload-appsync-files';
-import { getAdminRoles, mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from './utils';
+import { getAdminRoles, getIdentityPoolId, mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from './utils';
 import { loadProject as readTransformerConfiguration } from './transform-config';
 import { getSanityCheckRules, loadProject } from 'graphql-transformer-core';
 import { Template } from '@aws-amplify/graphql-transformer-core/lib/config/project-config';
@@ -34,11 +34,7 @@ import { AmplifyCLIFeatureFlagAdapter } from '../utils/amplify-cli-feature-flag-
 import { JSONUtilities, $TSContext } from 'amplify-cli-core';
 import { searchablePushChecks } from '../transform-graphql-schema';
 import { ResourceConstants } from 'graphql-transformer-common';
-import {
-  showGlobalSandboxModeWarning,
-  showSandboxModePrompts,
-  schemaHasSandboxModeEnabled,
-} from '../utils/sandbox-mode-helpers';
+import { showGlobalSandboxModeWarning, showSandboxModePrompts, schemaHasSandboxModeEnabled } from '../utils/sandbox-mode-helpers';
 import { printer } from 'amplify-prompts';
 import { GraphQLSanityCheck, SanityCheckRules } from './sanity-check';
 
@@ -71,14 +67,12 @@ function getTransformerFactory(
   resourceDir: string,
 ): (options: TransformerFactoryArgs) => Promise<TransformerPluginProvider[]> {
   return async (options?: TransformerFactoryArgs) => {
-    // TODO: Build dependency mechanism into transformers. Auth runs last
-    // so any resolvers that need to be protected will already be created.
-
     const modelTransformer = new ModelTransformer();
     const indexTransformer = new IndexTransformer();
     const hasOneTransformer = new HasOneTransformer();
     const authTransformer = new AuthTransformer({
-      adminRoles: options.authAdminIAMRoles ?? [],
+      adminRoles: options.adminRoles ?? [],
+      identityPoolId: options.identityPoolId,
     });
     const transformerList: TransformerPluginProvider[] = [
       modelTransformer,
@@ -264,8 +258,9 @@ export async function transformGraphQLSchema(context, options) {
     }
   }
 
-  // for auth check which functions have access to the api
+  // for auth transformer we get any admin roles and a cognito identity pool to check for potential authenticated roles outside of the provided authRole
   const adminRoles = await getAdminRoles(context, resourceName);
+  const identityPoolId = await getIdentityPoolId(context);
   // for the predictions directive get storage config
   const s3Resource = s3ResourceAlreadyExists(context);
   const storageConfig = s3Resource ? getBucketName(context, s3Resource, backEndDir) : undefined;
@@ -337,7 +332,8 @@ export async function transformGraphQLSchema(context, options) {
       addSearchableTransformer: searchableTransformerFlag,
       storageConfig,
       authConfig,
-      authAdminIAMRoles: adminRoles,
+      adminRoles,
+      identityPoolId,
     },
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
@@ -433,7 +429,8 @@ type TransformerFactoryArgs = {
   addSearchableTransformer: boolean;
   authConfig: any;
   storageConfig?: any;
-  authAdminIAMRoles?: Array<string>;
+  adminRoles?: Array<string>;
+  identityPoolId?: string;
 };
 export type ProjectOptions<T> = {
   buildParameters: {

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -7,7 +7,7 @@ import { $TSContext, JSONUtilities, stateManager } from 'amplify-cli-core';
 import { CloudFormation, Template, Fn } from 'cloudform';
 import { Diff, diff as getDiffs } from 'deep-diff';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { pullAllBy } from 'lodash';
+import { pullAllBy, find } from 'lodash';
 import { isAmplifyAdminApp } from '../utils/admin-helpers';
 
 const ROOT_STACK_FILE_NAME = 'cloudformation-template.json';
@@ -29,6 +29,13 @@ export interface GQLDiff {
   current: DiffableProject;
 }
 
+export const getIdentityPoolId = async (ctx: $TSContext): Promise<string | any> => {
+  const { allResources, resourcesToBeDeleted } = await ctx.amplify.getResourceStatus('auth');
+  const authResources = pullAllBy(allResources, resourcesToBeDeleted, 'resourceName');
+  const authResource = find(authResources, { service: 'Cognito', providerPlugin: providerName }) as any;
+  return authResource.output.IdentityPoolId;
+};
+
 export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string): Promise<Array<string>> => {
   const currentEnv = ctx.amplify.getEnvInfo().envName;
   const adminRoles = new Array<string>();
@@ -41,8 +48,8 @@ export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string): P
       adminRoles.push(`${res.userPoolID}${AMPLIFY_ADMIN_ROLE}`, `${res.userPoolID}${AMPLIFY_MANAGE_ROLE}`);
     }
   } catch (err) {
-    console.info('App not deployed yet.');
     // no need to error if not admin ui app
+    console.info('App not deployed yet.');
   }
 
   // lambda functions which have access to the api

--- a/packages/graphql-transformers-e2e-tests/src/IAMHelper.ts
+++ b/packages/graphql-transformers-e2e-tests/src/IAMHelper.ts
@@ -49,6 +49,26 @@ export class IAMHelper {
 
     return { authRole: authRole.Role, unauthRole: unauthRole.Role };
   }
+  async createRoleForCognitoGroup(name: string): Promise<IAM.Role> {
+    const role = await this.client
+      .createRole({
+        RoleName: name,
+        AssumeRolePolicyDocument: `{
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Federated": "cognito-identity.amazonaws.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity"
+          }
+        ]
+      }`,
+      })
+      .promise();
+    return role.Role;
+  }
 
   async createLambdaExecutionRole(name: string) {
     return await this.client


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- allow optional identity pool to be passed into auth transformer
  - this supports iam auth backed by a cognito identity pool (through amplify cli) this keeps all other authenticated identities with different arns to still be constricted to the same rules as private.
- updated unit and e2e

#### Description of how you validated changes
- [x] unit test
- [x] local testing
- [x] e2e

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
