### PR TITLE
test: add @searchable and @function migration unit tests

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
@@ -29,6 +29,22 @@ type Team @model @auth(rules: [{allow: public}]) {
 "
 `;
 
+exports[`Schema migration tests @function directive is migrated 1`] = `
+"type Query {
+  echo(msg: String!): Context @function(name: \\"echo\\")
+  echoEnv(msg: String!): Context @function(name: \\"long-prefix-e2e-test-functions-echo-\${env}-v2\\")
+  duplicate(msg: String!): Context @function(name: \\"long-prefix-e2e-test-functions-echo-dev-v2\\")
+  pipeline(msg: String!): String @function(name: \\"echo\\") @function(name: \\"hello\\")
+  echoRegion(msg: String!): Context @function(name: \\"echo-\${env}\\", region: \\"us-east-1\\")
+}
+
+type Context {
+  typeName: String
+  fieldName: String
+}
+"
+`;
+
 exports[`Schema migration tests @http directive is migrated 1`] = `
 "type Comment @model @auth(rules: [{allow: public}]) {
   id: ID!
@@ -56,6 +72,28 @@ exports[`Schema migration tests @predictions directive is migrated 1`] = `
   translateLabels: String @predictions(actions: [identifyLabels])
   translateThis: String @predictions(actions: [translateText])
   speakTranslatedText: String @predictions(actions: [translateText, convertTextToSpeech])
+}
+"
+`;
+
+exports[`Schema migration tests @searchable directive is migrated 1`] = `
+"type Book @model @searchable @auth(rules: [{allow: public}]) {
+  author: String! @primaryKey(sortKeyFields: [\\"name\\"])
+  name: String!
+  genre: String!
+}
+
+type Todo @model @searchable @auth(rules: [{allow: public}]) {
+  id: ID
+  name: String!
+  createdAt: AWSDateTime
+  description: String
+}
+
+type Comment @model @searchable @auth(rules: [{allow: public}]) {
+  id: ID!
+  version: Int! @index(name: \\"commentByVersion\\", sortKeyFields: [\\"id\\"])
+  content: String!
 }
 "
 `;

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
@@ -149,6 +149,48 @@ describe('Schema migration tests', () => {
     migrateAndValidate(schema);
   });
 
+  it('@function directive is migrated', () => {
+    const schema = `
+      type Query {
+        echo(msg: String!): Context @function(name: "echo")
+        echoEnv(msg: String!): Context @function(name: "long-prefix-e2e-test-functions-echo-\${env}-v2")
+        duplicate(msg: String!): Context @function(name: "long-prefix-e2e-test-functions-echo-dev-v2")
+        pipeline(msg: String!): String @function(name: "echo") @function(name: "hello")
+        echoRegion(msg: String!): Context @function(name: "echo-\${env}" region: "us-east-1")
+      }
+
+      type Context {
+        typeName: String
+        fieldName: String
+      }`;
+
+    migrateAndValidate(schema);
+  });
+
+  it('@searchable directive is migrated', () => {
+    const schema = `
+      type Book @model @key(fields: ["author", "name"]) @searchable {
+        author: String!
+        name: String!
+        genre: String!
+      }
+
+      type Todo @model @searchable {
+        id: ID
+        name: String!
+        createdAt: AWSDateTime
+        description: String
+      }
+
+      type Comment @model @key(name: "commentByVersion", fields: ["version", "id"]) @searchable {
+        id: ID!
+        version: Int!
+        content: String!
+      }`;
+
+    migrateAndValidate(schema);
+  });
+
   it('@http directive is migrated', () => {
     const schema = `
       type Comment @model {


### PR DESCRIPTION
#### Description of changes
This commit adds unit tests in the GQL v2 migrator for the `@searchable` and `@function` directives.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
