### PR TITLE
Fix: migrate fieldless hasOne directives correctly

### DIFF
--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
@@ -317,3 +317,15 @@ exports[`Schema migration tests renamed queries/mutations/subscriptions 1`] = `
 }
 "
 `;
+
+exports[`Schema migration tests Has One @connection without fields always mapped to has one, even in bidirectional 1`] = `
+"type Coffee @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  energy: Energy @hasOne
+}
+type Energy @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  coffee: Coffee @hasOne
+}
+"
+`;

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/__snapshots__/migrate-tests.ts.snap
@@ -11,7 +11,7 @@ type Comment @model @auth(rules: [{allow: public}]) {
   id: ID!
   postID: ID! @index(name: \\"byPost\\", sortKeyFields: [\\"content\\"])
   content: String!
-  post: Post @belongsTo(fields: [\\"postID\\"])
+  post: Post @hasOne(fields: [\\"postID\\"])
 }
 "
 `;
@@ -85,8 +85,8 @@ type PostEditor @model(queries: null) @auth(rules: [{allow: public}]) {
   id: ID!
   postID: ID! @index(name: \\"byPost\\", sortKeyFields: [\\"editorID\\"])
   editorID: ID! @index(name: \\"byEditor\\", sortKeyFields: [\\"postID\\"])
-  post: Post! @belongsTo(fields: [\\"postID\\"])
-  editor: User! @belongsTo(fields: [\\"editorID\\"])
+  post: Post! @hasOne(fields: [\\"postID\\"])
+  editor: User! @hasOne(fields: [\\"editorID\\"])
 }
 
 type User @model @auth(rules: [{allow: public}]) {
@@ -162,6 +162,19 @@ type Comment @model @searchable @auth(rules: [{allow: public}]) {
   id: ID!
   version: Int! @index(name: \\"commentByVersion\\", sortKeyFields: [\\"id\\"])
   content: String!
+}
+"
+`;
+
+exports[`Schema migration tests Has One @connection without fields always mapped to has one, even in bidirectional 1`] = `
+"type Coffee @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  energy: Energy @hasOne
+}
+
+type Energy @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  coffee: Coffee @hasOne
 }
 "
 `;
@@ -314,18 +327,6 @@ exports[`Schema migration tests renamed queries/mutations/subscriptions 1`] = `
 "type Entity @model(mutations: null, subscriptions: null, queries: {get: \\"getEntity\\"}) @auth(rules: [{allow: public}]) {
   id: ID!
   str: String
-}
-"
-`;
-
-exports[`Schema migration tests Has One @connection without fields always mapped to has one, even in bidirectional 1`] = `
-"type Coffee @model @auth(rules: [{allow: public}]) {
-  id: ID!
-  energy: Energy @hasOne
-}
-type Energy @model @auth(rules: [{allow: public}]) {
-  id: ID!
-  coffee: Coffee @hasOne
 }
 "
 `;

--- a/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/__tests__/migration/migrate-tests.ts
@@ -403,4 +403,19 @@ describe('Schema migration tests', () => {
 
     migrateAndValidate(schema);
   });
+
+  it('Has One @connection without fields always mapped to has one, even in bidirectional', () => {
+    const schema = `
+    type Coffee @model {
+      id: ID!
+      energy: Energy @connection # => @hasOne
+    }
+    
+    type Energy @model {
+      id: ID!
+      coffee: Coffee @connection # => @hasOne
+    }`;
+
+    migrateAndValidate(schema);
+  });
 });

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
@@ -7,7 +7,7 @@ export function getFieldsWithConnection(fields: any) {
 }
 
 export function getConnectionFieldsArg(connection: any) {
-  return connection.arguments.find((a: any) => a.name.value === 'fields').value.values.map((v: any) => v.value);
+  return connection.arguments.find((a: any) => a?.name?.value === 'fields')?.value?.values?.map((v: any) => v.value);
 }
 
 export function isFieldIndex(field: any) {
@@ -52,22 +52,22 @@ export function migrateConnection(node: any, ast: any) {
       }
     } else {
       const relatedType = getRelatedType(ast, getFieldType(connectionField));
-      const isBiDirectionalRelation = relatedType.fields.some((relatedField: any) => {
+      const biDirectionalRelation = relatedType.fields.some((relatedField: any) => {
         if (getFieldType(relatedField) !== node.name.value) {
           return false;
         }
 
-        const fieldsArg = node.fields.find((f: any) => f.name.value === getConnectionFieldsArg(connectionDirective)[0]);
+        const fieldsArg = node.fields.find((f: any) => f.name.value === getConnectionFieldsArg(connectionDirective)?.[0]);
         if (fieldsArg && !isFieldIndex(fieldsArg)) {
           return false;
         }
 
-        return relatedField.directives.some((relatedDirective: any) => {
+        return relatedField?.directives?.some((relatedDirective: any) => {
           return validConnectionDirectiveNames.has(relatedDirective.name.value);
         });
       });
 
-      if (isBiDirectionalRelation) {
+      if (biDirectionalRelation && isListType(biDirectionalRelation.type)) {
         connectionDirective.name.value = 'belongsTo';
       } else {
         connectionDirective.name.value = 'hasOne';

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
@@ -42,7 +42,7 @@ export function migrateConnection(node: any, ast: any) {
 
   connections.forEach((connectionField: any) => {
     const connectionDirective = getConnectionDirective(connectionField);
-    let typeIsList = isListType(connectionField.type);
+    let typeIsList = connectionField.type ? isListType(connectionField.type) : false;
     if (typeIsList) {
       connectionDirective.name.value = 'hasMany';
       const keyNameArg = connectionDirective.arguments.find((a: any) => a.name.value === 'keyName');

--- a/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/migrators/connection/index.ts
@@ -67,7 +67,7 @@ export function migrateConnection(node: any, ast: any) {
         });
       });
 
-      if (biDirectionalRelation && isListType(biDirectionalRelation.type)) {
+      if (biDirectionalRelation?.type && isListType(biDirectionalRelation.type)) {
         connectionDirective.name.value = 'belongsTo';
       } else {
         connectionDirective.name.value = 'hasOne';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Migrator was not correctly handling migration of relational directives without fields, added a unit test for our hasOne migration requirements
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Running the migrator

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
