### PR TITLE
fix: override none,DDB,lambda datasource logical IDs

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1193,7 +1193,6 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
 
     const cfnDataSource = dataSource.node.defaultChild as CfnDataSource;
     cfnDataSource.addDependsOn(role.node.defaultChild as CfnRole);
-    cfnDataSource.overrideLogicalId(datasourceRoleLogicalID);
 
     if (context.isProjectUsingDataStore()) {
       const datasourceDynamoDb = cfnDataSource.dynamoDbConfig as any;

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -134,7 +134,7 @@ Object {
     },
   },
   "Resources": Object {
-    "LambdaDataSource4DD51D23": Object {
+    "LambdaDataSource": Object {
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
@@ -1023,7 +1023,7 @@ Object {
     },
     "convertTextToSpeechFunctionconvertTextToSpeechFunctionAppSyncFunction15BC20B8": Object {
       "DependsOn": Array [
-        "LambdaDataSource4DD51D23",
+        "LambdaDataSource",
       ],
       "Properties": Object {
         "ApiId": Object {
@@ -1031,7 +1031,7 @@ Object {
         },
         "DataSourceName": Object {
           "Fn::GetAtt": Array [
-            "LambdaDataSource4DD51D23",
+            "LambdaDataSource",
             "Name",
           ],
         },

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -244,13 +244,17 @@ export class DefaultTransformHost implements TransformHostProvider {
    * @param stack  Stack to which this datasource needs to mapped to
    */
   protected doAddDynamoDbDataSource(id: string, table: ITable, options?: DynamoDbDataSourceOptions, stack?: Stack): DynamoDbDataSource {
-    return new DynamoDbDataSource(stack ?? this.api, id, {
+    const ds = new DynamoDbDataSource(stack ?? this.api, id, {
       api: this.api,
       table,
       name: options?.name,
       description: options?.description,
       serviceRole: options?.serviceRole,
     });
+
+    (ds as any).node.defaultChild.overrideLogicalId(id);
+
+    return ds;
   }
 
   /**

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -228,11 +228,15 @@ export class DefaultTransformHost implements TransformHostProvider {
    * @param stack  Stack to which this datasource needs to mapped to
    */
   protected doAddNoneDataSource(id: string, options?: DataSourceOptions, stack?: Stack): NoneDataSource {
-    return new NoneDataSource(stack ?? this.api, id, {
+    const ds = new NoneDataSource(stack ?? this.api, id, {
       api: this.api,
       name: options?.name,
       description: options?.description,
     });
+
+    (ds as any).node.defaultChild.overrideLogicalId(id);
+
+    return ds;
   }
 
   /**

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -308,11 +308,15 @@ export class DefaultTransformHost implements TransformHostProvider {
    * @param options The optional configuration for this data source
    */
   protected doAddLambdaDataSource(id: string, lambdaFunction: IFunction, options?: DataSourceOptions, stack?: Stack): LambdaDataSource {
-    return new LambdaDataSource(stack || this.api, id, {
+    const ds = new LambdaDataSource(stack || this.api, id, {
       api: this.api,
       lambdaFunction,
       name: options?.name,
       description: options?.description,
     });
+
+    (ds as any).node.defaultChild.overrideLogicalId(id);
+
+    return ds;
   }
 }


### PR DESCRIPTION
#### Description of changes
This PR overrides the CDK generated logical IDs for Lambda and None datasources to be compatible with transformer v1. This PR also moves the existing DDB datasource override logic for consistency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
