### PR TITLE
fix: stack generation logic when multiple paths ref same Lambda

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -76,21 +76,25 @@ export class ApigwStackTransform {
     }
 
     // Add Parameters
+    const addedFunctions = new Set();
     for (const path of Object.values(this.cliInputs.paths)) {
-      this.resourceTemplateObj.addCfnParameter(
-        {
-          type: 'String',
-          default: `function${path.lambdaFunction}Name`,
-        },
-        `function${path.lambdaFunction}Name`,
-      );
-      this.resourceTemplateObj.addCfnParameter(
-        {
-          type: 'String',
-          default: `function${path.lambdaFunction}Arn`,
-        },
-        `function${path.lambdaFunction}Arn`,
-      );
+      if (!addedFunctions.has(path.lambdaFunction)) {
+        addedFunctions.add(path.lambdaFunction);
+        this.resourceTemplateObj.addCfnParameter(
+          {
+            type: 'String',
+            default: `function${path.lambdaFunction}Name`,
+          },
+          `function${path.lambdaFunction}Name`,
+        );
+        this.resourceTemplateObj.addCfnParameter(
+          {
+            type: 'String',
+            default: `function${path.lambdaFunction}Arn`,
+          },
+          `function${path.lambdaFunction}Arn`,
+        );
+      }
     }
 
     this.resourceTemplateObj.addCfnParameter(

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -338,7 +338,7 @@ async function ensureAuth(context: $TSContext, apiRequirements: ApiRequirements,
 
 async function askCRUD(userType: string, permissions: string[] = []) {
   const crudOptions = ['create', 'read', 'update', 'delete'];
-  const crudAnswers = await prompter.pick<'many', string>(`What permissions do you want to grant to ${userType}`, crudOptions, {
+  const crudAnswers = await prompter.pick<'many', string>(`What permissions do you want to grant to ${userType} users?`, crudOptions, {
     returnSize: 'many',
     initial: permissions.map(p => crudOptions.indexOf(p)),
   });

--- a/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
@@ -31,7 +31,7 @@ describe('API Gateway e2e tests', () => {
     await addAuthWithGroupsAndAdminAPI(projRoot); // Groups: Admins, Users
     await amplifyPushAuth(projRoot);
     await addRestApi(projRoot, { isFirstRestApi: false, path: '/foo' });
-    await addRestApi(projRoot, { restrictAccess: true, allowGuestUsers: true });
+    await addRestApi(projRoot, { isFirstRestApi: false, restrictAccess: true, allowGuestUsers: true, hasUserPoolGroups: true });
     await amplifyPushAuth(projRoot); // Pushes multiple rest api updates
     const projMeta = getProjectMeta(projRoot);
     expect(projMeta).toBeDefined();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
