### PR TITLE
feat: consolidate dependent resource types in backend/

### DIFF
--- a/packages/amplify-category-custom/src/index.ts
+++ b/packages/amplify-category-custom/src/index.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { buildCustomResources } from './utils/build-custom-resources';
 import { categoryName } from './utils/constants';
 export { addCDKResourceDependency } from './utils/dependency-management-utils';
+export { generateDependentResourcesType } from './utils/build-custom-resources';
 
 export async function executeAmplifyCommand(context: $TSContext) {
   let commandPath = path.normalize(path.join(__dirname, 'commands'));

--- a/packages/amplify-category-custom/src/utils/build-custom-resources.ts
+++ b/packages/amplify-category-custom/src/utils/build-custom-resources.ts
@@ -4,7 +4,7 @@ import execa from 'execa';
 import * as fs from 'fs-extra';
 import ora from 'ora';
 import * as path from 'path';
-import { categoryName } from './constants';
+import { categoryName, TYPES_DIR_NAME, AMPLIFY_RESOURCES_TYPE_DEF_FILENAME } from './constants';
 import { getAllResources } from './dependency-management-utils';
 import { generateCloudFormationFromCDK } from './generate-cfn-from-cdk';
 
@@ -38,12 +38,14 @@ const getSelectedResources = async (context: $TSContext, resourceName?: string) 
   return (await context.amplify.getResourceStatus(categoryName, resourceName)).allResources as ResourceMeta[];
 };
 
-async function generateDependentResourcesType(context: $TSContext, resourceDirPath: string) {
+export async function generateDependentResourcesType(context: $TSContext) {
+  const resourceDirPath = path.join(pathManager.getBackendDirPath(), TYPES_DIR_NAME);
+
   const copyJobs = [
     {
       dir: resourcesDirRoot,
       template: amplifyDependentResourcesFilename,
-      target: path.join(resourceDirPath, 'amplify-dependent-resources-ref.d.ts'),
+      target: path.join(resourceDirPath, AMPLIFY_RESOURCES_TYPE_DEF_FILENAME),
     },
   ];
 
@@ -100,5 +102,5 @@ async function buildResource(context: $TSContext, resource: ResourceMeta) {
 
   await generateCloudFormationFromCDK(resource.resourceName);
 
-  await generateDependentResourcesType(context, targetDir);
+  await generateDependentResourcesType(context);
 }

--- a/packages/amplify-category-custom/src/utils/constants.ts
+++ b/packages/amplify-category-custom/src/utils/constants.ts
@@ -7,3 +7,5 @@ export const CFN_SERVICE_NAME = 'customCloudformation';
 export const DEPLOYMENT_PROVIDER_NAME = 'awscloudformation';
 export const customResourceCFNFilenameSuffix = `cloudformation-template.json`;
 export const cdkFileName = 'cdk-stack.ts';
+export const TYPES_DIR_NAME = 'types';
+export const AMPLIFY_RESOURCES_TYPE_DEF_FILENAME = 'amplify-dependent-resources-ref.d.ts';

--- a/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
+++ b/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
@@ -115,7 +115,7 @@ export function addCDKResourceDependency(
   dependentResources: AmplifyDependentResourceDefinition[],
 ) {
   const dependsOn: AmplifyDependentResourceDefinition[] = [];
-  const dependentParameters: $TSObject = {};
+  const dependentParameters: any = {};
 
   dependentResources.forEach(resource => {
     const attributeList = getResourceCfnOutputAttributes(resource.category, resource.resourceName);

--- a/packages/amplify-cli/src/__tests__/commands/build.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/build.test.ts
@@ -3,6 +3,7 @@ import { $TSContext } from 'amplify-cli-core';
 
 jest.mock('amplify-cli-core');
 jest.mock('amplify-provider-awscloudformation');
+jest.mock('@aws-amplify/amplify-category-custom');
 
 describe('run build command', () => {
   it('runs build command for only a resource', async () => {

--- a/packages/amplify-cli/src/commands/build.ts
+++ b/packages/amplify-cli/src/commands/build.ts
@@ -1,5 +1,6 @@
 import { $TSContext, IAmplifyResource } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
+import { generateDependentResourcesType } from '@aws-amplify/amplify-category-custom';
 /**
  * Command to transform CFN with overrides
  */
@@ -14,6 +15,7 @@ export const run = async (context: $TSContext) => {
   }
 
   try {
+    await generateDependentResourcesType(context);
     const resourcesToBuild: IAmplifyResource[] = await getResources(context);
     let filteredResources: IAmplifyResource[] = resourcesToBuild;
     if (categoryName) {

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -7,6 +7,7 @@ import { getProjectConfig } from './get-project-config';
 import { getProviderPlugins } from './get-provider-plugins';
 import { onCategoryOutputsChange } from './on-category-outputs-change';
 import { showResourceTable } from './resource-status';
+import { generateDependentResourcesType } from '@aws-amplify/amplify-category-custom';
 
 export async function pushResources(
   context: $TSContext,
@@ -53,6 +54,7 @@ export async function pushResources(
   }
 
   // building all CFN stacks here to get the resource Changes
+  await generateDependentResourcesType(context);
   const resourcesToBuild: IAmplifyResource[] = await getResources(context);
   await context.amplify.executeProviderUtils(context, 'awscloudformation', 'buildOverrides', { resourcesToBuild, forceCompile: true });
 

--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../amplify-provider-awscloudformation" },
     { "path": "../amplify-util-import" },
     { "path": "../graphql-transformer-core" },
-    { "path": "../amplify-category-auth" }
+    { "path": "../amplify-category-auth" },
+    { "path": "../amplify-category-custom" }
   ]
 }


### PR DESCRIPTION
1. Moved "amplify-dependent-resources-ref.d.ts" to amplify/backend/types folder instead of having multiple copies in each of the custom resource folder.
2. Generate "amplify-dependent-resources-ref.d.ts" as a part of amplify build and amplify push commands.