### PR TITLE
fix: gracefully exit on deprecated @connection parameterization

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/package.json
+++ b/packages/amplify-graphql-transformer-migrator/package.json
@@ -22,7 +22,7 @@
     "scripts": {
         "build": "tsc",
         "watch": "tsc -w",
-        "clean": "rimraf ./lib",
+        "clean": "rimraf ./lib tsconfig.tsbuildinfo",
         "test": "jest"
     },
     "dependencies": {

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/schema-inspector.test.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/schema-inspector.test.ts
@@ -1,0 +1,23 @@
+import { detectUnsupportedDirectives } from '../../schema-inspector';
+
+test('deprecated @connection parameterization fails gracefully', async () => {
+  const schema = /* GraphQL */ `
+    type PostConnection @model @auth(rules: [{ allow: public }]) {
+      id: ID!
+      title: String!
+      comments: [CommentConnection] @connection(name: "PostComments")
+    }
+
+    type CommentConnection @model {
+      id: ID!
+      content: String!
+      post: PostConnection @connection(name: "PostComments")
+    }
+  `;
+  const result = await detectUnsupportedDirectives(schema);
+  expect(result).toMatchInlineSnapshot(`
+    Array [
+      "Deprecated parameterization of @connection",
+    ]
+  `);
+});

--- a/packages/amplify-graphql-transformer-migrator/src/schema-inspector.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/schema-inspector.ts
@@ -1,10 +1,9 @@
 import { stateManager } from 'amplify-cli-core';
 import { DocumentNode } from 'graphql/language';
 import { visit } from 'graphql';
-import { collectDirectivesByTypeNames } from '@aws-amplify/graphql-transformer-core';
+import { collectDirectives, collectDirectivesByTypeNames } from '@aws-amplify/graphql-transformer-core';
 import { listContainsOnlySetString } from './utils';
 import * as fs from 'fs-extra';
-
 
 export function graphQLUsingSQL(apiName: string): boolean {
   const teamProviderInfo = stateManager.getTeamProviderInfo();
@@ -15,7 +14,6 @@ export function graphQLUsingSQL(apiName: string): boolean {
   return false;
 }
 
-
 export function detectCustomResolvers(schema: DocumentNode): boolean {
   let customResolversUsed = false;
   visit(schema, {
@@ -24,27 +22,48 @@ export function detectCustomResolvers(schema: DocumentNode): boolean {
         if (node.name.value === 'Mutation' || node.name.value === 'Query' || node.name.value === 'Subscription') {
           customResolversUsed = true;
         }
-      }
-    }
+      },
+    },
   });
   return customResolversUsed;
 }
 
-
 export function detectOverriddenResolvers(apiName: string): boolean {
   const files = fs.readdirSync(`amplify/backend/api/${apiName}/resolvers/`);
-  return !!(files.length);
+  return !!files.length;
 }
 
-
 export async function detectUnsupportedDirectives(schema: string): Promise<Array<string>> {
-  const supportedDirectives = new Set<string>(['connection', 'key', 'searchable', 'auth', 'model', 'function',
-    'predictions', 'aws_api_key', 'aws_iam', 'aws_oidc', 'aws_cognito_user_pools', 'aws_auth', 'aws_subscribe']);
+  const supportedDirectives = new Set<string>([
+    'connection',
+    'key',
+    'searchable',
+    'auth',
+    'model',
+    'function',
+    'predictions',
+    'aws_api_key',
+    'aws_iam',
+    'aws_oidc',
+    'aws_cognito_user_pools',
+    'aws_auth',
+    'aws_subscribe',
+  ]);
   const directiveMap: any = collectDirectivesByTypeNames(schema).types;
   let unsupportedDirSet = new Set<string>();
-  for(let type of Object.keys(directiveMap)) {
-    for(let dirName of listContainsOnlySetString(directiveMap[type], supportedDirectives)) {
+  for (let type of Object.keys(directiveMap)) {
+    for (let dirName of listContainsOnlySetString(directiveMap[type], supportedDirectives)) {
       unsupportedDirSet.add(dirName);
+    }
+  }
+
+  // check for old parameterization of @connection
+  const directives = collectDirectives(schema);
+  const deprecatedConnectionArgs = ['name', 'keyField', 'sortField', 'limit'];
+  const connectionDirectives = directives.filter(directive => directive.name.value === 'connection');
+  for (const connDir of connectionDirectives) {
+    if (connDir.arguments?.map(arg => deprecatedConnectionArgs.includes(arg.name.value))) {
+      unsupportedDirSet.add('Deprecated parameterization of @connection');
     }
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Detect and gracefully exit if schema uses the deprecated paramterization of @connection
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
