### PR TITLE
fix: remove trailing 's' in documentation link

### DIFF
--- a/packages/amplify-cli-core/src/overrides-manager/migration-message.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/migration-message.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { EOL } from 'os';
 
 export function getMigrateResourceMessageForOverride(categoryName: string, resourceName: string, isUpdate = true) {
-  const docsLink = 'https://docs.amplify.aws/cli/migration/overrides';
+  const docsLink = 'https://docs.amplify.aws/cli/migration/override';
 
   if (isUpdate) {
     return [


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
