### PR TITLE
chore(graphql-model-transformer): toggle transformer version

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
@@ -22,7 +22,7 @@ jest.mock('amplify-cli-core', () => ({
     getBoolean: jest.fn().mockReturnValue(true),
   },
   buildOverrideDir: jest.fn().mockResolvedValue(false),
-  writeCFNTemplate: jest.fn().mockImplementation(() => Promise.resolve())
+  writeCFNTemplate: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 const getCLIInputPayload_mock = jest
@@ -165,7 +165,7 @@ const mockPolicy1 =     {
   "resource": {
     "paramType": "!GetAtt",
     "keys": ["UserPool","Arn"]
-  } 
+  }
 }
 
 const context_stub = {

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -553,7 +553,7 @@ export class FeatureFlags {
         name: 'useExperimentalPipelinedTransformer',
         type: 'boolean',
         defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: false,
+        defaultValueForNewProjects: true,
       },
       {
         name: 'enableIterativeGSIUpdates',
@@ -577,7 +577,7 @@ export class FeatureFlags {
         name: 'transformerVersion',
         type: 'number',
         defaultValueForExistingProjects: 1,
-        defaultValueForNewProjects: 1,
+        defaultValueForNewProjects: 2,
       },
       {
         name: 'suppressSchemaMigrationPrompt',

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1,4 +1,5 @@
-import { nspawn as spawn, KEY_UP_ARROW, KEY_DOWN_ARROW, getCLIPath, getSocialProviders } from '..';
+import _ from 'lodash';
+import { getCLIPath, getSocialProviders, KEY_DOWN_ARROW, KEY_UP_ARROW, nspawn as spawn, setTransformerVersionFlag } from '..';
 
 export type AddAuthUserPoolOnlyNoOAuthSettings = {
   resourceName: string;
@@ -122,16 +123,19 @@ export function addAuthWithGroupTrigger(cwd: string, settings: any): Promise<voi
 interface AddApiOptions {
   apiName: string;
   testingWithLatestCodebase: boolean;
+  transformerVersion: number;
 }
 
 const defaultOptions: AddApiOptions = {
   apiName: '\r',
   testingWithLatestCodebase: true,
+  transformerVersion: 2,
 };
 
-export function addAuthViaAPIWithTrigger(cwd: string, settings: any): Promise<void> {
+export function addAuthViaAPIWithTrigger(cwd: string, opts: Partial<AddApiOptions> = {}): Promise<void> {
+  const options = _.assign(defaultOptions, opts);
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(defaultOptions.testingWithLatestCodebase), ['add', 'api'], { cwd, stripColors: true })
+    spawn(getCLIPath(options.testingWithLatestCodebase), ['add', 'api'], { cwd, stripColors: true })
       .wait('Select from one of the below mentioned services:')
       .sendCarriageReturn()
       .wait(/.*Here is the GraphQL API that we will create. Select a setting to edit or continue.*/)
@@ -174,12 +178,15 @@ export function addAuthViaAPIWithTrigger(cwd: string, settings: any): Promise<vo
           reject(err);
         }
       });
+
+    setTransformerVersionFlag(cwd, options.transformerVersion);
   });
 }
 
-export function addAuthwithUserPoolGroupsViaAPIWithTrigger(cwd: string, settings: any): Promise<void> {
+export function addAuthwithUserPoolGroupsViaAPIWithTrigger(cwd: string, opts: Partial<AddApiOptions> = {}): Promise<void> {
+  const options = _.assign(defaultOptions, opts);
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(defaultOptions.testingWithLatestCodebase), ['add', 'api'], { cwd, stripColors: true })
+    spawn(getCLIPath(options.testingWithLatestCodebase), ['add', 'api'], { cwd, stripColors: true })
       .wait('Select from one of the below mentioned services:')
       .sendCarriageReturn()
       .wait(/.*Here is the GraphQL API that we will create. Select a setting to edit or continue.*/)
@@ -261,6 +268,8 @@ export function addAuthwithUserPoolGroupsViaAPIWithTrigger(cwd: string, settings
           reject(err);
         }
       });
+
+    setTransformerVersionFlag(cwd, options.transformerVersion);
   });
 }
 

