### PR TITLE
feat: add min / max selection to prompter.pick

### DIFF
--- a/packages/amplify-prompts/src/demo/demo.ts
+++ b/packages/amplify-prompts/src/demo/demo.ts
@@ -124,6 +124,10 @@ const demo = async () => {
   (choices2[1] as any).hint = 'definitely the best';
   (choices2[2] as any).disabled = true;
   printResult(await prompter.pick<'many', number>('Pick your favorite Skittle color', choices2, { returnSize: 'many' }));
+
+  printer.info('A minimum and / or maximum number of choices can be specified');
+  (choices2[2] as any).disabled = false;
+  printResult(await prompter.pick<'many', number>('Pick 2 to 4 colors', choices2, { returnSize: 'many', pickAtLeast: 2, pickAtMost: 4 }));
 };
 
 demo().catch(console.error);

--- a/packages/amplify-prompts/src/prompter.ts
+++ b/packages/amplify-prompts/src/prompter.ts
@@ -183,6 +183,22 @@ class AmplifyPrompter implements Prompter {
           // this.state is bound to a property of enquirer's prompt object, it does not reference a property of AmplifyPrompter
           return this.state.index === i ? chalk.cyan('❯') : ' ';
         },
+        validate() {
+          if (opts && ('pickAtLeast' in opts || 'pickAtMost' in opts)) {
+            // this.selected is bound to a property of enquirer's prompt object, it does not reference a property of AmplifyPrompter
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            if (this.selected.length < (opts.pickAtLeast ?? 0)) {
+              return `Select at least ${opts.pickAtLeast} items`;
+            }
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            if (this.selected.length > (opts.pickAtMost ?? Number.POSITIVE_INFINITY)) {
+              return `Select at most ${opts.pickAtMost} items`;
+            }
+          }
+          return true;
+        },
       }));
       // remove the TSTP listener
       process.removeListener('SIGTSTP', sigTstpListener);
@@ -288,6 +304,18 @@ type InitialValueOption<T> = {
   initial?: T;
 };
 
+type MultiSelectMinimun<RS extends ReturnSize> = RS extends 'one'
+  ? {}
+  : {
+      pickAtLeast?: number;
+    };
+
+type MultiSelectMaximum<RS extends ReturnSize> = RS extends 'one'
+  ? {}
+  : {
+      pickAtMost?: number;
+    };
+
 type ValidateValueOption = {
   validate?: Validator;
 };
@@ -330,7 +358,10 @@ type MaybeOptionalPickOptions<RS extends ReturnSize, T> = RS extends 'many' ? [P
 type PromptReturn<RS extends ReturnSize, T> = RS extends 'many' ? T[] : T;
 
 // the following types are the method input types
-type PickOptions<RS extends ReturnSize, T> = ReturnSizeOption<RS> & InitialSelectionOption<RS, T>;
+type PickOptions<RS extends ReturnSize, T> = ReturnSizeOption<RS> &
+  InitialSelectionOption<RS, T> &
+  MultiSelectMaximum<RS> &
+  MultiSelectMinimun<RS>;
 
 type InputOptions<RS extends ReturnSize, T> = ReturnSizeOption<RS> &
   ValidateValueOption &


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds a min/max pick option to amplify-prompter

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
