### PR TITLE
fix: auth cloudformation generation error leading to push failure

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
@@ -22,7 +22,7 @@ jest.mock('amplify-cli-core', () => ({
     getBoolean: jest.fn().mockReturnValue(true),
   },
   buildOverrideDir: jest.fn().mockResolvedValue(false),
-  writeCFNTemplate: jest.fn(),
+  writeCFNTemplate: jest.fn().mockImplementation(() => Promise.resolve())
 }));
 
 const getCLIInputPayload_mock = jest

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -213,7 +213,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
       cognitoStackFileName,
     );
     // write CFN template
-    writeCFNTemplate(template, cognitostackFilePath, {
+    await writeCFNTemplate(template, cognitostackFilePath, {
       templateFormat: CFNTemplateFormat.JSON,
     });
     // write parameters.json


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
