### PR TITLE
test: add gql migrator @connection unit tests

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Schema migration tests @connection belongs to relationship 1`] = `
+"type Post @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  comments: [Comment] @hasMany(indexName: \\"byPost\\", fields: [\\"id\\"])
+}
+
+type Comment @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  postID: ID! @index(name: \\"byPost\\", sortKeyFields: [\\"content\\"])
+  content: String!
+  post: Post @belongsTo(fields: [\\"postID\\"])
+}
+"
+`;
+
 exports[`Schema migration tests @connection has many relationship 1`] = `
 "type Post @model @auth(rules: [{allow: public}]) {
   id: ID!
@@ -15,7 +31,36 @@ type Comment @model @auth(rules: [{allow: public}]) {
 "
 `;
 
-exports[`Schema migration tests @connection has one relationship 1`] = `
+exports[`Schema migration tests @connection has many relationship with limit 1`] = `
+"type Post @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  comments: [Comment] @hasMany(limit: 50)
+}
+
+type Comment @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  content: String!
+}
+"
+`;
+
+exports[`Schema migration tests @connection has one relationship with fields 1`] = `
+"type Project @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String
+  teamID: ID!
+  team: Team @hasOne(fields: [\\"teamID\\"])
+}
+
+type Team @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String!
+}
+"
+`;
+
+exports[`Schema migration tests @connection has one relationship with no fields 1`] = `
 "type Project @model @auth(rules: [{allow: public}]) {
   id: ID!
   name: String
@@ -25,6 +70,29 @@ exports[`Schema migration tests @connection has one relationship 1`] = `
 type Team @model @auth(rules: [{allow: public}]) {
   id: ID!
   name: String!
+}
+"
+`;
+
+exports[`Schema migration tests @connection many to many relationship 1`] = `
+"type Post @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  editors: [PostEditor] @hasMany(indexName: \\"byPost\\", fields: [\\"id\\"])
+}
+
+type PostEditor @model(queries: null) @auth(rules: [{allow: public}]) {
+  id: ID!
+  postID: ID! @index(name: \\"byPost\\", sortKeyFields: [\\"editorID\\"])
+  editorID: ID! @index(name: \\"byEditor\\", sortKeyFields: [\\"postID\\"])
+  post: Post! @belongsTo(fields: [\\"postID\\"])
+  editor: User! @belongsTo(fields: [\\"editorID\\"])
+}
+
+type User @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  username: String!
+  posts: [PostEditor] @hasMany(indexName: \\"byEditor\\", fields: [\\"id\\"])
 }
 "
 `;
@@ -147,6 +215,64 @@ exports[`Schema migration tests explicit creation and update timestamps 1`] = `
   id: ID!
   createdAt: AWSTimestamp
   updatedAt: AWSTimestamp
