### PR TITLE
fix: map readable attr name to ddb name in parameters.json

### DIFF
--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/ddb-stack-transform.test.ts.snap
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/ddb-stack-transform.test.ts.snap
@@ -182,9 +182,9 @@ Object {
 exports[`Test DDB transform generates correct CFN template Generated ddb template with all CLI configurations set with no overrides 2`] = `
 Object {
   "partitionKeyName": "id",
-  "partitionKeyType": "string",
+  "partitionKeyType": "S",
   "sortKeyName": "name",
-  "sortKeyType": "number",
+  "sortKeyType": "N",
   "tableName": "mocktablename",
 }
 `;

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
@@ -11,6 +11,7 @@ import { DynamoDBCLIInputs } from '../service-walkthrough-types/dynamoDB-user-in
 import { DynamoDBInputState } from '../service-walkthroughs/dynamoDB-input-state';
 import { AmplifyDDBResourceStack } from './ddb-stack-builder';
 import { AmplifyDDBResourceInputParameters } from './types';
+import { getDdbAttrType } from '../cfn-template-utils';
 
 export class DDBStackTransform {
   app: App;
@@ -49,11 +50,11 @@ export class DDBStackTransform {
     this._cfnInputParams = {
       tableName: this._cliInputs.tableName,
       partitionKeyName: this._cliInputs.partitionKey.fieldName,
-      partitionKeyType: this._cliInputs.partitionKey.fieldType,
+      partitionKeyType: getDdbAttrType(this._cliInputs.partitionKey.fieldType),
     };
     if (this._cliInputs.sortKey) {
       this._cfnInputParams.sortKeyName = this._cliInputs.sortKey.fieldName;
-      this._cfnInputParams.sortKeyType = this._cliInputs.sortKey.fieldType;
+      this._cfnInputParams.sortKeyType = getDdbAttrType(this._cliInputs.sortKey.fieldType);
     }
   }
 

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
@@ -1,13 +1,14 @@
 import { AmplifyCDKL1 } from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from '@aws-cdk/core';
 import { $TSObject } from 'amplify-cli-core';
+import { DdbAttrType } from '../cfn-template-utils';
 
 export interface AmplifyDDBResourceInputParameters {
   tableName: string;
   partitionKeyName: string;
-  partitionKeyType: string;
+  partitionKeyType: DdbAttrType;
   sortKeyName?: string;
-  sortKeyType?: string;
+  sortKeyType?: DdbAttrType;
 }
 
 export type AmplifyCfnParamType = {

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cfn-template-utils.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cfn-template-utils.ts
@@ -4,6 +4,7 @@ import Table, { AttributeDefinition, GlobalSecondaryIndex } from 'cloudform-type
 import _ from 'lodash';
 import * as path from 'path';
 import { AmplifyCategories } from 'amplify-cli-core';
+import { FieldType } from './service-walkthrough-types/dynamoDB-user-input-types';
 
 export const getCloudFormationTemplatePath = (resourceName: string) => {
   return path.join(
@@ -45,4 +46,59 @@ const getTableFromTemplate = (cfnTemplate?: Template): Table | undefined => {
   }
   const cfnTable = Object.values(cfnTemplate!.Resources!).find(resource => resource.Type === 'AWS::DynamoDB::Table') as Table | undefined;
   return cfnTable;
+};
+
+export enum DdbAttrType {
+  S = 'S', // string
+  N = 'N', // number
+  B = 'B', // binary
+  BOOL = 'BOOL', // boolean
+  NULL = 'NULL', // null
+  L = 'L', // list
+  M = 'M', // map
+  SS = 'SS', // string-set
+  NS = 'NS', // number-set
+  BS = 'BS', // binary-set
+}
+
+const ddbAttrToFieldType: Record<DdbAttrType, FieldType> = {
+  [DdbAttrType.S]: FieldType.string,
+  [DdbAttrType.N]: FieldType.number,
+  [DdbAttrType.B]: FieldType.binary,
+  [DdbAttrType.BOOL]: FieldType.boolean,
+  [DdbAttrType.NULL]: FieldType.null,
+  [DdbAttrType.L]: FieldType.list,
+  [DdbAttrType.M]: FieldType.map,
+  [DdbAttrType.SS]: FieldType.stringSet,
+  [DdbAttrType.NS]: FieldType.numberSet,
+  [DdbAttrType.BS]: FieldType.binarySet,
+};
+
+const fieldTypeToDdbAttr: Record<FieldType, DdbAttrType> = {
+  [FieldType.string]: DdbAttrType.S,
+  [FieldType.number]: DdbAttrType.N,
+  [FieldType.binary]: DdbAttrType.B,
+  [FieldType.boolean]: DdbAttrType.BOOL,
+  [FieldType.null]: DdbAttrType.NULL,
+  [FieldType.list]: DdbAttrType.L,
+  [FieldType.map]: DdbAttrType.M,
+  [FieldType.stringSet]: DdbAttrType.SS,
+  [FieldType.numberSet]: DdbAttrType.NS,
+  [FieldType.binarySet]: DdbAttrType.BS,
+};
+
+export const getFieldType = (ddbAttr: DdbAttrType): FieldType => {
+  const result = ddbAttrToFieldType[ddbAttr];
+  if (!result) {
+    throw new Error(`Unknown DDB attribute type ${ddbAttr}`);
+  }
+  return result;
+};
+
+export const getDdbAttrType = (fieldType: FieldType): DdbAttrType => {
+  const result = fieldTypeToDdbAttr[fieldType];
+  if (!result) {
+    throw new Error(`Unknown FieldType ${fieldType}`);
+  }
+  return result;
 };

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/import/import-dynamodb.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/import/import-dynamodb.ts
@@ -16,19 +16,6 @@ import {
   ProviderUtils,
 } from './types';
 
-const attrReverseMap: $TSObject = {
-  S: 'string',
-  N: 'number',
-  B: 'binary',
-  BOOL: 'boolean',
-  L: 'list',
-  M: 'map',
-  NULL: null,
-  SS: 'string-set',
-  NS: 'number-set',
-  BS: 'binary-set',
-};
-
 export const importDynamoDB = async (
   context: $TSContext,
   serviceSelection: ServiceSelection,
@@ -218,7 +205,7 @@ const createMetaOutput = (answers: DynamoDBImportAnswers, questionParameters: Dy
 
     if (attribute) {
       output.PartitionKeyName = hashKey.AttributeName;
-      output.PartitionKeyType = attrReverseMap[attribute.AttributeType];
+      output.PartitionKeyType = attribute.AttributeType;
     }
   }
 
@@ -227,7 +214,7 @@ const createMetaOutput = (answers: DynamoDBImportAnswers, questionParameters: Dy
 
     if (attribute) {
       output.SortKeyName = sortKeys[0].AttributeName;
-      output.SortKeyType = attrReverseMap[attribute.AttributeType];
+      output.SortKeyType = attribute.AttributeType;
     }
   }
 
@@ -253,7 +240,7 @@ const createEnvSpecificResourceParameters = (
 
     if (attribute) {
       envSpecificResourceParameters.partitionKeyName = hashKey.AttributeName;
-      envSpecificResourceParameters.partitionKeyType = attrReverseMap[attribute.AttributeType];
+      envSpecificResourceParameters.partitionKeyType = attribute.AttributeType;
     }
   }
 
@@ -262,7 +249,7 @@ const createEnvSpecificResourceParameters = (
 
     if (attribute) {
       envSpecificResourceParameters.sortKeyName = sortKeys[0].AttributeName;
-      envSpecificResourceParameters.sortKeyType = attrReverseMap[attribute.AttributeType];
+      envSpecificResourceParameters.sortKeyType = attribute.AttributeType;
     }
   }
 

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthrough-types/dynamoDB-user-input-types.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthrough-types/dynamoDB-user-input-types.ts
@@ -13,6 +13,9 @@ export enum FieldType {
   list = 'list',
   map = 'map',
   null = 'null',
+  stringSet = 'string-set',
+  numberSet = 'number-set',
+  binarySet = 'binary-set',
 }
 
 export interface DynamoDBAttributeDefType {

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/dynamoDB-input-state.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/dynamoDB-input-state.ts
@@ -9,6 +9,7 @@ import {
 } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { getFieldType } from '../cfn-template-utils';
 import { DynamoDBCLIInputs, DynamoDBCLIInputsGSIType } from '../service-walkthrough-types/dynamoDB-user-input-types';
 
 /* Need to move this logic to a base class */
@@ -69,18 +70,6 @@ export class DynamoDBInputState {
 
   public migrate() {
     let cliInputs: DynamoDBCLIInputs;
-    const attrReverseMap: $TSObject = {
-      S: 'string',
-      N: 'number',
-      B: 'binary',
-      BOOL: 'boolean',
-      L: 'list',
-      M: 'map',
-      NULL: null,
-      SS: 'string-set',
-      NS: 'number-set',
-      BS: 'binary-set',
-    };
 
     // migrate the resource to new directory structure if cli-inputs.json is not found for the resource
 
@@ -95,7 +84,7 @@ export class DynamoDBInputState {
 
     const partitionKey = {
       fieldName: oldParameters.partitionKeyName,
-      fieldType: attrReverseMap[oldParameters.partitionKeyType],
+      fieldType: getFieldType(oldParameters.partitionKeyType),
     };
 
     let sortKey;
@@ -103,7 +92,7 @@ export class DynamoDBInputState {
     if (oldParameters.sortKeyName) {
       sortKey = {
         fieldName: oldParameters.sortKeyName,
-        fieldType: attrReverseMap[oldParameters.sortKeyType],
+        fieldType: getFieldType(oldParameters.sortKeyType),
       };
     }
 
@@ -118,7 +107,7 @@ export class DynamoDBInputState {
 
       attrList.forEach((attr: $TSAny) => {
         if (attr.AttributeName === attrName) {
-          attrType = attrReverseMap[attr.AttributeType];
+          attrType = getFieldType(attr.AttributeType);
         }
       });
 

--- a/packages/amplify-nodejs-function-template-provider/src/providers/crudProvider.ts
+++ b/packages/amplify-nodejs-function-template-provider/src/providers/crudProvider.ts
@@ -5,14 +5,15 @@ import fs from 'fs-extra';
 import { askDynamoDBQuestions, getTableParameters } from '../utils/dynamoDBWalkthrough';
 import _ from 'lodash';
 import { getDstMap } from '../utils/destFileMapper';
+import { $TSContext } from 'amplify-cli-core';
 
 const pathToTemplateFiles = path.join(templateRoot, 'lambda/crud');
 
 // copied from legacy lambda-walkthrough with slight modifications for typescript and refactored FunctionParameters object
-export async function provideCrud(context: any): Promise<FunctionTemplateParameters> {
+export async function provideCrud(context: $TSContext): Promise<FunctionTemplateParameters> {
   const dynamoResource = await askDynamoDBQuestions(context);
 
-  const tableParameters = await getTableParameters(context, dynamoResource);
+  const tableParameters = await getTableParameters(dynamoResource);
   Object.assign(dynamoResource, { category: 'storage' }, { tableDefinition: { ...tableParameters } });
   const files = fs.readdirSync(pathToTemplateFiles);
   return {

--- a/packages/amplify-nodejs-function-template-provider/src/utils/dynamoDBWalkthrough.ts
+++ b/packages/amplify-nodejs-function-template-provider/src/utils/dynamoDBWalkthrough.ts
@@ -1,8 +1,9 @@
+import { $TSContext, AmplifyCategories, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
 import inquirer from 'inquirer';
 import path from 'path';
 const TransformPackage = require('graphql-transformer-core');
 const { ResourceDoesNotExistError, exitOnNextTick } = require('amplify-cli-core');
-export async function askDynamoDBQuestions(context: any, currentProjectOnly = false): Promise<{ resourceName: string }> {
+export async function askDynamoDBQuestions(context: $TSContext, currentProjectOnly = false): Promise<{ resourceName: string }> {
   const dynamoDbTypeQuestion = {
     type: 'list',
     name: 'dynamoDbType',
@@ -50,7 +51,7 @@ export async function askDynamoDBQuestions(context: any, currentProjectOnly = fa
         return { resourceName: dynamoResourceAnswer.dynamoDbResources as string };
       }
       case 'newResource': {
-        const resourceName = await context.amplify.invokePluginMethod(context, 'storage', undefined, 'add', [
+        const resourceName = await context.amplify.invokePluginMethod<string>(context, 'storage', undefined, 'add', [
           context,
           'awscloudformation',
           'DynamoDB',
@@ -67,7 +68,7 @@ export async function askDynamoDBQuestions(context: any, currentProjectOnly = fa
   throw new Error('Invalid option selected');
 }
 
-export async function getTableParameters(context: any, dynamoAnswers: any): Promise<any> {
+export async function getTableParameters(dynamoAnswers: any): Promise<TableParams | {}> {
   if (dynamoAnswers.Arn) {
     // Looking for table parameters on DynamoDB public API
     const hashKey = dynamoAnswers.KeySchema.find((attr: any) => attr.KeyType === 'HASH') || {};
@@ -81,19 +82,32 @@ export async function getTableParameters(context: any, dynamoAnswers: any): Prom
       sortKeyName: rangeKey.AttributeName,
       sortKeyType: rangeType.AttributeType,
     };
-  } // Looking for table parameters on local configuration
-  const projectBackendDirPath = context.amplify.pathManager.getBackendDirPath();
-  const resourceDirPath = path.join(projectBackendDirPath, 'storage', dynamoAnswers.resourceName);
-  const parametersFilePath = path.join(resourceDirPath, 'parameters.json');
-  let parameters;
-  try {
-    parameters = context.amplify.readJsonFile(parametersFilePath);
-  } catch (e) {
-    parameters = {};
   }
-
-  return parameters;
+  // Look for table config in parameters.json, then build/parameters.json, then fallback to {}
+  const parametersJson: TableParams = stateManager.getResourceParametersJson(
+    undefined,
+    AmplifyCategories.STORAGE,
+    dynamoAnswers.resourceName,
+    { throwIfNotExist: false },
+  );
+  const buildParamsJson = JSONUtilities.readJson<TableParams>(
+    path.join(
+      pathManager.getResourceDirectoryPath(undefined, AmplifyCategories.STORAGE, dynamoAnswers.resourceName),
+      'build',
+      'parameters.json',
+    ),
+    { throwIfNotExist: false },
+  );
+  return parametersJson ?? buildParamsJson ?? {};
 }
+
+type TableParams = {
+  tableName: string;
+  partitionKeyName: string;
+  partitionKeyType: string;
+  sortKeyName?: string;
+  sortKeyType?: string;
+};
 
 export async function askAPICategoryDynamoDBQuestions(context: any) {
   const { allResources } = await context.amplify.getResourceStatus();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Updates the mapper for creating `build/parameters.json` from `cli-inputs.json` in the storage category. The mapper now maps the human readable field attribute names "string", "number", "list", etc. to the corresponding DynamoDB attribute type "S", "N", "L", etc.

It also removes the reverse mapping when importing a table and placing these properties in amplify-meta to match the original behavior.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified that table properties are properly populated in function CRUD template

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
