### PR TITLE
feat: implement function hotswap feature

### DIFF
--- a/packages/amplify-category-function/Readme.md
+++ b/packages/amplify-category-function/Readme.md
@@ -4,9 +4,10 @@
 
 The following table lists the current set of commands supported by the Amplify Function Category Plugin.
 
-| Command              | Description |
-| --- | --- |
-| amplify function add | Takes you through steps in the CLI to add a function resource to your backend.   |
-| amplify function push | Provisions only function cloud resources with the latest local developments.  |
-| amplify function build | Builds node_modules for all of the function resources in the project. |
+| Command                 | Description                                                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| amplify function add    | Takes you through steps in the CLI to add a function resource to your backend.                                          |
+| amplify function push   | Provisions only function cloud resources with the latest local developments.                                            |
+| amplify function build  | Builds node_modules for all of the function resources in the project.                                                   |
 | amplify function remove | Removes the function resource from your local backend. The resource is removed from the cloud on the next push command. |
+| amplify function watch  | Watch amplify/backend/function/\* and update the function code. (for development, not production)                       |

--- a/packages/amplify-category-function/amplify-plugin.json
+++ b/packages/amplify-category-function/amplify-plugin.json
@@ -1,9 +1,10 @@
 {
   "name": "function",
   "type": "category",
-  "commands": ["add", "build", "console", "invoke", "push", "remove", "update", "help"],
+  "commands": ["add", "build", "console", "invoke", "push", "remove", "update", "watch", "help"],
   "commandAliases": {
-    "configure": "update"
+    "configure": "update",
+    "hotswap": "watch"
   },
   "eventHandlers": ["PrePush", "PostPush", "InternalOnlyPostEnvRemove"]
 }

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -25,8 +25,10 @@
     "amplify-cli-core": "1.31.1",
     "amplify-function-plugin-interface": "1.9.1",
     "archiver": "^5.3.0",
+    "async-lock": "^1.3.0",
     "aws-sdk": "^2.963.0",
     "chalk": "^4.1.1",
+    "chokidar": "^3.5.2",
     "cloudform-types": "^4.2.0",
     "enquirer": "^2.3.6",
     "folder-hash": "^4.0.1",
@@ -43,6 +45,7 @@
     "uuid": "^3.4.0"
   },
   "devDependencies": {
+    "@types/async-lock": "^1.1.3",
     "@types/folder-hash": "^4.0.0"
   },
   "jest": {

--- a/packages/amplify-category-function/src/commands/function.ts
+++ b/packages/amplify-category-function/src/commands/function.ts
@@ -34,6 +34,10 @@ module.exports = {
         name: 'build',
         description: 'Builds all the functions in the project (does an npm install on the functions src directory)',
       },
+      {
+        name: 'watch',
+        description: 'Watch amplify/backend/function/* and update the function code (for development, not production)',
+      },
     ];
 
     context.amplify.showHelp(header, commands);