--- a/packages/amplify-e2e-core/src/utils/api.ts
+++ b/packages/amplify-e2e-core/src/utils/api.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { TRANSFORM_CONFIG_FILE_NAME } from 'graphql-transformer-core';
+import { addFeatureFlag } from './feature-flags';
 
 export function updateSchema(projectDir: string, projectName: string, schemaText: string) {
   const schemaPath = path.join(projectDir, 'amplify', 'backend', 'api', projectName, 'schema.graphql');
@@ -22,4 +23,11 @@ export function writeToCustomResourcesJson(projectDir: string, apiName: string, 
   const customResourceJson = JSON.parse(fs.readFileSync(jsonPath).toString());
   const mergedJson = { ...customResourceJson, ...json };
   fs.writeFileSync(jsonPath, JSON.stringify(mergedJson));
+}
+
+export function setTransformerVersionFlag(cwd: string, transformerVersion: number) {
+  if (transformerVersion === 1) {
+    addFeatureFlag(cwd, 'graphqltransformer', 'transformerVersion', 1);
+    addFeatureFlag(cwd, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+  }
 }

--- a/packages/amplify-e2e-tests/src/__tests__/api_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_1.test.ts
@@ -49,7 +49,7 @@ describe('amplify add api (GraphQL)', () => {
     const envName = 'devtest';
     const projName = 'simplemodel';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projName, 'simple_model.graphql');
     await amplifyPush(projRoot);
 
@@ -81,7 +81,7 @@ describe('amplify add api (GraphQL)', () => {
     const envName = 'devtest';
     const projName = 'simplemodel';
     await initIosProjectWithProfile(projRoot, { name: projName, envName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projName, 'simple_model.graphql');
     await amplifyPush(projRoot);
 
@@ -107,7 +107,7 @@ describe('amplify add api (GraphQL)', () => {
     const envName = 'devtest';
     const projName = 'simplemodel';
     await initFlutterProjectWithProfile(projRoot, { name: projName, envName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projName, 'simple_model.graphql');
     await amplifyPushWithoutCodegen(projRoot);
 
@@ -141,7 +141,7 @@ describe('amplify add api (GraphQL)', () => {
     const initialSchema = 'initial_key_blog.graphql';
     const nextSchema = 'next_key_blog.graphql';
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema);
@@ -157,7 +157,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a project and add the simple_model api with multiple authorization providers', async () => {
     const appName = createRandomName();
     await initJSProjectWithProfile(projRoot, { name: appName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, appName, 'simple_model.graphql');
     await updateApiWithMultiAuth(projRoot, {});
     await amplifyPush(projRoot);
@@ -201,7 +201,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a project and add the simple_model api, match transformer version to current version', async () => {
     const name = `simplemodelv${TRANSFORM_CURRENT_VERSION}`;
     await initJSProjectWithProfile(projRoot, { name });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'simple_model.graphql');
     await amplifyPush(projRoot);
 
@@ -230,7 +230,7 @@ describe('amplify add api (GraphQL)', () => {
     const initialSchema = 'two-model-schema.graphql';
     const fnName = `integtestfn${random}`;
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await addFunction(
       projRoot,
@@ -278,7 +278,7 @@ describe('amplify add api (GraphQL)', () => {
   it('api force push with no changes', async () => {
     const projectName = `apinochange`;
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, 'two-model-schema.graphql');
     await amplifyPush(projRoot);
     let meta = getBackendAmplifyMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -47,7 +47,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a project with conflict detection enabled and a schema with @key, test update mutation', async () => {
     const name = `keyconflictdetection`;
     await initJSProjectWithProfile(projRoot, { name });
-    await addApiWithBlankSchemaAndConflictDetection(projRoot);
+    await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'key-conflict-detection.graphql');
     await amplifyPush(projRoot);
 
@@ -132,7 +132,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a project with conflict detection enabled and toggle disable', async () => {
     const name = `conflictdetection`;
     await initJSProjectWithProfile(projRoot, { name });
-    await addApiWithBlankSchemaAndConflictDetection(projRoot);
+    await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'simple_model.graphql');
 
     await amplifyPush(projRoot);
@@ -182,7 +182,7 @@ describe('amplify add api (GraphQL)', () => {
     // setupAdminUI
     await enableAdminUI(appId, envName, region);
 
-    await addApiWithBlankSchemaAndConflictDetection(projRoot);
+    await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'simple_model.graphql');
     await amplifyPush(projRoot);
 
@@ -204,7 +204,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a sync enabled project and update conflict resolution strategy', async () => {
     const name = `syncenabled`;
     await initJSProjectWithProfile(projRoot, { name });
-    await addApiWithBlankSchemaAndConflictDetection(projRoot);
+    await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'simple_model.graphql');
 
     let transformConfig = getTransformConfig(projRoot, name);
@@ -242,7 +242,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a datastore enabled project and then remove datastore config in update', async () => {
     const name = 'withoutdatastore';
     await initJSProjectWithProfile(projRoot, { name });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'simple_model.graphql');
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/api_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_3.test.ts
@@ -1,27 +1,28 @@
 import {
+  addApiWithoutSchema,
+  addFeatureFlag,
+  addHeadlessApi,
   amplifyPush,
   amplifyPushUpdate,
-  deleteProject,
-  initJSProjectWithProfile,
-  getSchemaPath,
-  addHeadlessApi,
-  updateHeadlessApi,
-  getProjectSchema,
-  removeHeadlessApi,
-  addApiWithoutSchema,
-  updateApiSchema,
   createNewProjectDir,
+  deleteProject,
   deleteProjectDir,
   getAppSyncApi,
   getProjectMeta,
+  getProjectSchema,
+  getSchemaPath,
   getTransformConfig,
+  initJSProjectWithProfile,
+  removeHeadlessApi,
+  updateApiSchema,
+  updateHeadlessApi,
 } from 'amplify-e2e-core';
-import path from 'path';
-import { existsSync } from 'fs';
-import { TRANSFORM_CURRENT_VERSION, TRANSFORM_BASE_VERSION, writeTransformerConfiguration } from 'graphql-transformer-core';
 import { AddApiRequest, UpdateApiRequest } from 'amplify-headless-interface';
+import { existsSync } from 'fs';
 import { readFileSync } from 'fs-extra';
+import { TRANSFORM_BASE_VERSION, TRANSFORM_CURRENT_VERSION, writeTransformerConfiguration } from 'graphql-transformer-core';
 import _ from 'lodash';
+import path from 'path';
 
 describe('amplify add api (GraphQL)', () => {
   let projRoot: string;
@@ -40,7 +41,7 @@ describe('amplify add api (GraphQL)', () => {
   it('init a project and add the simple_model api, change transformer version to base version and push', async () => {
     const name = `simplemodelv${TRANSFORM_BASE_VERSION}`;
     await initJSProjectWithProfile(projRoot, { name });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, name, 'simple_model.graphql');
     const transformConfig = getTransformConfig(projRoot, name);
     expect(transformConfig).toBeDefined();
@@ -81,6 +82,10 @@ describe('amplify add api (GraphQL)', () => {
   it('creates AppSync API in headless mode', async () => {
     await initJSProjectWithProfile(projRoot, {});
     await addHeadlessApi(projRoot, addApiRequest);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await amplifyPush(projRoot);
 
     // verify
@@ -123,6 +128,10 @@ describe('amplify add api (GraphQL)', () => {
   it('updates AppSync API in headless mode', async () => {
     await initJSProjectWithProfile(projRoot, {});
     await addHeadlessApi(projRoot, addApiRequest);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await amplifyPush(projRoot);
     await updateHeadlessApi(projRoot, updateApiRequest, true);
     await amplifyPushUpdate(projRoot, undefined, undefined, true);
@@ -148,6 +157,10 @@ describe('amplify add api (GraphQL)', () => {
   it('removes AppSync API in headless mode', async () => {
     await initJSProjectWithProfile(projRoot, {});
     await addHeadlessApi(projRoot, addApiRequest);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await amplifyPush(projRoot);
 
     // verify

--- a/packages/amplify-e2e-tests/src/__tests__/api_4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_4.test.ts
@@ -32,7 +32,7 @@ describe('multi-key GSI behavior', () => {
   beforeEach(async () => {
     projRoot = await createNewProjectDir(projName);
     await initJSProjectWithProfile(projRoot, { name: projName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projName, 'multi-gsi.graphql');
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/api_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_5.test.ts
@@ -178,7 +178,7 @@ describe('amplify add api (REST)', () => {
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
     await addFeatureFlag(projRoot, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
     await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', 2);
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await addFunction(projRoot, { functionTemplate: 'Hello World' }, 'nodejs');
     await updateApiSchema(projRoot, projName, 'cognito_simple_model.graphql');
     await amplifyPushGraphQlWithCognitoPrompt(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/api_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6.test.ts
@@ -20,7 +20,7 @@ let projRoot;
 beforeEach(async () => {
   projRoot = await createNewProjectDir(projName);
   await initJSProjectWithProfile(projRoot, { name: projName });
-  await addApiWithoutSchema(projRoot);
+  await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
   await amplifyPush(projRoot);
 });
 afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_2.test.ts
@@ -87,7 +87,7 @@ describe('amplify add auth...', () => {
 
   it('...should allow the user to add auth via API category, with a trigger', async () => {
     await initJSProjectWithProfile(projRoot, defaultsSettings);
-    await addAuthViaAPIWithTrigger(projRoot, {});
+    await addAuthViaAPIWithTrigger(projRoot, { transformerVersion: 1 });
     await amplifyPush(projRoot);
     const meta = getProjectMeta(projRoot);
 
@@ -109,7 +109,7 @@ describe('amplify add auth...', () => {
 
   it('...should allow the user to add auth via API category, with a trigger and function dependsOn API', async () => {
     await initJSProjectWithProfile(projRoot, defaultsSettings);
-    await addAuthwithUserPoolGroupsViaAPIWithTrigger(projRoot, {});
+    await addAuthwithUserPoolGroupsViaAPIWithTrigger(projRoot, { transformerVersion: 1 });
     await updateFunction(
       projRoot,
       {

--- a/packages/amplify-e2e-tests/src/__tests__/datastore-modelgen.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/datastore-modelgen.test.ts
@@ -1,5 +1,5 @@
 import { amplifyAppAndroid, amplifyAppAngular, amplifyAppIos, amplifyAppReact } from '../amplify-app-helpers/amplify-app-setup';
-import { updateApiSchema } from 'amplify-e2e-core';
+import { addFeatureFlag, updateApiSchema } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
 import { generateModels } from 'amplify-e2e-core';
 
@@ -20,6 +20,10 @@ describe('data store modelgen tests', () => {
   it('should generate models for android project', async () => {
     await amplifyAppAndroid(projRoot);
     updateApiSchema(projRoot, projName, schemaWithAppSyncScalars);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
     await expect(generateModels(projRoot)).rejects.toThrowError();
@@ -28,6 +32,10 @@ describe('data store modelgen tests', () => {
   it('should generate models for iOS project', async () => {
     await amplifyAppIos(projRoot);
     updateApiSchema(projRoot, projName, schemaWithAppSyncScalars);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
     await expect(generateModels(projRoot)).rejects.toThrowError();
@@ -36,6 +44,10 @@ describe('data store modelgen tests', () => {
   it('should generate models for angular project', async () => {
     await amplifyAppAngular(projRoot);
     updateApiSchema(projRoot, projName, schemaWithAppSyncScalars);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
     await expect(generateModels(projRoot)).rejects.toThrowError();
@@ -44,6 +56,10 @@ describe('data store modelgen tests', () => {
   it('should generate models for react project', async () => {
     await amplifyAppReact(projRoot);
     updateApiSchema(projRoot, projName, schemaWithAppSyncScalars);
+
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 1);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', false);
+
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
     await expect(generateModels(projRoot)).rejects.toThrowError();

--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -112,7 +112,7 @@ async function testDeletion(projRoot: string, settings: { ios?: Boolean; android
   expect(meta.Region).toBeDefined();
   const { AuthRoleName, UnauthRoleName } = meta;
   await addEnvironment(projRoot, { envName: 'test' });
-  await addApiWithoutSchema(projRoot);
+  await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
   await addCodegen(projRoot, settings);
   const deploymentBucketName2 = getProjectMeta(projRoot).providers.awscloudformation.DeploymentBucketName;
   expect(await bucketExists(deploymentBucketName1)).toBe(true);

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull.test.ts
@@ -104,7 +104,7 @@ describe('amplify export pull', () => {
 
   async function AddandPushCategories(frontend?: string) {
     await addAuthWithMaxOptions(projRoot, { frontend });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await addDEVHosting(projRoot);
     await addS3StorageWithIdpAuth(projRoot);
     await addConvert(projRoot, {});

--- a/packages/amplify-e2e-tests/src/__tests__/feature-flags.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/feature-flags.test.ts
@@ -35,7 +35,7 @@ describe('feature flags', () => {
       name: 'apifeatureflag',
       disableAmplifyAppCreation: false,
     });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, 'apifeatureflag', 'simple_model.graphql');
 
     const envName = 'test';

--- a/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
@@ -63,7 +63,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {
         name: 'graphqltriggerinfra',
       });
-      await addApiWithoutSchema(projRoot);
+      await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
       await updateApiSchema(projRoot, 'graphqltriggerinfra', 'simple_model.graphql');
       await addFunction(projRoot, { functionTemplate: 'Lambda trigger', triggerType: 'DynamoDB' }, 'nodejs', addLambdaTrigger);
 

--- a/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2.test.ts
@@ -1,9 +1,7 @@
 import {
   addApiWithoutSchema,
   updateApiSchema,
-  addApi,
   addAuthWithDefault,
-  addDDBWithTrigger,
   addFunction,
   addS3StorageWithSettings,
   addSimpleDDB,
@@ -14,18 +12,12 @@ import {
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
-  getBackendAmplifyMeta,
   getFunctionSrcNode,
   getProjectMeta,
   initJSProjectWithProfile,
   invokeFunction,
   overrideFunctionSrcNode,
-  addNodeDependencies,
-  readJsonFile,
   updateFunction,
-  overrideFunctionCodeNode,
-  getBackendConfig,
-  addFeatureFlag,
   addAuthWithGroupsAndAdminAPI,
   getFunction,
   loadFunctionTestFile,
@@ -129,7 +121,7 @@ describe('nodejs', () => {
       const ddbName = `integtestddb${random}`;
 
       // test ability to scan both appsync @model-backed and regular ddb tables
-      await addApiWithoutSchema(projRoot);
+      await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
       await updateApiSchema(projRoot, 'dynamodbscan', 'simple_model.graphql');
       await addSimpleDDB(projRoot, { name: ddbName });
 
@@ -215,7 +207,7 @@ describe('nodejs', () => {
       expect(functionName).toBeDefined();
       expect(region).toBeDefined();
 
-      await addApiWithoutSchema(projRoot);
+      await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
       await updateApiSchema(projRoot, appName, 'simple_model.graphql');
       await updateFunction(
         projRoot,
@@ -251,7 +243,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {
         name: 'modelbackedlambda',
       });
-      await addApiWithoutSchema(projRoot);
+      await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
       await updateApiSchema(projRoot, 'modelbackedlambda', 'simple_model.graphql');
 
       const random = Math.floor(Math.random() * 10000);

--- a/packages/amplify-e2e-tests/src/__tests__/function_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_5.test.ts
@@ -12,8 +12,8 @@ import {
   initJSProjectWithProfile,
   updateApiSchema,
   updateFunction,
-  getLambdaFunction,
   amplifyPushWithoutCodegen,
+  addFeatureFlag,
 } from 'amplify-e2e-core';
 import _ from 'lodash';
 
@@ -87,7 +87,7 @@ describe('test dependency in root stack', () => {
     await initJSProjectWithProfile(projRoot, {
       name: projectName,
     });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, 'simple_model.graphql');
 
     const random = Math.floor(Math.random() * 10000);

--- a/packages/amplify-e2e-tests/src/__tests__/function_9.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_9.test.ts
@@ -79,7 +79,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {
         name: appName,
       });
-      await addApiWithoutSchema(projRoot);
+      await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
       await updateApiSchema(projRoot, appName, 'two-model-schema.graphql');
 
       const random = Math.floor(Math.random() * 10000);
@@ -146,7 +146,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {
         name: appName,
       });
-      await addApiWithoutSchema(projRoot);
+      await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
       await updateApiSchema(projRoot, appName, 'two-model-schema.graphql');
 
       const random = Math.floor(Math.random() * 10000);
@@ -214,6 +214,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {});
       await addApi(projRoot, {
         IAM: {},
+        transformerVersion: 1,
       });
       const beforeMeta = getBackendConfig(projRoot);
       const apiName = Object.keys(beforeMeta.api)[0];
@@ -270,9 +271,9 @@ describe('nodejs', () => {
           }
         }`;
       await initJSProjectWithProfile(projRoot, { name: appName });
-      addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', GraphQLTransformerLatestVersion);
       await addApi(projRoot, {
         IAM: {},
+        transformerVersion: GraphQLTransformerLatestVersion,
       });
       updateApiSchema(projRoot, appName, 'iam_simple_model.graphql');
       const beforeMeta = getBackendConfig(projRoot);
@@ -321,6 +322,7 @@ describe('nodejs', () => {
       await initJSProjectWithProfile(projRoot, {});
       await addApi(projRoot, {
         IAM: {},
+        transformerVersion: 1,
       });
       const beforeMeta = getBackendConfig(projRoot);
       const apiName = Object.keys(beforeMeta.api)[0];

--- a/packages/amplify-e2e-tests/src/__tests__/global_sandbox.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/global_sandbox.test.ts
@@ -1,7 +1,6 @@
 import {
   initJSProjectWithProfile,
   deleteProject,
-  addFeatureFlag,
   addApiWithoutSchema,
   addApiWithOneModel,
   addApiWithThreeModels,
@@ -19,7 +18,6 @@ describe('global sandbox mode', () => {
   beforeEach(async () => {
     projectDir = await createNewProjectDir('sandbox');
     await initJSProjectWithProfile(projectDir);
-    addFeatureFlag(projectDir, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth.test.ts
@@ -8,14 +8,13 @@ import {
   getProjectMeta,
   initJSProjectWithProfile,
   updateApiSchema,
-  addApiWithAllAuthModesV2,
+  addApiWithAllAuthModes,
   amplifyPush,
 } from 'amplify-e2e-core';
 import gql from 'graphql-tag';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { addEnvironment, checkoutEnvironment, listEnvironment } from '../../environment/env';
 const providerName = 'awscloudformation';
-
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -69,9 +68,7 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
     const envName = 'devtest';
     const projName = 'lambdaauthenv';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', 2);
-    await addApiWithAllAuthModesV2(projRoot);
+    await addApiWithAllAuthModes(projRoot);
     await updateApiSchema(projRoot, projName, 'lambda-auth-field-auth-v2.graphql');
     await amplifyPush(projRoot);
 
@@ -95,11 +92,11 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
 
     meta = getProjectMeta(projRoot);
     region = meta.providers.awscloudformation.Region;
-    output = meta.api[projName]["output"];
-    GraphQLAPIIdOutput = output["GraphQLAPIIdOutput"];
-    GraphQLAPIEndpointOutput = output["GraphQLAPIEndpointOutput"];
-    GraphQLAPIKeyOutput = output["GraphQLAPIKeyOutput"];
-    graphqlApi = (await getAppSyncApi(GraphQLAPIIdOutput, region))["graphqlApi"];
+    output = meta.api[projName]['output'];
+    GraphQLAPIIdOutput = output['GraphQLAPIIdOutput'];
+    GraphQLAPIEndpointOutput = output['GraphQLAPIEndpointOutput'];
+    GraphQLAPIKeyOutput = output['GraphQLAPIKeyOutput'];
+    graphqlApi = (await getAppSyncApi(GraphQLAPIIdOutput, region))['graphqlApi'];
 
     expect(GraphQLAPIIdOutput).toBeDefined();
     expect(GraphQLAPIEndpointOutput).toBeDefined();
@@ -113,9 +110,7 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
     const envName = 'devtest';
     const projName = 'lambdaauthmode';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', 2);
-    await addApiWithAllAuthModesV2(projRoot);
+    await addApiWithAllAuthModes(projRoot);
     await updateApiSchema(projRoot, projName, 'lambda-auth-field-auth-v2.graphql');
     await amplifyPush(projRoot);
 
@@ -131,7 +126,6 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
 
     expect(graphqlApi).toBeDefined();
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
-
 
     const url = GraphQLAPIEndpointOutput as string;
     const apiKey = GraphQLAPIKeyOutput as string;
@@ -205,9 +199,7 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
     const envName = 'devtest';
     const projName = 'lambdaauthmodeerr';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', 2);
-    await addApiWithAllAuthModesV2(projRoot);
+    await addApiWithAllAuthModes(projRoot);
     await updateApiSchema(projRoot, projName, 'lambda-auth-field-auth-1-v2.graphql');
     await amplifyPush(projRoot);
 
@@ -223,7 +215,6 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
 
     expect(graphqlApi).toBeDefined();
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
-
 
     const url = GraphQLAPIEndpointOutput as string;
     const apiKey = GraphQLAPIKeyOutput as string;
@@ -267,11 +258,13 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
         }
       }
     `;
-    
-    await expect(appSyncClient.query({
-      query: gql(listNotesQuery),
-      fetchPolicy: 'no-cache',
-    })).rejects.toThrow(`GraphQL error: Not Authorized to access note on type String`);
+
+    await expect(
+      appSyncClient.query({
+        query: gql(listNotesQuery),
+        fetchPolicy: 'no-cache',
+      }),
+    ).rejects.toThrow(`GraphQL error: Not Authorized to access note on type String`);
 
     const appSyncInvalidClient = new AWSAppSyncClient({
       url,
@@ -283,19 +276,19 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
       },
     });
 
-    await expect(appSyncInvalidClient.query({
-      query: gql(listNotesQuery),
-      fetchPolicy: 'no-cache',
-    })).rejects.toThrow(`Network error: Response not successful: Received status code 401`);
+    await expect(
+      appSyncInvalidClient.query({
+        query: gql(listNotesQuery),
+        fetchPolicy: 'no-cache',
+      }),
+    ).rejects.toThrow(`Network error: Response not successful: Received status code 401`);
   });
 
   it('lambda auth with no create access', async () => {
     const envName = 'devtest';
     const projName = 'lambdaauth2';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', 2);
-    await addApiWithAllAuthModesV2(projRoot);
+    await addApiWithAllAuthModes(projRoot);
     await updateApiSchema(projRoot, projName, 'lambda-auth-field-auth-2-v2.graphql');
     await amplifyPush(projRoot);
 
@@ -339,11 +332,13 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
         note: 'initial note',
       },
     };
-    
-    await expect(appSyncClient.mutate({
-      mutation: gql(createMutation),
-      fetchPolicy: 'no-cache',
-      variables: createInput,
-    })).rejects.toThrow(`GraphQL error: Unauthorized on [note]`);
+
+    await expect(
+      appSyncClient.mutate({
+        mutation: gql(createMutation),
+        fetchPolicy: 'no-cache',
+        variables: createInput,
+      }),
+    ).rejects.toThrow(`GraphQL error: Unauthorized on [note]`);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/searchable-datastore.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/searchable-datastore.test.ts
@@ -20,7 +20,7 @@ describe('transformer model searchable migration test', () => {
   beforeEach(async () => {
     projectName = createRandomName();
     projRoot = await createNewProjectDir(createRandomName());
-    await initJSProjectWithProfile(projRoot, { 
+    await initJSProjectWithProfile(projRoot, {
       name: projectName,
     });
     await addAuthWithDefault(projRoot, {});
@@ -33,14 +33,12 @@ describe('transformer model searchable migration test', () => {
 
   it('migration of searchable directive - search should return expected results', async () => {
     const v2Schema = 'transformer_migration/searchable-v2.graphql';
-    
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'transformerVersion', 2);
-    await addFeatureFlag(projRoot, 'graphqltransformer', 'useExperimentalPipelinedTransformer', true);
+
     await addApiWithoutSchema(projRoot, { apiName: projectName });
     await apiEnableDataStore(projRoot, {});
     await updateApiSchema(projRoot, projectName, v2Schema);
     await amplifyPush(projRoot);
-    
+
     appSyncClient = getAppSyncClientFromProj(projRoot);
     await runAndValidateQuery('test1', 'test1', 10);
   });
@@ -97,15 +95,11 @@ describe('transformer model searchable migration test', () => {
     return await runMutation(getCreateTodosMutation(name, description, count));
   };
 
-  const searchTodos = async() => {
+  const searchTodos = async () => {
     return await runQuery(getTodos());
-  }
+  };
 
-  function getCreateTodosMutation(
-    name: string,
-    description: string,
-    count: number,
-  ): string {
+  function getCreateTodosMutation(name: string, description: string, count: number): string {
     return `mutation {
           createTodo(input: {
               name: "${name}"
@@ -134,21 +128,21 @@ describe('transformer model searchable migration test', () => {
 
     await waitForOSPropagate();
     const searchResponse = await searchTodos();
-    
+
     const expectedRows = 1;
     expect(searchResponse).toBeDefined();
     expect(searchResponse.errors).toBeUndefined();
     expect(searchResponse.data).toBeDefined();
     expect(searchResponse.data.searchTodos).toBeDefined();
     expect(searchResponse.data.searchTodos.items).toHaveLength(expectedRows);
-  }
+  };
 
   const waitForOSPropagate = async (initialWaitSeconds = 5, maxRetryCount = 5) => {
     const expectedCount = 1;
     let waitInMilliseconds = initialWaitSeconds * 1000;
     let currentRetryCount = 0;
     let searchResponse;
-  
+
     do {
       await new Promise(r => setTimeout(r, waitInMilliseconds));
       searchResponse = await searchTodos();

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1.test.ts
@@ -146,7 +146,7 @@ describe('auth import userpool only', () => {
   it('imported auth with graphql api and cognito should push', async () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
     await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' }); // space at to make sure its not web client
-    await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectRoot);
+    await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectRoot, { transformerVersion: 1 });
     await amplifyPush(projectRoot);
 
     expectApiHasCorrectAuthConfig(projectRoot, projectPrefix, ogProjectDetails.meta.UserPoolId);
@@ -225,6 +225,7 @@ describe('auth import userpool only', () => {
     await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
     await addApi(projectRoot, {
       IAM: {},
+      transformerVersion: 1,
     });
     await updateApiSchema(projectRoot, projectPrefix, 'model_with_iam_auth.graphql');
     await amplifyPush(projectRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
@@ -1,16 +1,9 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-
-import { $TSObject, JSONUtilities } from 'amplify-cli-core';
 import {
-  AddAuthUserPoolOnlyWithOAuthSettings,
-  addApiWithCognitoUserPoolAuthTypeWhenAuthExists,
   addAuthUserPoolOnlyWithOAuth,
+  AddAuthUserPoolOnlyWithOAuthSettings,
   addFunction,
   amplifyPull,
-  amplifyPush,
   amplifyPushAuth,
-  amplifyStatus,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
@@ -19,34 +12,24 @@ import {
   getTeamProviderInfo,
   initJSProjectWithProfile,
   initProjectWithAccessKey,
-  addApi,
-  updateApiSchema,
 } from 'amplify-e2e-core';
+import { addEnvironmentWithImportedAuth, checkoutEnvironment, removeEnvironment } from '../environment/env';
 import {
+  addAppClientWithoutSecret,
+  addAppClientWithSecret,
   AppClientSettings,
   AuthProjectDetails,
-  addAppClientWithSecret,
-  addAppClientWithoutSecret,
-  addS3WithAuthConfigurationMismatchErrorExit,
   createUserPoolOnlyWithOAuthSettings,
   deleteAppClient,
-  expectApiHasCorrectAuthConfig,
   expectAuthLocalAndOGMetaFilesOutputMatching,
   expectAuthProjectDetailsMatch,
   expectLocalAndCloudMetaFilesMatching,
   expectLocalAndPulledBackendConfigMatching,
-  expectLocalTeamInfoHasNoCategories,
-  expectNoAuthInMeta,
   getAuthProjectDetails,
   getOGAuthProjectDetails,
   getShortId,
-  importIdentityPoolAndUserPool,
   importUserPoolOnly,
-  readRootStack,
-  removeImportedAuthWithDefault,
 } from '../import-helpers';
-import { addEnvironmentWithImportedAuth, checkoutEnvironment, removeEnvironment } from '../environment/env';
-
 import { getCognitoResourceName } from '../schema-api-directives/authHelper';
 import { randomizedFunctionName } from '../schema-api-directives/functionTester';
 

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration.test.ts
@@ -19,9 +19,9 @@ describe('amplify add api', () => {
     const nextSchema1 = 'migrations_connection/cant_add_a_sort_key.graphql';
 
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
@@ -41,7 +41,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.connection.migration2.test.ts
@@ -19,9 +19,9 @@ describe('amplify add api', () => {
     const nextSchema1 = 'migrations_connection/cant_change_connection_field_name.graphql';
 
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);
@@ -40,9 +40,9 @@ describe('amplify add api', () => {
     const nextSchema2 = 'migrations_connection/add_a_sort_key.graphql';
 
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration1.test.ts
@@ -23,7 +23,7 @@ describe('amplify add api', () => {
     // testing this with old behavior with named lsi key
     addFeatureFlag(projRoot, 'graphqltransformer', 'secondarykeyasgsi', false);
 
-    await addApiWithoutSchema(projRoot, { apiKeyExpirationDays: 2 });
+    await addApiWithoutSchema(projRoot, { apiKeyExpirationDays: 2, transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 
@@ -44,7 +44,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 
@@ -62,7 +62,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 
@@ -80,7 +80,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration2.test.ts
@@ -19,7 +19,7 @@ describe('amplify add api', () => {
     const initial_schema = 'migrations_key/three_gsi_model_schema.graphql';
     const nextSchema = 'migrations_key/four_gsi_model_schema.graphql';
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initial_schema);
     await amplifyPush(projRoot);
 
@@ -33,7 +33,7 @@ describe('amplify add api', () => {
     const nextSchema1 = 'migrations_key/cant_change_key_schema.graphql';
 
     await initJSProjectWithProfile(projRoot, { name: projectName });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     await addEnvironment(projRoot, { envName: 'test' });

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration3.test.ts
@@ -22,7 +22,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 
@@ -43,7 +43,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
     updateApiSchema(projRoot, projectName, nextSchema1);

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration4.test.ts
@@ -22,7 +22,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 
@@ -38,7 +38,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/api.key.migration5.test.ts
@@ -22,7 +22,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 
@@ -44,7 +44,7 @@ describe('amplify add api', () => {
     await initJSProjectWithProfile(projRoot, { name: projectName });
     addFeatureFlag(projRoot, 'graphqltransformer', 'enableiterativegsiupdates', false);
 
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, initialSchema);
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
@@ -29,7 +29,7 @@ describe('amplify pull', () => {
       disableAmplifyAppCreation: false,
       name: 'testapi',
     });
-    await addApiWithoutSchema(projRoot);
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, 'testapi', 'simple_model.graphql');
     await amplifyPush(projRoot);
     const appId = getAppId(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/resolvers.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/resolvers.test.ts
@@ -23,8 +23,6 @@ describe('user created resolvers', () => {
   beforeEach(async () => {
     projectDir = await createNewProjectDir('overrideresolvers');
     await initJSProjectWithProfile(projectDir, {});
-    addFeatureFlag(projectDir, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
-    addFeatureFlag(projectDir, 'graphqltransformer', 'transformerVersion', 2);
   });
 
   afterEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-rollback-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-rollback-1.test.ts
@@ -36,7 +36,7 @@ describe('Iterative Rollback - add 2 @keys ', () => {
   });
   it('should support rolling back from the 2nd deployment on adding gsis', async () => {
     const initialSchema = path.join('iterative-push', 'two-key-add', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7 });
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
     await updateApiSchema(projectDir, appName, initialSchema);
     await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-rollback-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-rollback-2.test.ts
@@ -35,7 +35,7 @@ describe('Iterative Rollback - removing two @keys', () => {
   });
   it('should support rolling back from the 2nd deployment on adding gsis', async () => {
     const initialSchema = path.join('iterative-push', 'multiple-key-delete', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7 });
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
     await updateApiSchema(projectDir, appName, initialSchema);
     await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-1.test.ts
@@ -31,7 +31,7 @@ describe('Schema iterative update - rename @key', () => {
   });
   it('should support changing gsi name', async () => {
     const initialSchema = path.join('iterative-push', 'change-model-name', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7 });
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
     await updateApiSchema(projectDir, appName, initialSchema);
     await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-2.test.ts
@@ -9,7 +9,7 @@ import {
   updateApiSchema,
   amplifyPushUpdate,
   addApiWithoutSchema,
-  updateApiWithMultiAuth
+  updateApiWithMultiAuth,
 } from 'amplify-e2e-core';
 
 describe('Schema iterative update - add new @models and @key', () => {
@@ -29,7 +29,7 @@ describe('Schema iterative update - add new @models and @key', () => {
     const apiName = 'addkeyandmodel';
 
     const initialSchema = path.join('iterative-push', 'add-one-key-multiple-models', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiName });
+    await addApiWithoutSchema(projectDir, { apiName, transformerVersion: 1 });
     await updateApiWithMultiAuth(projectDir, {});
     updateApiSchema(projectDir, apiName, initialSchema);
     await amplifyPush(projectDir);

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-3.test.ts
@@ -30,7 +30,7 @@ describe('Schema iterative update - delete', () => {
     const apiName = 'deletekeys';
 
     const initialSchema = path.join('iterative-push', 'multiple-key-delete', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7 });
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
     await updateApiSchema(projectDir, apiName, initialSchema);
     await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
@@ -30,7 +30,7 @@ describe('Schema iterative update - create update and delete', () => {
     const apiName = 'iterativetest1';
 
     const initialSchema = path.join('iterative-push', 'add-remove-and-update-key', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7 });
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
     await updateApiSchema(projectDir, apiName, initialSchema);
     await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
@@ -41,7 +41,7 @@ describe('Schema iterative update - locking', () => {
 
     // Create and push project with API
     const initialSchema = path.join('iterative-push', 'change-model-name', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectRoot, { apiKeyExpirationDays: 7 });
+    await addApiWithoutSchema(projectRoot, { apiKeyExpirationDays: 7, transformerVersion: 1 });
     await updateApiSchema(projectRoot, apiName, initialSchema);
     await amplifyPush(projectRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
@@ -48,7 +48,7 @@ describe('transformer @auth migration test', () => {
     projRoot = await createNewProjectDir(projectName);
     await initJSProjectWithProfile(projRoot, { name: projectName });
 
-    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await addApiWithoutSchema(projRoot, { apiName: projectName, transformerVersion: 1 });
     await updateApiWithMultiAuth(projRoot, {});
     updateApiSchema(projRoot, projectName, modelSchemaV1);
     await updateAuthAddUserGroups(projRoot, [GROUPNAME]);
@@ -80,10 +80,7 @@ describe('transformer @auth migration test', () => {
       awsconfig.aws_appsync_region,
       apiKey,
     );
-    let appSyncClientViaIAM = getConfiguredAppsyncClientIAMAuth(
-      awsconfig.aws_appsync_graphqlEndpoint,
-      awsconfig.aws_appsync_region,
-    );
+    let appSyncClientViaIAM = getConfiguredAppsyncClientIAMAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region);
 
     let createPostMutation = /* GraphQL */ `
       mutation CreatePost {
@@ -156,12 +153,8 @@ describe('transformer @auth migration test', () => {
     await updateApiSchema(projRoot, projectName, modelSchemaV2);
     await amplifyPushUpdate(projRoot);
 
-    appSyncClientViaUser = getConfiguredAppsyncClientCognitoAuth(
-      awsconfig.aws_appsync_graphqlEndpoint,
-      awsconfig.aws_appsync_region,
-      user,
-    );
-    
+    appSyncClientViaUser = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+
     createPostMutation = /* GraphQL */ `
       mutation CreatePost {
         createPost(input: { title: "Created in V2" }) {

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/function-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/function-migration.test.ts
@@ -32,12 +32,12 @@ describe('api directives @function v1 to v2 migration', () => {
       schema,
       query,
       expected_result_query,
-    }
+    };
     const v1TransformerVersion = 'v1';
     const v2TransformerVersion = 'v2';
     const function1Name = await addSimpleFunction(projectDir, testModule, 'func1');
     const function2Name = await addSimpleFunction(projectDir, testModule, 'func2');
-    await addApi(projectDir);
+    await addApi(projectDir, { transformerVersion: 1 });
     updateSchemaInTestProject(projectDir, testModule.schema);
     updateFunctionNameInSchema(projectDir, '<function1-name>', function1Name);
     updateFunctionNameInSchema(projectDir, '<function2-name>', function2Name);

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/http-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/http-migration.test.ts
@@ -29,7 +29,7 @@ describe('transformer @http migration test', () => {
   it('migration of @http schema', async () => {
     const httpSchema = 'transformer_migration/http.graphql';
 
-    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await addApiWithoutSchema(projRoot, { apiName: projectName, transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, httpSchema);
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/model-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/model-migration.test.ts
@@ -33,7 +33,7 @@ describe('transformer model migration test', () => {
     const modelSchemaV1 = 'transformer_migration/basic-model-v1.graphql';
     const modelSchemaV2 = 'transformer_migration/basic-model-v2.graphql';
 
-    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await addApiWithoutSchema(projRoot, { apiName: projectName, transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, modelSchemaV1);
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
@@ -33,7 +33,7 @@ describe('transformer predictions migration test', () => {
   it('migration of predictions directives', async () => {
     const predictionsSchema = 'transformer_migration/predictions.graphql';
 
-    await addApiWithoutSchema(projRoot, { apiName: projectName });
+    await addApiWithoutSchema(projRoot, { apiName: projectName, transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, predictionsSchema);
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/searchable-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/searchable-migration.test.ts
@@ -21,7 +21,7 @@ describe('transformer model searchable migration test', () => {
   beforeEach(async () => {
     projectName = createRandomName();
     projRoot = await createNewProjectDir(createRandomName());
-    await initJSProjectWithProfile(projRoot, { 
+    await initJSProjectWithProfile(projRoot, {
       name: projectName,
     });
     await addAuthWithDefault(projRoot, {});
@@ -35,11 +35,11 @@ describe('transformer model searchable migration test', () => {
   it('migration of searchable directive - search should return expected results', async () => {
     const v1Schema = 'transformer_migration/searchable-v1.graphql';
     const v2Schema = 'transformer_migration/searchable-v2.graphql';
-    
-    await addApiWithoutSchema(projRoot, { apiName: projectName });
+
+    await addApiWithoutSchema(projRoot, { apiName: projectName, transformerVersion: 1 });
     await updateApiSchema(projRoot, projectName, v1Schema);
     await amplifyPush(projRoot);
-    
+
     appSyncClient = getAppSyncClientFromProj(projRoot);
     await runAndValidateQuery('test1', 'test1', 10);
 
@@ -91,11 +91,7 @@ describe('transformer model searchable migration test', () => {
     return await runMutation(getCreateTodosMutation(name, description, count));
   };
 
-  function getCreateTodosMutation(
-    name: string,
-    description: string,
-    count: number,
-  ): string {
+  function getCreateTodosMutation(name: string, description: string, count: number): string {
     return `mutation {
           createTodo(input: {
               name: "${name}"
@@ -111,5 +107,5 @@ describe('transformer model searchable migration test', () => {
     expect(response.errors).toBeUndefined();
     expect(response.data).toBeDefined();
     expect(response.data.createTodo).toBeDefined();
-  }
+  };
 });

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
@@ -24,8 +24,8 @@ function amplifyAppAndroid(projRoot: string): Promise<void> {
 function amplifyAppIos(projRoot: string): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(spawnCommand, ['--platform', 'ios'], { cwd: projRoot, stripColors: true })
-      .wait('Amplify setup completed successfully')
       .wait('Successfully created base Amplify Project')
+      .wait('Amplify setup completed successfully')
       .run(function (err) {
         if (!err) {
           resolve();

--- a/packages/amplify-e2e-tests/src/schema-api-directives/common.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/common.ts
@@ -19,7 +19,7 @@ const USERNAME = 'user1';
 const PASSWORD = 'user1Password';
 
 export async function runTest(projectDir: string, testModule: any) {
-  await addApi(projectDir);
+  await addApi(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
   await amplifyPush(projectDir);
 
@@ -34,6 +34,7 @@ export async function runTest(projectDir: string, testModule: any) {
 export async function runAuthTest(projectDir: string, testModule: any) {
   await addApi(projectDir, {
     'Amazon Cognito User Pool': {},
+    transformerVersion: 1,
   });
   updateSchemaInTestProject(projectDir, testModule.schema);
 
@@ -57,6 +58,7 @@ export async function runMultiAutTest(projectDir: string, testModule: any) {
     'API key': {},
     'Amazon Cognito User Pool': {},
     IAM: {},
+    transformerVersion: 1,
   });
   updateSchemaInTestProject(projectDir, testModule.schema);
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/functionTester.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/functionTester.ts
@@ -9,7 +9,7 @@ import { updateSchemaInTestProject, testQueries } from './common';
 
 export async function runFunctionTest(projectDir: string, testModule: any) {
   const functionName = await addSimpleFunction(projectDir, testModule, 'func');
-  await addApi(projectDir);
+  await addApi(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
   updateFunctionNameInSchema(projectDir, '<function-name>', functionName);
   await amplifyPush(projectDir);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
@@ -19,7 +19,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await addAuthWithPreTokenGenerationTrigger(projectDir);
   updateTriggerHandler(projectDir);
   await updateAuthAddUserGroups(projectDir, [GROUPNAME]);
-  await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectDir);
+  await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
   await amplifyPush(projectDir);
   const awsconfig = configureAmplify(projectDir);
@@ -73,10 +73,10 @@ exports.handler = async event => {
 };
 `;
 
-export const createPostMutation = ` 
+export const createPostMutation = `
 mutation CreatePost {
   createPost(input: {
-    id: "1", 
+    id: "1",
     postname: "post1",
     content: "post1 content"
   }) {

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
@@ -7,6 +7,7 @@ import { updateSchemaInTestProject, testMutations, testQueries } from '../common
 export async function runTest(projectDir: string, testModule: any) {
   await addApi(projectDir, {
     IAM: {},
+    transformerVersion: 1,
   });
   updateSchemaInTestProject(projectDir, testModule.schema);
   await amplifyPush(projectDir);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
@@ -5,7 +5,7 @@ import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } fro
 import { updateSchemaInTestProject, testMutations, testQueries } from '../common';
 
 export async function runTest(projectDir: string, testModule: any) {
-  await addApi(projectDir);
+  await addApi(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
   await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
@@ -7,6 +7,7 @@ import { updateSchemaInTestProject, testMutations, testQueries } from '../common
 export async function runTest(projectDir: string, testModule: any) {
   await addApi(projectDir, {
     IAM: {},
+    transformerVersion: 1,
   });
   updateSchemaInTestProject(projectDir, testModule.schema);
   await amplifyPush(projectDir);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
@@ -31,6 +31,7 @@ export async function runTest(projectDir: string, testModule: any) {
       ttlaAuthInMillisecond: '3600000',
     },
     IAM: {},
+    transformerVersion: 1,
   });
 
   updateSchemaInTestProject(projectDir, testModule.schema);
@@ -54,8 +55,8 @@ export async function runTest(projectDir: string, testModule: any) {
 //schema
 export const schema = `
 # private authorization with provider override
-#error: InvalidDirectiveError: @auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers, 
-#but found 'oidc' assigned. 
+#error: InvalidDirectiveError: @auth directive with 'private' strategy only supports 'userPools' (default) and 'iam' providers,
+#but found 'oidc' assigned.
 #change: changed type Post's @auth provider from oidc to iam
 type Post @model @auth(rules: [{allow: private, provider: iam}]) {
   id: ID!
@@ -72,7 +73,7 @@ type Profile @model @auth(rules: [{allow: owner, provider: oidc, identityClaim: 
 
 const createPostMutation = `
 mutation CreatePost {
-  createPost(input:{  
+  createPost(input:{
     id: "1",
     title: "title1"
   }) {

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
@@ -9,7 +9,7 @@ import { addSimpleFunction, updateFunctionNameInSchema } from '../functionTester
 export async function runTest(projectDir: string, testModule: any) {
   const function1Name = await addSimpleFunction(projectDir, testModule, 'func1');
   const function2Name = await addSimpleFunction(projectDir, testModule, 'func2');
-  await addApi(projectDir);
+  await addApi(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
   updateFunctionNameInSchema(projectDir, '<function1-name>', function1Name);
   updateFunctionNameInSchema(projectDir, '<function2-name>', function2Name);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
@@ -26,7 +26,7 @@ export async function runTest(projectDir: string, testModule: any) {
   try {
     const functionName = await setupFunction(functionProjectDirPath, functionRegion);
 
-    await addApi(projectDir);
+    await addApi(projectDir, { transformerVersion: 1 });
     updateSchemaInTestProject(projectDir, testModule.schema);
 
     updateFunctionNameAndRegionInSchema(projectDir, functionName, functionRegion);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-example2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-example2.ts
@@ -31,7 +31,7 @@ const PASSWORD = 'user1Password';
 export async function runTest(projectDir: string, testModule: any) {
   await addAuthWithDefault(projectDir);
   const functionName = await addFunctionWithAuthAccess(projectDir, testModule, 'func');
-  await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectDir);
+  await addApiWithCognitoUserPoolAuthTypeWhenAuthExists(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
 
   updateFunctionNameInSchema(projectDir, '<function-name>', functionName);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
@@ -8,7 +8,7 @@ export const schemaName = 'selective_sync.graphql';
 export const schema = `
 type Comment @model
 @key(name: "byUsername", fields: ["username", "createdAt"], queryField: "commentsByUsername")
-@key(name: "byeditor", fields: ["editor", "createdAt"], queryField: "commentsByeditors")  
+@key(name: "byeditor", fields: ["editor", "createdAt"], queryField: "commentsByeditors")
 {
   id: ID!
   content: String
@@ -270,7 +270,7 @@ export const expected_result_query5 = {
 };
 
 export async function runTest(projectDir: string, testModule: any, appName: string) {
-  await addApiWithBlankSchemaAndConflictDetection(projectDir);
+  await addApiWithBlankSchemaAndConflictDetection(projectDir, { transformerVersion: 1 });
   await updateApiSchema(projectDir, appName, testModule.schemaName);
   await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -14,7 +14,7 @@ const imageKey = 'public/myimage.jpg';
 export async function runTest(projectDir: string, testModule: any) {
   await addAuthWithDefault(projectDir);
   await addS3Storage(projectDir);
-  await addApi(projectDir);
+  await addApi(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
 
   await amplifyPush(projectDir);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
@@ -5,7 +5,7 @@ import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } fro
 import { updateSchemaInTestProject, testMutations, testQueries } from '../common';
 
 export async function runTest(projectDir: string, testModule: any) {
-  await addApi(projectDir);
+  await addApi(projectDir, { transformerVersion: 1 });
   updateSchemaInTestProject(projectDir, testModule.schema);
   await amplifyPush(projectDir);
   await new Promise<void>(res => setTimeout(() => res(), 60000));

--- a/packages/amplify-migration-tests/src/__tests__/update_tests/function_migration_update.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/update_tests/function_migration_update.test.ts
@@ -69,8 +69,9 @@ describe('amplify function migration', () => {
     expect(functionName).toBeDefined();
     expect(region).toBeDefined();
 
-    await addApiWithoutSchema(projRoot, { testingWithLatestCodebase: true });
-    updateApiSchema(projRoot, appName, 'simple_model.graphql');
+    await addApiWithoutSchema(projRoot, { testingWithLatestCodebase: true, transformerVersion: 1 });
+    await updateApiSchema(projRoot, appName, 'simple_model.graphql');
+
     await updateFunction(
       projRoot,
       {

--- a/packages/amplify-migration-tests/src/migration-helpers/api.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/api.ts
@@ -1,4 +1,12 @@
-import { defaultOptions, nspawn as spawn, getCLIPath, AddApiOptions, KEY_DOWN_ARROW, getSchemaPath } from 'amplify-e2e-core';
+import {
+  defaultOptions,
+  nspawn as spawn,
+  getCLIPath,
+  AddApiOptions,
+  KEY_DOWN_ARROW,
+  getSchemaPath,
+  addFeatureFlag,
+} from 'amplify-e2e-core';
 import _ from 'lodash';
 
 /**


### PR DESCRIPTION
#### Description of changes
- toggles default value for transformerVersion for new projects
- updates existing tests to still use transformerVersion 1

#### Description of how you validated changes
- `yarn test` passes
- [cloud-e2e tests](https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/lazpavel/toggle-transformer-version)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
