### PR TITLE
fix: don't migrate AppSync auth related directives

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
@@ -256,25 +256,4 @@ describe('Schema migration tests', () => {
       migrateAndValidate(schema);
     }).toThrow('Unknown directive "versioned".');
   });
-
-  // TODO(cjihrig): This test is currently failing.
-  // it('AppSync directives are not migrated', () => {
-  //   const schema1 = `
-  //     type Todo @model @aws_api_key {
-  //       id: ID!
-  //     }`;
-
-  //   expect(() => {
-  //     migrateAndValidate(schema1);
-  //   }).toThrow('Unknown directive "aws_api_key".');
-
-  //   const schema2 = `
-  //     type Todo @model @aws_iam {
-  //       id: ID!
-  //     }`;
-
-  //   expect(() => {
-  //     migrateAndValidate(schema2);
-  //   }).toThrow('Unknown directive "aws_iam".');
-  // });
 });

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/schema-inspector.test.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/schema-inspector.test.ts
@@ -21,3 +21,21 @@ test('deprecated @connection parameterization fails gracefully', async () => {
     ]
   `);
 });
+
+test('AppSync auth directives are not migrated', async () => {
+  const denylist = ['aws_api_key', 'aws_iam', 'aws_oidc', 'aws_cognito_user_pools', 'aws_auth'];
+
+  for (const directive of denylist) {
+    const schema = `
+      type Todo @model @${directive} {
+        id: ID!
+      }`;
+    const result = await detectUnsupportedDirectives(schema);
+
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        "${directive}",
+      ]
+    `);
+  }
+});

--- a/packages/amplify-graphql-transformer-migrator/src/schema-inspector.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/schema-inspector.ts
@@ -42,11 +42,6 @@ export async function detectUnsupportedDirectives(schema: string): Promise<Array
     'model',
     'function',
     'predictions',
-    'aws_api_key',
-    'aws_iam',
-    'aws_oidc',
-    'aws_cognito_user_pools',
-    'aws_auth',
     'aws_subscribe',
   ]);
   const directiveMap: any = collectDirectivesByTypeNames(schema).types;


### PR DESCRIPTION
#### Description of changes
This commit prevents schemas with AppSync auth related directives from being automatically migrated from transformer v1 to v2. This is to prevent any unknown interactions between these directives and the new auth.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
