### PR TITLE
test: add relational vtl tests

### DIFF
--- a/packages/amplify-appsync-simulator/src/index.ts
+++ b/packages/amplify-appsync-simulator/src/index.ts
@@ -19,7 +19,7 @@ import {
   AppSyncSimulatorMappingTemplate,
 } from './type-definition';
 import { filterSubscriptions } from './utils';
-export { AppSyncGraphQLExecutionContext, JWTToken } from './utils';
+export { AppSyncGraphQLExecutionContext, JWTToken, IAMToken } from './utils';
 export * from './type-definition';
 export * from './velocity';
 

--- a/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
+++ b/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
@@ -29,7 +29,7 @@ export type IAMToken = {
   username: string;
   cognitoIdentityPoolId?: string;
   cognitoIdentityId?: string;
-  cognitoIdentityAuthType?: string;
+  cognitoIdentityAuthType?: 'authenticated' | 'unauthenticated';
   cognitoIdentityAuthProvider?: string;
 };
 

--- a/packages/amplify-appsync-simulator/src/utils/auth-helpers/index.ts
+++ b/packages/amplify-appsync-simulator/src/utils/auth-helpers/index.ts
@@ -1,2 +1,2 @@
-export { extractHeader, extractJwtToken, getAllowedAuthTypes, isValidOIDCToken, JWTToken } from './helpers';
+export { extractHeader, extractJwtToken, getAllowedAuthTypes, isValidOIDCToken, JWTToken, IAMToken } from './helpers';
 export { getAuthorizationMode } from './current-auth-mode';

--- a/packages/amplify-appsync-simulator/src/utils/index.ts
+++ b/packages/amplify-appsync-simulator/src/utils/index.ts
@@ -1,2 +1,2 @@
-export { JWTToken } from './auth-helpers';
+export { JWTToken, IAMToken } from './auth-helpers';
 export * from './graphql-runner';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/conflict-resolution.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/conflict-resolution.test.ts.snap
@@ -14,15 +14,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$isAuthorized )
-    #set( $authFilter = [{
-  \\"owner\\": {
-      \\"eq\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
-  }
-}] )
-    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #set( $authFilter = [] )
+    #set( $role0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $role0 != \\"___xamznone____\\" )
+      $util.qr($authFilter.add({\\"owner\\": { \\"eq\\": $role0 }}))
+    #end
+    #if( !$authFilter.isEmpty() )
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
@@ -36,15 +38,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $primaryFieldMap = {} )
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$isAuthorized )
-    #set( $authFilter = [{
-  \\"owner\\": {
-      \\"eq\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
-  }
-}] )
-    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #set( $authFilter = [] )
+    #set( $role0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $role0 != \\"___xamznone____\\" )
+      $util.qr($authFilter.add({\\"owner\\": { \\"eq\\": $role0 }}))
+    #end
+    #if( !$authFilter.isEmpty() )
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -87,15 +87,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $primaryFieldMap = {} )
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$isAuthorized )
-    #set( $authFilter = [{
-  \\"editors\\": {
-      \\"contains\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
-  }
-}] )
-    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #set( $authFilter = [] )
+    #set( $role0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $role0 != \\"___xamznone____\\" )
+      $util.qr($authFilter.add({\\"editors\\": { \\"contains\\": $role0 }}))
+    #end
+    #if( !$authFilter.isEmpty() )
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
@@ -109,15 +111,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $primaryFieldMap = {} )
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$isAuthorized )
-    #set( $authFilter = [{
-  \\"editors\\": {
-      \\"contains\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
-  }
-}] )
-    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #set( $authFilter = [] )
+    #set( $role0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $role0 != \\"___xamznone____\\" )
+      $util.qr($authFilter.add({\\"editors\\": { \\"contains\\": $role0 }}))
+    #end
+    #if( !$authFilter.isEmpty() )
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -19,6 +19,8 @@ import {
   set,
   ifElse,
   nul,
+  notEquals,
+  parens,
 } from 'graphql-mapping-template';
 import {
   getIdentityClaimExp,
@@ -83,32 +85,22 @@ const generateAuthOnRelationalModelQueryExpression = (
           role.strategy === 'owner' ? getOwnerClaim(role.claim!) : getIdentityClaimExp(str(role.claim!), str(NONE_VALUE)),
         ),
         ifElse(
-          not(ref(`util.isNull($ctx.${claim}.${field})`)),
-          compoundExpression([
-            iff(
-              equals(ref(`ctx.${claim}.${field}`), ref(`primaryRole${idx}`)),
-              compoundExpression([
-                set(ref(IS_AUTHORIZED_FLAG), bool(true)),
-                qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
-              ]),
-            ),
+          and([
+            parens(not(ref(`util.isNull($ctx.${claim}.${field})`))),
+            parens(equals(ref(`ctx.${claim}.${field}`), ref(`primaryRole${idx}`))),
           ]),
+          compoundExpression([set(ref(IS_AUTHORIZED_FLAG), bool(true)), qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul()))]),
           iff(
-            not(ref(IS_AUTHORIZED_FLAG)),
+            and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter'))]),
             compoundExpression([
               qref(methodCall(ref(`ctx.${claim}.put`), str(field), ref(`primaryRole${idx}`))),
-              set(ref('primaryFieldAuth'), bool(true)),
+              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
             ]),
           ),
         ),
       );
     });
