### PR TITLE
chore(graphql-transformer-migrator): warn users about stripping out the comments in schema migration

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/schema-migrator.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/schema-migrator.ts
@@ -49,6 +49,14 @@ export async function attemptV2TransformerMigration(resourceDir: string, apiName
     throw Error(`Unidentified authorization mode for API found: ${defaultAuth}`);
   }
 
+  if (schemaHasComments(fullSchema)) {
+    printer.warn(
+      `Warning: The migration will not carry over any existing comments in your GraphQL schema, you'll be able to manually copy them in from the back-ups stored at ${backupLocation(
+        resourceDir,
+      )}.`,
+    );
+  }
+
   try {
     await backupSchemas(resourceDir);
     await runMigration(schemaDocs, authMode);
@@ -152,6 +160,10 @@ async function getSchemaDocs(resourceDir: string): Promise<SchemaDocument[]> {
     return await Promise.all(schemaFiles.map(async fileName => ({ schema: await fs.readFile(fileName, 'utf8'), filePath: fileName })));
   }
   return [];
+}
+
+function schemaHasComments(fullSchema: string): boolean {
+  return /#/.test(fullSchema);
 }
 
 // returns true if the project can be auto-migrated to v2, or a message explaining why the project cannot be auto-migrated


### PR DESCRIPTION
#### Description of changes
- warns users about removing graphql comment when using migrator tool

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