--- a/packages/amplify-category-function/src/commands/function/watch.ts
+++ b/packages/amplify-category-function/src/commands/function/watch.ts
@@ -1,0 +1,17 @@
+import { $TSContext } from 'amplify-cli-core';
+import { startWatcher } from '../../provider-utils/awscloudformation/utils/watch';
+
+const subcommand = 'watch';
+
+module.exports = {
+  name: subcommand,
+  alias: ['hotswap'],
+  run: async (context: $TSContext) => {
+    return startWatcher(context).catch(err => {
+      context.print.info(err.stack);
+      context.print.error('There was an error watching the function code');
+      context.usageData.emitError(err);
+      process.exitCode = 1;
+    });
+  },
+};

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/watch.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/watch.ts
@@ -1,0 +1,179 @@
+import { $TSAny, $TSContext, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
+import { ProjectLayer } from 'amplify-function-plugin-interface';
+import AsyncLock from 'async-lock';
+import chalk from 'chalk';
+import chokidar from 'chokidar';
+import fs from 'fs';
+import ora from 'ora';
+import path from 'path';
+import { buildFunction } from './buildFunction';
+import { ServiceName } from './constants';
+import { packageResource } from './package';
+
+const asyncLock = new AsyncLock();
+
+export async function startWatcher(context: $TSContext) {
+  const spinner = ora('Initializing...').start();
+  const lambdaClient = await getLambdaSdk(context);
+  spinner.succeed('Initialized');
+
+  chokidar
+    .watch(path.join(pathManager.getBackendDirPath(), 'function'), {
+      ignoreInitial: true,
+      ignored: /(dist|bin|obj|.*awscloudformation-template.json)/,
+    })
+    .on('all', (_event, changedPath) => {
+      onFileChange(context, lambdaClient, changedPath);
+    });
+}
+
+async function onFileChange(context: $TSContext, lambdaClient: $TSAny, changedPath: string) {
+  const resourcesToBuild = await getResourcesToBuild(context, changedPath);
+
+  await Promise.all(
+    resourcesToBuild.map(async resource => {
+      const { resourceName } = resource;
+
+      if (asyncLock.isBusy(resourceName)) {
+        return;
+      }
+
+      chalk.green(`Changes detected at ${changedPath}`);
+
+      await asyncLock.acquire(resourceName, async () => {
+        const zipFile = await createZip(context, resource);
+        if (!zipFile) {
+          chalk.yellow('There was no change in the package');
+          return;
+        }
+
+        switch (resource.service) {
+          case ServiceName.LambdaFunction:
+            return updateFunction(context, lambdaClient, resourceName, zipFile);
+          case ServiceName.LambdaLayer:
+            return updateLayer(context, lambdaClient, resourceName, zipFile);
+          default: // passthrough
+        }
+      });
+    }),
+  );
+}
+
+async function getLambdaSdk(context: $TSContext) {
+  const providerPlugin = await import(context.amplify.getProviderPlugins(context).awscloudformation);
+  return providerPlugin.getLambdaSdk(context);
+}
+
+async function getResourcesToBuild(context: $TSContext, changedPath: string) {
+  const resourceName = findResourceNameByChangedPath(changedPath);
+  if (!resourceName) return [];
+
+  const resourceStatus = await context.amplify.getResourceStatus('function', resourceName);
+  const { allResources } = resourceStatus;
+  return allResources
+    .filter(resource => resource.build)
+    .filter(resource => resource.service === ServiceName.LambdaFunction || resource.service === ServiceName.LambdaLayer);
+}
+
+function findResourceNameByChangedPath(changedPath: string): string | null {
+  const { sep } = path;
+  const match = changedPath.match(new RegExp(`function${sep}([^${sep}]*)${sep}`));
+  if (!match) return null;
+
+  return match[1];
+}
+
+async function createZip(context: $TSContext, resource: $TSAny) {
+  resource.lastBuildTimeStamp = await buildFunction(context, resource);
+
+  const { newPackageCreated, zipFilePath } = await packageResource(context, resource);
+  if (!newPackageCreated) return;
+
+  return fs.promises.readFile(zipFilePath);
+}
+
+async function updateFunction(context: $TSContext, lambdaClient: $TSAny, resourceName: string, zipFile: Buffer) {
+  const spinner = ora(`Updating function code... ${resourceName}`).start();
+
+  try {
+    const amplifyMeta = stateManager.getMeta();
+    const categoryAmplifyMeta = amplifyMeta.function;
+    const functionArn = categoryAmplifyMeta[resourceName].output.Arn;
+
+    await lambdaClient.updateFunctionCode(functionArn, zipFile);
+
+    spinner.succeed(`Function update successful ${resourceName}`);
+  } catch (e) {
+    spinner.fail(`Function update failed ${resourceName}`);
+    throw e;
+  } finally {
+    spinner.stop();
+  }
+}
+
+async function updateLayer(context: $TSContext, lambdaClient: $TSAny, resourceName: string, zipFile: Buffer) {
+  const spinner = ora(`Updating layer code... ${resourceName}`).start();
+
+  try {
+    const { runtimes } = JSONUtilities.readJson<{ runtimes: string[] }>(
+      path.join(pathManager.getBackendDirPath(), 'function', resourceName, 'parameters.json'),
+    );
+    const layer = await lambdaClient.updateLayer(resourceName, runtimes, zipFile);
+
+    const amplifyMeta = stateManager.getMeta();
+    const categoryAmplifyMeta = amplifyMeta.function;
+
+    await Promise.all(
+      findReferencedFunctionNames(context, resourceName).map(dependencyResourceName =>
+        updateLayerVersion(categoryAmplifyMeta, lambdaClient, layer, dependencyResourceName),
+      ),
+    );
+
+    spinner.succeed(`Layer code update successful ${resourceName}`);
+  } catch (e) {
+    spinner.fail(`Layer code update failed ${resourceName}`);
+    throw e;
+  } finally {
+    spinner.stop();
+  }
+}
+
+function findReferencedFunctionNames(context: $TSContext, resourceName: string): string[] {
+  const amplifyMeta = stateManager.getMeta();
+  const categoryAmplifyMeta = amplifyMeta.function;
+
+  return Object.keys(categoryAmplifyMeta)
+    .map(key => {
+      return { key, value: categoryAmplifyMeta[key] };
+    })
+    .filter(({ key, value: { dependsOn } }) => {
+      if (!dependsOn) return false;
+
+      const dependency = dependsOn.find(dependency => dependency.resourceName === resourceName);
+      if (!dependency) return false;
+
+      const parametersJSONPath = path.join(pathManager.getBackendDirPath(), 'function', key, 'function-parameters.json');
+      const { lambdaLayers } = JSONUtilities.readJson<{ lambdaLayers: ProjectLayer[] }>(parametersJSONPath);
+      const isLatestDependency = Boolean(lambdaLayers.find(layer => layer.resourceName === resourceName && layer.isLatestVersionSelected));
+
+      return dependency && isLatestDependency;
+    })
+    .map(({ key }) => key)
+    .sort();
+}
+
+async function updateLayerVersion(categoryAmplifyMeta: $TSAny, lambdaClient: $TSAny, layer: $TSAny, resourceName: string) {
+  const spinner = ora(`Updating function layer configuration... ${resourceName}`).start();
+
+  try {
+    const functionArn = categoryAmplifyMeta[resourceName].output.Arn;
+    await asyncLock.acquire(resourceName, () => lambdaClient.updateLayerVersion(functionArn, layer.LayerVersionArn));
+
+    spinner.succeed(`Function layer configuration update successful ${resourceName}`);
+  } catch (e) {
+    spinner.fail(`Function layer configuration update failed ${resourceName}`);
+    throw e;
+  } finally {
+    spinner.stop();
+  }
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

I implemented the `amplify function hotswap` command. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/8642

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I have mainly tested this feature manually.

```sh
$ amplify-dev function help

$ amplify-dev init
$ amplify-dev add function # JavaScript
$ amplify-dev add function # Python
$ amplify-dev add function # Go
$ amplify-dev add function # Java
$ amplify-dev add function # .NET
$ amplify-dev add function # JavaScript layer
$ amplify-dev update function # connect javascript layer to javascript function (latest)
$ amplify-dev update function # connect javascript layer to javascript function (specific version)

# start hotswap
$ amplify-dev watch function 
# ... or ...
$ amplify-dev hotswap function

# start the process to detect code changes
$ while true; do aws lambda invoke --function-name $ANY_FUNCTION_NAME /dev/stdout | jq; sleep 1; done

# change source code
$ vim amplify/backend/function/js/src/index.js
$ vim amplify/backend/function/python/src/index.py
$ vim amplify/backend/function/jslayer/lib/nodejs/index.js # and more...
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
