### PR TITLE
fix: userPool retain policy

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
@@ -273,7 +273,6 @@ Object {
       "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
     },
     "UserPool": Object {
-      "DeletionPolicy": "Retain",
       "Properties": Object {
         "AliasAttributes": Object {
           "Ref": "aliasAttributes",
@@ -335,7 +334,6 @@ Object {
         },
       },
       "Type": "AWS::Cognito::UserPool",
-      "UpdateReplacePolicy": "Retain",
     },
     "UserPoolClient": Object {
       "DependsOn": Array [
@@ -1801,7 +1799,6 @@ exports.handler = (event, context, callback) => {
       "Type": "AWS::IAM::Role",
     },
     "UserPool": Object {
-      "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "SNSRole",
       ],
@@ -1882,7 +1879,6 @@ exports.handler = (event, context, callback) => {
         },
       },
       "Type": "AWS::Cognito::UserPool",
-      "UpdateReplacePolicy": "Retain",
     },
     "UserPoolClient": Object {
       "DependsOn": Array [

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -354,11 +354,6 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         this.userPool.addDependsOn(this.snsRole!);
       }
 
-      this.userPool.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN, {
-        applyToUpdateReplacePolicy: true,
-        default: cdk.RemovalPolicy.RETAIN,
-      });
-
       // updating Lambda Config when FF is (breakcirculardependency : false)
 
       if (!props.breakCircularDependency && props.triggers && props.dependsOn) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Changed userPool policy
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
