### PR TITLE
fix: remove no-override check for category transformations

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
+++ b/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
@@ -13,9 +13,6 @@ import { storeRootStackTemplate } from '../initializer';
  */
 export async function transformResourceWithOverrides(context: $TSContext, resource?: IAmplifyResource) {
   const flags = context.parameters.options;
-  if (flags['no-override']) {
-    return;
-  }
   try {
     if (resource) {
       const { transformCategoryStack } = await import(`@aws-amplify/amplify-category-${resource.category}`);


### PR DESCRIPTION
remove --no-overrides param check from transformation step. This was causing Console CI/CD to fail as it uses that flag to avoid generating client-code in CI/CD.