### PR TITLE
feat(graphql-transformer-core): add support for user defined slots

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -1,7 +1,7 @@
 import { print } from 'graphql';
 import { EXTRA_DIRECTIVES_DOCUMENT } from './transformation/validation';
 export { GraphQLTransform, GraphQLTransformOptions, SyncUtils } from './transformation';
-export { DeploymentResources } from './transformation/types';
+export { DeploymentResources, UserDefinedSlot } from './transformation/types';
 export { validateModelSchema } from './transformation/validation';
 export {
   ConflictDetectionType,

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -32,8 +32,9 @@ import { StackManager } from '../transformer-context/stack-manager';
 import { adoptAuthModes, IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from '../utils/authType';
 import { TransformConfig } from '../config';
 import * as SyncUtils from './sync-utils';
+import { MappingTemplate } from '../cdk-compat';
 
-import Template, { DeploymentResources } from './types';
+import Template, { DeploymentResources, UserDefinedSlot } from './types';
 import {
   makeSeenTransformationKey,
   matchArgumentDirective,
@@ -72,6 +73,7 @@ export interface GraphQLTransformOptions {
   readonly featureFlags?: FeatureFlagProvider;
   readonly host?: TransformHostProvider;
   readonly sandboxModeEnabled?: boolean;
+  readonly userDefinedSlots?: Record<string, UserDefinedSlot[]>;
 }
 export type StackMapping = { [resourceId: string]: string };
 export class GraphQLTransform {
@@ -81,6 +83,7 @@ export class GraphQLTransform {
   private transformConfig: TransformConfig;
   private readonly authConfig: AppSyncAuthConfiguration;
   private readonly buildParameters: Record<string, any>;
+  private readonly userDefinedSlots: Record<string, UserDefinedSlot[]>;
 
   // A map from `${directive}.${typename}.${fieldName?}`: true
   // that specifies we have run already run a directive at a given location.
@@ -110,6 +113,7 @@ export class GraphQLTransform {
     this.buildParameters = options.buildParameters || {};
     this.stackMappingOverrides = options.stackMapping || {};
     this.transformConfig = options.transformConfig || {};
+    this.userDefinedSlots = options.userDefinedSlots || {} as Record<string, UserDefinedSlot[]>;
   }
 
   /**
@@ -356,7 +360,16 @@ export class GraphQLTransform {
 
   private collectResolvers(context: TransformerContext, api: GraphQLAPIProvider): void {
     const resolverEntries = context.resolvers.collectResolvers();
-    for (let [, resolver] of resolverEntries) {
+
+    for (const [resolverName, resolver] of resolverEntries) {
+      const userSlots = this.userDefinedSlots[resolverName];
+
+      if (userSlots) {
+        userSlots.forEach(({ slotName, template, fileName }: UserDefinedSlot) => {
+          resolver.addToSlot(slotName, MappingTemplate.s3MappingTemplateFromString(template, fileName));
+        });
+      }
+
       resolver.synthesize(context, api);
     }
   }

--- a/packages/amplify-graphql-transformer-core/src/transformation/types.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/types.ts
@@ -48,3 +48,11 @@ export interface DeploymentResources extends ResolversFunctionsAndSchema, Nested
   // The full stack mapping for the deployment.
   stackMapping: StackMapping;
 }
+
+export type UserDefinedSlot = {
+  fileName: string;
+  resolverTypeName: string;
+  resolverFieldName: string;
+  slotName: string;
+  template: string;
+};

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/user-defined-slots.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/user-defined-slots.test.ts
@@ -3,18 +3,20 @@ import { SLOT_NAMES, createUserDefinedSlot, parseUserDefinedSlots } from '../../
 describe('user defined slots', () => {
   describe('const SLOT_NAMES', () => {
     it('has expected value', () => {
-      expect(SLOT_NAMES).toEqual([
-        'init',
-        'preAuth',
-        'auth',
-        'postAuth',
-        'preDataLoad',
-        'preUpdate',
-        'preSubscribe',
-        'postDataLoad',
-        'postUpdate',
-        'finish',
-      ]);
+      expect(SLOT_NAMES).toEqual(
+        new Set([
+          'init',
+          'preAuth',
+          'auth',
+          'postAuth',
+          'preDataLoad',
+          'preUpdate',
+          'preSubscribe',
+          'postDataLoad',
+          'postUpdate',
+          'finish',
+        ]),
+      );
     });
   });
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/user-defined-slots.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/user-defined-slots.test.ts
@@ -1,0 +1,103 @@
+import { SLOT_NAMES, createUserDefinedSlot, parseUserDefinedSlots } from '../../graphql-transformer';
+
+describe('user defined slots', () => {
+  describe('const SLOT_NAMES', () => {
+    it('has expected value', () => {
+      expect(SLOT_NAMES).toEqual([
+        'init',
+        'preAuth',
+        'auth',
+        'postAuth',
+        'preDataLoad',
+        'preUpdate',
+        'preSubscribe',
+        'postDataLoad',
+        'postUpdate',
+        'finish',
+      ]);
+    });
+  });
+
+  describe('createUserDefinedSlot', () => {
+    it('creates the expected object shape', () => {
+      const fileName = 'Query.listTodos.postAuth.1.req.vtl';
+      const slicedName = ['Query', 'listTodos', 'postAuth', '2', 'req', 'vtl'];
+      const template = '$util.unauthorized()';
+
+      expect(createUserDefinedSlot(fileName, slicedName, template)).toEqual({
+        fileName,
+        resolverTypeName: slicedName[0],
+        resolverFieldName: slicedName[1],
+        slotName: slicedName[2],
+        template,
+      });
+    });
+  });
+
+  describe('parseUserDefinedSlots', () => {
+    it('creates the user defined slots map', () => {
+      const resolvers = {
+        'Query.listTodos.auth.2.req.vtl': 'template 1',
+        'Query.getTodo.auth.2.req.vtl': 'template 2',
+        'Query.getTodo.postAuth.2.req.vtl': 'template 3',
+        'Mutation.createTodo.auth.2.req.vtl': 'template 4',
+      };
+
+      expect(parseUserDefinedSlots(resolvers)).toEqual({
+        'Query.listTodos': [
+          {
+            fileName: 'Query.listTodos.auth.2.req.vtl',
+            resolverTypeName: 'Query',
+            resolverFieldName: 'listTodos',
+            slotName: 'auth',
+            template: 'template 1',
+          },
+        ],
+        'Query.getTodo': [
+          {
+            fileName: 'Query.getTodo.auth.2.req.vtl',
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'auth',
+            template: 'template 2',
+          },
+          {
+            fileName: 'Query.getTodo.postAuth.2.req.vtl',
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'postAuth',
+            template: 'template 3',
+          },
+        ],
+        'Mutation.createTodo': [
+          {
+            fileName: 'Mutation.createTodo.auth.2.req.vtl',
+            resolverTypeName: 'Mutation',
+            resolverFieldName: 'createTodo',
+            slotName: 'auth',
+            template: 'template 4',
+          },
+        ],
+      });
+    });
+
+    it('excludes invalid slot names', () => {
+      const resolvers = {
+        'Query.listTodos.beforeAuth.2.req.vtl': 'template 1',
+        'Query.getTodo.beforeAuth.2.req.vtl': 'template 2',
+        'Query.getTodo.afterAuth.2.req.vtl': 'template 3',
+        'Mutation.createTodo.preCreate.2.req.vtl': 'template 4',
+      };
+
+      expect(parseUserDefinedSlots(resolvers)).toEqual({});
+    });
+
+    it('exclused README file', () => {
+      const resolvers = {
+        'README.md': 'read me',
+      };
+
+      expect(parseUserDefinedSlots(resolvers)).toEqual({});
+    });
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/index.ts
@@ -1,1 +1,2 @@
 export { GraphQLResourceManager } from './amplify-graphql-resource-manager';
+export * from './user-defined-slots';

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -37,6 +37,7 @@ import { ResourceConstants } from 'graphql-transformer-common';
 import { showGlobalSandboxModeWarning, showSandboxModePrompts, schemaHasSandboxModeEnabled } from '../utils/sandbox-mode-helpers';
 import { printer } from 'amplify-prompts';
 import { GraphQLSanityCheck, SanityCheckRules } from './sanity-check';
+import { parseUserDefinedSlots } from './user-defined-slots';
 
 const API_CATEGORY = 'api';
 const STORAGE_CATEGORY = 'storage';
@@ -479,6 +480,7 @@ export async function buildAPIProject(opts: ProjectOptions<TransformerFactoryArg
 async function _buildProject(opts: ProjectOptions<TransformerFactoryArgs>) {
   const userProjectConfig = opts.projectConfig;
   const stackMapping = userProjectConfig.config.StackMapping;
+  const userDefinedSlots = parseUserDefinedSlots(userProjectConfig.resolvers);
   // Create the transformer instances, we've to make sure we're not reusing them within the same CLI command
   // because the StackMapping feature already builds the project once.
   const transformers = await opts.transformersFactory(opts.transformersFactoryArgs);
@@ -491,6 +493,7 @@ async function _buildProject(opts: ProjectOptions<TransformerFactoryArgs>) {
     stacks: opts.projectConfig.stacks || {},
     featureFlags: new AmplifyCLIFeatureFlagAdapter(),
     sandboxModeEnabled: opts.sandboxModeEnabled,
+    userDefinedSlots,
   });
 
   const schema = userProjectConfig.schema.toString();

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -480,7 +480,11 @@ export async function buildAPIProject(opts: ProjectOptions<TransformerFactoryArg
 async function _buildProject(opts: ProjectOptions<TransformerFactoryArgs>) {
   const userProjectConfig = opts.projectConfig;
   const stackMapping = userProjectConfig.config.StackMapping;
-  const userDefinedSlots = parseUserDefinedSlots(userProjectConfig.resolvers);
+  const userDefinedSlots = {
+    ...parseUserDefinedSlots(userProjectConfig.pipelineFunctions),
+    ...parseUserDefinedSlots(userProjectConfig.resolvers),
+  };
+
   // Create the transformer instances, we've to make sure we're not reusing them within the same CLI command
   // because the StackMapping feature already builds the project once.
   const transformers = await opts.transformersFactory(opts.transformersFactoryArgs);

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/user-defined-slots.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/user-defined-slots.ts
@@ -1,6 +1,6 @@
 import { UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
 
-export const SLOT_NAMES = [
+export const SLOT_NAMES = new Set([
   'init',
   'preAuth',
   'auth',
@@ -11,9 +11,9 @@ export const SLOT_NAMES = [
   'postDataLoad',
   'postUpdate',
   'finish',
-];
+]);
 
-const README = 'README.md';
+const EXCLUDE_FILES = new Set(['README.md']);
 
 export function createUserDefinedSlot(fileName: string, slicedSlotName: string[], template: string): UserDefinedSlot {
   return {
@@ -30,10 +30,10 @@ export function parseUserDefinedSlots(userDefinedTemplates: any): Record<string,
   const keys = Object.keys(userDefinedTemplates);
 
   keys.forEach(key => {
-    if (key === README) return;
+    if (EXCLUDE_FILES.has(key)) return;
 
     const slicedSlotName = key.split('.');
-    const isSlot = SLOT_NAMES.includes(slicedSlotName[2]);
+    const isSlot = SLOT_NAMES.has(slicedSlotName[2]);
 
     if (isSlot) {
       const slot = createUserDefinedSlot(key, slicedSlotName, userDefinedTemplates[key]);

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/user-defined-slots.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/user-defined-slots.ts
@@ -1,0 +1,48 @@
+import { UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
+
+export const SLOT_NAMES = [
+  'init',
+  'preAuth',
+  'auth',
+  'postAuth',
+  'preDataLoad',
+  'preUpdate',
+  'preSubscribe',
+  'postDataLoad',
+  'postUpdate',
+  'finish',
+];
+
+const README = 'README.md';
+
+export function createUserDefinedSlot(fileName: string, slicedSlotName: string[], template: string): UserDefinedSlot {
+  return {
+    fileName,
+    resolverTypeName: slicedSlotName[0],
+    resolverFieldName: slicedSlotName[1],
+    slotName: slicedSlotName[2],
+    template,
+  };
+}
+
+export function parseUserDefinedSlots(userDefinedTemplates: any): Record<string, UserDefinedSlot[]> {
+  const slots: Record<string, UserDefinedSlot[]> = {};
+  const keys = Object.keys(userDefinedTemplates);
+
+  keys.forEach(key => {
+    if (key === README) return;
+
+    const slicedSlotName = key.split('.');
+    const isSlot = SLOT_NAMES.includes(slicedSlotName[2]);
+
+    if (isSlot) {
+      const slot = createUserDefinedSlot(key, slicedSlotName, userDefinedTemplates[key]);
+      const resolverName = [slicedSlotName[0], slicedSlotName[1]].join('.');
+
+      if (!slots[resolverName]) slots[resolverName] = [slot];
+      else slots[resolverName].push(slot);
+    }
+  });
+
+  return slots;
+}

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/TransformerOptionsV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/TransformerOptionsV2.e2e.test.ts
@@ -1,0 +1,164 @@
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { Output } from 'aws-sdk/clients/cloudformation';
+import { CloudFormationClient } from '../CloudFormationClient';
+import { S3Client } from '../S3Client';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
+import { default as CognitoClient } from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import { default as S3 } from 'aws-sdk/clients/s3';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import moment from 'moment';
+import { createUserPool, createUserPoolClient, configureAmplify } from '../cognitoUtils';
+import { ResourceConstants } from 'graphql-transformer-common';
+import gql from 'graphql-tag';
+
+jest.setTimeout(2000000);
+
+const AWS_REGION = 'us-west-2';
+
+describe('V2 transformer options', () => {
+  const cf = new CloudFormationClient(AWS_REGION);
+  const customS3Client = new S3Client(AWS_REGION);
+  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: AWS_REGION });
+  const awsS3Client = new S3({ region: AWS_REGION });
+
+  const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+  const STACK_NAME = `TransformerOptionsV2Tests-${BUILD_TIMESTAMP}`;
+  const BUCKET_NAME = `appsync-transformer-options-test-bucket-${BUILD_TIMESTAMP}`;
+  const LOCAL_FS_BUILD_DIR = '/tmp/transformer_options_v2_tests/';
+  const S3_ROOT_DIR_KEY = 'deployments';
+
+  let USER_POOL_ID: string;
+  let GRAPHQL_ENDPOINT: string;
+  let GRAPHQL_CLIENT: AWSAppSyncClient<any>;
+
+  let validSchema: string;
+  let authConfig: AppSyncAuthConfiguration;
+  let userPoolClientId: string;
+  let getApiEndpoint: any;
+  let getApiKey: any;
+
+  function outputValueSelector(key: string) {
+    return (outputs: Output[]) => {
+      const output = outputs.find((o: Output) => o.OutputKey === key);
+      return output ? output.OutputValue : null;
+    };
+  }
+
+  beforeAll(async () => {
+    validSchema = `
+      type Post @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        title: String!
+        createdAt: AWSDateTime
+        updatedAt: AWSDateTime
+      }`;
+
+    try {
+      await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+    } catch (e) {
+      throw Error(`Could not create bucket: ${e}`);
+    }
+    authConfig = {
+      defaultAuthentication: {
+        authenticationType: 'API_KEY',
+      },
+      additionalAuthenticationProviders: [],
+    };
+
+    const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+    USER_POOL_ID = userPoolResponse.UserPool.Id;
+    const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+    userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+
+    getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+    getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+  });
+
+  afterAll(async () => {
+    await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf, { cognitoClient, userPoolId: USER_POOL_ID });
+  });
+
+  describe('userDefinedSlots', () => {
+    describe('created slot from a user', () => {
+      beforeAll(async () => {
+        try {
+          const userDefinedSlots = {
+            'Query.listPosts': [
+              {
+                fileName: 'Query.listPosts.preAuth.1.req.vtl',
+                resolverTypeName: 'Query',
+                resolverFieldName: 'listPosts',
+                slotName: 'preAuth',
+                template: '$util.error("Custom error")\n$util.toJson({})\n',
+              },
+            ],
+          };
+
+          const transformer = new GraphQLTransform({
+            authConfig,
+            transformers: [new ModelTransformer(), new AuthTransformer()],
+            userDefinedSlots,
+          });
+
+          const out = transformer.transform(validSchema);
+          const finishedStack = await deploy(
+            customS3Client,
+            cf,
+            STACK_NAME,
+            out,
+            {},
+            LOCAL_FS_BUILD_DIR,
+            BUCKET_NAME,
+            S3_ROOT_DIR_KEY,
+            BUILD_TIMESTAMP,
+          );
+
+          GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+          const apiKey = getApiKey(finishedStack.Outputs);
+
+          GRAPHQL_CLIENT = new AWSAppSyncClient({
+            url: GRAPHQL_ENDPOINT,
+            region: AWS_REGION,
+            auth: {
+              type: AUTH_TYPE.API_KEY,
+              apiKey: apiKey,
+            },
+            disableOffline: true,
+          });
+
+          configureAmplify(USER_POOL_ID, userPoolClientId);
+        } catch (e) {
+          console.error(`Could not setup tests ${e}`);
+          expect(true).toBe(false);
+        }
+      });
+
+      test('created slot from user', async () => {
+        const query = gql`
+          query {
+            listPosts {
+              items {
+                id
+                title
+              }
+            }
+          }
+        `;
+
+        try {
+          await expect(
+            GRAPHQL_CLIENT.query<any>({
+              query,
+              fetchPolicy: 'no-cache',
+            }),
+          ).rejects.toThrow('GraphQL error: Custom error');
+        } catch (err) {
+          expect(err).not.toBeDefined();
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds capability to add custom slots/pipeline functions to resolvers and uploads them to AppSync and S3.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Description of how you validated changes
- wrote unit tests
- tested locally
- CLI e2e test
- transformer e2e test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
