### PR TITLE
feat: add get project info helper to overrides helper package

### DIFF
--- a/packages/amplify-cli-overrides-helper/package.json
+++ b/packages/amplify-cli-overrides-helper/package.json
@@ -30,7 +30,8 @@
     "amplify-prompts": "1.1.2",
     "@aws-amplify/amplify-category-auth": "1.0.0",
     "@aws-amplify/amplify-category-storage": "1.0.0",
-    "@aws-amplify/amplify-category-custom": "1.0.0"
+    "@aws-amplify/amplify-category-custom": "1.0.0",
+    "amplify-cli-core": "1.31.1"
   },
   "devDependencies": {},
   "jest": {

--- a/packages/amplify-cli-overrides-helper/src/helpers/project-info.ts
+++ b/packages/amplify-cli-overrides-helper/src/helpers/project-info.ts
@@ -1,0 +1,14 @@
+import { stateManager } from 'amplify-cli-core';
+import { AmplifyProjectInfo } from '../types';
+
+export function getProjectInfo(): AmplifyProjectInfo {
+  const localEnvInfo = stateManager.getLocalEnvInfo();
+  const projectConfig = stateManager.getProjectConfig();
+
+  const projectInfo: AmplifyProjectInfo = {
+    envName: localEnvInfo.envName,
+    projectName: projectConfig.projectName,
+  };
+
+  return projectInfo;
+}

--- a/packages/amplify-cli-overrides-helper/src/helpers/project-info.ts
+++ b/packages/amplify-cli-overrides-helper/src/helpers/project-info.ts
@@ -1,7 +1,7 @@
 import { stateManager } from 'amplify-cli-core';
 import { AmplifyProjectInfo } from '../types';
 
-export function getProjectInfo(): AmplifyProjectInfo {
+export const getProjectInfo = (): AmplifyProjectInfo => {
   const localEnvInfo = stateManager.getLocalEnvInfo();
   const projectConfig = stateManager.getProjectConfig();
 
@@ -11,4 +11,4 @@ export function getProjectInfo(): AmplifyProjectInfo {
   };
 
   return projectInfo;
-}
+};

--- a/packages/amplify-cli-overrides-helper/src/index.ts
+++ b/packages/amplify-cli-overrides-helper/src/index.ts
@@ -1,21 +1,11 @@
-import { printer } from 'amplify-prompts';
-
 //import { AmplifyRootStackTemplate } from 'amplify-provider-awscloudformation';
 import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/amplify-category-auth';
-import { AmplifyDDBResourceTemplate, AmplifyS3ResourceTemplate } from '@aws-amplify/amplify-category-storage';
 import { addCDKResourceDependency } from '@aws-amplify/amplify-category-custom';
-
-function getProjectInfo(): void {
-  printer.info('Hello from the skeleton of get project info');
-}
-
-function addDependency(): void {
-  printer.info('Hello from the skeleton of add dependency');
-}
+import { AmplifyDDBResourceTemplate, AmplifyS3ResourceTemplate } from '@aws-amplify/amplify-category-storage';
+import { getProjectInfo } from './helpers/project-info';
 
 export {
   getProjectInfo,
-  addDependency,
   //AmplifyRootStackTemplate,
   AmplifyAuthCognitoStackTemplate,
   AmplifyDDBResourceTemplate,

--- a/packages/amplify-cli-overrides-helper/src/types.ts
+++ b/packages/amplify-cli-overrides-helper/src/types.ts
@@ -1,0 +1,4 @@
+export type AmplifyProjectInfo = {
+  envName: string;
+  projectName: string;
+};

--- a/packages/amplify-cli-overrides-helper/tsconfig.json
+++ b/packages/amplify-cli-overrides-helper/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "../amplify-category-auth" },
     { "path": "../amplify-category-storage" },
     { "path": "../amplify-category-custom" },
+    { "path": "../amplify-cli-core" },
     ]
 }
   


### PR DESCRIPTION
Adding getProjectInfo() helper function to the helpers package which would provide override and custom resource functions access to:
1. Project name
2. Current env name

This will enable customers to have conditional logic in code(override or custom-resources) per env.