### PR TITLE
feat: add default descriptions to cfn templates for metrics tracking

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/initializer.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/initializer.test.ts
@@ -21,6 +21,11 @@ describe('run', () => {
   it('transforms the root stack using the pre-push modifier', async () => {
     // setup
     const context_stub = {
+      pluginPlatform: {
+        plugins: {
+          core: [{ packageVersion: '5.2' }],
+        },
+      },
       exeInfo: {
         isNewEnv: true,
         projectConfig: {

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -2,6 +2,7 @@ import { $TSContext, FeatureFlags, Template, pathManager, PathConstants, stateMa
 import _ from 'lodash';
 import { transformRootStack } from './override-manager';
 import { rootStackFileName } from './push-resources';
+import { getDefaultTemplateDescription } from './template-description-utils';
 
 const moment = require('moment');
 const path = require('path');
@@ -56,10 +57,7 @@ export async function run(context) {
 
     await prePushCfnTemplateModifier(rootStack);
 
-    // Track Amplify Console generated stacks
-    if (!!process.env.CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_DELETION) {
-      rootStack.Description = 'Root Stack for AWS Amplify Console';
-    }
+    rootStack.Description = getDefaultTemplateDescription(context, 'root');
 
     // deploy steps
     const params = {

--- a/packages/amplify-provider-awscloudformation/src/template-description-utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/template-description-utils.ts
@@ -1,0 +1,98 @@
+import { $TSAny, $TSContext, readCFNTemplate, writeCFNTemplate } from 'amplify-cli-core';
+import * as os from 'os';
+import * as path from 'path';
+import { getCfnFiles } from './push-resources';
+
+enum DeploymentTypes {
+  AMPLIFY_CLI = 'Amplify',
+  AMPLIFY_ADMIN = 'AmplifyAdmin',
+}
+
+enum SupportedPlatforms {
+  WINDOWS = 'Windows',
+  MAC = 'Mac',
+  LINUX = 'Linux',
+  OTHER = 'Other',
+}
+
+type TemplateDescription = {
+  createdOn: SupportedPlatforms;
+  createdBy: DeploymentTypes;
+  createdWith: string;
+  stackType: string;
+  metadata: object;
+};
+
+export async function prePushTemplateDescriptionHandler(context: $TSContext, resourcesToBeCreated: $TSAny) {
+  let promises = [];
+
+  for (const { category, resourceName, service } of resourcesToBeCreated) {
+    const { resourceDir, cfnFiles } = getCfnFiles(category, resourceName);
+    for (const cfnFile of cfnFiles) {
+      const cfnFilePath = path.resolve(path.join(resourceDir, cfnFile));
+      promises.push(await setDefaultTemplateDescription(context, category, resourceName, service, cfnFilePath));
+    }
+  }
+
+  await Promise.all(promises);
+}
+
+export async function setDefaultTemplateDescription(
+  context: $TSContext,
+  category: string,
+  resourceName: string,
+  service: string,
+  cfnFilePath: string,
+) {
+  const { templateFormat, cfnTemplate } = readCFNTemplate(cfnFilePath);
+
+  cfnTemplate.Description = getDefaultTemplateDescription(context, category, service);
+
+  await writeCFNTemplate(cfnTemplate, cfnFilePath, { templateFormat });
+}
+
+export function getDefaultTemplateDescription(context: $TSContext, category: string, service?: string): string {
+  let descriptionJson: TemplateDescription;
+
+  // get platform "createdOn"
+
+  let platformDescription: SupportedPlatforms;
+  let deploymentTypeDescription: DeploymentTypes;
+  let stackTypeDescription: string;
+
+  const platform = os.platform();
+
+  if (platform == 'darwin') {
+    platformDescription = SupportedPlatforms.MAC;
+  } else if (platform == 'win32') {
+    platformDescription = SupportedPlatforms.WINDOWS;
+  } else if (platform == 'linux') {
+    platformDescription = SupportedPlatforms.LINUX;
+  } else {
+    platformDescription = SupportedPlatforms.OTHER;
+  }
+
+  // get deployment mchanism "createdBy"
+
+  if (!!process.env.CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_DELETION) {
+    deploymentTypeDescription = DeploymentTypes.AMPLIFY_ADMIN;
+  } else {
+    deploymentTypeDescription = DeploymentTypes.AMPLIFY_CLI;
+  }
+
+  // get CLI version number "createdWith"
+  const cliVersion = context.pluginPlatform.plugins.core[0].packageVersion;
+
+  // get stack type "stackType"
+  stackTypeDescription = service ? `${category}-${service}` : category;
+
+  descriptionJson = {
+    createdOn: platformDescription,
+    createdBy: deploymentTypeDescription,
+    createdWith: cliVersion,
+    stackType: stackTypeDescription,
+    metadata: {},
+  };
+
+  return JSON.stringify(descriptionJson);
+}


### PR DESCRIPTION
Add default descriptions to root and sub-stacks at create time.

SampleRoot-stack description: 

{"createdOn":"Mac","createdBy":"Amplify","createdWith":"6.3.1","stackType":"root","metadata":{}}

Sample category sub-stack description: 

{"createdOn":"Mac","createdBy":"Amplify","createdWith":"6.3.1","stackType":"storage-S3","metadata":{}}