### PR TITLE
fix: auth trigger params parsing and test wait lines

### DIFF
--- a/packages/amplify-category-auth/src/commands/auth/update.ts
+++ b/packages/amplify-category-auth/src/commands/auth/update.ts
@@ -53,8 +53,8 @@ export const run = async (context: $TSContext) => {
   }
   const resourceName = await getAuthResourceName(context);
   await checkAuthResourceMigration(context, resourceName);
-  const cliState = new AuthInputState(resourceName);
-  context.updatingAuth = await cliState.loadResourceParameters(context, cliState.getCLIInputPayload());
+  const providerPlugin = context.amplify.getPluginInstance(context, servicesMetadata.Cognito.provider);
+  context.updatingAuth = providerPlugin.loadResourceParameters(context, 'auth', resourceName);
 
   try {
     const result = await amplify.serviceSelectionPrompt(context, category, getSupportedServices());

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
@@ -49,8 +49,9 @@ export const getResourceUpdater = async (context: $TSAny, request: Readonly<Cogn
     await addAdminAuth(context, request.resourceName!, 'add', request.adminQueryGroup);
   }
 
-  const previouslySaved =
-    typeof context.updatingAuth.triggers === 'string' ? JSON.parse(context.updatingAuth.triggers) : context.updatingAuth.triggers;
+  const providerPlugin = context.amplify.getPluginInstance(context, 'awscloudformation');
+  const previouslySaved = JSON.parse(providerPlugin.loadResourceParameters(context, 'auth', request.resourceName)?.triggers || '{}');
+
   await lambdaTriggers(request, context, previouslySaved);
 
   await copyS3Assets(request);

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1242,18 +1242,15 @@ export function addAuthWithPreTokenGenerationTrigger(projectDir: string): Promis
       .wait('How do you want users to be able to sign in')
       .sendCarriageReturn()
       .wait('Do you want to configure advanced settings')
-      .send(KEY_DOWN_ARROW)
-      .sendCarriageReturn()
+      .sendLine(KEY_DOWN_ARROW)
       .wait('What attributes are required for signing up?')
       .sendCarriageReturn()
       .wait('Do you want to enable any of the following capabilities')
       .send(KEY_UP_ARROW) //Override ID Token Claims
-      .send(' ')
-      .sendCarriageReturn()
+      .sendLine(' ')
+      .wait('Successfully added the Lambda function locally')
       .wait('Do you want to edit your alter-claims function now')
-      .send('n')
-      .sendCarriageReturn()
-      .wait('"amplify publish" will build all your local backend and frontend resources')
+      .sendLine('n')
       .run((err: Error) => {
         if (!err) {
           resolve();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a wait line in a test and fixes the updatingAuth object that hangs off of context to read from build/parameters.json instead of cli-inputs.json

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested and ran the e2e test locally. The test failed due to not having some env vars set up right, but should be g2g.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