-    return [
-      iff(
-        and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter'))]),
-        compoundExpression(modelQueryExpression),
-      ),
-    ];
+    return [iff(not(ref(IS_AUTHORIZED_FLAG)), compoundExpression(modelQueryExpression))];
   }
   return modelQueryExpression;
 };
@@ -116,6 +108,7 @@ const generateAuthOnRelationalModelQueryExpression = (
 /**
  * In the event that an owner/group field is the same as a primary field we can validate against the args if provided
  * if the field is not in the args we include it in the KeyConditionExpression which is formed as a part of the query
+ * when it is formed as a part of the query we can consider the request authorized
  */
 const generateAuthOnModelQueryExpression = (
   roles: Array<RoleDefinition>,
@@ -132,13 +125,29 @@ const generateAuthOnModelQueryExpression = (
         modelQueryExpression.push(
           ifElse(
             not(ref(`util.isNull($ctx.args.${role.entity})`)),
-            iff(
-              equals(ref(`ctx.args.${role.entity}`), claimExpression),
-              compoundExpression([
-                set(ref(IS_AUTHORIZED_FLAG), bool(true)),
-                qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
-              ]),
-            ),
+            compoundExpression([
+              set(ref(`${role.entity}Claim`), claimExpression),
+              ifElse(
+                ref(`util.isString($ctx.args.${role.entity})`),
+                set(ref(`${role.entity}Condition`), parens(equals(ref(`${role.entity}Claim`), ref(`$ctx.args.${role.entity}`)))),
+                set(
+                  ref(`${role.entity}Condition`),
+                  parens(
+                    equals(
+                      ref(`${role.entity}Claim`),
+                      methodCall(ref('util.defaultIfNull'), raw(`$ctx.args.${role.entity}.get("eq")`), str(NONE_VALUE)),
+                    ),
+                  ),
+                ),
+              ),
+              iff(
+                ref(`${role.entity}Condition`),
+                compoundExpression([
+                  set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+                  qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
+                ]),
+              ),
+            ]),
             qref(methodCall(ref('primaryFieldMap.put'), str(role.entity), claimExpression)),
           ),
         );
@@ -153,6 +162,7 @@ const generateAuthOnModelQueryExpression = (
           compoundExpression([
             forEach(ref('entry'), ref('primaryFieldMap.entrySet()'), [
               qref(methodCall(ref('ctx.args.put'), ref('entry.key'), ref('entry.value'))),
+              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
             ]),
           ]),
         ),
@@ -164,7 +174,31 @@ const generateAuthOnModelQueryExpression = (
         modelQueryExpression.push(
           ifElse(
             not(ref(`util.isNull($ctx.args.${role.entity})`)),
-            compoundExpression([iff(equals(ref(`ctx.args.${role.entity}`), claimExpression), set(ref(IS_AUTHORIZED_FLAG), bool(true)))]),
+            compoundExpression([
+              set(ref(`${role.entity}Claim`), claimExpression),
+              ifElse(
+                ref(`util.isString($ctx.args.${role.entity})`),
+                set(ref(`${role.entity}Condition`), parens(equals(ref(`${role.entity}Claim`), ref(`ctx.args.${role.entity}`)))),
+                // this type is mainly applied on list queries with primaryKeys therefore we can use the get "eq" key
+                // to check if the dynamic role condition is met
+                set(
+                  ref(`${role.entity}Condition`),
+                  parens(
+                    equals(
+                      ref(`${role.entity}Claim`),
+                      methodCall(ref('util.defaultIfNull'), raw(`$ctx.args.${role.entity}.get("eq")`), str(NONE_VALUE)),
+                    ),
+                  ),
+                ),
+              ),
+              iff(
+                ref(`${role.entity}Condition`),
+                compoundExpression([
+                  set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+                  qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
+                ]),
+              ),
+            ]),
             qref(methodCall(ref('primaryFieldMap.put'), str(role.entity), claimExpression)),
           ),
         );
@@ -184,6 +218,7 @@ const generateAuthOnModelQueryExpression = (
               qref(ref('modelQueryExpression.expressionValues.put(":${entry.value}", $util.dynamodb.toDynamoDB($entry.value))')),
             ]),
             qref(methodCall(ref('ctx.stash.put'), str('modelQueryExpression'), ref('modelQueryExpression'))),
+            set(ref(IS_AUTHORIZED_FLAG), bool(true)),
           ]),
         ),
       );
