### PR TITLE
fix(graphql-transformer-core): remove the allow_public_global directive

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -142,7 +142,6 @@ export class GraphQLTransform {
         aws_oidc: true,
         aws_lambda: true,
         aws_cognito_user_pools: true,
-        allow_public_data_access_with_api_key: true,
         deprecated: true,
       },
     );

--- a/packages/amplify-graphql-transformer-core/src/transformation/validation.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/validation.ts
@@ -112,7 +112,6 @@ directive @aws_api_key on FIELD_DEFINITION | OBJECT
 directive @aws_iam on FIELD_DEFINITION | OBJECT
 directive @aws_oidc on FIELD_DEFINITION | OBJECT
 directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT
-directive @allow_public_data_access_with_api_key(in: [String!]) on OBJECT
 
 # Allows transformer libraries to deprecate directive arguments.
 directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Removes references to `@allow_public_api_access` global directive that was used for Global Auth. This has been changed in favor of an `allow` field on an `input AMPLIFY`.


#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
