### PR TITLE
fix(graphql-model-transformer): subscription resolver logical id fix

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -752,7 +752,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
             typeName: 'Subscription',
             fieldName: fieldName,
             type: SubscriptionFieldType.ON_CREATE,
-            resolverLogicalId: ModelResourceIDs.ModelOnCreateSubscriptionName(type.name.value),
+            resolverLogicalId: ResolverResourceIDs.ResolverResourceID('Subscription', fieldName),
           });
         }
       }
@@ -763,7 +763,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
             typeName: 'Subscription',
             fieldName: fieldName,
             type: SubscriptionFieldType.ON_UPDATE,
-            resolverLogicalId: ModelResourceIDs.ModelOnUpdateSubscriptionName(type.name.value),
+            resolverLogicalId: ResolverResourceIDs.ResolverResourceID('Subscription', fieldName),
           });
         }
       }
@@ -774,7 +774,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
             typeName: 'Subscription',
             fieldName: fieldName,
             type: SubscriptionFieldType.ON_DELETE,
-            resolverLogicalId: ModelResourceIDs.ModelOnDeleteSubscriptionName(type.name.value),
+            resolverLogicalId: ResolverResourceIDs.ResolverResourceID('Subscription', fieldName),
           });
         }
       }

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -49,7 +49,6 @@ export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string): P
     }
   } catch (err) {
     // no need to error if not admin ui app
-    console.info('App not deployed yet.');
   }
 
   // lambda functions which have access to the api


### PR DESCRIPTION
#### Description of changes
- V2 subscription resolver logical ID should match V1 subscription resolver logical ID

#### Description of how you validated changes
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
