### PR TITLE
fix: create pipeline resolvers for @http v2

### DIFF
--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.10.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.10.1",
+    "@aws-cdk/aws-appsync": "~1.124.0",
     "@aws-cdk/aws-lambda": "~1.124.0",
     "@aws-cdk/core": "~1.124.0",
     "graphql": "^14.5.8",

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.10.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.10.1",
+    "@aws-cdk/aws-appsync": "~1.124.0",
     "@aws-cdk/core": "~1.124.0",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.18.4",

--- a/packages/amplify-graphql-http-transformer/src/__tests__/__snapshots__/amplify-graphql-http-transformer.test.ts.snap
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/__snapshots__/amplify-graphql-http-transformer.test.ts.snap
@@ -2,12 +2,7 @@
 
 exports[`generates expected VTL 1`] = `
 Object {
-  "Comment.complexPut.res.vtl": "$util.toJson($ctx.prev.result)",
-  "Comment.content.res.vtl": "$util.toJson($ctx.prev.result)",
-  "Comment.contentDelete.res.vtl": "$util.toJson($ctx.prev.result)",
-  "Comment.contentPatch.res.vtl": "$util.toJson($ctx.prev.result)",
-  "Comment.contentPost.res.vtl": "$util.toJson($ctx.prev.result)",
-  "httpsjsonplaceholdertypicodecomDataSourceCommentcomplexPutFunction.req.vtl": "## [Start] Create request. **
+  "Comment.complexPut.DataResolver.req.vtl": "## [Start] Create request. **
 ## START: Manually checking that all non-null arguments are provided either in the query or the body **
 #if( (!$ctx.args.body.userId && !$ctx.args.query.userId) )
 $util.error(\\"An argument you marked as Non-Null is not present in the query nor the body of your request.\\"))
@@ -28,7 +23,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValuePut\\"))
   }
 }
 ## [End] Create request. **",
-  "httpsjsonplaceholdertypicodecomDataSourceCommentcomplexPutFunction.res.vtl": "## [Start] Process response. **
+  "Comment.complexPut.DataResolver.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 || $ctx.result.statusCode == 201 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -39,31 +34,8 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
-  "httpswwwapicomDataSourceCommentcontentDeleteFunction.req.vtl": "## [Start] Create request. **
-#set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
-$util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
-$util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValueDelete\\"))
-{
-  \\"version\\": \\"2018-05-29\\",
-  \\"method\\": \\"DELETE\\",
-  \\"resourcePath\\": \\"/ping\\",
-  \\"params\\": {
-      \\"headers\\": $util.toJson($headers)
-  }
-}
-## [End] Create request. **",
-  "httpswwwapicomDataSourceCommentcontentDeleteFunction.res.vtl": "## [Start] Process response. **
-#if( $ctx.result.statusCode == 200 )
-  #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
-$utils.xml.toJsonString($ctx.result.body)
-  #else
-$ctx.result.body
-  #end
-#else
-$util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
-#end
-## [End] Process response. **",
-  "httpswwwapicomDataSourceCommentcontentFunction.req.vtl": "## [Start] Create request. **
+  "Comment.complexPut.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.content.DataResolver.req.vtl": "## [Start] Create request. **
 #set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
 $util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
 $util.qr($headers.put(\\"X-Header\\", \\"X-Header-Value\\"))
@@ -77,7 +49,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-Value\\"))
   }
 }
 ## [End] Create request. **",
-  "httpswwwapicomDataSourceCommentcontentFunction.res.vtl": "## [Start] Process response. **
+  "Comment.content.DataResolver.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -88,7 +60,33 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
-  "httpswwwapicomDataSourceCommentcontentPatchFunction.req.vtl": "## [Start] Create request. **
+  "Comment.content.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.contentDelete.DataResolver.req.vtl": "## [Start] Create request. **
+#set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
+$util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
+$util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValueDelete\\"))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"DELETE\\",
+  \\"resourcePath\\": \\"/ping\\",
+  \\"params\\": {
+      \\"headers\\": $util.toJson($headers)
+  }
+}
+## [End] Create request. **",
+  "Comment.contentDelete.DataResolver.res.vtl": "## [Start] Process response. **
+#if( $ctx.result.statusCode == 200 )
+  #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
+$utils.xml.toJsonString($ctx.result.body)
+  #else
+$ctx.result.body
+  #end
+#else
+$util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
+#end
+## [End] Process response. **",
+  "Comment.contentDelete.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.contentPatch.DataResolver.req.vtl": "## [Start] Create request. **
 #set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
 $util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
 $util.qr($headers.put(\\"Content-Type\\", \\"application/json\\"))
@@ -104,7 +102,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValuePatch\\"))
   }
 }
 ## [End] Create request. **",
-  "httpswwwapicomDataSourceCommentcontentPatchFunction.res.vtl": "## [Start] Process response. **
+  "Comment.contentPatch.DataResolver.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 || $ctx.result.statusCode == 201 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -115,7 +113,8 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
-  "httpswwwapicomDataSourceCommentcontentPostFunction.req.vtl": "## [Start] Create request. **
+  "Comment.contentPatch.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.contentPost.DataResolver.req.vtl": "## [Start] Create request. **
 #set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
 $util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
 $util.qr($headers.put(\\"Content-Type\\", \\"application/json\\"))
@@ -131,7 +130,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValuePost\\"))
   }
 }
 ## [End] Create request. **",
-  "httpswwwapicomDataSourceCommentcontentPostFunction.res.vtl": "## [Start] Process response. **
+  "Comment.contentPost.DataResolver.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 || $ctx.result.statusCode == 201 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -142,5 +141,6 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
+  "Comment.contentPost.res.vtl": "$util.toJson($ctx.prev.result)",
 }
 `;

