### PR TITLE
fix: revert none data source logical id override

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -228,15 +228,11 @@ export class DefaultTransformHost implements TransformHostProvider {
    * @param stack  Stack to which this datasource needs to mapped to
    */
   protected doAddNoneDataSource(id: string, options?: DataSourceOptions, stack?: Stack): NoneDataSource {
-    const ds = new NoneDataSource(stack ?? this.api, id, {
+    return new NoneDataSource(stack ?? this.api, id, {
       api: this.api,
       name: options?.name,
       description: options?.description,
     });
-
-    (ds as any).node.defaultChild.overrideLogicalId(id);
-
-    return ds;
   }
 
   /**


### PR DESCRIPTION
#### Description of changes
This causes issues due to Amplify's use of `NONE_DS`, which is not alphanumeric.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
