### PR TITLE
fix: allow mock to run if @searchable is used

### DIFF
--- a/packages/amplify-appsync-simulator/src/data-loader/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/index.ts
@@ -1,6 +1,7 @@
 import { DynamoDBDataLoader } from './dynamo-db';
 import { NoneDataLoader } from './none';
 import { LambdaDataLoader } from './lambda';
+import { OpenSearchDataLoader } from './opensearch';
 
 export interface AmplifyAppSyncSimulatorDataLoader {
   load(payload: any, extraData?: any): Promise<object | null>;
@@ -32,3 +33,4 @@ export function removeDataLoader(sourceType: string) {
 addDataLoader('AMAZON_DYNAMODB', DynamoDBDataLoader);
 addDataLoader('NONE', NoneDataLoader);
 addDataLoader('AWS_LAMBDA', LambdaDataLoader);
+addDataLoader('AMAZON_ELASTICSEARCH', OpenSearchDataLoader);

--- a/packages/amplify-appsync-simulator/src/data-loader/opensearch/index.ts
+++ b/packages/amplify-appsync-simulator/src/data-loader/opensearch/index.ts
@@ -1,0 +1,8 @@
+import { AmplifyAppSyncSimulatorDataLoader } from '..';
+
+export class OpenSearchDataLoader implements AmplifyAppSyncSimulatorDataLoader {
+  load(request): any {
+    console.error('@searchable mocking is not supported.');
+    return null;
+  }
+}

--- a/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
+++ b/packages/amplify-util-mock/src/CFNParser/appsync-resource-processor.ts
@@ -1,5 +1,10 @@
 import { AmplifyAppSyncSimulatorAuthenticationType, AmplifyAppSyncSimulatorConfig } from 'amplify-appsync-simulator';
-import { registerAppSyncResourceProcessor, registerIAMResourceProcessor, registerLambdaResourceProcessor } from './resource-processors';
+import {
+  registerAppSyncResourceProcessor,
+  registerIAMResourceProcessor,
+  registerLambdaResourceProcessor,
+  registerOpenSearchResourceProcessor,
+} from './resource-processors';
 import { AppSyncAPIKeyProcessedResource, AppSyncAPIProcessedResource } from './resource-processors/appsync';
 import { processCloudFormationStack } from './stack/index';
 import { CloudFormationTemplateFetcher, CloudFormationTemplate } from './stack/types';
@@ -111,6 +116,7 @@ export function processTransformerStacks(transformResult, params = {}): AmplifyA
   registerAppSyncResourceProcessor();
   registerIAMResourceProcessor();
   registerLambdaResourceProcessor();
+  registerOpenSearchResourceProcessor();
 
   const rootStack = JSON.parse(JSON.stringify(transformResult.rootStack)); // rootstack is not
   const cfnParams = {

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -34,7 +34,7 @@ export function dynamoDBResourceHandler(resourceName, resource, cfnContext: Clou
 
 export type AppSyncDataSourceProcessedResource = CloudFormationProcessedResourceResult & {
   name: string;
-  type: 'AMAZON_DYNAMODB' | 'AWS_LAMBDA' | 'NONE';
+  type: 'AMAZON_DYNAMODB' | 'AWS_LAMBDA' | 'AMAZON_ELASTICSEARCH' | 'NONE';
   LambdaFunctionArn?: string;
   config?: {
     tableName: string;
@@ -76,6 +76,16 @@ export function appSyncDataSourceHandler(
       type: 'AWS_LAMBDA',
       name: resource.Properties.Name,
       LambdaFunctionArn: lambdaArn,
+    };
+  }
+
+  if (typeName === 'AMAZON_ELASTICSEARCH') {
+    console.log(`@searchable mocking is not supported. Search queries will not work as expected.`);
+
+    return {
+      ...commonProps,
+      type: 'AMAZON_ELASTICSEARCH',
+      name: resource.Properties.Name,
     };
   }
 

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/index.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/index.ts
@@ -1,5 +1,5 @@
 import { $TSAny } from 'amplify-cli-core';
-import { lambdaFunctionHandler } from './lambda';
+import { lambdaEventSourceHandler, lambdaFunctionHandler } from './lambda';
 import { CloudFormationResource, ProcessedLambdaFunction } from '../stack/types';
 import { CloudFormationParseContext } from '../types';
 import {
@@ -12,6 +12,7 @@ import {
   dynamoDBResourceHandler,
 } from './appsync';
 import { iamPolicyResourceHandler, iamRoleResourceHandler } from './iam';
+import { openSearchDomainHandler } from './opensearch';
 
 export type CloudFormationResourceProcessorFn = (
   resourceName: string,
@@ -48,4 +49,9 @@ export function registerIAMResourceProcessor(): void {
 
 export function registerLambdaResourceProcessor(): void {
   registerResourceProcessors('AWS::Lambda::Function', lambdaFunctionHandler);
+  registerResourceProcessors('AWS::Lambda::EventSourceMapping', lambdaEventSourceHandler);
+}
+
+export function registerOpenSearchResourceProcessor(): void {
+  registerResourceProcessors('AWS::Elasticsearch::Domain', openSearchDomainHandler);
 }

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/lambda.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/lambda.ts
@@ -1,6 +1,11 @@
 import { CloudFormationParseContext } from '../types';
 import { parseValue } from '../field-parser';
-import { CloudFormationResource, CloudFormationResourceProperty, ProcessedLambdaFunction } from '../stack/types';
+import {
+  CloudFormationResource,
+  CloudFormationResourceProperty,
+  ProcessedLambdaEventSource,
+  ProcessedLambdaFunction,
+} from '../stack/types';
 
 /**
  * Handles the parsing of a lambda CFN resource into relevant bits of information
@@ -30,5 +35,24 @@ export const lambdaFunctionHandler = (
     name,
     handler,
     environment,
+  };
+};
+
+export const lambdaEventSourceHandler = (
+  resourceName: string,
+  resource: CloudFormationResource,
+  cfnContext: CloudFormationParseContext,
+): ProcessedLambdaEventSource => {
+  const batchSize: number = parseValue(resource.Properties.BatchSize, cfnContext);
+  const eventSourceArn: string = parseValue(resource.Properties.EventSourceArn, cfnContext);
+  const functionName: string = parseValue(resource.Properties.FunctionName, cfnContext);
+  const startingPosition: string = parseValue(resource.Properties.StartingPosition, cfnContext);
+
+  return {
+    cfnExposedAttributes: {},
+    batchSize,
+    eventSourceArn,
+    functionName,
+    startingPosition,
   };
 };

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/opensearch.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/opensearch.ts
@@ -1,0 +1,15 @@
+import { CloudFormationParseContext } from '../types';
+import { CloudFormationResource, ProcessedOpenSearchDomain } from '../stack/types';
+
+export const openSearchDomainHandler = (
+  resourceName: string,
+  resource: CloudFormationResource,
+  cfnContext: CloudFormationParseContext,
+): ProcessedOpenSearchDomain => {
+  return {
+    cfnExposedAttributes: { Arn: 'arn', DomainArn: 'arn', DomainEndpoint: 'endpoint' },
+    arn: `arn:aws:es:{aws-region}:{aws-account-number}:domain/${resourceName}`,
+    ref: resourceName,
+    endpoint: 'localhost:9200',
+  };
+};

--- a/packages/amplify-util-mock/src/CFNParser/stack/types.ts
+++ b/packages/amplify-util-mock/src/CFNParser/stack/types.ts
@@ -110,3 +110,14 @@ export type ProcessedLambdaFunction = CloudFormationProcessedResourceResult & {
   handler: string;
   environment: Record<string, string>;
 };
+
+export type ProcessedLambdaEventSource = CloudFormationProcessedResourceResult & {
+  batchSize: number;
+  eventSourceArn: string;
+  functionName: string;
+  startingPosition: string;
+};
+
+export type ProcessedOpenSearchDomain = CloudFormationProcessedResourceResult & {
+  endpoint: string;
+};


### PR DESCRIPTION
#### Description of changes

`@searchable` mocking is not currently implemented. However, it should still be possible to use mock with a schema containing `@searchable` - search queries will just not work properly. This commit updates mock to allow schemas with `@searchable`. Messages are now printed on initial startup, and each time a search query is executed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