--- a/packages/amplify-graphql-http-transformer/src/__tests__/__snapshots__/amplify-graphql-http-transformer.test.ts.snap
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/__snapshots__/amplify-graphql-http-transformer.test.ts.snap
@@ -2,7 +2,12 @@
 
 exports[`generates expected VTL 1`] = `
 Object {
-  "Comment.complexPut.req.vtl": "## [Start] Create request. **
+  "Comment.complexPut.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.content.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.contentDelete.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.contentPatch.res.vtl": "$util.toJson($ctx.prev.result)",
+  "Comment.contentPost.res.vtl": "$util.toJson($ctx.prev.result)",
+  "httpsjsonplaceholdertypicodecomDataSourceCommentcomplexPutFunction.req.vtl": "## [Start] Create request. **
 ## START: Manually checking that all non-null arguments are provided either in the query or the body **
 #if( (!$ctx.args.body.userId && !$ctx.args.query.userId) )
 $util.error(\\"An argument you marked as Non-Null is not present in the query nor the body of your request.\\"))
@@ -23,7 +28,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValuePut\\"))
   }
 }
 ## [End] Create request. **",
-  "Comment.complexPut.res.vtl": "## [Start] Process response. **
+  "httpsjsonplaceholdertypicodecomDataSourceCommentcomplexPutFunction.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 || $ctx.result.statusCode == 201 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -34,7 +39,31 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
-  "Comment.content.req.vtl": "## [Start] Create request. **
+  "httpswwwapicomDataSourceCommentcontentDeleteFunction.req.vtl": "## [Start] Create request. **
+#set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
+$util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
+$util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValueDelete\\"))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"DELETE\\",
+  \\"resourcePath\\": \\"/ping\\",
+  \\"params\\": {
+      \\"headers\\": $util.toJson($headers)
+  }
+}
+## [End] Create request. **",
+  "httpswwwapicomDataSourceCommentcontentDeleteFunction.res.vtl": "## [Start] Process response. **
+#if( $ctx.result.statusCode == 200 )
+  #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
+$utils.xml.toJsonString($ctx.result.body)
+  #else
+$ctx.result.body
+  #end
+#else
+$util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
+#end
+## [End] Process response. **",
+  "httpswwwapicomDataSourceCommentcontentFunction.req.vtl": "## [Start] Create request. **
 #set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
 $util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
 $util.qr($headers.put(\\"X-Header\\", \\"X-Header-Value\\"))
@@ -48,7 +77,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-Value\\"))
   }
 }
 ## [End] Create request. **",
-  "Comment.content.res.vtl": "## [Start] Process response. **
+  "httpswwwapicomDataSourceCommentcontentFunction.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -59,31 +88,7 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
-  "Comment.contentDelete.req.vtl": "## [Start] Create request. **
-#set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
-$util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
-$util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValueDelete\\"))
-{
-  \\"version\\": \\"2018-05-29\\",
-  \\"method\\": \\"DELETE\\",
-  \\"resourcePath\\": \\"/ping\\",
-  \\"params\\": {
-      \\"headers\\": $util.toJson($headers)
-  }
-}
-## [End] Create request. **",
-  "Comment.contentDelete.res.vtl": "## [Start] Process response. **
-#if( $ctx.result.statusCode == 200 )
-  #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
-$utils.xml.toJsonString($ctx.result.body)
-  #else
-$ctx.result.body
-  #end
-#else
-$util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
-#end
-## [End] Process response. **",
-  "Comment.contentPatch.req.vtl": "## [Start] Create request. **
+  "httpswwwapicomDataSourceCommentcontentPatchFunction.req.vtl": "## [Start] Create request. **
 #set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
 $util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
 $util.qr($headers.put(\\"Content-Type\\", \\"application/json\\"))
@@ -99,7 +104,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValuePatch\\"))
   }
 }
 ## [End] Create request. **",
-  "Comment.contentPatch.res.vtl": "## [Start] Process response. **
+  "httpswwwapicomDataSourceCommentcontentPatchFunction.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 || $ctx.result.statusCode == 201 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)
@@ -110,7 +115,7 @@ $ctx.result.body
 $util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))
 #end
 ## [End] Process response. **",
-  "Comment.contentPost.req.vtl": "## [Start] Create request. **
+  "httpswwwapicomDataSourceCommentcontentPostFunction.req.vtl": "## [Start] Create request. **
 #set( $headers = $utils.http.copyHeaders($ctx.request.headers) )
 $util.qr($headers.put(\\"accept-encoding\\", \\"application/json\\"))
 $util.qr($headers.put(\\"Content-Type\\", \\"application/json\\"))
@@ -126,7 +131,7 @@ $util.qr($headers.put(\\"X-Header\\", \\"X-Header-ValuePost\\"))
   }
 }
 ## [End] Create request. **",
-  "Comment.contentPost.res.vtl": "## [Start] Process response. **
+  "httpswwwapicomDataSourceCommentcontentPostFunction.res.vtl": "## [Start] Process response. **
 #if( $ctx.result.statusCode == 200 || $ctx.result.statusCode == 201 )
   #if( $ctx.result.headers.get(\\"Content-Type\\").toLowerCase().contains(\\"xml\\") )
 $utils.xml.toJsonString($ctx.result.body)

--- a/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer.test.ts
@@ -119,22 +119,14 @@ test('it generates the expected resources', () => {
     }),
   );
   cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 5));
+  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 5));
   expect(stack.Resources!.CommentcontentResolver).toBeTruthy();
   cdkExpect(stack).to(
     haveResource('AWS::AppSync::Resolver', {
       ApiId: { Ref: anything() },
       FieldName: 'content',
       TypeName: 'Comment',
-      DataSourceName: {
-        'Fn::GetAtt': [anything(), 'Name'],
-      },
-      Kind: 'UNIT',
-      RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content.req.vtl']],
-      },
-      ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content.res.vtl']],
-      },
+      Kind: 'PIPELINE',
     }),
   );
   expect(stack.Resources!.Commentcontent2Resolver).toBeTruthy();
@@ -143,16 +135,7 @@ test('it generates the expected resources', () => {
       ApiId: { Ref: anything() },
       FieldName: 'content2',
       TypeName: 'Comment',
-      DataSourceName: {
-        'Fn::GetAtt': [anything(), 'Name'],
-      },
-      Kind: 'UNIT',
-      RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content2.req.vtl']],
-      },
-      ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.content2.res.vtl']],
-      },
+      Kind: 'PIPELINE',
     }),
   );
   expect(stack.Resources!.CommentmoreResolver).toBeTruthy();
@@ -161,16 +144,7 @@ test('it generates the expected resources', () => {
       ApiId: { Ref: anything() },
       FieldName: 'more',
       TypeName: 'Comment',
-      DataSourceName: {
-        'Fn::GetAtt': [anything(), 'Name'],
-      },
-      Kind: 'UNIT',
-      RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.more.req.vtl']],
-      },
-      ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.more.res.vtl']],
-      },
+      Kind: 'PIPELINE',
     }),
   );
   expect(stack.Resources!.CommentevenMoreResolver).toBeTruthy();
@@ -179,16 +153,7 @@ test('it generates the expected resources', () => {
       ApiId: { Ref: anything() },
       FieldName: 'evenMore',
       TypeName: 'Comment',
-      DataSourceName: {
-        'Fn::GetAtt': [anything(), 'Name'],
-      },
-      Kind: 'UNIT',
-      RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.evenMore.req.vtl']],
-      },
-      ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.evenMore.res.vtl']],
-      },
+      Kind: 'PIPELINE',
     }),
   );
   expect(stack.Resources!.CommentstillMoreResolver).toBeTruthy();
@@ -197,16 +162,7 @@ test('it generates the expected resources', () => {
       ApiId: { Ref: anything() },
       FieldName: 'stillMore',
       TypeName: 'Comment',
-      DataSourceName: {
-        'Fn::GetAtt': [anything(), 'Name'],
-      },
-      Kind: 'UNIT',
-      RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.stillMore.req.vtl']],
-      },
-      ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Comment.stillMore.res.vtl']],
-      },
+      Kind: 'PIPELINE',
     }),
   );
 });
@@ -297,7 +253,8 @@ test('env on the URI path', () => {
   expect(out.stacks).toBeDefined();
   parse(out.schema);
   const stack = out.stacks.HttpStack;
-  const reqTemplate = stack.Resources!.CommentcontentResolver.Properties.RequestMappingTemplate;
+  const functionId = stack.Resources!.CommentcontentResolver.Properties.PipelineConfig.Functions[0]['Fn::GetAtt'][0];
+  const reqTemplate = stack.Resources![functionId].Properties.RequestMappingTemplate;
   expect(reqTemplate['Fn::Sub']).toBeTruthy();
   expect(reqTemplate['Fn::Sub'][0]).toMatch('"resourcePath": "/ping${env}"');
   expect(reqTemplate['Fn::Sub'][1].env.Ref).toBeTruthy();
@@ -412,7 +369,8 @@ test('aws_region on the URI path', () => {
   expect(out.stacks).toBeDefined();
   parse(out.schema);
   const stack = out.stacks.HttpStack;
-  const reqTemplate = stack.Resources!.CommentcontentResolver.Properties.RequestMappingTemplate;
+  const functionId = stack.Resources!.CommentcontentResolver.Properties.PipelineConfig.Functions[0]['Fn::GetAtt'][0];
+  const reqTemplate = stack.Resources![functionId].Properties.RequestMappingTemplate;
   expect(reqTemplate['Fn::Sub']).toBeTruthy();
   expect(reqTemplate['Fn::Sub'][0]).toMatch('"resourcePath": "/ping${aws_region}"');
   expect(reqTemplate['Fn::Sub'][1].aws_region.Ref).toBeTruthy();

--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -1,5 +1,13 @@
-import { DirectiveWrapper, MappingTemplate, TransformerContractError, TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
+import {
+  DirectiveWrapper,
+  IAM_AUTH_ROLE_PARAMETER,
+  IAM_UNAUTH_ROLE_PARAMETER,
+  MappingTemplate,
+  TransformerContractError,
+  TransformerPluginBase,
+} from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider, TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { AuthorizationType } from '@aws-cdk/aws-appsync';
 import * as cdk from '@aws-cdk/core';
 import {
   DirectiveNode,
@@ -24,6 +32,7 @@ import {
   and,
   comment,
   compoundExpression,
+  Expression,
   ifElse,
   iff,
   obj,
@@ -267,15 +276,42 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
     }),
   );
 
-  const requestTemplateString = replaceEnvAndRegion(env, region, printBlock('Create request')(compoundExpression(reqCompoundExpr)));
-  const requestMappingTemplate = cdk.Token.isUnresolved(requestTemplateString)
-    ? MappingTemplate.inlineTemplateFromString(requestTemplateString)
-    : MappingTemplate.s3MappingTemplateFromString(requestTemplateString, `${config.resolverTypeName}.${config.resolverFieldName}.req.vtl`);
+  const requestTemplate: Array<Expression> = [
+    qref(`$ctx.stash.put("typeName", "${config.resolverTypeName}")`),
+    qref(`$ctx.stash.put("fieldName", "${config.resolverFieldName}")`),
+  ];
+  const authModes = [context.authConfig.defaultAuthentication, ...(context.authConfig.additionalAuthenticationProviders || [])].map(
+    mode => mode?.authenticationType,
+  );
 
-  return context.api.host.addResolver(
-    config.resolverTypeName,
-    config.resolverFieldName,
-    requestMappingTemplate,
+  if (authModes.includes(AuthorizationType.IAM)) {
+    const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+    const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+
+    requestTemplate.push(
+      qref(
+        `$ctx.stash.put("authRole", "arn:aws:sts::${
+          cdk.Stack.of(context.stackManager.rootStack).account
+        }:assumed-role/${authRoleParameter}/CognitoIdentityCredentials")`,
+      ),
+      qref(
+        `$ctx.stash.put("unauthRole", "arn:aws:sts::${
+          cdk.Stack.of(context.stackManager.rootStack).account
+        }:assumed-role/${unauthRoleParameter}/CognitoIdentityCredentials")`,
+      ),
+    );
+  }
+
+  requestTemplate.push(obj({}));
+
+  const functionId = `${dataSourceId}${config.resolverTypeName}${config.resolverFieldName}Function`;
+  const functionRequestTemplateString = replaceEnvAndRegion(env, region, printBlock('Create request')(compoundExpression(reqCompoundExpr)));
+  const functionRequestMappingTemplate = cdk.Token.isUnresolved(functionRequestTemplateString)
+    ? MappingTemplate.inlineTemplateFromString(functionRequestTemplateString)
+    : MappingTemplate.s3MappingTemplateFromString(functionRequestTemplateString, `${functionId}.req.vtl`);
+  const appsyncFunction = context.api.host.addAppSyncFunction(
+    functionId,
+    functionRequestMappingTemplate,
     MappingTemplate.s3MappingTemplateFromString(
       printBlock('Process response')(
         ifElse(
@@ -288,11 +324,23 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
           ref('util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))'),
         ),
       ),
+      `${functionId}.res.vtl`,
+    ),
+    dataSourceId,
+    stack,
+  );
+
+  return context.api.host.addResolver(
+    config.resolverTypeName,
+    config.resolverFieldName,
+    MappingTemplate.inlineTemplateFromString(printBlock('Stash resolver specific context.')(compoundExpression(requestTemplate))),
+    MappingTemplate.s3MappingTemplateFromString(
+      '$util.toJson($ctx.prev.result)',
       `${config.resolverTypeName}.${config.resolverFieldName}.res.vtl`,
     ),
     undefined,
-    dataSourceId,
     undefined,
+    [appsyncFunction.functionId],
     stack,
   );
 }

