### PR TITLE
fix: auto migrate auth for headless flows

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/check-for-auth-migration.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/check-for-auth-migration.test.ts
@@ -64,10 +64,13 @@ test('migration gets called when cli-inputs doesnt exist', async () => {
   });
 
   const mockContext = {
-    amplify : {
-      getImportedAuthProperties : jest.fn().mockReturnValue({ imported : false })
-    }
-  }
+    amplify: {
+      getImportedAuthProperties: jest.fn().mockReturnValue({ imported: false }),
+    },
+    input: {
+      options: {},
+    },
+  };
 
   await checkAuthResourceMigration(mockContext as unknown as $TSContext, 'mockResource');
   expect(migrateResourceToSupportOverride).toBeCalled();
@@ -79,10 +82,10 @@ test('migration doesnt called when cli-inputs exist', async () => {
   jest.spyOn(AuthInputState.prototype, 'cliInputFileExists').mockImplementation(() => true);
   jest.spyOn(AuthInputState.prototype, 'getCLIInputPayload');
   const mockContext = {
-    amplify : {
-      getImportedAuthProperties : jest.fn().mockReturnValue({ imported : false })
-    }
-  }
+    amplify: {
+      getImportedAuthProperties: jest.fn().mockReturnValue({ imported: false }),
+    },
+  };
 
   await checkAuthResourceMigration(mockContext as unknown as $TSContext, 'mockResource');
   expect(migrateResourceToSupportOverride).not.toBeCalled();

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/check-for-auth-migration.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/check-for-auth-migration.ts
@@ -6,14 +6,14 @@ import { migrateResourceToSupportOverride } from './migrate-override-resource';
 
 export const checkAuthResourceMigration = async (context: $TSContext, authName: string) => {
   // check if its imported auth
-  const { imported} = context.amplify.getImportedAuthProperties(context);
-  if(!imported){
+  const { imported } = context.amplify.getImportedAuthProperties(context);
+  if (!imported) {
     const cliState = new AuthInputState(authName);
     if (!cliState.cliInputFileExists()) {
       printer.debug('Cli-inputs.json doesnt exist');
       // put spinner here
-      const isMigrate = await prompter.yesOrNo(`Do you want to migrate this ${authName} to support overrides?`, true);
-      if (isMigrate) {
+      const headlessMigrate = context.input.options?.yes || context.input.options?.forcePush || context.input.options?.headless;
+      if (headlessMigrate || (await prompter.yesOrNo(`Do you want to migrate this ${authName} to support overrides?`, true))) {
         // generate cli-inputs for migration from parameters.json
         await migrateResourceToSupportOverride(authName);
         // fetch cli Inputs again


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- added auto Migration for Auth when using --forcePush or --yes or --headless
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manual testing and unit tests added

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
