### PR TITLE
fix(graphql-model-transformer): fix model transformer ID generation when ID field is not specified

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1056,4 +1056,37 @@ describe('ModelTransformer: ', () => {
 
     validateModelSchema(parsed);
   });
+
+  it('should generate the ID field when not specified', () => {
+    const validSchema = `type Todo @model {
+      name: String
+    }`;
+
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+    });
+
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+
+    const definition = out.schema;
+    expect(definition).toBeDefined();
+
+    const parsed = parse(definition);
+    validateModelSchema(parsed);
+
+    const createTodoInput = getInputType(parsed, 'CreateTodoInput');
+    expect(createTodoInput).toBeDefined();
+
+    expectFieldsOnInputType(createTodoInput!, ['id', 'name']);
+
+    const idField = createTodoInput!.fields!.find(f => f.name.value === 'id');
+    expect((idField!.type as NamedTypeNode).name!.value).toEqual('ID');
+    expect((idField!.type as NamedTypeNode).kind).toEqual('NamedType');
+
+    const updateTodoInput = getInputType(parsed, 'UpdateTodoInput');
+    expect(updateTodoInput).toBeDefined();
+
+    expectFieldsOnInputType(updateTodoInput!, ['name']);
+  });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
@@ -45,9 +45,7 @@ export const makeUpdateInputField = (
   input.fields.forEach(f => f.makeNullable());
 
   // Add id field and make it optional
-  if (!hasIdField) {
-    input.addField(InputFieldWrapper.create('id', 'ID', false));
-  } else {
+  if (hasIdField) {
     const idField = input.fields.find(f => f.name === 'id');
     if (idField) {
       idField.makeNonNullable();
@@ -127,7 +125,7 @@ export const makeCreateInputField = (
 
   // Add id field and make it optional
   if (!hasIdField) {
-    input.addField(InputFieldWrapper.create('id', 'ID'));
+    input.addField(InputFieldWrapper.create('id', 'ID', true));
   } else {
     const idField = input.fields.find(f => f.name === 'id');
     if (idField) {


### PR DESCRIPTION
#### Description of changes
- updated how ID field is generated in mutation input objects to match V1

#### Issue #, if available
- https://app.asana.com/0/1174852957705151/1201295218402690/f

#### Description of how you validated changes
- `yarn test` passes
- unit test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
