### PR TITLE
Modify update custom flow + update cdk skeleton sample

### DIFF
--- a/packages/amplify-category-custom/resources/cdk-stack.ts.sample
+++ b/packages/amplify-category-custom/resources/cdk-stack.ts.sample
@@ -1,64 +1,55 @@
 import * as cdk from '@aws-cdk/core';
 import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
-/*import * as iam from '@aws-cdk/aws-iam';
-import * as sns from '@aws-cdk/aws-sns';
-import * as subs from '@aws-cdk/aws-sns-subscriptions';
-import * as sqs from '@aws-cdk/aws-sqs';
-*/
-
+//import * as iam from '@aws-cdk/aws-iam';
+//import * as sns from '@aws-cdk/aws-sns';
+//import * as subs from '@aws-cdk/aws-sns-subscriptions';
+//import * as sqs from '@aws-cdk/aws-sqs';
 
 export class cdkStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps, amplifyResourceProps?: AmplifyHelpers.AmplifyResourceProps) {
     super(scope, id, props);
-
-    /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input paramater */
+    /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input parameter */
     new cdk.CfnParameter(this, 'env', {
       type: 'String',
       description: 'Current Amplify CLI env name',
     });
-
-    /* AWS CDK Code goes here - Learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
+    /* AWS CDK code goes here - learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
     
+    // Example 1: Set up an SQS queue with an SNS topic 
 
-    /* Example 1: Set up an SQS queue with an SNS topic 
-
+    /*
     const amplifyProjectInfo = AmplifyHelpers.getProjectInfo();
-
     const sqsQueueResourceNamePrefix = `sqs-queue-${amplifyProjectInfo.projectName}`;
-
     const queue = new sqs.Queue(this, 'sqs-queue', {
-      queueName: cdk.Fn.join('-', [sqsQueueResourceNamePrefix, cdk.Fn.ref('env')])
+      queueName: `${sqsQueueResourceNamePrefix}-${cdk.Fn.ref('env')}`
     });
-
-    // 👇 create sns topic
+    // 👇create sns topic
     
     const snsTopicResourceNamePrefix = `sns-topic-${amplifyProjectInfo.projectName}`;
     const topic = new sns.Topic(this, 'sns-topic', {
-      topicName: cdk.Fn.join('-', [snsTopicResourceNamePrefix, cdk.Fn.ref('env')])
+      topicName: `${snsTopicResourceNamePrefix}-${cdk.Fn.ref('env')}`
     });
-
     // 👇 subscribe queue to topic
     topic.addSubscription(new subs.SqsSubscription(queue));
-
     new cdk.CfnOutput(this, 'snsTopicArn', {
       value: topic.topicArn,
       description: 'The arn of the SNS topic',
     });
     */
 
-    /* Example 2: Adding IAM role to the custom stack 
-   
+    // Example 2: Adding IAM role to the custom stack 
+    /*
     const roleResourceNamePrefix = `CustomRole-${amplifyProjectInfo.projectName}`;
     
     const role = new iam.Role(this, 'CustomRole', {
       assumedBy: new iam.AccountRootPrincipal(),
-      roleName: cdk.Fn.join('-', [roleResourceNamePrefix, cdk.Fn.ref('env')])
+      roleName: `${roleResourceNamePrefix}-${cdk.Fn.ref('env')}`
     }); 
-
     */
 
-    /* Example 3: Adding policy to the IAM role
+    // Example 3: Adding policy to the IAM role
+    /*
     role.addToPolicy(
       new iam.PolicyStatement({
         actions: ['*'],
@@ -67,8 +58,8 @@ export class cdkStack extends cdk.Stack {
     );
     */
 
-    /* Access other Amplify Resources 
-
+    // Access other Amplify Resources 
+    /*
     const retVal:AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(this, 
       amplifyResourceProps.category, 
       amplifyResourceProps.resourceName, 
@@ -76,8 +67,6 @@ export class cdkStack extends cdk.Stack {
         {category: <insert-amplify-category>, resourceName: <insert-amplify-resourcename>},
       ]
     );
-
     */
-
   }
 }

--- a/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
+++ b/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
@@ -177,10 +177,6 @@ function addDependsOnToResource(category: string, resourceName: string, dependsO
 }
 
 export async function addCFNResourceDependency(context: $TSContext, customResourceName: string) {
-  if (!(await prompter.yesOrNo('Do you want to access Amplify generated resources in your custom CloudFormation file?', false))) {
-    return;
-  }
-
   const selectResourcesInCategory = (
     choices: DistinctChoice<any>[],
     currentResourceDependencyMap: $TSObject,
@@ -214,6 +210,16 @@ export async function addCFNResourceDependency(context: $TSContext, customResour
       }
       existingDependentResources[resource.category].push(resource.resourceName);
     });
+  }
+
+  const isExistingResources = Object.keys(existingDependentResources).length > 0;
+
+  if (
+    !(await prompter.yesOrNo('Do you want to access Amplify generated resources in your custom CloudFormation file?', isExistingResources))
+  ) {
+    // Remove all dependencies for the custom resource
+    await context.amplify.updateamplifyMetaAfterResourceUpdate(categoryName, customResourceName, 'dependsOn', []);
+    return;
   }
 
   const categories = Object.keys(amplifyMeta).filter(category => category !== 'providers');

--- a/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
+++ b/packages/amplify-category-custom/src/utils/dependency-management-utils.ts
@@ -212,10 +212,10 @@ export async function addCFNResourceDependency(context: $TSContext, customResour
     });
   }
 
-  const isExistingResources = Object.keys(existingDependentResources).length > 0;
+  const hasExistingResources = Object.keys(existingDependentResources).length > 0;
 
   if (
-    !(await prompter.yesOrNo('Do you want to access Amplify generated resources in your custom CloudFormation file?', isExistingResources))
+    !(await prompter.yesOrNo('Do you want to access Amplify generated resources in your custom CloudFormation file?', hasExistingResources))
   ) {
     // Remove all dependencies for the custom resource
     await context.amplify.updateamplifyMetaAfterResourceUpdate(categoryName, customResourceName, 'dependsOn', []);


### PR DESCRIPTION
1. `amplify update custom` flow improvements to allow deselection of all other Amplify resource dependencies.
2. Update cdk sample skeleton app to not use cdk.fn.join as it's not needed + fix one typo + make comments better