### PR TITLE
test: add more @http v2 E2E tests

### DIFF
--- a/packages/graphql-transformers-e2e-tests/resources/jsonServer/src-server/index.js
+++ b/packages/graphql-transformers-e2e-tests/resources/jsonServer/src-server/index.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -13,6 +13,14 @@ fs.writeFileSync(writableDbPath, JSON.stringify(db));
 const app = jsonServer.create();
 const router = jsonServer.router(writableDbPath);
 const middlewares = jsonServer.defaults();
+
+app.use('/config/:region/:env', (req, res) => {
+  res.json({
+    apiKey: req.headers['x-api-key'],
+    env: req.params.env,
+    region: req.params.region,
+  });
+});
 
 app.use(middlewares);
 app.use(router);


### PR DESCRIPTION
#### Description of changes
This commit adds E2E tests for the `@http` v2 directive. This verifies `${env}`, `${aws_region}`, and request header behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