@@ -194,7 +229,7 @@ const generateAuthOnModelQueryExpression = (
 };
 
 const generateAuthFilter = (roles: Array<RoleDefinition>, fields: ReadonlyArray<FieldDefinitionNode>): Array<Expression> => {
-  const authFilter = new Array<Expression>();
+  const authCollectionExp = new Array<Expression>();
   const groupMap = new Map<string, Array<string>>();
   const groupContainsExpression = new Array<Expression>();
   if (!(roles.length > 0)) return [];
@@ -209,13 +244,20 @@ const generateAuthFilter = (roles: Array<RoleDefinition>, fields: ReadonlyArray<
    * if groupsField is a list
    * we create contains experession for each cognito group
    *  */
-  for (let role of roles) {
+  roles.forEach((role, idx) => {
     const entityIsList = fieldIsList(fields, role.entity);
     if (role.strategy === 'owner') {
       const ownerCondition = entityIsList ? 'contains' : 'eq';
-      authFilter.push(obj({ [role.entity]: obj({ [ownerCondition]: getOwnerClaim(role.claim!) }) }));
-    }
-    if (role.strategy === 'groups') {
+      authCollectionExp.push(
+        ...[
+          set(ref(`role${idx}`), getOwnerClaim(role.claim!)),
+          iff(
+            notEquals(ref(`role${idx}`), str(NONE_VALUE)),
+            qref(methodCall(ref('authFilter.add'), raw(`{"${role.entity}": { "${ownerCondition}": $role${idx} }}`))),
+          ),
+        ],
+      );
+    } else if (role.strategy === 'groups') {
       // for fields where the group is a list and the token is a list we must add every group in the claim
       if (entityIsList) {
         if (groupMap.has(role.claim!)) {
@@ -224,16 +266,26 @@ const generateAuthFilter = (roles: Array<RoleDefinition>, fields: ReadonlyArray<
           groupMap.set(role.claim!, [role.entity]);
         }
       } else {
-        authFilter.push(obj({ [role.entity]: obj({ in: getIdentityClaimExp(str(role.claim!), list([str(NONE_VALUE)])) }) }));
+        authCollectionExp.push(
+          ...[
+            set(ref(`role${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
+            iff(
+              not(methodCall(ref(`role${idx}.isEmpty`))),
+              qref(methodCall(ref('authFilter.add'), raw(`{ "${role.entity}": { "in": $role${idx} } }`))),
+            ),
+          ],
+        );
       }
     }
-  }
+  });
   for (let [groupClaim, fieldList] of groupMap) {
     groupContainsExpression.push(
       forEach(
         ref('group'),
-        ref(`util.defaultIfNull($ctx.identity.claims.get("${groupClaim}"), ["${NONE_VALUE}"])`),
-        fieldList.map(field => qref(methodCall(ref('authFilter.add'), raw(`{"${field}": { "contains": $group }}`)))),
+        ref(`util.defaultIfNull($ctx.identity.claims.get("${groupClaim}"), [])`),
+        fieldList.map(field =>
+          iff(not(methodCall(ref(`group.isEmpty`))), qref(methodCall(ref('authFilter.add'), raw(`{"${field}": { "contains": $group }}`)))),
+        ),
       ),
     );
   }
@@ -241,9 +293,13 @@ const generateAuthFilter = (roles: Array<RoleDefinition>, fields: ReadonlyArray<
     iff(
       not(ref(IS_AUTHORIZED_FLAG)),
       compoundExpression([
-        set(ref('authFilter'), list(authFilter)),
-        ...(groupContainsExpression.length > 0 ? groupContainsExpression : []),
-        qref(methodCall(ref('ctx.stash.put'), str('authFilter'), raw('{ "or": $authFilter }'))),
+        set(ref('authFilter'), list([])),
+        ...authCollectionExp,
+        ...groupContainsExpression,
+        iff(
+          not(methodCall(ref('authFilter.isEmpty'))),
+          qref(methodCall(ref('ctx.stash.put'), str('authFilter'), raw('{ "or": $authFilter }'))),
+        ),
       ]),
     ),
   ];
@@ -298,10 +354,7 @@ export const generateAuthExpressionForQueries = (
     );
   }
   totalAuthExpressions.push(
-    iff(
-      and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter')), ref('primaryFieldMap.isEmpty()')]),
-      ref('util.unauthorized()'),
-    ),
+    iff(and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter'))]), ref('util.unauthorized()')),
   );
   return printBlock('Authorization Steps')(compoundExpression([...totalAuthExpressions, emptyPayload]));
 };
@@ -315,11 +368,7 @@ export const generateAuthExpressionForRelationQuery = (
   const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } =
     splitRoles(roles);
   const getNonPrimaryFieldRoles = (roles: RoleDefinition[]) => roles.filter(roles => !primaryFieldMap.has(roles.entity));
-  const totalAuthExpressions: Array<Expression> = [
-    setHasAuthExpression,
-    set(ref(IS_AUTHORIZED_FLAG), bool(false)),
-    set(ref('primaryFieldAuth'), bool(false)),
-  ];
+  const totalAuthExpressions: Array<Expression> = [setHasAuthExpression, set(ref(IS_AUTHORIZED_FLAG), bool(false))];
   if (providers.hasApiKey) {
     totalAuthExpressions.push(apiKeyExpression(apiKeyRoles));
   }
@@ -354,10 +403,7 @@ export const generateAuthExpressionForRelationQuery = (
     );
   }
   totalAuthExpressions.push(
-    iff(
-      and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter')), not(ref('primaryFieldAuth'))]),
-      ref('util.unauthorized()'),
-    ),
+    iff(and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter'))]), ref('util.unauthorized()')),
   );
   return printBlock('Authorization Steps')(compoundExpression([...totalAuthExpressions, emptyPayload]));
 };

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -15,7 +15,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
@@ -62,7 +62,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
@@ -457,15 +457,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$isAuthorized )
-    #set( $authFilter = [{
-  \\"owner\\": {
-      \\"eq\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
-  }
-}] )
-    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #set( $authFilter = [] )
+    #set( $role0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $role0 != \\"___xamznone____\\" )
+      $util.qr($authFilter.add({\\"owner\\": { \\"eq\\": $role0 }}))
+    #end
+    #if( !$authFilter.isEmpty() )
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
@@ -514,15 +516,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$isAuthorized )
-    #set( $authFilter = [{
-  \\"owner\\": {
-      \\"eq\\":     $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\"))
-  }
-}] )
-    $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #set( $authFilter = [] )
+    #set( $role0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $role0 != \\"___xamznone____\\" )
+      $util.qr($authFilter.add({\\"owner\\": { \\"eq\\": $role0 }}))
+    #end
+    #if( !$authFilter.isEmpty() )
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #end
   #end
 #end
-#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && $primaryFieldMap.isEmpty() )
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
 $util.unauthorized()
 #end
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})

--- a/packages/amplify-util-mock/src/__tests__/velocity/relational-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/relational-auth.test.ts
@@ -1,0 +1,162 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { PrimaryKeyTransformer, IndexTransformer } from '@aws-amplify/graphql-index-transformer';
+import { HasManyTransformer, HasOneTransformer, BelongsToTransformer } from '@aws-amplify/graphql-relational-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionContext } from 'amplify-appsync-simulator';
+import { VelocityTemplateSimulator, getJWTToken, getIAMToken } from '../../velocity';
+
+const USER_POOL_ID = 'us-fake-1ID';
+
+describe('relational tests', () => {
+  let vtlTemplate: VelocityTemplateSimulator;
+  let transformer: GraphQLTransform;
+  const ownerRequest: AppSyncGraphQLExecutionContext = {
+    requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
+    jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
+    headers: {},
+  };
+  const adminGroupRequest: AppSyncGraphQLExecutionContext = {
+    requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
+    jwt: getJWTToken(USER_POOL_ID, 'user2', 'user2@test.com', ['admin']),
+    headers: {},
+  };
+  const iamAuthRole: AppSyncGraphQLExecutionContext = {
+    requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM,
+    iamToken: getIAMToken('authRole', {
+      cognitoIdentityAuthProvider: `cognito-idp.us-fake1.amazonaws.com/${USER_POOL_ID}`,
+      cognitoIdentityAuthType: 'authenticated',
+      cognitoIdentityPoolId: `${USER_POOL_ID}:000-111-222`,
+      cognitoIdentityId: 'us-fake-1:000',
+    }),
+    headers: {},
+  };
+
+  beforeEach(() => {
+    const authConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [
+        {
+          authenticationType: 'AWS_IAM',
+        },
+      ],
+    };
+    transformer = new GraphQLTransform({
+      authConfig,
+      transformers: [
+        new ModelTransformer(),
+        new AuthTransformer(),
+        new PrimaryKeyTransformer(),
+        new IndexTransformer(),
+        new HasManyTransformer(),
+        new HasOneTransformer(),
+        new BelongsToTransformer(),
+      ],
+    });
+    vtlTemplate = new VelocityTemplateSimulator({ authConfig });
+  });
+
+  test('1:1 nested auth read', () => {
+    // public signed user pools should only be able to read
+    // blogs and they can't see the editor
+    const validSchema = `
+      type Blog @model @auth(rules: [{ allow: private, operations: [read], provider: userPools }]) {
+        id: ID!
+        name: String
+        title: String        
+        editor: Editor @hasOne(fields: ["id", "name"])
+      }
+
+      type Editor @model @auth(rules: [{ allow: owner }]) {
+        id: ID! @primaryKey(sortKeyFields: ["name"])
+        name: String!
+        email: AWSEmail
+      }`;
+
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    const listBlogTemplate = out.resolvers['Query.listBlogs.auth.1.req.vtl'];
+    const blogEditor = out.resolvers['Blog.editor.auth.1.req.vtl'];
+
+    // signed in as a cognito user should not yield unauthorized
+    const upResponse = vtlTemplate.render(listBlogTemplate, { context: {}, requestParameters: ownerRequest });
+    expect(upResponse.hadException).toBe(false);
+
+    // signed in via iam will yield unauthorized
+    const iamResponse = vtlTemplate.render(listBlogTemplate, { context: {}, requestParameters: iamAuthRole });
+    expect(iamResponse.hadException).toBe(true);
+    expect(iamResponse.errors[0].errorType).toEqual('Unauthorized');
+
+    // query for blogEditor should have an owner rule filter
+    const ownerFieldResponse = vtlTemplate.render(blogEditor, { context: {}, requestParameters: ownerRequest });
+    expect(ownerFieldResponse.hadException).toBe(false);
+    expect(ownerFieldResponse.stash.authFilter).toEqual(
+      expect.objectContaining({
+        or: [{ owner: { eq: 'user1' } }],
+      }),
+    );
+  });
+
+  test('1:M nested auth read', () => {
+    // checking for the following cases
+    // don't apply the authFilter if the owner is not in any valid groups
+    // remove auth filter if the primaryRole (ex. the owner rule) condition is met
+    // pass the auth filter if the primaryRole condition is not met
+
+    const validSchema = `
+    type Post @model @auth(rules: [{allow: owner}, { allow: groups, groupsField: "editors" }]) {
+      id: ID!
+      title: String!
+      editors: [String]
+      author: User @belongsTo(fields: ["owner"])
+      owner: ID! @index(name: "byOwner", sortKeyFields: ["id"])
+    }
+    
+    type User @model @auth(rules: [{ allow: owner }]) {
+      id: ID!
+      name: String
+      posts: [Post] @hasMany(indexName: "byOwner", fields: ["id"])
+    }`;
+    const out = transformer.transform(validSchema);
+    const userPostTemplate = out.resolvers['User.posts.auth.1.req.vtl'];
+
+    // request as admin editor where the user is not the user in the record so therefore the auth filter is applied
+    const adminWithFilterResponse = vtlTemplate.render(userPostTemplate, {
+      context: {
+        source: { id: 'user1' },
+      },
+      requestParameters: adminGroupRequest,
+    });
+    expect(adminWithFilterResponse.hadException).toEqual(false);
+    expect(adminWithFilterResponse.stash.authFilter).toEqual(
+      expect.objectContaining({
+        or: [{ editors: { contains: 'admin' } }],
+      }),
+    );
+
+    // response where the editor member is the owner therefore the auth filter does not need to be applied
+    const adminWithNoFilterResponse = vtlTemplate.render(userPostTemplate, {
+      context: {
+        source: { id: 'user2' },
+      },
+      requestParameters: adminGroupRequest,
+    });
+    expect(adminWithNoFilterResponse.hadException).toEqual(false);
+    expect(adminWithNoFilterResponse.stash.authFilter).toBeNull();
+
+    // request as a user that is niether the owner nor has any valid groups
+    // therefore the request is changed to include the current user to ensure they are only seeing their correct records
+    // NOTE: will only really happen in the group claim rule is different than that of the related type therefore the owner rule should still be enforced
+    const ownerWithNoFilter = vtlTemplate.render(userPostTemplate, {
+      context: {
+        source: { id: 'user3' },
+      },
+      requestParameters: ownerRequest,
+    });
+    expect(ownerWithNoFilter.hadException).toEqual(false);
+    expect(ownerWithNoFilter.stash.authFilter).not.toBeDefined();
+  });
+});

--- a/packages/amplify-util-mock/src/velocity/index.ts
+++ b/packages/amplify-util-mock/src/velocity/index.ts
@@ -8,12 +8,17 @@ import {
   AppSyncVTLRenderContext,
   AppSyncGraphQLExecutionContext,
   JWTToken,
+  IAMToken,
 } from 'amplify-appsync-simulator';
 
 const DEFAULT_SCHEMA = `
   type Query {
     noop: String
   }`;
+
+type iamCognitoIdentityContext = Partial<
+  Pick<IAMToken, 'cognitoIdentityPoolId' | 'cognitoIdentityAuthProvider' | 'cognitoIdentityAuthType' | 'cognitoIdentityId'>
+>;
 
 export interface VelocityTemplateSimulatorOptions {
   authConfig: AppSyncAuthConfiguration;
@@ -87,5 +92,21 @@ export const getGenericToken = (username: string, email: string, groups: string[
     username,
     email,
     groups,
+  };
+};
+
+export const getIAMToken = (username: string, identityInfo?: iamCognitoIdentityContext): IAMToken => {
+  let iamRoleName = username;
+  if (identityInfo?.cognitoIdentityAuthType) {
+    iamRoleName = identityInfo.cognitoIdentityAuthType === 'authenticated' ? 'authRole' : 'unauthRole';
+  }
+  return {
+    username,
+    userArn: `arn:aws:sts::123456789012:assumed-role/${iamRoleName}/CognitoIdentityCredentials`,
+    accountId: '123456789012',
+    cognitoIdentityPoolId: identityInfo?.cognitoIdentityPoolId,
+    cognitoIdentityAuthProvider: identityInfo?.cognitoIdentityAuthProvider,
+    cognitoIdentityId: identityInfo?.cognitoIdentityId,
+    cognitoIdentityAuthType: identityInfo?.cognitoIdentityAuthType,
   };
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- add relational vtl test for 1:1 and 1:M which capture auth field logic
- update auth filter to not include none values as this causes unnecessary filtering
- default back to auth flag instead of using primaryField checks for regular and relational queries
- updated snapshot testing since the resolver logic changed

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
