### PR TITLE
feat: add accountid and arbitrary additional info in usagedata

### DIFF
--- a/packages/amplify-cli/src/__tests__/context-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/context-manager.test.ts
@@ -35,6 +35,13 @@ describe('test attachUsageData', () => {
   mockContext.pluginPlatform = new PluginPlatform();
   mockContext.pluginPlatform.plugins['core'] = [new PluginInfo('', version, '', new PluginManifest('', ''))];
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const amplifyToolkit = jest.createMockFromModule<any>('../domain/amplify-toolkit').AmplifyToolkit;
+    amplifyToolkit['executeProviderUtils'] = jest.fn().mockReturnValue('accountId');
+    mockContext.amplify = amplifyToolkit;
+    jest.clearAllMocks();
+  });
   afterEach(() => {});
 
   it('constructContext', () => {
@@ -60,7 +67,7 @@ describe('test attachUsageData', () => {
       returnValue.usageDataConfig.installationUuid,
       version,
       mockContext.input,
-      '',
+      'accountId',
       {},
     );
   });
@@ -80,7 +87,7 @@ describe('test attachUsageData', () => {
       returnValue.usageDataConfig.installationUuid,
       version,
       mockContext.input,
-      '',
+      'accountId',
       {},
     );
   });

--- a/packages/amplify-cli/src/__tests__/version-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/version-manager.test.ts
@@ -21,6 +21,7 @@ describe('test version manager', () => {
       '12311232',
       { frontend: 'javascript', editor: 'vscode', framework: 'react' },
       {},
+      [],
     );
     expect(payload.payloadVersion).toEqual(getLatestPayloadVersion());
   });

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -24,7 +24,9 @@ export async function attachUsageData(context: Context) {
   } else {
     context.usageData = NoUsageData.Instance;
   }
-  context.usageData.init(config.usageDataConfig.installationUuid, getVersion(context), context.input, '', getProjectSettings());
+
+  const accountId = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getAccountId');
+  context.usageData.init(config.usageDataConfig.installationUuid, getVersion(context), context.input, accountId, getProjectSettings());
 }
 
 const getVersion = (context: Context) => context.pluginPlatform.plugins.core[0].packageVersion;

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageData.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageData.ts
@@ -18,6 +18,7 @@ export class UsageData implements IUsageData {
   url: UrlWithStringQuery;
   inputOptions: InputOptions;
   requestTimeout: number = 100;
+  record: Record<string, any>[];
   private static instance: UsageData;
 
   private constructor() {
@@ -26,6 +27,7 @@ export class UsageData implements IUsageData {
     this.input = new Input([]);
     this.projectSettings = {};
     this.inputOptions = {};
+    this.record = [];
   }
 
   init(installationUuid: string, version: string, input: Input, accountId: string, projectSettings: ProjectSettings): void {
@@ -55,6 +57,10 @@ export class UsageData implements IUsageData {
     return this.emit(null, WorkflowState.Successful);
   }
 
+  addRecord(arbitraryData: Record<string, any>) {
+    this.record.push(arbitraryData);
+  }
+
   async emit(error: Error | null, state: string): Promise<void> {
     const payload = new UsageDataPayload(
       this.sessionUuid,
@@ -66,6 +72,7 @@ export class UsageData implements IUsageData {
       this.accountId,
       this.projectSettings,
       this.inputOptions,
+      this.record,
     );
     return this.send(payload);
   }

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
@@ -18,6 +18,7 @@ export class UsageDataPayload {
   isCi: boolean;
   accountId: string;
   projectSetting: ProjectSettings;
+  record: Record<string, any>[];
   constructor(
     sessionUuid: string,
     installationUuid: string,
@@ -28,6 +29,7 @@ export class UsageDataPayload {
     accountId: string,
     project: ProjectSettings,
     inputOptions: InputOptions,
+    record: Record<string, any>[],
   ) {
     this.sessionUuid = sessionUuid;
     this.installationUuid = installationUuid;
@@ -43,6 +45,7 @@ export class UsageDataPayload {
     this.isCi = ci.isCI;
     this.projectSetting = project;
     this.inputOptions = inputOptions;
+    this.record = record;
     if (error) {
       this.error = new SerializableError(error);
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Previously, we sent `accountId` along with all usageData reports. This was reverted (https://github.com/aws-amplify/amplify-cli/pull/7092) in an effort to mitigate https://github.com/aws-amplify/amplify-cli/issues/7090. 

However, I have re-implemented this change and I am unable to reproduce the customer issue that caused us to revert (again, https://github.com/aws-amplify/amplify-cli/issues/7090)

This PR re-adds the accountId to our usageData statistics. It also adds a new property to our usage data, `record` that allows us to include arbitrary additional data fields to our payloads.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

- Wrote a plugin that uses the new `addRecord` functionality
- Attempted to reproduce the failure described in https://github.com/aws-amplify/amplify-cli/issues/7090, was unable to
- Interacted with projects in a sandbox environment, including without any credentials set in `~/.aws/credentials`. No errors or unexpected auth prompts.
- Interacted with projects in a non-sandbox, authenticated environment. No errors or unexpected auth prompts.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
