### PR TITLE
Remove pipelineFunction references in favor of resolvers

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/resolvers.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/resolvers.test.ts
@@ -32,7 +32,7 @@ describe('user created resolvers', () => {
     it('adds the overwritten resolver to the build', async () => {
       const resolverName = 'Query.listTodos.req.vtl';
       const resolver = '$util.unauthorized()';
-      const generatedResolverPath = join(projectDir, 'amplify', 'backend', 'api', apiName, 'build', 'pipelineFunctions', resolverName);
+      const generatedResolverPath = join(projectDir, 'amplify', 'backend', 'api', apiName, 'build', 'resolvers', resolverName);
 
       await addApiWithoutSchema(projectDir, { apiName });
       await updateApiSchema(projectDir, apiName, 'simple_model.graphql');
@@ -55,26 +55,8 @@ describe('user created resolvers', () => {
       const resolverReq = '$util.unauthorized()';
       const resolverRes = '$util.toJson({})';
 
-      const generatedReqResolverPath = join(
-        projectDir,
-        'amplify',
-        'backend',
-        'api',
-        apiName,
-        'build',
-        'pipelineFunctions',
-        resolverReqName,
-      );
-      const generatedResResolverPath = join(
-        projectDir,
-        'amplify',
-        'backend',
-        'api',
-        apiName,
-        'build',
-        'pipelineFunctions',
-        resolverResName,
-      );
+      const generatedReqResolverPath = join(projectDir, 'amplify', 'backend', 'api', apiName, 'build', 'resolvers', resolverReqName);
+      const generatedResResolverPath = join(projectDir, 'amplify', 'backend', 'api', apiName, 'build', 'resolvers', resolverResName);
       const stackPath = join(projectDir, 'amplify', 'backend', 'api', apiName, 'build', 'stacks', 'CustomResources.json');
 
       const Resources = {
@@ -90,7 +72,7 @@ describe('user created resolvers', () => {
               FieldName: 'commentsForTodo',
               RequestMappingTemplateS3Location: {
                 'Fn::Sub': [
-                  's3://${S3DeploymentBucket}/${S3DeploymentRootKey}/pipelineFunctions/Query.commentsForTodo.req.vtl',
+                  's3://${S3DeploymentBucket}/${S3DeploymentRootKey}/resolvers/Query.commentsForTodo.req.vtl',
                   {
                     S3DeploymentBucket: {
                       Ref: 'S3DeploymentBucket',
@@ -103,7 +85,7 @@ describe('user created resolvers', () => {
               },
               ResponseMappingTemplateS3Location: {
                 'Fn::Sub': [
-                  's3://${S3DeploymentBucket}/${S3DeploymentRootKey}/pipelineFunctions/Query.commentsForTodo.res.vtl',
+                  's3://${S3DeploymentBucket}/${S3DeploymentRootKey}/resolvers/Query.commentsForTodo.res.vtl',
                   {
                     S3DeploymentBucket: {
                       Ref: 'S3DeploymentBucket',

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -297,6 +297,6 @@ test('Test simple model with AdminUI enabled should add IAM policy only for fiel
   ]);
   // should throw unauthorized if it's not signed by the admin ui iam role
   ['Mutation.createPost.auth.1.req.vtl', 'Mutation.updatePost.auth.1.res.vtl', 'Mutation.deletePost.auth.1.res.vtl'].forEach(r => {
-    expect(out.pipelineFunctions[r]).toMatchSnapshot();
+    expect(out.resolvers[r]).toMatchSnapshot();
   });
 });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/conflict-resolution.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/conflict-resolution.test.ts
@@ -33,7 +33,7 @@ test('test single auth model is enabled with conflict resolution', () => {
   expect(out.schema).toContain(
     `syncPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String, lastSync: AWSTimestamp): ModelPostConnection`,
   );
-  expect(out.pipelineFunctions['Query.syncPosts.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.syncPosts.auth.1.req.vtl']).toMatchSnapshot();
 });
 
 test('test multi auth model with conflict resolution', () => {
@@ -66,5 +66,5 @@ test('test multi auth model with conflict resolution', () => {
   expect(out.schema).toContain(
     `syncPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String, lastSync: AWSTimestamp): ModelPostConnection @aws_iam @aws_cognito_user_pools`,
   );
-  expect(out.pipelineFunctions['Query.syncPosts.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.syncPosts.auth.1.req.vtl']).toMatchSnapshot();
 });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -33,11 +33,11 @@ test('subscriptions are only generated if the respective mutation operation exis
   expect(out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
     'AMAZON_COGNITO_USER_POOLS',
   );
-  expect(out.pipelineFunctions['Salary.secret.res.vtl']).toContain('#if( $operation == "Mutation" )');
+  expect(out.resolvers['Salary.secret.res.vtl']).toContain('#if( $operation == "Mutation" )');
 
-  expect(out.pipelineFunctions['Mutation.createSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
-  expect(out.pipelineFunctions['Mutation.updateSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
-  expect(out.pipelineFunctions['Mutation.deleteSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+  expect(out.resolvers['Mutation.createSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+  expect(out.resolvers['Mutation.updateSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
+  expect(out.resolvers['Mutation.deleteSalary.res.vtl']).toContain('$util.qr($ctx.result.put("__operation", "Mutation"))');
 });
 
 test('per-field @auth without @model', () => {
@@ -61,7 +61,7 @@ test('per-field @auth without @model', () => {
   const resources = out.rootStack.Resources;
   const authPolicyIdx = Object.keys(out.rootStack.Resources).find(r => r.includes('AuthRolePolicy'));
   expect(resources[authPolicyIdx]).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.listContext.req.vtl']).toContain(
+  expect(out.resolvers['Query.listContext.req.vtl']).toContain(
     '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"Allowed"}] )',
   );
 });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -360,12 +360,12 @@ describe('schema generation directive tests', () => {
     // Check that resolvers containing the authMode check block
     const authStepSnippet = '## [Start] Authorization Steps. **';
 
-    expect(out.pipelineFunctions['Query.getPost.auth.1.req.vtl']).toContain(authStepSnippet);
-    expect(out.pipelineFunctions['Query.listPosts.auth.1.req.vtl']).toContain(authStepSnippet);
-    expect(out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl']).toContain(authStepSnippet);
-    expect(out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl']).toContain(authStepSnippet);
-    expect(out.pipelineFunctions['Mutation.updatePost.auth.1.res.vtl']).toContain(authStepSnippet);
-    expect(out.pipelineFunctions['Mutation.deletePost.auth.1.res.vtl']).toContain(authStepSnippet);
+    expect(out.resolvers['Query.getPost.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toContain(authStepSnippet);
+    expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toContain(authStepSnippet);
+    expect(out.resolvers['Mutation.deletePost.auth.1.res.vtl']).toContain(authStepSnippet);
   });
 
   test(`Operation fields are getting the directive added, when type has the @auth only for allowed operations`, () => {
@@ -419,10 +419,10 @@ describe('schema generation directive tests', () => {
     // Check that resolvers containing the authMode check block
     const authModeCheckSnippet = '## [Start] Field Authorization Steps. **';
     // resolvers to check is all other resolvers other than protected
-    expect(out.pipelineFunctions['Post.id.req.vtl']).toContain(authModeCheckSnippet);
-    expect(out.pipelineFunctions['Post.title.req.vtl']).toContain(authModeCheckSnippet);
-    expect(out.pipelineFunctions['Post.createdAt.req.vtl']).toContain(authModeCheckSnippet);
-    expect(out.pipelineFunctions['Post.updatedAt.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.id.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.title.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.createdAt.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.updatedAt.req.vtl']).toContain(authModeCheckSnippet);
   });
 
   test(`'groups' @auth at field level is propagated to type and the type related operations`, () => {
@@ -446,10 +446,10 @@ describe('schema generation directive tests', () => {
     const authModeCheckSnippet = '## [Start] Field Authorization Steps. **';
 
     // resolvers to check is all other resolvers other than protected
-    expect(out.pipelineFunctions['Post.id.req.vtl']).toContain(authModeCheckSnippet);
-    expect(out.pipelineFunctions['Post.title.req.vtl']).toContain(authModeCheckSnippet);
-    expect(out.pipelineFunctions['Post.createdAt.req.vtl']).toContain(authModeCheckSnippet);
-    expect(out.pipelineFunctions['Post.updatedAt.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.id.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.title.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.createdAt.req.vtl']).toContain(authModeCheckSnippet);
+    expect(out.resolvers['Post.updatedAt.req.vtl']).toContain(authModeCheckSnippet);
   });
 
   test(`'groups' @auth at field level is propagated to type and the type related operations, also default provider for read`, () => {
@@ -472,10 +472,10 @@ describe('schema generation directive tests', () => {
     const groupCheckSnippet = '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"admin"}] )';
 
     // resolvers to check is all other resolvers other than protected by the group rule
-    expect(out.pipelineFunctions['Post.id.req.vtl']).toContain(groupCheckSnippet);
-    expect(out.pipelineFunctions['Post.title.req.vtl']).toContain(groupCheckSnippet);
-    expect(out.pipelineFunctions['Post.createdAt.req.vtl']).toContain(groupCheckSnippet);
-    expect(out.pipelineFunctions['Post.updatedAt.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.id.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.title.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.createdAt.req.vtl']).toContain(groupCheckSnippet);
+    expect(out.resolvers['Post.updatedAt.req.vtl']).toContain(groupCheckSnippet);
   });
 
   test(`Nested types without @model not getting directives applied for iam, and no policy is generated`, () => {
@@ -618,11 +618,11 @@ describe('iam checks', () => {
     });
     const out = transformer.transform(schema);
     expect(out).toBeDefined();
-    const createResolver = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createResolver = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     expect(createResolver).toContain(
       `#if( ($ctx.identity.userArn == $ctx.stash.authRole) || ($ctx.identity.cognitoIdentityPoolId == \"${identityPoolId}\" && $ctx.identity.cognitoIdentityAuthType == \"authenticated\") )`,
     );
-    const queryResolver = out.pipelineFunctions['Query.listPosts.auth.1.req.vtl'];
+    const queryResolver = out.resolvers['Query.listPosts.auth.1.req.vtl'];
     expect(queryResolver).toContain(
       `#if( ($ctx.identity.userArn == $ctx.stash.authRole) || ($ctx.identity.cognitoIdentityPoolId == \"${identityPoolId}\" && $ctx.identity.cognitoIdentityAuthType == \"authenticated\") )`,
     );
@@ -636,9 +636,9 @@ describe('iam checks', () => {
     });
     const out = transformer.transform(schema);
     expect(out).toBeDefined();
-    const createResolver = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createResolver = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     expect(createResolver).toContain(`#if( $ctx.identity.userArn == $ctx.stash.unauthRole )`);
-    const queryResolver = out.pipelineFunctions['Query.listPosts.auth.1.req.vtl'];
+    const queryResolver = out.resolvers['Query.listPosts.auth.1.req.vtl'];
     expect(queryResolver).toContain(`#if( $ctx.identity.userArn == $ctx.stash.unauthRole )`);
   });
 
@@ -650,7 +650,7 @@ describe('iam checks', () => {
     });
     const out = transformer.transform(schema);
     expect(out).toBeDefined();
-    const createResolver = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createResolver = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     expect(createResolver).toContain(`#set( $adminRoles = [\"helloWorldFunction\",\"echoMessageFunction\"] )`);
     expect(createResolver).toMatchSnapshot();
   });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -55,11 +55,11 @@ test('ownerfield where the field is a list', () => {
   expect(out.rootStack.Resources[ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
     'AMAZON_COGNITO_USER_POOLS',
   );
-  expect(out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updatePost.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deletePost.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.getPost.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.listPosts.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updatePost.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deletePost.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getPost.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toMatchSnapshot();
 });
 
 test('ownerfield with subscriptions', () => {
@@ -90,13 +90,13 @@ test('ownerfield with subscriptions', () => {
   expect(out.schema).toContain('onDeletePost(postOwner: String)');
 
   // expect logic in the resolvers to check for postOwner args as an allowed owner
-  expect(out.pipelineFunctions['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
   );
-  expect(out.pipelineFunctions['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
   );
-  expect(out.pipelineFunctions['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
   );
 });
@@ -134,24 +134,24 @@ test('multiple owner rules with subscriptions', () => {
   expect(out.schema).toContain('onDeletePost(owner: String, editor: String)');
 
   // expect logic in the resolvers to check for owner args as an allowedOwner
-  expect(out.pipelineFunctions['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
   );
-  expect(out.pipelineFunctions['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
   );
-  expect(out.pipelineFunctions['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
   );
 
   // expect logic in the resolvers to check for editor args as an allowedOwner
-  expect(out.pipelineFunctions['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
   );
-  expect(out.pipelineFunctions['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
   );
-  expect(out.pipelineFunctions['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
     '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
   );
 });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -51,11 +51,11 @@ test('auth logic is enabled on owner/static rules in es request', () => {
   const out = transformer.transform(validSchema);
   // expect response resolver to contain auth logic for owner rule
   expect(out).toBeDefined();
-  expect(out.pipelineFunctions['Query.searchComments.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Query.searchComments.auth.1.req.vtl']).toContain(
     '"terms":       [$util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), "___xamznone____"))],',
   );
   // expect response resolver to contain auth logic for group rule
-  expect(out.pipelineFunctions['Query.searchComments.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Query.searchComments.auth.1.req.vtl']).toContain(
     '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"writer"}] )',
   );
 });
@@ -104,7 +104,7 @@ test('auth logic is enabled for iam/apiKey auth rules', () => {
   }
   // expect the searchbable types to have the auth directives for total providers
   // expect the allowed fields for agg to exclude secret
-  expect(out.pipelineFunctions['Query.searchPosts.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Query.searchPosts.auth.1.req.vtl']).toContain(
     `#set( $allowedAggFields = ["createdAt","updatedAt","id","content"] )`,
   );
 });

--- a/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
@@ -94,16 +94,10 @@ test('it generates the expected resources', () => {
       FunctionVersion: '2018-05-29',
       Name: 'InvokeEchofunctionLambdaDataSource',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': [
-          '',
-          ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/InvokeEchofunctionLambdaDataSource.req.vtl'],
-        ],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunctionLambdaDataSource.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': [
-          '',
-          ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/InvokeEchofunctionLambdaDataSource.res.vtl'],
-        ],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunctionLambdaDataSource.res.vtl']],
       },
     }),
   );
@@ -118,11 +112,11 @@ test('it generates the expected resources', () => {
       },
       RequestMappingTemplate: anything(),
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Query.echo.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Query.echo.res.vtl']],
       },
     }),
   );
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 });
 
 test('two @function directives for the same lambda should produce a single datasource, single role and two resolvers', () => {

--- a/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
@@ -26,7 +26,7 @@ test('generates expected VTL', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   expect(out.stacks).toBeDefined();
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
   parse(out.schema);
 });
 
@@ -130,10 +130,10 @@ test('it generates the expected resources', () => {
       },
       Kind: 'UNIT',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.content.req.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.content.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content.res.vtl']],
       },
     }),
   );
@@ -148,10 +148,10 @@ test('it generates the expected resources', () => {
       },
       Kind: 'UNIT',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.content2.req.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content2.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.content2.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content2.res.vtl']],
       },
     }),
   );
@@ -166,10 +166,10 @@ test('it generates the expected resources', () => {
       },
       Kind: 'UNIT',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.more.req.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.more.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.more.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.more.res.vtl']],
       },
     }),
   );
@@ -184,10 +184,10 @@ test('it generates the expected resources', () => {
       },
       Kind: 'UNIT',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.evenMore.req.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.evenMore.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.evenMore.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.evenMore.res.vtl']],
       },
     }),
   );
@@ -202,10 +202,10 @@ test('it generates the expected resources', () => {
       },
       Kind: 'UNIT',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.stillMore.req.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.stillMore.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/pipelineFunctions/Comment.stillMore.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.stillMore.res.vtl']],
       },
     }),
   );

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -177,7 +177,7 @@ test('@index with multiple sort keys adds a query field and GSI correctly', () =
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as any;
   expect(queryType).toBeDefined();
@@ -245,7 +245,7 @@ test('@index with a single sort key adds a query field and GSI correctly', () =>
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as any;
   expect(queryType).toBeDefined();
@@ -307,7 +307,7 @@ test('@index with no sort key field adds a query field and GSI correctly', () =>
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as any;
   expect(queryType).toBeDefined();
@@ -398,7 +398,7 @@ test('creates a primary key and a secondary index', () => {
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as any;
   expect(queryType).toBeDefined();
@@ -634,7 +634,7 @@ test('validate resolver code', () => {
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
   validateModelSchema(parse(out.schema));
 });
 
@@ -843,8 +843,8 @@ test('GSI composite sort keys are wrapped in conditional to check presence in mu
   const schema = parse(out.schema);
 
   validateModelSchema(schema);
-  expect(out.pipelineFunctions['Mutation.createPerson.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updatePerson.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createPerson.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updatePerson.req.vtl']).toMatchSnapshot();
 });
 
 it('should support index/primary key with sync resolvers', () => {
@@ -879,7 +879,7 @@ it('should support index/primary key with sync resolvers', () => {
 
   const definition = out.schema;
   expect(definition).toBeDefined();
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   validateModelSchema(parse(definition));
 });

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
@@ -181,7 +181,7 @@ test('a primary key with no sort key is properly configured', () => {
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType: any = schema.definitions.find((def: any) => def.name && def.name.value === 'Query');
   const getTestField: any = queryType.fields.find((f: any) => f.name && f.name.value === 'getTest');
@@ -231,7 +231,7 @@ test('a primary key with a single sort key field is properly configured', () => 
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType: any = schema.definitions.find((def: any) => def.name && def.name.value === 'Query');
   const getTestField: any = queryType.fields.find((f: any) => f.name && f.name.value === 'getTest');
@@ -271,7 +271,7 @@ test('a primary key with a composite sort key is properly configured', () => {
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType: any = schema.definitions.find((def: any) => def.name && def.name.value === 'Query');
   const getTestField: any = queryType.fields.find((f: any) => f.name && f.name.value === 'getTest');
@@ -347,7 +347,7 @@ test('enums are supported in keys', () => {
     }),
   );
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   const queryType: any = schema.definitions.find((def: any) => def.name && def.name.value === 'Query');
   const getTestField: any = queryType.fields.find((f: any) => f.name && f.name.value === 'getTest');
@@ -474,7 +474,7 @@ test('resolvers can be renamed by @model', () => {
   const query: any = schema.definitions.find((d: any) => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === 'Query');
   const mutation: any = schema.definitions.find((d: any) => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === 'Mutation');
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 
   expect(query).toBeDefined();
   expect(query.fields.length).toEqual(2);
@@ -517,7 +517,7 @@ test('individual resolvers can be made null by @model', () => {
   const stack = out.stacks.Test;
   const query: any = schema.definitions.find((d: any) => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === 'Query');
 
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
   expect(query).toBeDefined();
   expect(query.fields.length).toEqual(1);
   const getQuery = query.fields.find((f: any) => f.name.value === 'testGet');
@@ -676,6 +676,6 @@ test('list queries use correct pluralization', () => {
   const listQuery = query.fields.find((f: any) => f.name.value === 'listBosses');
   expect(listQuery).toBeDefined();
 
-  expect(out.pipelineFunctions['Query.listBosses.req.vtl']).toBeDefined();
-  expect(out.pipelineFunctions['Query.listBosses.res.vtl']).toBeDefined();
+  expect(out.resolvers['Query.listBosses.req.vtl']).toBeDefined();
+  expect(out.resolvers['Query.listBosses.res.vtl']).toBeDefined();
 });

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -13303,7 +13303,7 @@ $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **"
 `;
 
-exports[`ModelTransformer:  should support timestamp parameters when generating pipelineFunctions and output schema 1`] = `
+exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 1`] = `
 "
 type Post {
   id: ID!
@@ -13457,7 +13457,7 @@ type Subscription {
 "
 `;
 
-exports[`ModelTransformer:  should support timestamp parameters when generating pipelineFunctions and output schema 2`] = `
+exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 2`] = `
 "## [Start] Create Request template. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -13525,7 +13525,7 @@ $util.toJson($PutObject)
 ## [End] Create Request template. **"
 `;
 
-exports[`ModelTransformer:  should support timestamp parameters when generating pipelineFunctions and output schema 3`] = `
+exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 3`] = `
 "## [Start] Mutation Update resolver. **
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -411,7 +411,7 @@ describe('ModelTransformer: ', () => {
     expect(defaultIdField).toBeDefined();
     expect(getBaseType(defaultIdField.type)).toEqual('Int');
     // It should not add default value for ctx.arg.id as id is of type Int
-    expect(result.pipelineFunctions['Mutation.createPost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
   });
 
   it('should generate only create mutation', () => {
@@ -670,7 +670,7 @@ describe('ModelTransformer: ', () => {
     validateModelSchema(schema);
   });
 
-  it('should support timestamp parameters when generating pipelineFunctions and output schema', () => {
+  it('should support timestamp parameters when generating resolvers and output schema', () => {
     const validSchema = `
     type Post @model(timestamps: { createdAt: "createdOn", updatedAt: "updatedOn"}) {
       id: ID!
@@ -688,8 +688,8 @@ describe('ModelTransformer: ', () => {
     const schema = parse(result.schema);
     validateModelSchema(schema);
 
-    expect(result.pipelineFunctions['Mutation.createPost.req.vtl']).toMatchSnapshot();
-    expect(result.pipelineFunctions['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
   });
 
   it('should not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime', () => {
@@ -712,8 +712,8 @@ describe('ModelTransformer: ', () => {
     const schema = parse(result.schema);
     validateModelSchema(schema);
 
-    expect(result.pipelineFunctions['Mutation.createPost.req.vtl']).toMatchSnapshot();
-    expect(result.pipelineFunctions['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
   });
 
   it('should have timestamps as nullable fields when the type makes it non-nullable', () => {
@@ -737,8 +737,8 @@ describe('ModelTransformer: ', () => {
     const schema = parse(result.schema);
     validateModelSchema(schema);
 
-    expect(result.pipelineFunctions['Mutation.createPost.req.vtl']).toMatchSnapshot();
-    expect(result.pipelineFunctions['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
   });
 
   it('should not to include createdAt and updatedAt field when timestamps is set to null', () => {
@@ -759,8 +759,8 @@ describe('ModelTransformer: ', () => {
     const schema = parse(result.schema);
     validateModelSchema(schema);
 
-    expect(result.pipelineFunctions['Mutation.createPost.req.vtl']).toMatchSnapshot();
-    expect(result.pipelineFunctions['Mutation.updatePost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.createPost.req.vtl']).toMatchSnapshot();
+    expect(result.resolvers['Mutation.updatePost.req.vtl']).toMatchSnapshot();
   });
 
   it('should filter known input types from create and update input fields', () => {
@@ -908,7 +908,7 @@ describe('ModelTransformer: ', () => {
 
     const definition = out.schema;
     expect(definition).toBeDefined();
-    expect(out.pipelineFunctions).toMatchSnapshot();
+    expect(out.resolvers).toMatchSnapshot();
 
     validateModelSchema(parse(definition));
   });
@@ -945,7 +945,7 @@ describe('ModelTransformer: ', () => {
 
     const definition = out.schema;
     expect(definition).toBeDefined();
-    expect(out.pipelineFunctions).toMatchSnapshot();
+    expect(out.resolvers).toMatchSnapshot();
 
     validateModelSchema(parse(definition));
   });
@@ -979,7 +979,7 @@ describe('ModelTransformer: ', () => {
 
     const definition = out.schema;
     expect(definition).toBeDefined();
-    expect(out.pipelineFunctions).toMatchSnapshot();
+    expect(out.resolvers).toMatchSnapshot();
 
     validateModelSchema(parse(definition));
   });

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -317,7 +317,7 @@ function createResolver(
   context: TransformerContextProvider,
   stack: cdk.Stack,
   config: PredictionsDirectiveConfiguration,
-  pipelineFunctions: any[],
+  resolvers: any[],
   bucketName: string,
 ): appsync.CfnResolver {
   const substitutions: { [key: string]: string } = {
@@ -385,7 +385,7 @@ function createResolver(
     ),
     undefined,
     undefined,
-    pipelineFunctions,
+    resolvers,
     stack,
   );
 }

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -543,7 +543,7 @@ test('the limit of 100 is used by default', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect(out.pipelineFunctions['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 100) )');
+  expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 100) )');
 });
 
 test('the default limit argument can be overridden', () => {
@@ -566,7 +566,7 @@ test('the default limit argument can be overridden', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect(out.pipelineFunctions['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 50) )');
+  expect(out.resolvers['Post.comments.req.vtl']).toContain('#set( $limit = $util.defaultIfNull($context.args.limit, 50) )');
 });
 
 test('validates VTL of a complex schema', () => {
@@ -644,5 +644,5 @@ test('validates VTL of a complex schema', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 });

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
@@ -171,7 +171,7 @@ test('valid schema', () => {
   validateModelSchema(schema);
 
   expect(out.schema).toMatchSnapshot();
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 });
 
 test('join table inherits auth from first table', () => {
@@ -190,29 +190,23 @@ test('join table inherits auth from first table', () => {
   const schema = parse(out.schema);
   validateModelSchema(schema);
 
-  expect(out.pipelineFunctions['Query.getFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.getFoo.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Query.getFooBar.postAuth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.getFoo.postAuth.1.req.vtl']);
-  expect(out.pipelineFunctions['Query.getFooBar.res.vtl']).toEqual(out.pipelineFunctions['Query.getFoo.res.vtl']);
-  expect(out.pipelineFunctions['Query.listFooBars.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.listFoos.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Query.listFooBars.postAuth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.listFoos.postAuth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.createFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Mutation.createFoo.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.createFooBar.postAuth.1.req.vtl']).toEqual(
-    out.pipelineFunctions['Mutation.createFoo.postAuth.1.req.vtl'],
-  );
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteFoo.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.postAuth.1.req.vtl']).toEqual(
-    out.pipelineFunctions['Mutation.deleteFoo.postAuth.1.req.vtl'],
-  );
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.res.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteFoo.auth.1.res.vtl']);
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.req.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteFoo.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.res.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteFoo.res.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Mutation.updateFoo.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.postAuth.1.req.vtl']).toEqual(
-    out.pipelineFunctions['Mutation.updateFoo.postAuth.1.req.vtl'],
-  );
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.res.vtl']).toEqual(out.pipelineFunctions['Mutation.updateFoo.auth.1.res.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.req.vtl']).toEqual(out.pipelineFunctions['Mutation.updateFoo.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.res.vtl']).toEqual(out.pipelineFunctions['Mutation.updateFoo.res.vtl']);
+  expect(out.resolvers['Query.getFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Query.getFoo.auth.1.req.vtl']);
+  expect(out.resolvers['Query.getFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Query.getFoo.postAuth.1.req.vtl']);
+  expect(out.resolvers['Query.getFooBar.res.vtl']).toEqual(out.resolvers['Query.getFoo.res.vtl']);
+  expect(out.resolvers['Query.listFooBars.auth.1.req.vtl']).toEqual(out.resolvers['Query.listFoos.auth.1.req.vtl']);
+  expect(out.resolvers['Query.listFooBars.postAuth.1.req.vtl']).toEqual(out.resolvers['Query.listFoos.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.createFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Mutation.createFoo.auth.1.req.vtl']);
+  expect(out.resolvers['Mutation.createFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Mutation.createFoo.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Mutation.deleteFoo.auth.1.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Mutation.deleteFoo.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.res.vtl']).toEqual(out.resolvers['Mutation.deleteFoo.auth.1.res.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.req.vtl']).toEqual(out.resolvers['Mutation.deleteFoo.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.res.vtl']).toEqual(out.resolvers['Mutation.deleteFoo.res.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Mutation.updateFoo.auth.1.req.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Mutation.updateFoo.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.res.vtl']).toEqual(out.resolvers['Mutation.updateFoo.auth.1.res.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.req.vtl']).toEqual(out.resolvers['Mutation.updateFoo.req.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.res.vtl']).toEqual(out.resolvers['Mutation.updateFoo.res.vtl']);
 });
 
 test('join table inherits auth from second table', () => {
@@ -231,29 +225,23 @@ test('join table inherits auth from second table', () => {
   const schema = parse(out.schema);
   validateModelSchema(schema);
 
-  expect(out.pipelineFunctions['Query.getFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.getBar.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Query.getFooBar.postAuth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.getBar.postAuth.1.req.vtl']);
-  expect(out.pipelineFunctions['Query.getFooBar.res.vtl']).toEqual(out.pipelineFunctions['Query.getBar.res.vtl']);
-  expect(out.pipelineFunctions['Query.listFooBars.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.listBars.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Query.listFooBars.postAuth.1.req.vtl']).toEqual(out.pipelineFunctions['Query.listBars.postAuth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.createFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Mutation.createBar.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.createFooBar.postAuth.1.req.vtl']).toEqual(
-    out.pipelineFunctions['Mutation.createBar.postAuth.1.req.vtl'],
-  );
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteBar.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.postAuth.1.req.vtl']).toEqual(
-    out.pipelineFunctions['Mutation.deleteBar.postAuth.1.req.vtl'],
-  );
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.res.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteBar.auth.1.res.vtl']);
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.req.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteBar.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.res.vtl']).toEqual(out.pipelineFunctions['Mutation.deleteBar.res.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.req.vtl']).toEqual(out.pipelineFunctions['Mutation.updateBar.auth.1.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.postAuth.1.req.vtl']).toEqual(
-    out.pipelineFunctions['Mutation.updateBar.postAuth.1.req.vtl'],
-  );
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.res.vtl']).toEqual(out.pipelineFunctions['Mutation.updateBar.auth.1.res.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.req.vtl']).toEqual(out.pipelineFunctions['Mutation.updateBar.req.vtl']);
-  expect(out.pipelineFunctions['Mutation.updateFooBar.res.vtl']).toEqual(out.pipelineFunctions['Mutation.updateBar.res.vtl']);
+  expect(out.resolvers['Query.getFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Query.getBar.auth.1.req.vtl']);
+  expect(out.resolvers['Query.getFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Query.getBar.postAuth.1.req.vtl']);
+  expect(out.resolvers['Query.getFooBar.res.vtl']).toEqual(out.resolvers['Query.getBar.res.vtl']);
+  expect(out.resolvers['Query.listFooBars.auth.1.req.vtl']).toEqual(out.resolvers['Query.listBars.auth.1.req.vtl']);
+  expect(out.resolvers['Query.listFooBars.postAuth.1.req.vtl']).toEqual(out.resolvers['Query.listBars.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.createFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Mutation.createBar.auth.1.req.vtl']);
+  expect(out.resolvers['Mutation.createFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Mutation.createBar.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Mutation.deleteBar.auth.1.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Mutation.deleteBar.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.res.vtl']).toEqual(out.resolvers['Mutation.deleteBar.auth.1.res.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.req.vtl']).toEqual(out.resolvers['Mutation.deleteBar.req.vtl']);
+  expect(out.resolvers['Mutation.deleteFooBar.res.vtl']).toEqual(out.resolvers['Mutation.deleteBar.res.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.req.vtl']).toEqual(out.resolvers['Mutation.updateBar.auth.1.req.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.postAuth.1.req.vtl']).toEqual(out.resolvers['Mutation.updateBar.postAuth.1.req.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.res.vtl']).toEqual(out.resolvers['Mutation.updateBar.auth.1.res.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.req.vtl']).toEqual(out.resolvers['Mutation.updateBar.req.vtl']);
+  expect(out.resolvers['Mutation.updateFooBar.res.vtl']).toEqual(out.resolvers['Mutation.updateBar.res.vtl']);
 });
 
 test('join table inherits auth from both tables', () => {
@@ -272,23 +260,23 @@ test('join table inherits auth from both tables', () => {
   const schema = parse(out.schema);
   validateModelSchema(schema);
 
-  expect(out.pipelineFunctions['Query.getFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.getFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.getFooBar.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.listFooBars.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.listFooBars.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.createFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.createFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getFooBar.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listFooBars.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listFooBars.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.res.vtl']).toMatchSnapshot();
 });
 
 test('join table inherits auth from tables with similar rules', () => {
@@ -312,23 +300,23 @@ test('join table inherits auth from tables with similar rules', () => {
   const schema = parse(out.schema);
   validateModelSchema(schema);
 
-  expect(out.pipelineFunctions['Query.getFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.getFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.getFooBar.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.listFooBars.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Query.listFooBars.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.createFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.createFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.auth.1.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.deleteFooBar.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.auth.1.res.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.req.vtl']).toMatchSnapshot();
-  expect(out.pipelineFunctions['Mutation.updateFooBar.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.getFooBar.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listFooBars.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Query.listFooBars.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.createFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.auth.1.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.deleteFooBar.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.postAuth.1.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.auth.1.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updateFooBar.res.vtl']).toMatchSnapshot();
 });
 
 function createTransformer(authConfig?: AppSyncAuthConfiguration) {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/relational-auth.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/relational-auth.test.ts
@@ -45,7 +45,7 @@ test('per-field auth on relational field', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
 
-  expect(out.pipelineFunctions['Post.comments.auth.1.req.vtl']).toContain(
+  expect(out.resolvers['Post.comments.auth.1.req.vtl']).toContain(
     '#set( $staticGroupRoles = [{"claim":"cognito:groups","entity":"admin"}] )',
   );
 });

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.tests.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.tests.ts
@@ -50,7 +50,7 @@ test('Test SearchableModelTransformer vtl', () => {
 
   const out = transformer.transform(validSchema);
   expect(parse(out.schema)).toBeDefined();
-  expect(out.pipelineFunctions).toMatchSnapshot();
+  expect(out.resolvers).toMatchSnapshot();
 });
 
 test('Test SearchableModelTransformer with query overrides', () => {
@@ -329,7 +329,7 @@ test('Test SearchableModelTransformer enum type generates StringFilterInput', ()
       lastName: String!
       type: EmploymentType!
     }
-    
+
     enum EmploymentType {
       FULLTIME
       HOURLY

--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/template-asset.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/template-asset.ts
@@ -84,12 +84,8 @@ export class MappingTemplate {
   static inlineTemplateFromString(template: string): InlineTemplate {
     return new InlineTemplate(template);
   }
-  static s3MappingTemplateFromString(
-    template: string,
-    templateName: string,
-    type: 'pipeline' | 'resolver' | 'function' = 'pipeline',
-  ): S3MappingTemplate {
-    const templatePrefix = type == 'pipeline' ? 'pipelineFunctions' : 'resolvers';
+  static s3MappingTemplateFromString(template: string, templateName: string): S3MappingTemplate {
+    const templatePrefix = 'resolvers';
     return new S3MappingTemplate(template, `${templatePrefix}/${templateName}`);
   }
 }

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -173,8 +173,8 @@ export class TransformerResolver implements TransformerResolverProvider {
   synthesize = (context: TransformerContextProvider, api: GraphQLAPIProvider): void => {
     const stack = this.stack || (context.stackManager as StackManager).rootStack;
     this.ensureNoneDataSource(api);
-    const requestFns = this.synthesizePipelineFunctions(stack, api, this.requestSlots);
-    const responseFns = this.synthesizePipelineFunctions(stack, api, this.responseSlots);
+    const requestFns = this.synthesizeResolvers(stack, api, this.requestSlots);
+    const responseFns = this.synthesizeResolvers(stack, api, this.responseSlots);
     // substitue template name values
     [this.requestMappingTemplate, this.requestMappingTemplate].map(template => this.substitueSlotInfo(template, 'main', 0));
 
@@ -288,7 +288,7 @@ export class TransformerResolver implements TransformerResolverProvider {
     );
   };
 
-  synthesizePipelineFunctions = (stack: Stack, api: GraphQLAPIProvider, slotsNames: string[]): AppSyncFunctionConfigurationProvider[] => {
+  synthesizeResolvers = (stack: Stack, api: GraphQLAPIProvider, slotsNames: string[]): AppSyncFunctionConfigurationProvider[] => {
     const appSyncFunctions: AppSyncFunctionConfigurationProvider[] = [];
 
     for (let slotName of slotsNames) {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
@@ -61,7 +61,7 @@ describe('graphql transformer utils', () => {
       it('merges the custom resolver with transformer output', () => {
         const output = mergeUserConfigWithTransformOutput(userConfig, transformerOutput);
 
-        expect(output.pipelineFunctions['Query.listTodos.req.vtl']).toEqual('$util.unauthorized\n');
+        expect(output.resolvers['Query.listTodos.req.vtl']).toEqual('$util.unauthorized\n');
       });
     });
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
@@ -7,10 +7,10 @@ describe('graphql transformer utils', () => {
 
   beforeAll(() => {
     transformerOutput = {
-      resolvers: {},
-      pipelineFunctions: {
+      resolvers: {
         'Query.listTodos.req.vtl': '## [Start] List Request. **\n' + '#set( $limit = $util.defaultIfNull($context.args.limit, 100) )\n',
       },
+      pipelineFunctions: {},
       functions: {},
       schema: '',
       stackMapping: {},
@@ -80,9 +80,9 @@ describe('graphql transformer utils', () => {
       });
 
       it('merges custom pipeline function with transformer output', () => {
-        const { pipelineFunctions } = mergeUserConfigWithTransformOutput(userConfig, transformerOutput);
+        const { resolvers } = mergeUserConfigWithTransformOutput(userConfig, transformerOutput);
 
-        expect(pipelineFunctions['Query.listTodos.req.vtl']).toEqual('$util.unauthorized\n');
+        expect(resolvers['Query.listTodos.req.vtl']).toEqual('$util.unauthorized\n');
       });
     });
 

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-config.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-config.ts
@@ -71,7 +71,7 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
     }
   }
 
-  // load pipeline functions
+  // load pipeline functions - deprecated
   const pipelineFunctions = {};
   if (!(opts && opts.disablePipelineFunctionOverrides === true)) {
     const pipelineFunctionDirectory = path.join(projectDirectory, 'pipelineFunctions');

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -496,5 +496,5 @@ async function _buildProject(opts: ProjectOptions<TransformerFactoryArgs>) {
   const schema = userProjectConfig.schema.toString();
   const transformOutput = transform.transform(schema);
 
-  return mergeUserConfigWithTransformOutput(userProjectConfig, transformOutput);
+  return mergeUserConfigWithTransformOutput(userProjectConfig, transformOutput, opts);
 }

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -121,18 +121,24 @@ export function mergeUserConfigWithTransformOutput(
   const userResolvers = userConfig.resolvers || {};
   const userPipelineFunctions = userConfig.pipelineFunctions || {};
   const functions = transformOutput.functions;
+  const resolvers = transformOutput.resolvers;
   const pipelineFunctions = transformOutput.pipelineFunctions;
 
   for (const userFunction of Object.keys(userFunctions)) functions[userFunction] = userFunctions[userFunction];
   for (const userPipelineFunction of Object.keys(userPipelineFunctions))
     pipelineFunctions[userPipelineFunction] = userPipelineFunctions[userPipelineFunction];
-  for (const userResolver of Object.keys(userResolvers)) pipelineFunctions[userResolver] = userResolvers[userResolver];
+  for (const userResolver of Object.keys(userResolvers)) {
+    if (userResolver !== 'README.md') {
+      resolvers[userResolver] = userResolvers[userResolver];
+    }
+  }
 
   const stacks = overrideUserDefinedStacks(userConfig, transformOutput);
 
   return {
     ...transformOutput,
     functions,
+    resolvers,
     pipelineFunctions,
     stacks,
   };
@@ -294,10 +300,6 @@ function initStacksAndResolversDirectories(directory: string) {
   const resolverRootPath = resolverDirectoryPath(directory);
   if (!fs.existsSync(resolverRootPath)) {
     fs.mkdirSync(resolverRootPath);
-  }
-  const pipelineFunctionRootPath = pipelineFunctionDirectoryPath(directory);
-  if (!fs.existsSync(pipelineFunctionRootPath)) {
-    fs.mkdirSync(pipelineFunctionRootPath);
   }
   const stackRootPath = stacksDirectoryPath(directory);
   if (!fs.existsSync(stackRootPath)) {

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -47,7 +47,7 @@ describe('@model owner mutation checks', () => {
     };
 
     // expect the query resolver to contain a filter for the owner
-    const queryTemplate = out.pipelineFunctions['Query.listPosts.auth.1.req.vtl'];
+    const queryTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
     const queryResponse = vtlTemplate.render(queryTemplate, { context: {}, requestParameters: ownerRequest });
     expect(queryResponse).toBeDefined();
     expect(queryResponse.stash.hasAuth).toEqual(true);
@@ -57,7 +57,7 @@ describe('@model owner mutation checks', () => {
       }),
     );
 
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -66,7 +66,7 @@ describe('@model owner mutation checks', () => {
     // since we have an owner rule we expect the owner field to be defined in the argument input
     expect(createVTLRequest.args.input.owner).toEqual('user1');
 
-    const updateRequestTemplate = out.pipelineFunctions['Mutation.updatePost.auth.1.req.vtl'];
+    const updateRequestTemplate = out.resolvers['Mutation.updatePost.auth.1.req.vtl'];
     const updateVTLRequest = vtlTemplate.render(updateRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(updateVTLRequest).toBeDefined();
     // here we expect a get item payload to verify the owner making the update request is valid
@@ -79,7 +79,7 @@ describe('@model owner mutation checks', () => {
     );
     // atm there is there is nothing in the stash yet
     expect(updateVTLRequest.stash).toEqual({});
-    const updateResponseTemplate = out.pipelineFunctions['Mutation.updatePost.auth.1.res.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
     // response where the owner is indeed the owner
     const updateVTLResponse = vtlTemplate.render(updateResponseTemplate, {
       context: { ...ownerContext, result: { id: '001', owner: 'user1' } },
@@ -119,7 +119,7 @@ describe('@model owner mutation checks', () => {
       arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -145,7 +145,7 @@ describe('@model owner mutation checks', () => {
       arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -171,7 +171,7 @@ describe('@model owner mutation checks', () => {
       arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -213,7 +213,7 @@ describe('@model owner mutation checks', () => {
       arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     expect(createRequestTemplate).toBeDefined();
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
@@ -300,10 +300,10 @@ describe('@model operations', () => {
     const out = transformer.transform(validSchema);
     expect(out).toBeDefined();
     // load vtl templates
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
-    const readRequestTemplate = out.pipelineFunctions['Query.listPosts.auth.1.req.vtl'];
-    const updateResponseTemplate = out.pipelineFunctions['Mutation.updatePost.auth.1.res.vtl'];
-    const deleteResponseTemplate = out.pipelineFunctions['Mutation.deletePost.auth.1.res.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+    const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
     // run create request as owner and admin
     // even though they are not the owner it will still pass as they one making the request is in the admin group
@@ -379,10 +379,10 @@ describe('@model operations', () => {
     `;
     const out = transformer.transform(validSchema);
     // load vtl templates
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createPost.auth.1.req.vtl'];
-    const readRequestTemplate = out.pipelineFunctions['Query.listPosts.auth.1.req.vtl'];
-    const updateResponseTemplate = out.pipelineFunctions['Mutation.updatePost.auth.1.res.vtl'];
-    const deleteResponseTemplate = out.pipelineFunctions['Mutation.deletePost.auth.1.res.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+    const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
     // check that a editor member can't create a post under another owner
     const createPostAsEditor = vtlTemplate.render(createRequestTemplate, {
@@ -465,7 +465,7 @@ describe('@model field auth', () => {
         ssn: String
       }`;
     const out = transformer.transform(validSchema);
-    const updateResponseTemplate = out.pipelineFunctions['Mutation.updateStudent.auth.1.res.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updateStudent.auth.1.res.vtl'];
     const updateContext: AppSyncVTLContext = {
       arguments: {
         input: {
@@ -526,7 +526,7 @@ describe('@model field auth', () => {
     };
     ['name', 'ssn'].forEach(field => {
       // expect owner to get denied on these fields
-      const readFieldTemplate = out.pipelineFunctions[`Student.${field}.req.vtl`];
+      const readFieldTemplate = out.resolvers[`Student.${field}.req.vtl`];
       const ownerReadResponse = vtlTemplate.render(readFieldTemplate, { context: readFieldContext, requestParameters: ownerRequest });
       expect(ownerReadResponse.hadException).toEqual(true);
       // expect admin to be allowed
@@ -536,7 +536,7 @@ describe('@model field auth', () => {
 
     ['id', 'email'].forEach(field => {
       // since the only two roles have access to these fields there are no field resolvers
-      expect(out.pipelineFunctions?.[`Student.${field}.req.vtl`]).not.toBeDefined();
+      expect(out.resolvers?.[`Student.${field}.req.vtl`]).not.toBeDefined();
     });
   });
 });

--- a/packages/amplify-util-mock/src/__tests__/velocity/multi-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/multi-auth.test.ts
@@ -59,7 +59,7 @@ describe('@model + @auth with oidc provider', () => {
     };
 
     const out = transformer.transform(validSchema);
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createProfile.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createProfile.auth.1.req.vtl'];
     const createRequestAsSubOwner = vtlTemplate.render(createRequestTemplate, {
       context: createProfileInput,
       requestParameters: subIdUser,
@@ -94,8 +94,8 @@ describe('@model + @auth with oidc provider', () => {
       },
     };
     const out = transformer.transform(validSchema);
-    const createRequestTemplate = out.pipelineFunctions['Mutation.createComment.auth.1.req.vtl'];
-    const getRequestTemplate = out.pipelineFunctions['Query.getComment.auth.1.req.vtl'];
+    const createRequestTemplate = out.resolvers['Mutation.createComment.auth.1.req.vtl'];
+    const getRequestTemplate = out.resolvers['Query.getComment.auth.1.req.vtl'];
     // mutations
     const createRequestAsEditor = vtlTemplate.render(createRequestTemplate, {
       context: createCommentInput,

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -297,7 +297,7 @@ export class APITest {
       interval: 100,
       ignoreInitial: true,
       followSymlinks: false,
-      ignored: ['**/build/**', '**/resolvers/**'],
+      ignored: '**/build/**',
       awaitWriteFinish: true,
     });
   }

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -297,7 +297,7 @@ export class APITest {
       interval: 100,
       ignoreInitial: true,
       followSymlinks: false,
-      ignored: '**/build/**',
+      ignored: ['**/build/**', '**/resolvers/**'],
       awaitWriteFinish: true,
     });
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- generates new projects with only `resolvers` directory (no `pipelineFunctions` directory) for transformer v2 projects
- gracefully handles existing pipelineFunctions directories by either porting resolvers to `resolvers` on compile or using the existing `pipelineFunctions` directory
- uses the `resolvers` directory when running `amplify mock`
- updates tests for v2 to use `resolvers` key in transformer output
- displays a warning to user when they are using pipelineFunctions instead of resolvers directory for custom and overrides

#### Description of how you validated changes
Updated the tests around using pipelineFunctions instead of resolvers; kept the unit tests that tested that both directories work for custom/overrides; running cloud e2e to confirm.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
