### PR TITLE
chore: update overrides helper package reference in skeleton samples

### DIFF
--- a/packages/amplify-category-auth/resources/overrides-resource/auth/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/auth/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"

--- a/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"

--- a/packages/amplify-category-custom/resources/package.json
+++ b/packages/amplify-category-custom/resources/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0",
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0",
       "@aws-cdk/core": "~1.124.0",
       "@aws-cdk/aws-iam": "~1.124.0",
       "@aws-cdk/aws-sns-subscriptions": "~1.124.0",

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
       
     },
     "devDependencies": {

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
@@ -8,7 +8,7 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "1.0.1-ext19.0"
+      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
     },
     "devDependencies": {
       "typescript": "^4.2.4"


### PR DESCRIPTION
Make the skeleton package.json reference to the versions of the override helpers to be released.