### PR TITLE
fix(amplify-provider-awscloudformation): exclude admin queries APIGWAuth stack

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-export.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-export.ts
@@ -341,7 +341,7 @@ export class ResourceExport extends ResourcePackager {
       _.set(this.amplifyMeta, [PROVIDER, PROVIDER_NAME, NETWORK_STACK_S3_URL], this.createTemplateUrl(bucket, NETWORK_STACK_FILENAME));
     }
 
-    if(this.resourcesHasApiGateways(resources)){
+    if(this.resourcesHasApiGatewaysButNotAdminQueries(resources)){
       const apiGWAuthFile = path.join(pathManager.getBackendDirPath(), API_CATEGORY.NAME, APIGW_AUTH_STACK_FILE_NAME);
       // don't check for the api gateway rest api just check for the consolidated file
       if (fs.existsSync(apiGWAuthFile)) {

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -195,10 +195,11 @@ export abstract class ResourcePackager {
     );
   }
 
-  protected resourcesHasApiGateways(packagedResources: PackagedResourceDefinition[]): boolean {
+  protected resourcesHasApiGatewaysButNotAdminQueries(packagedResources: PackagedResourceDefinition[]): boolean {
     const { API_CATEGORY, } = Constants;
+    const resources = packagedResources.filter(r => r.resourceName !== 'AdminQueries');
     return (
-      this.resourcesHasCategoryService(packagedResources, API_CATEGORY.NAME, API_CATEGORY.SERVICE.API_GATEWAY)
+      this.resourcesHasCategoryService(resources, API_CATEGORY.NAME, API_CATEGORY.SERVICE.API_GATEWAY)
     );
   }
 
@@ -226,7 +227,7 @@ export abstract class ResourcePackager {
    * @param resources
    */
   protected async generateCategoryCloudFormation(resources: UploadedResourceDefinition[] | PackagedResourceDefinition[]) {
-    if (this.resourcesHasApiGateways(resources)) {
+    if (this.resourcesHasApiGatewaysButNotAdminQueries(resources)) {
       const { PROVIDER, PROVIDER_NAME } = Constants;
       const { StackName: stackName } = this.amplifyMeta[PROVIDER][PROVIDER_NAME];
       consolidateApiGatewayPolicies(this.context, stackName);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
