### PR TITLE
fix: passthrough group auth rule config

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
@@ -9,7 +9,16 @@ exports[`Schema migration tests for @auth default auth is user pools migrates @a
 "
 `;
 
-exports[`Schema migration tests for @auth default auth uses api key migrates @auth default with correctly 1`] = `
+exports[`Schema migration tests for @auth default auth uses api key migrates @auth to public @auth with api key 1`] = `
+"type Todo @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String!
+  description: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth uses api key migrates default api_key auth correctly 1`] = `
 "type Todo @model @auth(rules: [{allow: public}]) {
   id: ID!
   name: String!
@@ -19,15 +28,6 @@ exports[`Schema migration tests for @auth default auth uses api key migrates @au
 type Comment @model @auth(rules: [{allow: private}]) {
   id: ID!
   content: String!
-}
-"
-`;
-
-exports[`Schema migration tests for @auth default auth uses api key migrates @auth to public @auth with api key 1`] = `
-"type Todo @model @auth(rules: [{allow: public}]) {
-  id: ID!
-  name: String!
-  description: String
 }
 "
 `;

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
@@ -44,3 +44,20 @@ exports[`Schema migration tests for @auth default auth uses iam migrates @auth p
 }
 "
 `;
+
+exports[`Schema migration tests for @auth group auth retains dynamic groups in auth rules 1`] = `
+"type Todo @model @auth(rules: [{allow: groups, groups: [\\"Admins\\"]}]) {
+  id: ID!
+  rating: Int
+  title: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth group auth retains groupClaims in auth rules 1`] = `
+"type Todo @model @auth(rules: [{allow: groups, provider: oidc, groups: [\\"Admins\\"], groupClaim: \\"https://myapp.com/claims/groups\\"}]) {
+  id: ID!
+  title: String!
+}
+"
+`;

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
@@ -9,6 +9,20 @@ exports[`Schema migration tests for @auth default auth is user pools migrates @a
 "
 `;
 
+exports[`Schema migration tests for @auth default auth uses api key migrates @auth default with correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String!
+  description: String
+}
+
+type Comment @model @auth(rules: [{allow: private}]) {
+  id: ID!
+  content: String!
+}
+"
+`;
+
 exports[`Schema migration tests for @auth default auth uses api key migrates @auth to public @auth with api key 1`] = `
 "type Todo @model @auth(rules: [{allow: public}]) {
   id: ID!

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/auth-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/auth-tests.ts
@@ -74,4 +74,31 @@ describe('Schema migration tests for @auth', () => {
       migrateAndValidate(schema, IAM);
     });
   });
+
+  describe('group auth', () => {
+    it('retains dynamic groups in auth rules', () => {
+      const schema = /* GraphQL */ `
+        type Todo @model @auth(rules: [{ allow: groups, groups: ["Admins"] }]) {
+          id: ID!
+          rating: Int
+          title: String
+        }
+      `;
+
+      migrateAndValidate(schema);
+    });
+
+    it('retains groupClaims in auth rules', () => {
+      const schema = /* GraphQL */ `
+        type Todo
+          @model
+          @auth(rules: [{ allow: groups, provider: oidc, groups: ["Admins"], groupClaim: "https://myapp.com/claims/groups" }]) {
+          id: ID!
+          title: String!
+        }
+      `;
+
+      migrateAndValidate(schema);
+    });
+  });
 });

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/auth-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/auth-tests.ts
@@ -26,6 +26,22 @@ describe('Schema migration tests for @auth', () => {
       migrateAndValidate(schema, API_KEY);
     });
 
+    it('migrates @auth default with correctly', () => {
+      const schema = `
+        type Todo @model {
+          id: ID!
+          name: String!
+          description: String
+      }
+
+      type Comment @model @auth(rules: [{ allow: private }]) {
+          id: ID!
+          content: String!
+      }`;
+
+      migrateAndValidate(schema, API_KEY);
+    });
+
     it('migrates @auth to public @auth with api key', () => {
       const schema = `
         type Todo @model @auth(rules: [{ allow: public }]) {

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/auth-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/auth-tests.ts
@@ -26,7 +26,7 @@ describe('Schema migration tests for @auth', () => {
       migrateAndValidate(schema, API_KEY);
     });
 
-    it('migrates @auth default with correctly', () => {
+    it('migrates default api_key auth correctly', () => {
       const schema = `
         type Todo @model {
           id: ID!

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/auth/defaultAuth.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/auth/defaultAuth.ts
@@ -1,30 +1,12 @@
-import { getAuthRules, hasAuthDirectives, addAuthRuleToNode } from '.'
-import { createAuthRule } from '../generators'
+import { hasAuthDirectives, addAuthRuleToNode } from '.';
+import { createAuthRule } from '../generators';
 
 const defaultAuthModeMap: Map<string, string> = new Map<string, string>([
   ['apiKey', 'public'],
   ['iam', 'private'],
   ['userPools', 'private'],
-  ['oidc', 'private']
+  ['oidc', 'private'],
 ]);
-
-function getDefaultAuthRule(authMode: any, rules: any) {
-  const parsedRules = rules.map((rule: any) => ({
-    provider: rule.fields.find((r: any) => r.name.value === 'provider')?.value?.value,
-    strategy: rule.fields.find((r: any) => r.name.value === 'allow')?.value?.value
-  }));
-
-  const foundRules = parsedRules.filter((r: any) => r.strategy === defaultAuthModeMap.get(authMode));
-  if (foundRules.length === 0) {
-    return null;
-  }
-
-  if (authMode === "iam") {
-    return foundRules.find((r: any) => r.provider === 'iam');
-  }
-
-  return foundRules.find((r: any) => r.provider === undefined || r.provider === authMode);
-}
 
 export function migrateDefaultAuthMode(node: any, defaultAuthMode: any) {
   if (defaultAuthMode === 'iam') {
@@ -34,14 +16,5 @@ export function migrateDefaultAuthMode(node: any, defaultAuthMode: any) {
   if (!hasAuthDirectives(node)) {
     const authRule = createAuthRule(defaultAuthModeMap.get(defaultAuthMode), defaultAuthMode);
     addAuthRuleToNode(node, authRule);
-    return;
-  }
-
-  const authRules = getAuthRules(node);
-
-  // if rule with default auth mode exist, then don't mess with it otherwise add it
-  const defaultAuthRule = getDefaultAuthRule(defaultAuthMode, authRules);
-  if (!defaultAuthRule) {
-    addAuthRuleToNode(node, createAuthRule(defaultAuthModeMap.get(defaultAuthMode), defaultAuthMode));
   }
 }

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/auth/index.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/auth/index.ts
@@ -2,7 +2,7 @@ import { isModelType } from '../model';
 import { migrateDefaultAuthMode } from './defaultAuth';
 import { migrateFieldAuth } from './fieldAuth';
 import { migrateOwnerAuth } from './ownerAuth';
-import { createArgumentNode, createAuthRule, createDirectiveNode, createListValueNode } from '../generators';
+import { createArgumentNode, createDirectiveNode, createListValueNode } from '../generators';
 
 export function hasAuthDirectives(node: any) {
   return node.directives.some((dir: any) => dir.name.value === 'auth');
@@ -30,57 +30,12 @@ export function addAuthRuleToNode(node: any, rule: any) {
   }
 }
 
-function getAuthStrategy(rule: any) {
-  return rule.fields.find((f: any) => f.name.value === 'allow').value.value
-}
-
-function getAuthOperations(rule: any) {
-  return rule.fields.find((f: any) => f.name.value === 'operations')
-    ?.value.values.map((op: any) => op.value)
-    ?? ["create", "read", "update", "delete"]
-}
-
 export const defaultProviderMap: Map<string, string> = new Map<string, string>([
   ['public', 'apiKey'],
   ['private', 'userPools'],
   ['owner', 'userPools'],
-  ['groups', 'userPools']
+  ['groups', 'userPools'],
 ]);
-
-function getAuthProvider(rule: any) {
-  return rule.fields.find((f: any) => f.name.value === 'provider')
-    ?.value.value
-    ?? defaultProviderMap.get(getAuthStrategy(rule));
-}
-
-function getAuthRuleWithSameScopeIndex(rules: any[], rule: any) {
-  return rules.findIndex((r) => {
-    return (getAuthStrategy(r) === getAuthStrategy(rule) && getAuthProvider(r) === getAuthProvider(rule));
-  });
-}
-
-function mergeOperations(a: any, b: any) {
-  const aOps = getAuthOperations(a)
-  const bOps = getAuthOperations(b)
-
-  const operationsUnion = new Set([aOps, bOps].flat())
-
-  return Array.from(operationsUnion)
-}
-
-function mergeAuthRules(node: any, rules: any[]) {
-  let newRules: any[] = [];
-  rules.forEach(rule => {
-    const existingRuleIndex = getAuthRuleWithSameScopeIndex(newRules, rule);
-    if (existingRuleIndex >= 0) {
-      newRules[existingRuleIndex] = createAuthRule(getAuthStrategy(rule), getAuthProvider(rule), mergeOperations(newRules[existingRuleIndex], rule));
-    } else {
-      newRules.push(rule);
-    }
-  });
-
-  setAuthRules(node, newRules.map((r: any) => createAuthRule(getAuthStrategy(r), getAuthProvider(r), getAuthOperations(r))));
-}
 
 export function migrateAuth(node: any, defaultAuthMode: any) {
   if (!isModelType(node)) {
@@ -94,6 +49,4 @@ export function migrateAuth(node: any, defaultAuthMode: any) {
   }
 
   migrateDefaultAuthMode(node, defaultAuthMode);
-
-  mergeAuthRules(node, getAuthRules(node));
 }

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/generators/index.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/generators/index.ts
@@ -1,45 +1,48 @@
-import { parseValue } from "graphql"
-import { defaultProviderMap } from "../auth"
+import { parseValue } from 'graphql';
+import { defaultProviderMap } from '../auth';
 
 export function createNameNode(name: any) {
-    return {
-        kind: 'Name',
-        value: name
-    };
+  return {
+    kind: 'Name',
+    value: name,
+  };
 }
 
 export function createDirectiveNode(name: any, args: any) {
-    return {
-        kind: 'Directive',
-        name: createNameNode(name),
-        arguments: args
-    };
+  return {
+    kind: 'Directive',
+    name: createNameNode(name),
+    arguments: args,
+  };
 }
 
 export function createArgumentNode(name: any, value: any) {
-    return {
-        kind: 'Argument',
-        name: createNameNode(name),
-        value: value
-    };
+  return {
+    kind: 'Argument',
+    name: createNameNode(name),
+    value: value,
+  };
 }
 
 export function createListValueNode(values: any) {
-    return {
-        kind: 'ListValue',
-        values: values
-    };
+  return {
+    kind: 'ListValue',
+    values: values,
+  };
 }
 
+/**
+ * Note this only supports strategy, provider and operations. Group and owner auth is not supported
+ */
 export function createAuthRule(strategy: any, provider: any, operations?: any) {
-    let rule = `{allow: ${strategy}`;
-    if (provider && provider !== defaultProviderMap.get(strategy)) {
-        rule += `, provider: ${provider}`;
-    }
+  let rule = `{allow: ${strategy}`;
+  if (provider && provider !== defaultProviderMap.get(strategy)) {
+    rule += `, provider: ${provider}`;
+  }
 
-    if (operations && operations.length !== 4) {
-        rule += `, operations: [${operations.join(', ')}]`;
-    }
-    rule += '}';
-    return parseValue(rule);
+  if (operations && operations.length !== 4) {
+    rule += `, operations: [${operations.join(', ')}]`;
+  }
+  rule += '}';
+  return parseValue(rule);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes 2 issues with the schema migrator. One was erroneously adding a public auth rule and the other was not retaining the group auth rule params (group name or group claim).

The key line in the diff is 98 of `packages/amplify-graphql-transformer-migrator/src/migrators/auth/index.ts` where we are no longer calling `mergeAuthRules`. All the other deletions are functions that are no longer being used because that one is no longer used. And there are a bunch of lint fixes.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
