### PR TITLE
fix: remove duplicate error messages

### DIFF
--- a/packages/amplify-category-api/src/commands/api/update.js
+++ b/packages/amplify-category-api/src/commands/api/update.js
@@ -1,3 +1,5 @@
+const { printer } = require('amplify-prompts');
+
 const subcommand = 'update';
 const category = 'api';
 
@@ -13,15 +15,14 @@ module.exports = {
       .then(result => {
         const providerController = require(`../../provider-utils/${result.providerName}/index`);
         if (!providerController) {
-          context.print.error('Provider not configured for this category');
+          printer.error('Provider not configured for this category');
           return;
         }
         return providerController.updateResource(context, category, result.service);
       })
-      .then(() => context.print.success('Successfully updated resource'))
+      .then(() => printer.success('Successfully updated resource'))
       .catch(err => {
-        context.print.error(err.message);
-        console.log(err.stack);
+        printer.error(err.message || err);
         context.usageData.emitError(err);
         process.exitCode = 1;
       });

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -2,6 +2,7 @@ import sequential from 'promise-sequential';
 import ora from 'ora';
 import { $TSAny, $TSContext, $TSObject, stateManager, exitOnNextTick, ConfigurationError } from 'amplify-cli-core';
 import { getProviderPlugins } from '../extensions/amplify-helpers/get-provider-plugins';
+import { printer } from 'amplify-prompts';
 
 const spinner = ora('');
 
@@ -64,7 +65,7 @@ export const run = async (context: $TSContext) => {
   } catch (e) {
     if (e.name !== 'InvalidDirectiveError') {
       const message = e.name === 'GraphQLError' ? e.toString() : e.message;
-      context.print.error(`An error occurred during the push operation: ${message}`);
+      printer.error(`An error occurred during the push operation: ${message}`);
     }
     await context.usageData.emitError(e);
     exitOnNextTick(1);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -4,14 +4,7 @@ import { onCategoryOutputsChange } from './on-category-outputs-change';
 import { initializeEnv } from '../../initialize-env';
 import { getProviderPlugins } from './get-provider-plugins';
 import { getEnvInfo } from './get-env-info';
-import {
-  EnvironmentDoesNotExistError,
-  exitOnNextTick,
-  stateManager,
-  $TSAny,
-  $TSContext,
-} from 'amplify-cli-core';
-import { printer } from 'amplify-prompts';
+import { EnvironmentDoesNotExistError, exitOnNextTick, stateManager, $TSAny, $TSContext } from 'amplify-cli-core';
 
 export async function pushResources(
   context: $TSContext,
@@ -95,9 +88,6 @@ export async function pushResources(
           retryPush = await handleValidGraphQLAuthError(context, err.message);
         }
         if (!retryPush) {
-          // Handle the errors and print them nicely for the user.
-          printer.blankLine();
-          printer.error(err.message);
           throw err;
         }
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes 2 different issues that were causing duplicate error messages to be printed. The first was duplicate messages when updating an API if the graphql compile failed. The second was duplicate messages if the push operation failed.
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
