### PR TITLE
ci: downgrade to medium cci hosts to save on costs

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -9,7 +9,7 @@ executors:
   w: &windows-e2e-executor
     machine:
       image: 'windows-server-2019-vs2019:stable'
-      resource_class: 'windows.large'
+      resource_class: 'windows.medium'
       shell: bash.exe
     working_directory: ~/repo
     environment:
@@ -20,7 +20,7 @@ executors:
     docker:
       - image: public.ecr.aws/a6e6w2n0/amplify-cli-e2e-base-image-repo-public:latest
     working_directory: ~/repo
-    resource_class: large
+    resource_class: medium
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
@@ -448,7 +448,7 @@ jobs:
 
   integration_test:
     working_directory: ~/repo
-    resource_class: large
+    resource_class: medium
     docker:
       - image: cypress/base:14.17.0
         environment:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

We're running a lot more tests now and there doesn't seem to be a compelling reason to run our tests on large hosts
#### Description of how you validated changes

cloud-e2e

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
