### PR TITLE
fix(amplify-category-api): change auth directive type and fix codegen bug

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/global-sandbox-mode.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/global-sandbox-mode.test.ts
@@ -4,7 +4,7 @@ describe('global sandbox mode GraphQL directive', () => {
   it('returns input AMPLIFY with code comment', () => {
     expect(defineGlobalSandboxMode()).toEqual(`# This "input" configures a global authorization rule to enable public access to
 # all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql-transformer/auth
-input AMPLIFY { global_auth_rule: AuthorizationRule = { allow: public } } # FOR TESTING ONLY!\n
+input AMPLIFY { global_auth_rule: AuthRule = { allow: public } } # FOR TESTING ONLY!\n
 `);
   });
 });

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/global-sandbox-mode.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/global-sandbox-mode.ts
@@ -1,6 +1,6 @@
 export function defineGlobalSandboxMode(): string {
   return `# This "input" configures a global authorization rule to enable public access to
 # all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql-transformer/auth
-input AMPLIFY { global_auth_rule: AuthorizationRule = { allow: public } } # FOR TESTING ONLY!\n
+input AMPLIFY { global_auth_rule: AuthRule = { allow: public } } # FOR TESTING ONLY!\n
 `;
 }

--- a/packages/amplify-e2e-tests/schemas/model_with_sandbox_mode.graphql
+++ b/packages/amplify-e2e-tests/schemas/model_with_sandbox_mode.graphql
@@ -1,5 +1,5 @@
 input AMPLIFY {
-  global_auth_rule: AuthorizationRule = { allow: public }
+  global_auth_rule: AuthRule = { allow: public }
 }
 
 type Todo @model {

--- a/packages/amplify-e2e-tests/src/__tests__/global_sandbox.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/global_sandbox.test.ts
@@ -8,6 +8,7 @@ import {
   updateApiSchema,
   apiGqlCompile,
   amplifyPush,
+  generateModels,
 } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
 
@@ -29,12 +30,14 @@ describe('global sandbox mode', () => {
   it('compiles schema with one model and pushes to cloud', async () => {
     await addApiWithOneModel(projectDir);
     await apiGqlCompile(projectDir, true);
+    await generateModels(projectDir);
     await amplifyPush(projectDir, true);
   });
 
   it.skip('compiles schema with three models and pushes to cloud', async () => {
     await addApiWithThreeModels(projectDir);
     await apiGqlCompile(projectDir, true);
+    await generateModels(projectDir);
     await amplifyPush(projectDir, true);
   });
 
@@ -42,6 +45,7 @@ describe('global sandbox mode', () => {
     await addApiWithoutSchema(projectDir, { apiName });
     updateApiSchema(projectDir, apiName, 'model_with_sandbox_mode.graphql');
     await apiGqlCompile(projectDir, true);
+    await generateModels(projectDir);
     await amplifyPush(projectDir, true);
   });
 });

--- a/packages/amplify-graphql-transformer-core/src/transformation/validation.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/validation.ts
@@ -103,7 +103,6 @@ scalar AWSPhone
 scalar AWSIPAddress
 scalar BigInt
 scalar Double
-scalar AuthorizationRule
 `);
 
 export const EXTRA_DIRECTIVES_DOCUMENT = parse(`
@@ -160,7 +159,13 @@ export const validateAuthModes = (authConfig: AppSyncAuthConfiguration) => {
   for (let i = 0; i < authModes.length; i++) {
     const mode = authModes[i];
 
-    if (mode !== 'API_KEY' && mode !== 'AMAZON_COGNITO_USER_POOLS' && mode !== 'AWS_IAM' && mode !== 'OPENID_CONNECT' && mode !== 'AWS_LAMBDA') {
+    if (
+      mode !== 'API_KEY' &&
+      mode !== 'AMAZON_COGNITO_USER_POOLS' &&
+      mode !== 'AWS_IAM' &&
+      mode !== 'OPENID_CONNECT' &&
+      mode !== 'AWS_LAMBDA'
+    ) {
       throw new Error(`Invalid auth mode ${mode}`);
     }
   }

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/sandbox-mode-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/sandbox-mode-helpers.test.ts
@@ -35,7 +35,7 @@ describe('sandbox mode helpers', () => {
         expect(prompts.printer.info).toBeCalledWith(
           `
 ⚠️  WARNING: Global Sandbox Mode has been enabled, which requires a valid API key. If
-you'd like to disable, remove ${chalk.green('"input AMPLIFY { global_auth_rule: AuthorizationRule = { allow: public } }"')}
+you'd like to disable, remove ${chalk.green('"input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }"')}
 from your GraphQL schema and run 'amplify push' again. If you'd like to proceed with
 sandbox mode disabled, do not create an API Key.
 `,
@@ -62,7 +62,7 @@ sandbox mode disabled, do not create an API Key.
   describe('schemaHasSandboxModeEnabled', () => {
     it('parses sandbox AMPLIFY input on schema', () => {
       const schema = `
-        input AMPLIFY { global_auth_rule: AuthorizationRule = { allow: public } }
+        input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }
       `;
 
       expect(schemaHasSandboxModeEnabled(schema)).toEqual(true);
@@ -90,7 +90,7 @@ sandbox mode disabled, do not create an API Key.
         );
       });
 
-      it('guards for AuthorizationRule', () => {
+      it('guards for AuthRule', () => {
         const schema = `
           input AMPLIFY { global_auth_rule: AuthenticationRule = { allow: public } }
         `;
@@ -104,7 +104,7 @@ sandbox mode disabled, do not create an API Key.
 
       it('checks for "allow" field name', () => {
         const schema = `
-          input AMPLIFY { global_auth_rule: AuthorizationRule = { allows: public } }
+          input AMPLIFY { global_auth_rule: AuthRule = { allows: public } }
         `;
 
         expect(() => schemaHasSandboxModeEnabled(schema)).toThrow(
@@ -116,7 +116,7 @@ sandbox mode disabled, do not create an API Key.
 
       it('checks for "public" value from "allow" field', () => {
         const schema = `
-          input AMPLIFY { global_auth_rule: AuthorizationRule = { allow: private } }
+          input AMPLIFY { global_auth_rule: AuthRule = { allow: private } }
         `;
 
         expect(() => schemaHasSandboxModeEnabled(schema)).toThrowError(

--- a/packages/amplify-provider-awscloudformation/src/utils/sandbox-mode-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/sandbox-mode-helpers.ts
@@ -6,7 +6,7 @@ import { parse } from 'graphql';
 
 const AMPLIFY = 'AMPLIFY';
 const GLOBAL_AUTH_RULE = 'global_auth_rule';
-const AUTHORIZATION_RULE = 'AuthorizationRule';
+const AUTHORIZATION_RULE = 'AuthRule';
 const ALLOW = 'allow';
 const PUBLIC = 'public';
 
@@ -15,7 +15,7 @@ export async function showSandboxModePrompts(context: $TSContext): Promise<any> 
     printer.info(
       `
 ⚠️  WARNING: Global Sandbox Mode has been enabled, which requires a valid API key. If
-you'd like to disable, remove ${chalk.green('"input AMPLIFY { global_auth_rule: AuthorizationRule = { allow: public } }"')}
+you'd like to disable, remove ${chalk.green('"input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }"')}
 from your GraphQL schema and run 'amplify push' again. If you'd like to proceed with
 sandbox mode disabled, do not create an API Key.
 `,


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

changes the global authorization type to use `AuthRule` -> this also fixes the reported `amplify codegen models` bug.

#### Description of how you validated changes
Changed unit tests, tested locally, added codegen models to the e2e tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
