### PR TITLE
fix: trigger when break circular dependency  FF is off

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/update-amplify-meta.ts
@@ -64,7 +64,7 @@ function moveBackendResourcesToCurrentCloudBackend(resources: $TSObject[]) {
     // in the case that the resource is being deleted, the sourceDir won't exist
     if (fs.pathExistsSync(sourceDir)) {
       fs.copySync(sourceDir, targetDir);
-      if (resource?.service === ServiceName.LambdaFunction || resource?.service.includes('custom')) {
+      if (resource?.service === ServiceName.LambdaFunction || (resource?.service && resource?.service.includes('custom'))) {
         removeNodeModulesDir(targetDir);
       }
     }

--- a/packages/amplify-provider-awscloudformation/resources/update-idp-roles-cfn.json
+++ b/packages/amplify-provider-awscloudformation/resources/update-idp-roles-cfn.json
@@ -136,14 +136,14 @@
               },
               {
                 "Effect": "Allow",
-                "Action": "iam:UpdateAssumeRolePolicy",
+                "Action": ["iam:UpdateAssumeRolePolicy", "iam:GetRole"],
                 "Resource": {
                   "Fn::GetAtt": ["AuthRole", "Arn"]
                 }
               },
               {
                 "Effect": "Allow",
-                "Action": "iam:UpdateAssumeRolePolicy",
+                "Action": ["iam:UpdateAssumeRolePolicy", "iam:GetRole"],
                 "Resource": {
                   "Fn::GetAtt": ["UnauthRole", "Arn"]
                 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- fixed resource.service when service is not defined
- fixed template for cognito triggers when rbreah circular dependency FF is OFF

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

#8873 
#8870 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
