### PR TITLE
fix: use output when looking up relational related type index

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
@@ -292,3 +292,25 @@ test('creates belongs to relationship with implicit fields', () => {
   expect(updateInput.fields.find((f: any) => f.name.value === 'email')).toBeDefined();
   expect(createInput.fields.find((f: any) => f.name.value === 'testOtherHalfId')).toBeDefined();
 });
+
+test('regression test for implicit id field on related type', () => {
+  const inputSchema = `
+    type BatteryCharger @model {
+      powerSourceID: ID
+      powerSource: PowerSource @hasOne(fields: ["powerSourceID"])
+    }
+    
+    type PowerSource @model {
+      sourceID: ID!
+      chargerID: ID
+      charger: BatteryCharger @belongsTo(fields: ["chargerID"])
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -15,7 +15,8 @@ export function getRelatedTypeIndex(
   ctx: TransformerContextProvider,
   indexName?: string,
 ): FieldDefinitionNode[] {
-  const { directiveName, field, fieldNodes, relatedType } = config;
+  const { directiveName, field, fieldNodes } = config;
+  const relatedType = ctx.output.getType(config.relatedType.name.value) as any;
   const fieldMap = new Map<string, FieldDefinitionNode>();
   let partitionFieldName;
   let partitionField;


### PR DESCRIPTION
#### Description of changes
This allows the implicitly added 'id' field to be properly used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
