### PR TITLE
feat(amplify-provider-awscloudformation): change global_auth_rule to globalAuthRule for global auth

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/global-sandbox-mode.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/global-sandbox-mode.test.ts
@@ -4,7 +4,7 @@ describe('global sandbox mode GraphQL directive', () => {
   it('returns input AMPLIFY with code comment', () => {
     expect(defineGlobalSandboxMode()).toEqual(`# This "input" configures a global authorization rule to enable public access to
 # all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql-transformer/auth
-input AMPLIFY { global_auth_rule: AuthRule = { allow: public } } # FOR TESTING ONLY!\n
+input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!\n
 `);
   });
 });

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/global-sandbox-mode.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/global-sandbox-mode.ts
@@ -1,6 +1,6 @@
 export function defineGlobalSandboxMode(): string {
   return `# This "input" configures a global authorization rule to enable public access to
 # all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql-transformer/auth
-input AMPLIFY { global_auth_rule: AuthRule = { allow: public } } # FOR TESTING ONLY!\n
+input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!\n
 `;
 }

--- a/packages/amplify-e2e-tests/schemas/model_with_sandbox_mode.graphql
+++ b/packages/amplify-e2e-tests/schemas/model_with_sandbox_mode.graphql
@@ -1,5 +1,5 @@
 input AMPLIFY {
-  global_auth_rule: AuthRule = { allow: public }
+  globalAuthRule: AuthRule = { allow: public }
 }
 
 type Todo @model {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/sandbox-mode-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/sandbox-mode-helpers.test.ts
@@ -35,7 +35,7 @@ describe('sandbox mode helpers', () => {
         expect(prompts.printer.info).toBeCalledWith(
           `
 ⚠️  WARNING: Global Sandbox Mode has been enabled, which requires a valid API key. If
-you'd like to disable, remove ${chalk.green('"input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }"')}
+you'd like to disable, remove ${chalk.green('"input AMPLIFY { globalAuthRule: AuthRule = { allow: public } }"')}
 from your GraphQL schema and run 'amplify push' again. If you'd like to proceed with
 sandbox mode disabled, do not create an API Key.
 `,
@@ -62,7 +62,7 @@ sandbox mode disabled, do not create an API Key.
   describe('schemaHasSandboxModeEnabled', () => {
     it('parses sandbox AMPLIFY input on schema', () => {
       const schema = `
-        input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }
+        input AMPLIFY { globalAuthRule: AuthRule = { allow: public } }
       `;
 
       expect(schemaHasSandboxModeEnabled(schema)).toEqual(true);
@@ -80,19 +80,27 @@ sandbox mode disabled, do not create an API Key.
     });
 
     describe('input AMPLIFY has incorrect values', () => {
-      it('checks for "global_auth_rule"', () => {
+      it('checks for "globalAuthRule"', () => {
         const schema = `
           input AMPLIFY { auth_rule: AuthenticationRule = { allow: public } }
         `;
 
         expect(() => schemaHasSandboxModeEnabled(schema)).toThrow(
-          Error('input AMPLIFY requires "global_auth_rule" field. Learn more here: https://docs.amplify.aws/cli/graphql-transformer/auth'),
+          Error('input AMPLIFY requires "globalAuthRule" field. Learn more here: https://docs.amplify.aws/cli/graphql-transformer/auth'),
         );
+      });
+
+      it('allows "global_auth_rule"', () => {
+        const schema = `
+          input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }
+        `;
+
+        expect(schemaHasSandboxModeEnabled(schema)).toEqual(true);
       });
 
       it('guards for AuthRule', () => {
         const schema = `
-          input AMPLIFY { global_auth_rule: AuthenticationRule = { allow: public } }
+          input AMPLIFY { globalAuthRule: AuthenticationRule = { allow: public } }
         `;
 
         expect(() => schemaHasSandboxModeEnabled(schema)).toThrow(
@@ -104,7 +112,7 @@ sandbox mode disabled, do not create an API Key.
 
       it('checks for "allow" field name', () => {
         const schema = `
-          input AMPLIFY { global_auth_rule: AuthRule = { allows: public } }
+          input AMPLIFY { globalAuthRule: AuthRule = { allows: public } }
         `;
 
         expect(() => schemaHasSandboxModeEnabled(schema)).toThrow(
@@ -116,7 +124,7 @@ sandbox mode disabled, do not create an API Key.
 
       it('checks for "public" value from "allow" field', () => {
         const schema = `
-          input AMPLIFY { global_auth_rule: AuthRule = { allow: private } }
+          input AMPLIFY { globalAuthRule: AuthRule = { allow: private } }
         `;
 
         expect(() => schemaHasSandboxModeEnabled(schema)).toThrowError(

--- a/packages/amplify-provider-awscloudformation/src/utils/sandbox-mode-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/sandbox-mode-helpers.ts
@@ -5,7 +5,6 @@ import { printer } from 'amplify-prompts';
 import { parse } from 'graphql';
 
 const AMPLIFY = 'AMPLIFY';
-const GLOBAL_AUTH_RULE = 'global_auth_rule';
 const AUTHORIZATION_RULE = 'AuthRule';
 const ALLOW = 'allow';
 const PUBLIC = 'public';
@@ -15,7 +14,7 @@ export async function showSandboxModePrompts(context: $TSContext): Promise<any> 
     printer.info(
       `
 ⚠️  WARNING: Global Sandbox Mode has been enabled, which requires a valid API key. If
-you'd like to disable, remove ${chalk.green('"input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }"')}
+you'd like to disable, remove ${chalk.green('"input AMPLIFY { globalAuthRule: AuthRule = { allow: public } }"')}
 from your GraphQL schema and run 'amplify push' again. If you'd like to proceed with
 sandbox mode disabled, do not create an API Key.
 `,
@@ -34,6 +33,10 @@ export function showGlobalSandboxModeWarning(): void {
   );
 }
 
+function matchesGlobalAuth(field: any): boolean {
+  return ['global_auth_rule', 'globalAuthRule'].includes(field.name.value);
+}
+
 export function schemaHasSandboxModeEnabled(schema: string): boolean {
   const { definitions } = parse(schema);
   const amplifyInputType: any = definitions.find((d: any) => d.kind === 'InputObjectTypeDefinition' && d.name.value === AMPLIFY);
@@ -42,10 +45,10 @@ export function schemaHasSandboxModeEnabled(schema: string): boolean {
     return false;
   }
 
-  const authRuleField = amplifyInputType.fields.find(f => f.name.value === GLOBAL_AUTH_RULE);
+  const authRuleField = amplifyInputType.fields.find(matchesGlobalAuth);
 
   if (!authRuleField) {
-    throw Error('input AMPLIFY requires "global_auth_rule" field. Learn more here: https://docs.amplify.aws/cli/graphql-transformer/auth');
+    throw Error('input AMPLIFY requires "globalAuthRule" field. Learn more here: https://docs.amplify.aws/cli/graphql-transformer/auth');
   }
 
   const typeName = authRuleField.type.name.value;


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Changes the Global Auth field from `global_auth_rule` to `globalAuthRule`. Non breaking as new projects and text specifies `globalAuthRule`, but the compile still works with `global_auth_rule`.

#### Description of how you validated changes
Run unit tests and test binary locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
