### PR TITLE
fix(graphql): add warning to missing auth modes on amplify push yes flag

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/apply-auth-mode.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/apply-auth-mode.ts
@@ -1,0 +1,66 @@
+import { $TSContext } from "amplify-cli-core";
+import { getProjectMeta } from './get-project-meta';
+
+const errAuthMissingIAM = `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`;
+const errAuthMissingUserPools = `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`;
+const errAuthMissingOIDC = `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`;
+const errAuthMissingApiKey = `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`;
+const errAuthMissingLambda = `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`;
+
+export function isValidGraphQLAuthError(message: string): boolean {
+  return [errAuthMissingIAM, errAuthMissingUserPools, errAuthMissingOIDC, errAuthMissingApiKey, errAuthMissingLambda].includes(message);
+}
+
+export async function handleValidGraphQLAuthError(context: $TSContext, message: string): Promise<boolean> {
+  if (message === errAuthMissingIAM) {
+    await addGraphQLAuthRequirement(context, 'AWS_IAM');
+    return true;
+  } else if (checkIfAuthExists() && message === errAuthMissingUserPools) {
+      await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS');
+      return true;
+  } else if (!context?.parameters?.options?.yes) {
+    if (message === errAuthMissingUserPools) {
+      await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS');
+      return true;
+    } else if (message === errAuthMissingOIDC) {
+      await addGraphQLAuthRequirement(context, 'OPENID_CONNECT');
+      return true;
+    } else if (message === errAuthMissingApiKey) {
+      await addGraphQLAuthRequirement(context, 'API_KEY');
+      return true;
+    } else if (message === errAuthMissingLambda) {
+      await addGraphQLAuthRequirement(context, 'AWS_LAMBDA');
+      return true;
+    }
+  }
+  return false;
+}
+
+async function addGraphQLAuthRequirement(context, authType): Promise<any> {
+  return await context.amplify.invokePluginMethod(context, 'api', undefined, 'addGraphQLAuthorizationMode', [
+    context,
+    {
+      authType: authType,
+      printLeadText: true,
+      authSettings: undefined,
+    },
+  ]);
+}
+
+/**
+ * Query Amplify Metafile and check if Auth is configured
+ * @param context
+ * @returns true if Auth is configured else false
+ */
+ export function checkIfAuthExists(): boolean {
+  const amplifyMeta = getProjectMeta();
+  let authExists = false;
+  const authServiceName = 'Cognito';
+  const authCategory = 'auth';
+
+  const categoryResources = amplifyMeta[authCategory];
+  if (categoryResources !== null && typeof categoryResources === 'object') {
+    authExists = Object.keys(categoryResources).some(resource => categoryResources[resource].service === authServiceName);
+  }
+  return authExists;
+}

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -7,6 +7,8 @@ import { getProviderPlugins } from './get-provider-plugins';
 import { onCategoryOutputsChange } from './on-category-outputs-change';
 import { showResourceTable } from './resource-status';
 import { generateDependentResourcesType } from '@aws-amplify/amplify-category-custom';
+import { isValidGraphQLAuthError, handleValidGraphQLAuthError } from './apply-auth-mode';
+import { printer } from 'amplify-prompts';
 
 export async function pushResources(
   context: $TSContext,
@@ -91,10 +93,15 @@ export async function pushResources(
         await providersPush(context, rebuild, category, resourceName, filteredResources);
         await onCategoryOutputsChange(context, currentAmplifyMeta);
       } catch (err) {
-        if (await isValidGraphQLAuthError(err.message)) {
+        const isAuthError = isValidGraphQLAuthError(err.message);
+        if (isAuthError) {
           retryPush = await handleValidGraphQLAuthError(context, err.message);
         }
         if (!retryPush) {
+          if (isAuthError) {
+            printer.warn(`You defined authorization rules (@auth) but haven't enabled their authorization providers on your GraphQL API. Run "amplify update api" to configure your GraphQL API to include the appropriate authorization providers as an authorization mode.`);
+            printer.error(err.message);
+          }
           throw err;
         }
       }
@@ -105,67 +112,6 @@ export async function pushResources(
   }
 
   return continueToPush;
-}
-
-async function isValidGraphQLAuthError(message: string) {
-  if (
-    message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.` ||
-    message ===
-      `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.` ||
-    message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.` ||
-    message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.` ||
-    message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`
-  ) {
-    return true;
-  }
-}
-
-async function handleValidGraphQLAuthError(context: $TSContext, message: string) {
-  if (message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`) {
-    await addGraphQLAuthRequirement(context, 'AWS_IAM');
-    return true;
-  } else if (!context?.parameters?.options?.yes) {
-    if (
-      message ===
-      `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`
-    ) {
-      await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS');
-      return true;
-    } else if (
-      message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`
-    ) {
-      await addGraphQLAuthRequirement(context, 'OPENID_CONNECT');
-      return true;
-    } else if (
-      message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`
-    ) {
-      await addGraphQLAuthRequirement(context, 'API_KEY');
-      return true;
-    } else if (
-      message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`
-    ) {
-      await addGraphQLAuthRequirement(context, 'AWS_LAMBDA');
-      return true;
-    }
-  }
-  return false;
-}
-
-async function addGraphQLAuthRequirement(context, authType) {
-  try {
-    await context.amplify.invokePluginMethod(context, 'api', undefined, 'addGraphQLAuthorizationMode', [
-      context,
-      {
-        authType: authType,
-        printLeadText: true,
-        authSettings: undefined,
-      },
-    ]);
-  } catch (err) {
-    if (err.name !== 'InvalidDirectiveError') {
-      throw err;
-    }
-  }
 }
 
 async function providersPush(


### PR DESCRIPTION
#### Description of changes
add warning to missing auth modes on amplify push yes flag

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.