### PR TITLE
feat: exclude amplify/backend/awscloudformation from gitignore path

### DIFF
--- a/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
+++ b/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
@@ -57,7 +57,7 @@ export function getResourceCfnOutputAttributes(category: string, resourceName: s
   }
   if (cfnFilePath) {
     const { cfnTemplate } = readCFNTemplate(cfnFilePath);
-    if (cfnTemplate.Outputs) {
+    if (cfnTemplate && cfnTemplate.Outputs) {
       const allOutputs: $TSObject = cfnTemplate.Outputs;
       let outputsWithoutConditions: any = {};
 

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/git-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/git-manager.test.ts
@@ -19,7 +19,6 @@ const ignoreList = [
   `amplify/${LocalLogDirectory}`,
   'amplify/mock-data',
   'amplify/backend/amplify-meta.json',
-  'amplify/backend/awscloudformation',
   'amplify/backend/.temp',
   'build/',
   'dist/',

--- a/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/git-manager.ts
@@ -53,7 +53,6 @@ function getGitIgnoreAppendString() {
     `amplify/${LocalLogDirectory}`,
     'amplify/mock-data',
     'amplify/backend/amplify-meta.json',
-    'amplify/backend/awscloudformation',
     'amplify/backend/.temp',
     'build/',
     'dist/',

--- a/packages/amplify-cli/src/input-manager.ts
+++ b/packages/amplify-cli/src/input-manager.ts
@@ -4,6 +4,8 @@ import { constants } from './domain/constants';
 import { PluginPlatform } from './domain/plugin-platform';
 import { getPluginsWithName, getAllPluginNames } from './plugin-manager';
 import { InputVerificationResult } from './domain/input-verification-result';
+import { pathManager, stateManager } from 'amplify-cli-core';
+import { insertAmplifyIgnore } from './extensions/amplify-helpers/git-manager';
 
 export function getCommandLineInput(pluginPlatform: PluginPlatform): Input {
   const result = new Input(process.argv);
@@ -197,5 +199,10 @@ export function verifyInput(pluginPlatform: PluginPlatform, input: Input): Input
 function aliasArgs(argv: string[]) {
   if (argv.length >= 4 && argv[2] === 'override' && argv[3] === 'project') {
     argv[3] = 'root';
+
+    // Also update gitignore to latest list - mainly to exclude amplify/backend/awscloudformation dir from .gitingore for older projects
+    const { projectPath } = stateManager.getLocalEnvInfo();
+    const gitIgnoreFilePath = pathManager.getGitIgnoreFilePath(projectPath);
+    insertAmplifyIgnore(gitIgnoreFilePath);
   }
 }

--- a/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
+++ b/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
@@ -1,11 +1,12 @@
-import { $TSContext, FeatureFlags, IAmplifyResource, JSONUtilities, pathManager } from 'amplify-cli-core';
+import { $TSContext, IAmplifyResource, JSONUtilities, pathManager } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
-import { transformRootStack } from '.';
 import * as fs from 'fs-extra';
-import { prePushCfnTemplateModifier } from '../pre-push-cfn-processor/pre-push-cfn-modifier';
 import * as path from 'path';
+import { transformRootStack } from '.';
+import { prePushCfnTemplateModifier } from '../pre-push-cfn-processor/pre-push-cfn-modifier';
 import { rootStackFileName } from '../push-resources';
-import { storeRootStackTemplate } from '../initializer';
+import ora from 'ora';
+
 /**
  *
  * @param context
@@ -13,11 +14,22 @@ import { storeRootStackTemplate } from '../initializer';
  */
 export async function transformResourceWithOverrides(context: $TSContext, resource?: IAmplifyResource) {
   const flags = context.parameters.options;
+  let spinner: ora.Ora;
+
+  console.log('im here');
+  console.log(resource);
+
   try {
     if (resource) {
       const { transformCategoryStack } = await import(`@aws-amplify/amplify-category-${resource.category}`);
+      console.log(transformCategoryStack);
+
       if (transformCategoryStack) {
-        return await transformCategoryStack(context, resource);
+        spinner = ora(`Building resource ${resource.category}/${resource.resourceName}`);
+        spinner.start();
+        await transformCategoryStack(context, resource);
+        spinner.stop();
+        return;
       } else {
         printer.info('Overrides functionality is not impleented for this category');
       }
@@ -32,6 +44,7 @@ export async function transformResourceWithOverrides(context: $TSContext, resour
       JSONUtilities.writeJson(rootStackBackendFilePath, template);
     }
   } catch (err) {
+    spinner.stop();
     return;
   }
 }

--- a/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
+++ b/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
@@ -16,13 +16,9 @@ export async function transformResourceWithOverrides(context: $TSContext, resour
   const flags = context.parameters.options;
   let spinner: ora.Ora;
 
-  console.log('im here');
-  console.log(resource);
-
   try {
     if (resource) {
       const { transformCategoryStack } = await import(`@aws-amplify/amplify-category-${resource.category}`);
-      console.log(transformCategoryStack);
 
       if (transformCategoryStack) {
         spinner = ora(`Building resource ${resource.category}/${resource.resourceName}`);


### PR DESCRIPTION
1.exclude amplify/backend/awscloudformation from gitignore path
2.add spinner when building resources
