### PR TITLE
fix: reintroduce connection stack in transformer v2

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -279,8 +279,8 @@ test('bidirectional has many query case', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect((out.stacks as any).User.Resources.PostauthorResolver).toBeTruthy();
-  expect((out.stacks as any).Post.Resources.UserpostsResolver).toBeTruthy();
+  expect((out.stacks as any).ConnectionStack.Resources.PostauthorResolver).toBeTruthy();
+  expect((out.stacks as any).ConnectionStack.Resources.UserpostsResolver).toBeTruthy();
 
   const userType = schema.definitions.find((def: any) => def.name && def.name.value === 'User') as any;
   expect(userType).toBeDefined();
@@ -327,7 +327,7 @@ test('has many query with a composite sort key', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
-  expect((out.stacks as any).Test1.Resources.TestotherPartsResolver).toBeTruthy();
+  expect((out.stacks as any).ConnectionStack.Resources.TestotherPartsResolver).toBeTruthy();
 
   const testObjType = schema.definitions.find((def: any) => def.name && def.name.value === 'Test') as any;
   expect(testObjType).toBeDefined();

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -44,6 +44,7 @@ import {
 import { HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from './types';
 import { getConnectionAttributeName } from './utils';
 
+const CONNECTION_STACK = 'ConnectionStack';
 const authFilter = ref('ctx.stash.authFilter');
 
 export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider) {
@@ -144,7 +145,7 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
     ),
   );
 
-  resolver.mapToStack(table.stack);
+  resolver.mapToStack(getConnectionStack(ctx));
   ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
 }
 
@@ -251,7 +252,7 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
     ),
   );
 
-  resolver.mapToStack(table.stack);
+  resolver.mapToStack(getConnectionStack(ctx));
   ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
 }
 
@@ -373,4 +374,12 @@ function appendIndex(list: any, newIndex: any): any[] {
   }
 
   return [newIndex];
+}
+
+function getConnectionStack(ctx: TransformerContextProvider): cdk.Stack {
+  if (ctx.stackManager.hasStack(CONNECTION_STACK)) {
+    return ctx.stackManager.getStack(CONNECTION_STACK);
+  }
+
+  return ctx.stackManager.createStack(CONNECTION_STACK);
 }


### PR DESCRIPTION
#### Description of changes

This commit reintroduces the dedicated connection stack in v2 of the GraphQL transformer. This allows v1 `@connection` users to migrate existing applications to v2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
