### PR TITLE
fix(cli): rewire override project to override rootStack internally

### DIFF
--- a/packages/amplify-cli/src/input-manager.ts
+++ b/packages/amplify-cli/src/input-manager.ts
@@ -10,7 +10,7 @@ export function getCommandLineInput(pluginPlatform: PluginPlatform): Input {
   /* tslint:disable */
   if (result.argv && result.argv.length > 2) {
     let index = 2;
-
+    aliasArgs(result.argv);
     // pick up plugin name, allow plugin name to be in the 2nd or 3rd position
     const pluginNames = getAllPluginNames(pluginPlatform);
 
@@ -192,4 +192,10 @@ export function verifyInput(pluginPlatform: PluginPlatform, input: Input): Input
   }
 
   return result;
+}
+
+function aliasArgs(argv: string[]) {
+  if (argv.length >= 4 && argv[2] === 'override' && argv[3] === 'project') {
+    argv[3] = 'root';
+  }
 }

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -719,7 +719,7 @@ export function rebuildApi(projDir: string, apiName: string) {
 export function addRestContainerApiForCustomPolicies(projectDir: string, settings: { name: string }) {
   return new Promise<void>((resolve, reject) => {
     spawn(getCLIPath(), ['add', 'api'], { cwd: projectDir, stripColors: true })
-      .wait('Please select from one of the below mentioned services:')
+      .wait('Select from one of the below mentioned services:')
       .sendKeyDown()
       .sendCarriageReturn()
       .wait('Which service would you like to use')

--- a/packages/amplify-provider-awscloudformation/amplify-plugin.json
+++ b/packages/amplify-provider-awscloudformation/amplify-plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "awscloudformation",
-  "aliases": ["awscfn", "aws", "root", "project"],
+  "aliases": ["awscfn", "aws", "root"],
   "type": "provider",
   "commands": ["configure", "console", "reset-cache", "setupNewUser", "help", "override"],
   "commandAliases": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Test passing

 PASS  src/__tests__/configure-project.test.ts (153.965 s)
  amplify configure project tests
    ✓ should update the project to use access keys (12781 ms)
    ✓ should update the project to use a profile (12998 ms)
    ✓ should update the project to remove a profile (12539 ms)
    ✓ should update the project to add access keys when configLevel is general (12626 ms)
    ✓ should update the project to use a profile (12653 ms)



 PASS  src/__tests__/containers-api.test.ts (2270.977 s)
  amplify api add
  amplify api add
    ✓ init project, enable containers and add multicontainer api (1002251 ms)
    ✓ init project, enable containers and add multicontainer api push, edit and push (1259656 ms)

 PASS  src/__tests__/custom_policies_container.test.ts (914.739 s)
  ✓ should init and deploy a api container, attach custom policies to the Fargate task (912354 ms)






By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
