### PR TITLE
fix(graphql): add enum to aggregate field type

### DIFF
--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state.ts
@@ -132,7 +132,7 @@ export class S3InputState {
       backendDir,
       AmplifyCategories.STORAGE,
       this._resourceName,
-      `${AmplifySupportedService.S3}-cloudformation-template.json`,
+      's3-cloudformation-template.json',
     );
     const oldStorageParamsFilepath = path.join(backendDir, AmplifyCategories.STORAGE, this._resourceName, `storage-params.json`);
     const oldParameters = JSONUtilities.readJson<$TSAny>(oldParametersFilepath, { throwIfNotExist: true });
@@ -241,7 +241,7 @@ export class S3InputState {
       backendDir,
       AmplifyCategories.STORAGE,
       this._resourceName,
-      `${AmplifySupportedService.S3}-cloudformation-template.json`,
+      's3-cloudformation-template.json',
     );
     return fs.existsSync(oldParametersFilepath) && fs.existsSync(oldCFNFilepath);
   }

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -113,6 +113,7 @@ enum SearchableEmployeeAggregateField {
   id
   firstName
   lastName
+  type
 }
 
 input SearchableEmployeeAggregationInput {

--- a/packages/amplify-graphql-searchable-transformer/src/definitions.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/definitions.ts
@@ -8,6 +8,7 @@ import {
   DocumentNode,
   EnumTypeDefinitionNode,
   EnumValueDefinitionNode,
+  isEnumType,
 } from 'graphql';
 import {
   graphqlName,
@@ -194,11 +195,11 @@ export function makeSearchableXSortableFieldsEnumObject(obj: ObjectTypeDefinitio
   };
 }
 
-export function makeSearchableXAggregateFieldEnumObject(obj: ObjectTypeDefinitionNode): EnumTypeDefinitionNode {
+export function makeSearchableXAggregateFieldEnumObject(obj: ObjectTypeDefinitionNode, document: DocumentNode): EnumTypeDefinitionNode {
   const name = graphqlName(`Searchable${obj.name.value}AggregateField`);
   assert(obj.fields);
   const values: EnumValueDefinitionNode[] = obj.fields
-    .filter((field: FieldDefinitionNode) => isScalar(field.type))
+    .filter((field: FieldDefinitionNode) => isScalar(field.type) || isEnum(field.type, document))
     .map((field: FieldDefinitionNode) => ({
       kind: Kind.ENUM_VALUE_DEFINITION,
       name: field.name,

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -358,7 +358,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
     }
 
     if (!ctx.output.hasType(`Searchable${definition.name.value}AggregateField`)) {
-      const searchableXAggregationField = makeSearchableXAggregateFieldEnumObject(definition);
+      const searchableXAggregationField = makeSearchableXAggregateFieldEnumObject(definition, ctx.inputDocument);
       ctx.output.addEnum(searchableXAggregationField);
     }
 

--- a/packages/amplify-provider-awscloudformation/src/export-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-resources.ts
@@ -166,7 +166,7 @@ function writeExportManifest(stackParameters: StackParameters, exportPath: strin
   const rootStackParametersKey = _.first(Object.keys(stackParameters));
   const manifestJson = {
     stackName: rootStackParametersKey,
-    props: transformManifestParameters(stackParameters[rootStackParametersKey], exportPath),
+    props: transformManifestParameters(stackParameters[rootStackParametersKey], amplifyExportFolder),
   };
   JSONUtilities.writeJson(path.join(amplifyExportFolder, PathConstants.ExportManifestJsonFilename), manifestJson);
 }


### PR DESCRIPTION
#### Description of changes
Add Enum fields to aggregate field type.

#### Description of how you validated changes
- yarn test
- manual test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
