### PR TITLE
fix: exit migration if improvePluralization is false

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/schema-inspector.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/schema-inspector.ts
@@ -1,4 +1,4 @@
-import { stateManager } from 'amplify-cli-core';
+import { FeatureFlags, stateManager } from 'amplify-cli-core';
 import { DocumentNode } from 'graphql/language';
 import { visit } from 'graphql';
 import { collectDirectives, collectDirectivesByTypeNames } from '@aws-amplify/graphql-transformer-core';
@@ -29,8 +29,8 @@ export function detectCustomResolvers(schema: DocumentNode): boolean {
 }
 
 export function detectOverriddenResolvers(apiName: string): boolean {
-  const files = fs.readdirSync(`amplify/backend/api/${apiName}/resolvers/`);
-  return !!files.length;
+  const vtlFiles = fs.readdirSync(`amplify/backend/api/${apiName}/resolvers/`).filter(file => file.endsWith('.vtl'));
+  return !!vtlFiles.length;
 }
 
 export async function detectUnsupportedDirectives(schema: string): Promise<Array<string>> {
@@ -62,10 +62,14 @@ export async function detectUnsupportedDirectives(schema: string): Promise<Array
   const deprecatedConnectionArgs = ['name', 'keyField', 'sortField', 'limit'];
   const connectionDirectives = directives.filter(directive => directive.name.value === 'connection');
   for (const connDir of connectionDirectives) {
-    if (connDir.arguments?.map(arg => deprecatedConnectionArgs.includes(arg.name.value))) {
+    if (connDir.arguments?.some(arg => deprecatedConnectionArgs.includes(arg.name.value))) {
       unsupportedDirSet.add('Deprecated parameterization of @connection');
     }
   }
 
   return Array.from(unsupportedDirSet);
+}
+
+export function isImprovedPluralizationEnabled() {
+  return FeatureFlags.getBoolean('graphqlTransformer.improvePluralization');
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Gracefully exits migration if the "improvePluralization" FF is false.
Also fixes 3 other bugs in the exit early detection logic.
1. detection of overridden resolvers did not account for other files in the directory
2. detection of deprecated connection directives used .map instead of .some so it was always coming back truthy
3. the customResolvers check was excluded from the if statement to print the error message.
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
