### PR TITLE
ci: update split test to windows e2e

### DIFF
--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -60,6 +60,9 @@ const WINDOWS_TEST_FAILURES = [
   'migration-api-key-migration3-amplify_e2e_tests',
   'migration-api-key-migration4-amplify_e2e_tests',
   'migration-api-key-migration5-amplify_e2e_tests',
+  'transformer-migrations-model-migration-amplify_e2e_tests',
+  'global_sandbox-amplify_e2e_tests',
+  'api_5-amplify_e2e_tests',
 
   // 👇 These fail due to ExpiredToken. 👇
   // 👇 Tests should be split to speed up execution time. 👇


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Updated the list of tests that needs to be excluded on windows e2e which are failing due to the way windows terminal splits the text and not matching the nexpect expectation.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
