### PR TITLE
feat: overrides uniformity accross all the categories

### DIFF
--- a/packages/amplify-category-auth/resources/overrides-resource/override.ts
+++ b/packages/amplify-category-auth/resources/overrides-resource/override.ts
@@ -1,5 +1,3 @@
 import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-overrides-helper';
 
-export function overrideProps(props: AmplifyAuthCognitoStackTemplate) {
-  return props;
-}
+export function override(resources: AmplifyAuthCognitoStackTemplate) {}

--- a/packages/amplify-category-auth/resources/overrides-resource/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/package.json
@@ -8,8 +8,6 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@types/fs-extra": "^9.0.11",
-      "fs-extra": "^9.1.0",
       "@aws-amplify/cli-overrides-helper": "1.1.0-ext11.0"
     },
     "devDependencies": {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -110,7 +110,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
         formatter.list(['No override File Found', `To override ${this.resourceName} run amplify override auth`]);
         return '';
       });
-      const cognitoStackTemplateObj = this._authTemplateObj as AmplifyAuthCognitoStack & AmplifyStackTemplate;
+
       const sandboxNode = new vm.NodeVM({
         console: 'inherit',
         timeout: 5000,
@@ -122,9 +122,9 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
         },
       });
       try {
-        this._authTemplateObj = await sandboxNode
+        await sandboxNode
           .run(overrideCode, path.join(overrideDir, 'build', 'override.js'))
-          .overrideProps(cognitoStackTemplateObj);
+          .override(this._authTemplateObj as AmplifyAuthCognitoStack & AmplifyStackTemplate);
       } catch (err: $TSAny) {
         const error = new Error(`Skipping override due to ${err}${os.EOL}`);
         printer.error(`${error}`);

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -183,14 +183,13 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
         formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override auth`]);
         return '';
       });
-      const cognitoStackTemplateObj = this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate;
       const sandboxNode = new vm.NodeVM({
         console: 'inherit',
         timeout: 5000,
         sandbox: {},
       });
       try {
-        this._userPoolGroupTemplateObj = sandboxNode.run(overrideCode).overrideProps(cognitoStackTemplateObj);
+        sandboxNode.run(overrideCode).override(this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate);
       } catch (err: $TSAny) {
         const error = new Error(`Skipping override due to ${err}${os.EOL}`);
         printer.error(`${error}`);

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -40,7 +40,8 @@
     "inquirer": "^7.3.3",
     "lodash": "^4.17.21",
     "promise-sequential": "^1.1.1",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "vm2": "^3.9.3"
   },
   "devDependencies": {
     "aws-sdk": "^2.963.0",

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts
@@ -1,5 +1,3 @@
 import { AmplifyDDBResourceTemplate } from '@aws-amplify/cli-overrides-helper';
 
-export function overrideProps(props: AmplifyDDBResourceTemplate) {
-  return props;
-}
+export function override(resources: AmplifyDDBResourceTemplate) {}

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "overrides-for-root-stack",
+    "name": "overrides-dependencies",
     "version": "1.0.0",
     "description": "",
     "scripts": {
@@ -8,8 +8,6 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@types/fs-extra": "^9.0.11",
-      "fs-extra": "^9.1.0",
       "@aws-amplify/cli-overrides-helper": "1.1.0-ext11.0"
       
     },

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts
@@ -1,5 +1,3 @@
 import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-overrides-helper';
 
-export function overrideProps(props: AmplifyS3ResourceTemplate) {
-  return props;
-}
+export function override(resources: AmplifyS3ResourceTemplate) {}

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "overrides-for-root-stack",
+    "name": "overrides-dependencies",
     "version": "1.0.0",
     "description": "",
     "scripts": {
@@ -8,8 +8,6 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@types/fs-extra": "^9.0.11",
-      "fs-extra": "^9.1.0",
       "@aws-amplify/cli-overrides-helper": "1.1.0-ext11.0"
     },
     "devDependencies": {

--- a/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
@@ -4,7 +4,6 @@ import execa from 'execa';
 import * as path from 'path';
 import { printer, prompter } from 'amplify-prompts';
 import { JSONUtilities } from '../jsonUtilities';
-import { initial } from 'lodash';
 
 export const generateOverrideSkeleton = async (context: $TSContext, srcResourceDirPath: string, destDirPath: string): Promise<void> => {
   // 1. Create skeleton package

--- a/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
@@ -4,6 +4,7 @@ import execa from 'execa';
 import * as path from 'path';
 import { printer, prompter } from 'amplify-prompts';
 import { JSONUtilities } from '../jsonUtilities';
+import { initial } from 'lodash';
 
 export const generateOverrideSkeleton = async (context: $TSContext, srcResourceDirPath: string, destDirPath: string): Promise<void> => {
   // 1. Create skeleton package
@@ -25,7 +26,7 @@ export const generateOverrideSkeleton = async (context: $TSContext, srcResourceD
   await buildOverrideDir(backendDir, destDirPath);
 
   printer.success(`Successfully generated "override.ts" folder at ${destDirPath}`);
-  const isOpen = await prompter.confirmContinue('Do you want to edit override.ts file now?');
+  const isOpen = await prompter.yesOrNo('Do you want to edit override.ts file now?', true);
   if (isOpen) {
     await context.amplify.openEditor(context, overrideFile);
   }

--- a/packages/amplify-cli/amplify-plugin.json
+++ b/packages/amplify-cli/amplify-plugin.json
@@ -21,7 +21,7 @@
     "uninstall",
     "upgrade",
     "version",
-    "build-override"
+    "build"
   ],
   "commandAliases": {
     "h": "help",

--- a/packages/amplify-cli/src/__tests__/commands/build.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/build.test.ts
@@ -1,11 +1,11 @@
-import { run } from '../../commands/build-override';
+import { run } from '../../commands/build';
 import { $TSContext } from 'amplify-cli-core';
 
 jest.mock('amplify-cli-core');
 jest.mock('amplify-provider-awscloudformation');
 
-describe('run build-override command', () => {
-  it('runs override command for only a resource', async () => {
+describe('run build command', () => {
+  it('runs build command for only a resource', async () => {
     const context_stub = {
       amplify: {
         getResourceStatus: jest.fn().mockResolvedValue({
@@ -48,7 +48,7 @@ describe('run build-override command', () => {
     expect(context_stub_typed.amplify.invokePluginMethod).toBeCalledTimes(1);
   });
 
-  it('runs override command for only all resources in a category', async () => {
+  it('runs build command for only all resources in a category', async () => {
     const context_stub = {
       amplify: {
         getResourceStatus: jest.fn().mockResolvedValue({
@@ -91,7 +91,7 @@ describe('run build-override command', () => {
     expect(context_stub_typed.amplify.invokePluginMethod).toBeCalledTimes(3);
   });
 
-  it('runs override command successfully for all resources in all categories', async () => {
+  it('runs build command successfully for all resources in all categories', async () => {
     const context_stub = {
       amplify: {
         getResourceStatus: jest.fn().mockResolvedValue({

--- a/packages/amplify-cli/src/commands/build.ts
+++ b/packages/amplify-cli/src/commands/build.ts
@@ -3,7 +3,7 @@ import { printer } from 'amplify-prompts';
 /**
  * Command to transform CFN with overrides
  */
-const subcommand = 'build-override';
+const subcommand = 'build';
 
 export const run = async (context: $TSContext) => {
   const categoryName = context?.input?.subCommands?.[0];

--- a/packages/amplify-cli/src/commands/export.ts
+++ b/packages/amplify-cli/src/commands/export.ts
@@ -10,7 +10,7 @@ import { printer } from 'amplify-prompts';
 import chalk from 'chalk';
 import { getResourceOutputs } from '../extensions/amplify-helpers/get-resource-outputs';
 import Ora from 'ora';
-import { getResources } from './build-override';
+import { getResources } from './build';
 import * as _ from 'lodash';
 
 export const run = async (context: $TSContext) => {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -1,6 +1,6 @@
 import { $TSAny, $TSContext, EnvironmentDoesNotExistError, exitOnNextTick, IAmplifyResource, stateManager } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
-import { getResources } from '../../commands/build-override';
+import { getResources } from '../../commands/build';
 import { initializeEnv } from '../../initialize-env';
 import { getEnvInfo } from './get-env-info';
 import { getProjectConfig } from './get-project-config';

--- a/packages/amplify-e2e-core/src/categories/storage.ts
+++ b/packages/amplify-e2e-core/src/categories/storage.ts
@@ -244,7 +244,7 @@ export function overrideDDB(cwd: string, settings: {}) {
 export function buildOverrideStorage(cwd: string, settings: {}) {
   return new Promise((resolve, reject) => {
     // Add 'storage' as a category param once implemented
-    const args = ['build-override'];
+    const args = ['build'];
 
     spawn(getCLIPath(), args, { cwd, stripColors: true })
       .sendEof()

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts
@@ -1,5 +1,3 @@
 import { AmplifyRootStackTemplate } from '@aws-amplify/cli-overrides-helper';
 
-export function overrideProps(props: AmplifyRootStackTemplate) {
-  return props;
-}
+export function override(resources: AmplifyRootStackTemplate) {}

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "overrides-for-root-stack",
+    "name": "overrides-dependencies",
     "version": "1.0.0",
     "description": "",
     "scripts": {
@@ -8,8 +8,6 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@types/fs-extra": "^9.0.11",
-      "fs-extra": "^9.1.0",
       "@aws-amplify/cli-overrides-helper": "1.1.0-ext11.0"
     },
     "devDependencies": {

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -60,14 +60,13 @@ export class AmplifyRootStackTransform {
         amplifyPrinter.formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override auth`]);
         return '';
       });
-      const rootStackTemplateObj = this._rootTemplateObj as AmplifyRootStackTemplate;
       const sandboxNode = new vm.NodeVM({
         console: 'inherit',
         timeout: 5000,
         sandbox: {},
       });
       try {
-        this._rootTemplateObj = sandboxNode.run(overrideCode).overrideProps(rootStackTemplateObj);
+        sandboxNode.run(overrideCode).overrideProps(this._rootTemplateObj);
       } catch (err: $TSAny) {
         const error = new Error(`Skipping override due to ${err}${os.EOL}`);
         printer.error(`${error}`);


### PR DESCRIPTION
1. Rename "overrideProps" to "override"
2. Rename "props" parameter to "resources"
3. Remove "return props" requirement and test that it doesn't crash
4. "✔ Do you want to edit override.ts file now? (y/N)" should default to "true"
5. Support for: amplify build -> from amplify build-override
6. Changes are applied to all categories
7. use vm2 uniformly