### PR TITLE
fix(cli): add noUpdateBackend cli argument for pull and add headless pull sample

### DIFF
--- a/packages/amplify-cli/sample-headless-scripts/headless_pull.sh
+++ b/packages/amplify-cli/sample-headless-scripts/headless_pull.sh
@@ -1,0 +1,36 @@
+!/bin/bash
+
+set -e
+IFS='|'
+
+REACTCONFIG="{\
+\"SourceDir\":\"src\",\
+\"DistributionDir\":\"build\",\
+\"BuildCommand\":\"npm run-script build\",\
+\"StartCommand\":\"npm run-script start\"\
+}"
+AWSCLOUDFORMATIONCONFIG="{\
+\"configLevel\":\"project\",\
+\"useProfile\":true,\
+\"profileName\":\"default\",\
+}"
+AMPLIFY="{\
+\"projectName\":\"headlessProjectName\",\
+\"defaultEditor\":\"code\"\
+}"
+FRONTEND="{\
+\"frontend\":\"javascript\",\
+\"framework\":\"react\",\
+\"config\":$REACTCONFIG\
+}"
+PROVIDERS="{\
+\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\
+}"
+
+amplify pull \
+--appId myappId \
+--envName mydevabc \
+--amplify $AMPLIFY \
+--frontend $FRONTEND \
+--providers $PROVIDERS \
+--noUpdateBackend

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -61,7 +61,7 @@ async function onSuccess(context: $TSContext) {
   if (!inputParams.yes) {
     const shouldKeepAmplifyDir = context.exeInfo.existingLocalEnvInfo?.noUpdateBackend
       ? !context.exeInfo.existingLocalEnvInfo.noUpdateBackend
-      : await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true);
+      : !inputParams.noUpdateBackend && (await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true));
 
     if (shouldKeepAmplifyDir) {
       if (stateManager.currentMetaFileExists()) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds an option to the cli when using the pull option that lets you specify not to update the
backend (--noUpdateBackend) to be able to generate aws-exports.js. This is an alternative to --yes option which defaults
to modifying the backend and is good for frontend custom CICD deployments.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
re #7468

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested with pull script and was able to pull down an existing amplify app to an empty project directory. 
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
