### PR TITLE
fix(graphql-default-value-transformer): handle null same way as undefined with @default

### DIFF
--- a/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
@@ -67,13 +67,18 @@ export class DefaultValueTransformer extends TransformerPluginBase {
       }
 
       this.updateResolverWithDefaultValues(context, `create${typeName}`, snippets);
-      this.updateResolverWithDefaultValues(context, `update${typeName}`, snippets);
     }
   };
 
   private makeDefaultValueSnippet = (fieldName: string, defaultValue: string, isString: boolean): string => {
     return printBlock(`Setting "${fieldName}" to default value of "${defaultValue}"`)(
-      qref(methodCall(ref('ctx.stash.defaultValues.put'), str(fieldName), isString ? str(defaultValue) : raw(defaultValue))),
+      qref(
+        methodCall(
+          ref('context.args.input.put'),
+          str(fieldName),
+          methodCall(ref('util.defaultIfNull'), ref(`ctx.args.input.${fieldName}`), isString ? str(defaultValue) : raw(defaultValue)),
+        ),
+      ),
     );
   };
 


### PR DESCRIPTION
#### Description of changes
- changes to @default resolver to handle null in the same way as undefined arguments

#### Description of how you validated changes
- [x] `yarn test` passes
- [x] default transformer e2e test passes
- [x] manual testing console AppSync GraphQL 
- [ ] manual testing API/Datastore javascript (in progress)
- [ ] manual testing API/Datastore android (in progress)
- [ ] manual testing API/Datastore ios (in progress)  
- [ ] manual testing Datastore flutter (in progress)  

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
