### PR TITLE
test: admin queries extensibility migration test

### DIFF
--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1585,7 +1585,7 @@ export function addAuthUserPoolOnlyNoOAuth(cwd: string, settings: AddAuthUserPoo
   });
 }
 
-export function updateAuthAddAdminQueries(projectDir: string, groupName: string = 'adminQueriesGroup', settings?: any): Promise<void> {
+export function updateAuthAddAdminQueries(projectDir: string, groupName: string = 'adminQueriesGroup', settings: any = {}): Promise<void> {
   const testingWithLatestCodebase = settings.testingWithLatestCodebase ?? false;
   return new Promise((resolve, reject) => {
     const chain = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'auth'], { cwd: projectDir, stripColors: true });
@@ -1594,10 +1594,7 @@ export function updateAuthAddAdminQueries(projectDir: string, groupName: string 
     }
     chain
       .wait('What do you want to do?')
-      .send(KEY_DOWN_ARROW)
-      .send(KEY_DOWN_ARROW)
-      .send(KEY_DOWN_ARROW)
-      .send(KEY_DOWN_ARROW)
+      .sendKeyUp()
       .sendCarriageReturn() // Create or update Admin queries API
       .wait('Do you want to restrict access to the admin queries API to a specific Group')
       .sendConfirmYes()
@@ -1666,4 +1663,22 @@ export function updateAuthWithoutTrigger(cwd: string, settings: any): Promise<vo
         }
       });
   });
+}
+
+export function updateAuthAdminQueriesWithExtMigration(cwd: string): Promise<void> {
+  return spawn(getCLIPath(), ['update', 'auth'], { cwd, stripColors: true })
+    .wait('Do you want to migrate auth resource')
+    .sendYes()
+    .wait('What do you want to do')
+    .sendKeyUp()
+    .sendCarriageReturn() // Create or update Admin queries API
+    .wait('Do you want to restrict access to the admin queries API to a specific Group')
+    .sendConfirmYes()
+    .wait('Select the group to restrict access with')
+    .sendCarriageReturn() // Enter a custom group
+    .wait('Provide a group name')
+    .sendLine('mycustomgroup')
+    .wait('Migration for AdminQueries is required. Continue')
+    .sendYes()
+    .runAsync();
 }

--- a/packages/amplify-e2e-tests/src/__tests__/migration/apigw-ext-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/apigw-ext-migration.test.ts
@@ -6,9 +6,12 @@ import {
   deleteProject,
   deleteProjectDir,
   getCLIInputs,
-  getCLIPath,
   initJSProjectWithProfile,
   updateRestApi,
+  addAuthWithDefault,
+  updateAuthAddAdminQueries,
+  updateAuthAdminQueriesWithExtMigration,
+  getProjectMeta,
 } from 'amplify-e2e-core';
 import { v4 as uuid } from 'uuid';
 
@@ -31,10 +34,30 @@ describe('API Gateway CDK migration', () => {
   it('migrates on api update', async () => {
     await addRestApi(projRoot, { existingLambda: false, apiName: 'restapimig' });
     await amplifyPushAuth(projRoot);
-    await cliVersionController.resetCliVersion();
+    cliVersionController.resetCliVersion();
     await updateRestApi(projRoot, { updateOperation: 'Add another path', newPath: '/foo', expectMigration: true });
     await amplifyPushAuth(projRoot);
     const cliInputs = getCLIInputs(projRoot, 'api', 'restapimig');
     expect(cliInputs).toBeDefined();
+  });
+
+  it('migrates auth with admin queries', async () => {
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddAdminQueries(projRoot);
+    await amplifyPushAuth(projRoot);
+
+    cliVersionController.resetCliVersion();
+
+    await updateAuthAdminQueriesWithExtMigration(projRoot);
+    await amplifyPushAuth(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    const authName = Object.keys(meta.auth)[0];
+
+    const authCliInputs = getCLIInputs(projRoot, 'auth', authName);
+    expect(authCliInputs).toBeDefined();
+
+    const adminQueriesCliInputs = getCLIInputs(projRoot, 'api', 'AdminQueries');
+    expect(adminQueriesCliInputs).toBeDefined();
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds an e2e migration test for converting the AdminQueries API to support extensibility

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran e2e test locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
