### PR TITLE
fix: allow both email and phone number type

### DIFF
--- a/packages/amplify-category-auth/resources/schemas/awsCognito/CognitoCLIInputs.schema.json
+++ b/packages/amplify-category-auth/resources/schemas/awsCognito/CognitoCLIInputs.schema.json
@@ -72,7 +72,7 @@
         "usernameAttributes": {
           "type": "array",
           "items": {
-            "enum": ["email", "phone_number"],
+            "enum": ["email", "email, phone_number", "phone_number"],
             "type": "string"
           }
         },

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types/awsCognito-user-input-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types/awsCognito-user-input-types.ts
@@ -106,11 +106,12 @@ export enum AttributeType {
   EMAIL = 'email',
   PHONE_NUMBER = 'phone_number',
   PREFERRED_USERNAME = 'preferred_username',
+  EMAIL_AND_PHONE_NUMBER = 'email, phone_number',
 }
 
 export type PasswordPolicy = 'Requires Lowercase' | 'Requires Numbers' | 'Requires Symbols' | 'Requires Uppercase';
 
-export type UsernameAttributes = AttributeType.EMAIL | AttributeType.PHONE_NUMBER;
+export type UsernameAttributes = AttributeType.EMAIL | AttributeType.PHONE_NUMBER | AttributeType.EMAIL_AND_PHONE_NUMBER;
 
 export type AliasAttributes = AttributeType.EMAIL | AttributeType.PHONE_NUMBER | AttributeType.PREFERRED_USERNAME;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Adds email,  number type to CognitoCLIInputs type

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