+}
+"
+`;
+
+exports[`Schema migration tests migrates complex schema from documentation 1`] = `
+"type Order @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  customerID: ID! @index(name: \\"byCustomerByStatusByDate\\", sortKeyFields: [\\"status\\", \\"date\\"]) @index(name: \\"byCustomerByDate\\", sortKeyFields: [\\"date\\"])
+  accountRepresentativeID: ID! @index(name: \\"byRepresentativebyDate\\", sortKeyFields: [\\"date\\"])
+  productID: ID! @index(name: \\"byProduct\\", sortKeyFields: [\\"id\\"])
+  status: String!
+  amount: Int!
+  date: String!
+}
+
+type Customer @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String!
+  phoneNumber: String
+  accountRepresentativeID: ID! @index(name: \\"byRepresentative\\", sortKeyFields: [\\"id\\"])
+  ordersByDate: [Order] @hasMany(indexName: \\"byCustomerByDate\\", fields: [\\"id\\"])
+  ordersByStatusDate: [Order] @hasMany(indexName: \\"byCustomerByStatusByDate\\", fields: [\\"id\\"])
+}
+
+type Employee @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String! @index(name: \\"byName\\", queryField: \\"employeeByName\\", sortKeyFields: [\\"id\\"])
+  startDate: String!
+  phoneNumber: String!
+  warehouseID: ID! @index(name: \\"byWarehouse\\", sortKeyFields: [\\"id\\"])
+  jobTitle: String! @index(name: \\"byTitle\\", queryField: \\"employeesByJobTitle\\", sortKeyFields: [\\"id\\"])
+  newHire: String! @index(name: \\"newHire\\", queryField: \\"employeesNewHire\\", sortKeyFields: [\\"id\\"]) @index(name: \\"newHireByStartDate\\", queryField: \\"employeesNewHireByStartDate\\", sortKeyFields: [\\"startDate\\"])
+}
+
+type Warehouse @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  employees: [Employee] @hasMany(indexName: \\"byWarehouse\\", fields: [\\"id\\"])
+}
+
+type AccountRepresentative @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  customers: [Customer] @hasMany(indexName: \\"byRepresentative\\", fields: [\\"id\\"])
+  orders: [Order] @hasMany(indexName: \\"byRepresentativebyDate\\", fields: [\\"id\\"])
+  orderTotal: Int
+  salesPeriod: String @index(name: \\"bySalesPeriodByOrderTotal\\", queryField: \\"repsByPeriodAndTotal\\", sortKeyFields: [\\"orderTotal\\"])
+}
+
+type Inventory @model @auth(rules: [{allow: public}]) {
+  productID: ID! @primaryKey(sortKeyFields: [\\"warehouseID\\"])
+  warehouseID: ID! @index(name: \\"byWarehouseID\\", queryField: \\"itemsByWarehouseID\\")
+  inventoryAmount: Int!
+}
+
+type Product @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String!
+  orders: [Order] @hasMany(indexName: \\"byProduct\\", fields: [\\"id\\"])
+  inventories: [Inventory] @hasMany(fields: [\\"id\\"])
 }
 "
 `;

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
@@ -1,27 +1,27 @@
 import { isListType } from 'graphql-transformer-common';
 
-const validConnectionDirectiveNames = new Set(["hasOne", "hasMany", "connection"]);
+const validConnectionDirectiveNames = new Set(['hasOne', 'hasMany', 'connection']);
 
 export function getFieldsWithConnection(fields: any) {
-  return fields.filter((field: any) => field.directives.find((d: any) => d.name.value === "connection"));
+  return fields.filter((field: any) => field.directives.find((d: any) => d.name.value === 'connection'));
 }
 
 export function getConnectionFieldsArg(connection: any) {
-  return connection.arguments.find((a: any) => a.name.value === "fields").value.values.map((v: any) => v.value);
+  return connection.arguments.find((a: any) => a.name.value === 'fields').value.values.map((v: any) => v.value);
 }
 
 export function isFieldIndex(field: any) {
-  return field.directives.some((dir: any) => dir.name.value === "index");
+  return field.directives.some((dir: any) => dir.name.value === 'index');
 }
 
 export function getConnectionDirective(field: any) {
-  return field.directives.find((d: any) => d.name.value === "connection" || d.name.value === 'hasMany' || d.name.value === 'hasOne' || d.name.value === 'belongsTo');
+  return field.directives.find(
+    (d: any) => d.name.value === 'connection' || d.name.value === 'hasMany' || d.name.value === 'hasOne' || d.name.value === 'belongsTo',
+  );
 }
 
 function getRelatedType(output: any, relatedTypeName: any) {
-  const relatedType = output.definitions.find(
-    (d: any) => d.kind === "ObjectTypeDefinition" && d.name.value === relatedTypeName,
-  );
+  const relatedType = output.definitions.find((d: any) => d.kind === 'ObjectTypeDefinition' && d.name.value === relatedTypeName);
 
   return relatedType;
 }
@@ -44,8 +44,12 @@ export function migrateConnection(node: any, ast: any) {
     const connectionDirective = getConnectionDirective(connectionField);
     let typeIsList = isListType(connectionField.type);
     if (typeIsList) {
-      connectionDirective.name.value = "hasMany";
-      connectionDirective.arguments.find((a: any) => a.name.value === "keyName").name.value = "indexName";
+      connectionDirective.name.value = 'hasMany';
+      const keyNameArg = connectionDirective.arguments.find((a: any) => a.name.value === 'keyName');
+
+      if (keyNameArg) {
+        keyNameArg.name.value = 'indexName';
+      }
     } else {
       const relatedType = getRelatedType(ast, getFieldType(connectionField));
       const isBiDirectionalRelation = relatedType.fields.some((relatedField: any) => {
@@ -64,10 +68,10 @@ export function migrateConnection(node: any, ast: any) {
       });
 
       if (isBiDirectionalRelation) {
-        connectionDirective.name.value = "belongsTo";
+        connectionDirective.name.value = 'belongsTo';
       } else {
-        connectionDirective.name.value = "hasOne";
+        connectionDirective.name.value = 'hasOne';
       }
     }
-  })
+  });
 }


### PR DESCRIPTION
#### Description of changes

This PR adds additional `@connection` unit tests to the GQL migrator tool. I also made a minor bug fix on lines 48-52 of `packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts`, which triggered the linter to be run on that file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
