### PR TITLE
test: add @http migration test

### DIFF
--- a/packages/amplify-e2e-tests/schemas/transformer_migration/http.graphql
+++ b/packages/amplify-e2e-tests/schemas/transformer_migration/http.graphql
@@ -1,0 +1,15 @@
+type Comment @model {
+  id: ID!
+  title: String
+  simpleGet: CompObj @http(method: GET, url: "https://amazon.com/posts/1")
+  simpleGet2: CompObj @http(url: "https://amazon.com/posts/2")
+  complexPost(id: Int, title: String!, body: String, userId: Int): CompObj @http(method: POST, url: "https://amazon.com/posts")
+  complexPut(id: Int!, title: String, body: String, userId: Int): CompObj @http(method: PUT, url: "https://amazon.com/posts/${env}")
+  deleter: String @http(method: DELETE, url: "https://amazon.com/posts/4")
+}
+type CompObj {
+  userId: Int
+  id: Int
+  title: String
+  body: String
+}

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/http-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/http-migration.test.ts
@@ -1,0 +1,42 @@
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  amplifyPushForce,
+  addFeatureFlag,
+  createRandomName,
+  addAuthWithDefault,
+} from 'amplify-e2e-core';
+import { addApiWithoutSchema, updateApiSchema } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+
+describe('transformer @http migration test', () => {
+  let projRoot: string;
+  let projectName: string;
+
+  beforeEach(async () => {
+    projectName = createRandomName();
+    projRoot = await createNewProjectDir(createRandomName());
+    await initJSProjectWithProfile(projRoot, { name: projectName });
+    await addAuthWithDefault(projRoot, {});
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('migration of @http schema', async () => {
+    const httpSchema = 'transformer_migration/http.graphql';
+
+    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await updateApiSchema(projRoot, projectName, httpSchema);
+    await amplifyPush(projRoot);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 2);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', true);
+
+    await updateApiSchema(projRoot, projectName, httpSchema);
+    await amplifyPushForce(projRoot);
+  });
+});


### PR DESCRIPTION
#### Description of changes
This commit adds a test that pushes an `@http` schema with gql transformer v1, updates the transformer to v2, and pushes again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
