### PR TITLE
fix: reload feature flags after gql v2 flag migration

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
@@ -630,7 +630,7 @@ export function getTransformerVersion(context) {
   return transformerVersion;
 }
 
-function migrateToTransformerVersionFeatureFlag(context) {
+async function migrateToTransformerVersionFeatureFlag(context) {
   const projectPath = pathManager.findProjectRoot() ?? process.cwd();
 
   let config = stateManager.getCLIJSON(projectPath, undefined, {
@@ -644,6 +644,7 @@ function migrateToTransformerVersionFeatureFlag(context) {
   if (useExperimentalPipelineTransformer && transformerVersion === 1) {
     config.features.graphqltransformer.transformerversion = 2;
     stateManager.setCLIJSON(projectPath, config);
+    await FeatureFlags.reloadValues();
 
     context.print.warning(
       `\nThe project is configured with 'transformerVersion': ${transformerVersion}, but 'useExperimentalPipelinedTransformer': ${useExperimentalPipelineTransformer}. Setting the 'transformerVersion': ${config.features.graphqltransformer.transformerversion}. 'useExperimentalPipelinedTransformer' is deprecated.`,


### PR DESCRIPTION
#### Description of changes
This commit reloads the feature flags if `migrateToTransformerVersionFeatureFlag()` writes new values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
