### PR TITLE
fix: storage migration for only-groups and headless allowUnauthenticatedIdentities flag missing in auth

### DIFF
--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-resource-api.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-resource-api.ts
@@ -64,7 +64,7 @@ export async function s3GetAdminTriggerFunctionName(context: $TSContext) : Promi
  * @param storageInput - Storage + Auth configurations as required by the calling category
  * @returns Name of the storage resource.
  */
-export async function s3CreateStorageResource(context: $TSContext, storageInput: S3UserInputs): Promise<S3UserInputs | undefined> {
+export async function s3CreateStorageResource(context: $TSContext, storageInput: S3UserInputs): Promise<S3UserInputs> {
   //if s3 resource exists throw exception
   let storageResourceName: string | undefined = s3GetResourceName();
   if (storageResourceName) {

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state.ts
@@ -183,7 +183,7 @@ export class S3InputState {
       resourceName: this._resourceName,
       bucketName: oldParams.bucketName,
       policyUUID: buildShortUUID(), //Since UUID is unique for every resource, we re-create the policy names with new UUID.
-      storageAccess: undefined,
+      storageAccess: S3AccessType.AUTH_ONLY,
       guestAccess: [],
       authAccess: [],
       triggerFunction: 'NONE',


### PR DESCRIPTION
1. storage - migration fixes
2. headless-storage add/update ( unauth role fix)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Default parameters were undefined for required fields for this flow. Validated migration flows with only-groups, auth+guest+groups, only-auth+guest
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/8875#issuecomment-969240042

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [*] PR description included
- [*] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
