### PR TITLE
fix: add missing types for override file, enable vm2

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/override.ts.sample
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/override.ts.sample
@@ -1,6 +1,6 @@
 // This file is used to override the REST API resource configuration
 import { AmplifyApigwResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(props: AmplifyApigwResourceTemplate) {
+export function override(resource: AmplifyApigwResourceTemplate) {
 
 }

--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/override.ts.sample
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/override.ts.sample
@@ -1,8 +1,6 @@
 // This file is used to override the REST API resource configuration
-// import { AmplifyApigwResourceTemplate } from '@aws-amplify/cli-overrides-helper';
+import { AmplifyApigwResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-/* TODO: Need to change props to Root-Stack specific props when props are ready */
-export function overrideProps(props: any) {
-  /* Override props (AmplifyApigwResourceTemplate) with new parameters */
-  return props;
+export function override(props: AmplifyApigwResourceTemplate) {
+
 }

--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "overrides-for-apigw-stack",
+  "name": "overrides",
   "version": "1.0.0",
   "description": "",
   "scripts": {

--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "overrides-for-root-stack",
+  "name": "overrides-for-apigw-stack",
   "version": "1.0.0",
   "description": "",
   "scripts": {
@@ -11,7 +11,7 @@
     "fs-extra": "^9.1.0"
   },
   "devDependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0",
+    "@aws-amplify/cli-extensibility-helper": "^2.2.2",
     "@types/fs-extra": "^9.0.11",
     "typescript": "^4.2.4"
   }

--- a/packages/amplify-category-api/src/commands/api/override.ts
+++ b/packages/amplify-category-api/src/commands/api/override.ts
@@ -3,6 +3,7 @@ import {
   AmplifyCategories,
   AmplifySupportedService,
   generateOverrideSkeleton,
+  getMigrateResourceMessageForOverride,
   pathManager,
   stateManager,
 } from 'amplify-cli-core';
@@ -56,7 +57,7 @@ export const run = async (context: $TSContext) => {
     // Migration logic goes in here
     const apigwInputState = new ApigwInputState(context, selectedResourceName);
     if (!apigwInputState.cliInputsFileExists()) {
-      if (await prompter.yesOrNo('File migration required to continue. Do you want to continue?', true)) {
+      if (await prompter.yesOrNo(getMigrateResourceMessageForOverride(AmplifyCategories.API, selectedResourceName, false), true)) {
         await apigwInputState.migrateApigwResource(selectedResourceName);
         const stackGenerator = new ApigwStackTransform(context, selectedResourceName);
         stackGenerator.transform();

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
@@ -1,4 +1,4 @@
-/* These tests test the tranform and in run the cdk builder tool which is used within this file */
+/* These tests test the DDBStackTransform and run the cdk builder tool which is used within this file */
 
 import { DDBStackTransform } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform';
 import {

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
@@ -1,14 +1,11 @@
-/* These tests, test the tranform and in rurn the cdk builder too which is used within this file */
+/* These tests test the tranform and in run the cdk builder tool which is used within this file */
 
-import { JSONUtilities, buildOverrideDir, pathManager } from 'amplify-cli-core';
-import * as fs from 'fs-extra';
 import { DDBStackTransform } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform';
 import {
   DynamoDBCLIInputs,
   FieldType,
 } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/dynamoDB-user-input-types';
 import { DynamoDBInputState } from '../../../../provider-utils/awscloudformation/service-walkthroughs/dynamoDB-input-state';
-import path from 'path';
 
 jest.mock('amplify-cli-core', () => ({
   buildOverrideDir: jest.fn().mockResolvedValue(false),

--- a/packages/amplify-cli-extensibility-helper/package.json
+++ b/packages/amplify-cli-extensibility-helper/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-category-custom": "2.3.1",
+    "@aws-cdk/aws-apigateway": "~1.124.0",
     "@aws-cdk/aws-cognito": "~1.124.0",
     "@aws-cdk/aws-dynamodb": "~1.124.0",
     "@aws-cdk/aws-iam": "~1.124.0",

--- a/packages/amplify-cli-extensibility-helper/src/index.ts
+++ b/packages/amplify-cli-extensibility-helper/src/index.ts
@@ -1,8 +1,8 @@
-export { AmplifyRootStackTemplate } from './types/project/types';
-export { AmplifyAuthCognitoStackTemplate, AmplifyUserPoolGroupStackTemplate } from './types/auth/types';
-import { addCDKResourceDependency } from '@aws-amplify/amplify-category-custom';
-export { AmplifyDDBResourceTemplate, AmplifyS3ResourceTemplate, AmplifyCDKL1 } from './types/storage/types';
+import { addCDKResourceDependency, AmplifyResourceProps } from '@aws-amplify/amplify-category-custom';
 import { getProjectInfo } from './helpers/project-info';
-import { AmplifyResourceProps } from '@aws-amplify/amplify-category-custom';
 
+export { AmplifyAuthCognitoStackTemplate, AmplifyUserPoolGroupStackTemplate } from './types/auth/types';
+export { AmplifyApigwResourceTemplate } from './types/api/types';
+export { AmplifyRootStackTemplate } from './types/project/types';
+export { AmplifyCDKL1, AmplifyDDBResourceTemplate, AmplifyS3ResourceTemplate } from './types/storage/types';
 export { getProjectInfo, addCDKResourceDependency as addResourceDependency, AmplifyResourceProps };

--- a/packages/amplify-cli-extensibility-helper/src/types/api/types.ts
+++ b/packages/amplify-cli-extensibility-helper/src/types/api/types.ts
@@ -1,0 +1,25 @@
+import * as cdk from '@aws-cdk/core';
+import * as apigwCdk from '@aws-cdk/aws-apigateway';
+import * as iamCdk from '@aws-cdk/aws-iam';
+
+type AmplifyCDKL1 = {
+  addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void;
+  addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void;
+  addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void;
+  addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void;
+  addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void;
+};
+
+export type AmplifyApigwResourceTemplate = {
+  restApi?: apigwCdk.CfnRestApi;
+  deploymentResource?: apigwCdk.CfnDeployment;
+  policies?: {
+    [pathName: string]: ApigwPathPolicy;
+  };
+} & AmplifyCDKL1;
+
+export type ApigwPathPolicy = {
+  auth?: iamCdk.CfnPolicy;
+  guest?: iamCdk.CfnPolicy;
+  groups?: { [groupName: string]: iamCdk.CfnPolicy };
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
