### PR TITLE
test: add additional gql migrator edge case unit tests

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
@@ -174,6 +174,16 @@ exports[`Schema migration tests no amplify directives in schema 1`] = `
 "
 `;
 
+exports[`Schema migration tests passes built-in directives through 1`] = `
+"scalar UUID @specifiedBy(url: \\"https://tools.ietf.org/html/rfc4122\\")
+
+type Todo {
+  newField: String
+  oldField: String @deprecated(reason: \\"Use newField.\\")
+}
+"
+`;
+
 exports[`Schema migration tests renamed queries/mutations/subscriptions 1`] = `
 "type Entity @model(mutations: null, subscriptions: null, queries: {get: \\"getEntity\\"}) @auth(rules: [{allow: public}]) {
   id: ID!

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
@@ -21,6 +21,18 @@ describe('Schema migration tests', () => {
     migrateAndValidate(schema);
   });
 
+  it('passes built-in directives through', () => {
+    const schema = `
+      scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
+
+      type Todo {
+        newField: String
+        oldField: String @deprecated(reason: "Use newField.")
+      }`;
+
+    migrateAndValidate(schema);
+  });
+
   it('basic @model type', () => {
     const schema = `
       type Todo @model {

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/schema-inspector.test.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/schema-inspector.test.ts
@@ -35,3 +35,33 @@ test('AppSync auth directives are not migrated', async () => {
     `);
   }
 });
+
+test('custom directives are not migrated', async () => {
+  const schema = `
+    type Restaurant @model {
+      blt: String! @sandwich
+    }
+  `;
+  const result = await detectPassthroughDirectives(schema);
+
+  expect(result).toMatchInlineSnapshot(`
+    Array [
+      "sandwich",
+    ]
+  `);
+});
+
+test('@versioned is not migrated', async () => {
+  const schema = `
+    type Restaurant @model @versioned {
+      blt: String!
+    }
+  `;
+  const result = await detectPassthroughDirectives(schema);
+
+  expect(result).toMatchInlineSnapshot(`
+    Array [
+      "versioned",
+    ]
+  `);
+});


### PR DESCRIPTION
#### Description of changes

This commit adds unit tests for the GQL migrator to verify scenarios such as overwritten resolvers, custom resolvers, the use of SQL, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
