### PR TITLE
fix(graphql): add enum to aggregate field type

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.tests.ts.snap
@@ -113,6 +113,7 @@ enum SearchableEmployeeAggregateField {
   id
   firstName
   lastName
+  type
 }
 
 input SearchableEmployeeAggregationInput {

--- a/packages/amplify-graphql-searchable-transformer/src/definitions.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/definitions.ts
@@ -194,11 +194,11 @@ export function makeSearchableXSortableFieldsEnumObject(obj: ObjectTypeDefinitio
   };
 }
 
-export function makeSearchableXAggregateFieldEnumObject(obj: ObjectTypeDefinitionNode): EnumTypeDefinitionNode {
+export function makeSearchableXAggregateFieldEnumObject(obj: ObjectTypeDefinitionNode, document: DocumentNode): EnumTypeDefinitionNode {
   const name = graphqlName(`Searchable${obj.name.value}AggregateField`);
   assert(obj.fields);
   const values: EnumValueDefinitionNode[] = obj.fields
-    .filter((field: FieldDefinitionNode) => isScalar(field.type))
+    .filter((field: FieldDefinitionNode) => isScalar(field.type) || isEnum(field.type, document))
     .map((field: FieldDefinitionNode) => ({
       kind: Kind.ENUM_VALUE_DEFINITION,
       name: field.name,

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -358,7 +358,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
     }
 
     if (!ctx.output.hasType(`Searchable${definition.name.value}AggregateField`)) {
-      const searchableXAggregationField = makeSearchableXAggregateFieldEnumObject(definition);
+      const searchableXAggregationField = makeSearchableXAggregateFieldEnumObject(definition, ctx.inputDocument);
       ctx.output.addEnum(searchableXAggregationField);
     }
 


### PR DESCRIPTION
#### Description of changes
Add Enum fields to aggregate field type.

#### Description of how you validated changes
- yarn test
- manual test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