--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -308,7 +308,10 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
   const functionRequestTemplateString = replaceEnvAndRegion(env, region, printBlock('Create request')(compoundExpression(reqCompoundExpr)));
   const functionRequestMappingTemplate = cdk.Token.isUnresolved(functionRequestTemplateString)
     ? MappingTemplate.inlineTemplateFromString(functionRequestTemplateString)
-    : MappingTemplate.s3MappingTemplateFromString(functionRequestTemplateString, `${functionId}.req.vtl`);
+    : MappingTemplate.s3MappingTemplateFromString(
+        functionRequestTemplateString,
+        `${config.resolverTypeName}.${config.resolverFieldName}.DataResolver.req.vtl`,
+      );
   const appsyncFunction = context.api.host.addAppSyncFunction(
     functionId,
     functionRequestMappingTemplate,
@@ -324,7 +327,7 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
           ref('util.qr($util.appendError($ctx.result.body, $ctx.result.statusCode))'),
         ),
       ),
-      `${functionId}.res.vtl`,
+      `${config.resolverTypeName}.${config.resolverFieldName}.DataResolver.res.vtl`,
     ),
     dataSourceId,
     stack,


### PR DESCRIPTION
#### Description of changes
This commit updates `@http` v2 to create pipeline resolvers instead of unit resolvers. This allows `@http` to be used with other directives such as `@auth`.

This commit also adds missing auth information to `@http` v2 and adds a missing `package.json` dependency to `@function` v2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
