### PR TITLE
fix: override http datasource logical IDs

### DIFF
--- a/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
@@ -48,7 +48,7 @@ test('it generates the expected resources', () => {
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   parse(out.schema);
-  const stack = out.stacks.HttpDirectiveStack;
+  const stack = out.stacks.HttpStack;
   cdkExpect(stack).to(
     haveResource('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
@@ -254,7 +254,7 @@ test('URL params happy path', () => {
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   parse(out.schema);
-  const stack = out.stacks.HttpDirectiveStack;
+  const stack = out.stacks.HttpStack;
   cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 1));
   cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 7));
   expect(stack.Resources!.CommentcomplexResolver).toBeTruthy();
@@ -296,7 +296,7 @@ test('env on the URI path', () => {
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   parse(out.schema);
-  const stack = out.stacks.HttpDirectiveStack;
+  const stack = out.stacks.HttpStack;
   const reqTemplate = stack.Resources!.CommentcontentResolver.Properties.RequestMappingTemplate;
   expect(reqTemplate['Fn::Sub']).toBeTruthy();
   expect(reqTemplate['Fn::Sub'][0]).toMatch('"resourcePath": "/ping${env}"');
@@ -321,7 +321,7 @@ test('env on the hostname', () => {
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   parse(out.schema);
-  const stack = out.stacks.HttpDirectiveStack;
+  const stack = out.stacks.HttpStack;
   cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 4));
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::DataSource', {
@@ -411,7 +411,7 @@ test('aws_region on the URI path', () => {
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   parse(out.schema);
-  const stack = out.stacks.HttpDirectiveStack;
+  const stack = out.stacks.HttpStack;
   const reqTemplate = stack.Resources!.CommentcontentResolver.Properties.RequestMappingTemplate;
   expect(reqTemplate['Fn::Sub']).toBeTruthy();
   expect(reqTemplate['Fn::Sub'][0]).toMatch('"resourcePath": "/ping${aws_region}"');
@@ -436,7 +436,7 @@ test('aws_region on the hostname', () => {
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
   parse(out.schema);
-  const stack = out.stacks.HttpDirectiveStack;
+  const stack = out.stacks.HttpStack;
   cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 4));
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::DataSource', {

--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -59,7 +59,7 @@ type HttpDirectiveConfiguration = {
 const SPLIT_URL_REGEX = /(http(s)?:\/\/|www\.)|(\/.*)/g;
 const URL_REGEX = /(http(s)?:\/\/)|(\/.*)/g;
 const VALID_PROTOCOLS_REGEX = /^http(s)?:\/\//;
-const HTTP_DIRECTIVE_STACK = 'HttpDirectiveStack';
+const HTTP_DIRECTIVE_STACK = 'HttpStack';
 const RESOLVER_VERSION = '2018-05-29';
 const directiveDefinition = /* GraphQL */ `
   directive @http(method: HttpMethod = GET, url: String!, headers: [HttpHeader] = []) on FIELD_DEFINITION

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -927,7 +927,7 @@ Object {
       },
       "Type": "AWS::AppSync::Resolver",
     },
-    "RekognitionDataSourceC6790FED": Object {
+    "RekognitionDataSource": Object {
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
@@ -974,7 +974,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "TranslateDataSource2C33F90C": Object {
+    "TranslateDataSource": Object {
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
@@ -1081,7 +1081,7 @@ $util.toJson($ctx.result.url)",
     },
     "identifyLabelsFunctionidentifyLabelsFunctionAppSyncFunction7C2A1E61": Object {
       "DependsOn": Array [
-        "RekognitionDataSourceC6790FED",
+        "RekognitionDataSource",
       ],
       "Properties": Object {
         "ApiId": Object {
@@ -1089,7 +1089,7 @@ $util.toJson($ctx.result.url)",
         },
         "DataSourceName": Object {
           "Fn::GetAtt": Array [
-            "RekognitionDataSourceC6790FED",
+            "RekognitionDataSource",
             "Name",
           ],
         },
@@ -1159,7 +1159,7 @@ $util.error($ctx.result.body)
     },
     "identifyTextFunctionidentifyTextFunctionAppSyncFunction7877885A": Object {
       "DependsOn": Array [
-        "RekognitionDataSourceC6790FED",
+        "RekognitionDataSource",
       ],
       "Properties": Object {
         "ApiId": Object {
@@ -1167,7 +1167,7 @@ $util.error($ctx.result.body)
         },
         "DataSourceName": Object {
           "Fn::GetAtt": Array [
-            "RekognitionDataSourceC6790FED",
+            "RekognitionDataSource",
             "Name",
           ],
         },
@@ -1378,7 +1378,7 @@ $utils.error($ctx.result.body)
     },
     "translateTextFunctiontranslateTextFunctionAppSyncFunction77C9D7A9": Object {
       "DependsOn": Array [
-        "TranslateDataSource2C33F90C",
+        "TranslateDataSource",
       ],
       "Properties": Object {
         "ApiId": Object {
@@ -1386,7 +1386,7 @@ $utils.error($ctx.result.body)
         },
         "DataSourceName": Object {
           "Fn::GetAtt": Array [
-            "TranslateDataSource2C33F90C",
+            "TranslateDataSource",
             "Name",
           ],
         },

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -262,13 +262,17 @@ export class DefaultTransformHost implements TransformHostProvider {
    * @param stack Stack to which the http datasource needs to be created in
    */
   protected doAddHttpDataSource(id: string, endpoint: string, options?: HttpDataSourceOptions, stack?: Stack): HttpDataSource {
-    return new HttpDataSource(stack ?? this.api, id, {
+    const ds = new HttpDataSource(stack ?? this.api, id, {
       api: this.api,
       endpoint,
       name: options?.name,
       description: options?.description,
       authorizationConfig: options?.authorizationConfig,
     });
+
+    (ds as any).node.defaultChild.overrideLogicalId(id);
+
+    return ds;
   }
 
   /**


### PR DESCRIPTION
#### Description of changes
This commit overrides the logical IDs of http datasources
created by the gql v2 transformer to prevent issues when
migrating from v1. It also renames the `@http` stack to be
consistent with v1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
