### PR TITLE
fix(graphql-transformer-migrator): fix incorrect migrations of owner and group based auth

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/auth-tests.ts.snap
@@ -1,10 +1,110 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Schema migration tests for @auth default auth is user pools group based auth migrates @auth with groups correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: groups, groups: [\\"Admins\\"]}]) {
+  id: ID!
+  name: String!
+  description: String
+}
+"
+`;
+
 exports[`Schema migration tests for @auth default auth is user pools migrates @auth private with user pools correctly 1`] = `
 "type Todo @model @auth(rules: [{allow: private}]) {
   id: ID!
   name: String!
   description: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools multi-use for user groups migrates non specified @auth correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: owner}]) {
+  id: ID!
+  name: String!
+  description: String
+}
+
+type Task @model @auth(rules: [{allow: private}]) {
+  id: ID!
+  title: String!
+  owner: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth array of owners migrates owner array fields correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: owner, ownerField: \\"editors\\"}]) {
+  id: ID!
+  rating: Int
+  title: String
+  editors: [String]
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth explicit operations adds private delete rule 1`] = `
+"type Todo @model @auth(rules: [{allow: owner}, {allow: private, operations: [read, update]}]) {
+  id: ID!
+  rating: Int
+  title: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth explicit operations adds private update rule 1`] = `
+"type Todo @model @auth(rules: [{allow: owner}, {allow: private, operations: [update]}]) {
+  id: ID!
+  rating: Int
+  title: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth explicit owner field migrates @auth with custom owner field correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: owner, ownerField: \\"editor\\"}]) {
+  id: ID!
+  name: String!
+  description: String
+  editor: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth explicit owner field migrates @auth with owners correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: owner}]) {
+  id: ID!
+  name: String!
+  description: String
+  owner: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth implicit owner field migrates @auth with owners and field correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: owner, ownerField: \\"editor\\"}]) {
+  id: ID!
+  name: String!
+  description: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth implicit owner field migrates @auth with owners correctly 1`] = `
+"type Todo @model @auth(rules: [{allow: owner}]) {
+  id: ID!
+  name: String!
+  description: String
+}
+"
+`;
+
+exports[`Schema migration tests for @auth default auth is user pools owner based auth multiple owner rules retains the owner operations 1`] = `
+"type Todo @model @auth(rules: [{allow: owner, operations: [create]}, {allow: owner, ownerField: \\"admin\\", operations: [read, update, delete]}]) {
+  id: ID!
+  title: String!
+  admin: String
+  owner: String
 }
 "
 `;

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/auth/ownerAuth.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/auth/ownerAuth.ts
@@ -1,64 +1,58 @@
-import { getAuthRules } from '.'
-import { createAuthRule } from '../generators'
+import { getAuthRules } from '.';
+import { createAuthRule } from '../generators';
 
 function getPrivateAuthRule(rules: any, provider: any) {
   return rules.find((rule: any) => {
-    const foundStrategy = rule.fields.find((f: any) => f.name.value === "allow")?.value?.value;
-    const foundProvider = rule.fields.find((f: any) => f.name.value === "provider")?.value?.value;
+    const foundStrategy = rule.fields.find((f: any) => f.name.value === 'allow')?.value?.value;
+    const foundProvider = rule.fields.find((f: any) => f.name.value === 'provider')?.value?.value;
 
     if (foundStrategy !== 'private') {
       return false;
     }
 
-    if (provider === "userPools" && (foundProvider === undefined || foundProvider === "userPools")) {
+    if (provider === 'userPools' && (foundProvider === undefined || foundProvider === 'userPools')) {
       return true;
-    } else if (provider === "iam" && foundProvider === "iam") {
+    } else if (provider === 'iam' && foundProvider === 'iam') {
       return true;
     }
     return false;
-  })
+  });
 }
 
 function getOwnerAuthRules(rules: any) {
   return rules.filter((rule: any) => rule.fields.find((f: any) => f?.name?.value === 'allow')?.value?.value === 'owner');
 }
 
+const ops = ['create', 'read', 'update', 'delete'];
+
 export function migrateOwnerAuth(node: any, defaultAuthMode: any) {
   const authRules = getAuthRules(node);
 
   // check if owner-based auth exist and if operations allow everything.
-  const deniedOperations = new Set();
+  const deniedOperations: Set<string> = new Set();
   const ownerRules = getOwnerAuthRules(authRules);
-  if (ownerRules.length !== 0) {
-    ownerRules.forEach((rule: any) => {
-      const operationsIndex = rule.fields.findIndex((f: any) => f.name.value === 'operations');
 
-      if (operationsIndex === -1) {
-        deniedOperations.add('update');
-        deniedOperations.add('read');
-        deniedOperations.add('delete');
-      } else {
-        // remember denied operations
-        rule.fields[operationsIndex].value.values.forEach((op: any) => deniedOperations.add(op.value));
+  if (ownerRules.length === 0) return;
 
-        // maintain full CRUD access for owners
-        rule.fields.splice(operationsIndex, 1);
-      }
-    })
+  ownerRules.forEach((rule: any) => {
+    const operationsFieldIndex = rule.fields.findIndex((f: any) => f.name.value === 'operations');
 
-    // convert owner auth from deny-others to allow-only basis
-    // remove create because it's not a denied operation
-    deniedOperations.delete('create')
-
-    const explicitPrivateAllowRule = {
-      strategy: 'private',
-      provider: defaultAuthMode === "iam" ? "iam" : "userPools",
-      operations: ['create', 'read', 'update', 'delete'].filter(x => !deniedOperations.has(x))
+    if (operationsFieldIndex === -1) {
+      ops.forEach(op => deniedOperations.add(op));
+    } else {
+      // remember denied operations
+      rule.fields[operationsFieldIndex].value.values.forEach((op: any) => deniedOperations.add(op.value));
+      // maintain full CRUD access for owners
+      if (ownerRules.length === 1) rule.fields.splice(operationsFieldIndex, 1);
     }
+  });
 
-    const privateRule = getPrivateAuthRule(authRules, explicitPrivateAllowRule.provider)
-    if (!privateRule) {
-      authRules.push(createAuthRule(explicitPrivateAllowRule.strategy, explicitPrivateAllowRule.provider, explicitPrivateAllowRule.operations))
-    }
-  }
+  const hasAllImplicitOperations = deniedOperations.size === 4;
+  const privateRule = getPrivateAuthRule(authRules, defaultAuthMode);
+
+  if (hasAllImplicitOperations || privateRule) return;
+
+  const explicitOperations = ops.filter(x => !deniedOperations.has(x));
+
+  authRules.push(createAuthRule('private', defaultAuthMode, explicitOperations));
 }


### PR DESCRIPTION

#### Description of changes
Fixes migration of `{ allow: owner }` and `{ allow: groups }` to remove the private rule that is generated.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
