### PR TITLE
test(graphql-predictions-transformer): predictions directive migration v1 to v2 test

### DIFF
--- a/packages/amplify-e2e-tests/schemas/transformer_migration/predictions.graphql
+++ b/packages/amplify-e2e-tests/schemas/transformer_migration/predictions.graphql
@@ -1,0 +1,6 @@
+type Query {
+  translateImageText: String @predictions(actions: [identifyText])
+  translateLabels: String @predictions(actions: [identifyLabels])
+  translateThis: String @predictions(actions: [translateText])
+  speakTranslatedText: String @predictions(actions: [translateText, convertTextToSpeech])
+}

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
@@ -1,0 +1,123 @@
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  amplifyPushUpdate,
+  addFeatureFlag,
+  createRandomName,
+  addAuthWithDefault,
+} from 'amplify-e2e-core';
+import { addApiWithoutSchema, updateApiSchema, getProjectMeta } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+(global as any).fetch = require('node-fetch');
+
+describe('transformer predictions migration test', () => {
+  let projRoot: string;
+  let projectName: string;
+
+  beforeEach(async () => {
+    projectName = createRandomName();
+    projRoot = await createNewProjectDir(createRandomName());
+    await initJSProjectWithProfile(projRoot, { name: projectName });
+    await addAuthWithDefault(projRoot, {});
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('migration of predictions directives', async () => {
+    const predictionsSchema = 'transformer_migration/predictions.graphql';
+
+    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await updateApiSchema(projRoot, projectName, predictionsSchema);
+    await amplifyPush(projRoot);
+
+    let appSyncClient = getAppSyncClientFromProj(projRoot);
+
+    let translateQuery = /* GraphQL */ `
+      query TranslateThis($input: TranslateThisInput!) {
+        translateThis(input: {
+          translateText: {
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            text: 'this is a voice test',
+          }
+        )
+      }
+    `;
+
+    let translateResult = await appSyncClient.query({
+      query: gql(translateQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(translateResult.errors).toBeUndefined();
+    expect(translateResult.data).toBeDefined();
+    expect((translateResult.data as any).translateThis).toMatch(/((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein Sprachtest/i);
+
+    let speakQuery = /* GraphQL */ `
+      query SpeakTranslatedText($input: SpeakTranslatedTextInput!) {
+        speakTranslatedText(input: {
+          translateText: {
+            sourceLanguage: 'en',
+            targetLanguage: 'es',
+            text: 'this is a voice test',
+          },
+          convertTextToSpeech: {
+            voiceID: 'Conchita',
+          }
+        )
+      }
+    `;
+
+    let speakResult = await appSyncClient.query({
+      query: gql(speakQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(speakResult.errors).toBeUndefined();
+    expect(speakResult.data).toBeDefined();
+    expect((speakResult.data as any).speakTranslatedText).toMatch(
+      /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/,
+    );
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 2);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', true);
+
+    await updateApiSchema(projRoot, projectName, predictionsSchema);
+    await amplifyPushUpdate(projRoot);
+
+    appSyncClient = getAppSyncClientFromProj(projRoot);
+
+    translateResult = await appSyncClient.query({
+      query: gql(translateQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    expect(translateResult.errors).toBeUndefined();
+    expect(translateResult.data).toBeDefined();
+    expect((translateResult.data as any).translateThis).toMatch(/((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein Sprachtest/i);
+  });
+
+  const getAppSyncClientFromProj = (projRoot: string) => {
+    const meta = getProjectMeta(projRoot);
+    const region = meta['providers']['awscloudformation']['Region'] as string;
+    const { output } = meta.api[projectName];
+    const url = output.GraphQLAPIEndpointOutput as string;
+    const apiKey = output.GraphQLAPIKeyOutput as string;
+
+    return new AWSAppSyncClient({
+      url,
+      region,
+      disableOffline: true,
+      auth: {
+        type: AUTH_TYPE.API_KEY,
+        apiKey,
+      },
+    });
+  };
+});


### PR DESCRIPTION
#### Description of changes
- v1 to v2 migration predictions e2e test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
