### PR TITLE
fix: remove await from sync read cfn calls

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers-artifacts.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/containers-artifacts.ts
@@ -288,9 +288,7 @@ export async function processDockerConfig(context: any, resource: ApiResource, s
       secretsArns.set(secretName, secretArn);
     }
   } else {
-    const { cfnTemplate } = await readCFNTemplate(
-      path.join(pathManager.getBackendDirPath(), category, resourceName, cfnFileName(resourceName)),
-    );
+    const { cfnTemplate } = readCFNTemplate(path.join(pathManager.getBackendDirPath(), category, resourceName, cfnFileName(resourceName)));
     setExistingSecretArns(secretsArns, cfnTemplate);
   }
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -415,7 +415,7 @@ export async function updateConfigOnEnvInit(context: $TSContext, resourceName: s
       }
 
       const currentCfnTemplatePath = pathManager.getCurrentCfnTemplatePath(projectPath, categoryName, resourceName);
-      const { cfnTemplate: currentCfnTemplate } = (await readCFNTemplate(currentCfnTemplatePath, { throwIfNotExist: false })) || {};
+      const { cfnTemplate: currentCfnTemplate } = readCFNTemplate(currentCfnTemplatePath, { throwIfNotExist: false }) || {};
       if (currentCfnTemplate !== undefined) {
         await writeCFNTemplate(currentCfnTemplate, pathManager.getResourceCfnTemplatePath(projectPath, categoryName, resourceName));
       }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
@@ -4,14 +4,16 @@ import * as path from 'path';
 import { pathManager, readCFNTemplate, writeCFNTemplate } from 'amplify-cli-core';
 import { categoryName } from '../../../constants';
 
-const functionCloudFormationFilePath = (functionName: string) => path.join(pathManager.getBackendDirPath(), categoryName, functionName, `${functionName}-cloudformation-template.json`);
+const functionCloudFormationFilePath = (functionName: string) =>
+  path.join(pathManager.getBackendDirPath(), categoryName, functionName, `${functionName}-cloudformation-template.json`);
 
 export const getFunctionCloudFormationTemplate = async (functionName: string) => {
-  const { cfnTemplate } = await readCFNTemplate(functionCloudFormationFilePath(functionName));
+  const { cfnTemplate } = readCFNTemplate(functionCloudFormationFilePath(functionName));
   return cfnTemplate;
-}
+};
 
-export const setFunctionCloudFormationTemplate = async (functionName: string, cfnTemplate: object) => writeCFNTemplate(cfnTemplate, functionCloudFormationFilePath(functionName));
+export const setFunctionCloudFormationTemplate = async (functionName: string, cfnTemplate: object) =>
+  writeCFNTemplate(cfnTemplate, functionCloudFormationFilePath(functionName));
 
 export function getNewCFNEnvVariables(oldCFNEnvVariables, currentDefaults, newCFNEnvVariables, newDefaults, apiResourceName?) {
   const currentResources = [];

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/s3-trigger-helpers.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/s3-trigger-helpers.ts
@@ -11,7 +11,7 @@ export async function removeTrigger(context: $TSContext, resourceName: string, t
   const projectRoot = pathManager.findProjectRoot();
   const resourceDirPath = pathManager.getResourceDirectoryPath(projectRoot, categoryName, resourceName);
   const storageCFNFilePath = path.join(resourceDirPath, 's3-cloudformation-template.json');
-  const { cfnTemplate: storageCFNFile }: { cfnTemplate: $TSAny } = await readCFNTemplate(storageCFNFilePath);
+  const { cfnTemplate: storageCFNFile }: { cfnTemplate: $TSAny } = readCFNTemplate(storageCFNFilePath);
   const bucketParameters = stateManager.getResourceParametersJson(projectRoot, categoryName, resourceName);
   const adminTrigger = bucketParameters.adminTriggerFunction;
 
@@ -126,7 +126,7 @@ export async function addTrigger(
   );
 
   if (useExistingFunction) {
-    const { cfnTemplate: functionCFNFile }: { cfnTemplate: $TSAny } = await readCFNTemplate(functionCFNFilePath);
+    const { cfnTemplate: functionCFNFile }: { cfnTemplate: $TSAny } = readCFNTemplate(functionCFNFilePath);
 
     functionCFNFile.Outputs.LambdaExecutionRole = {
       Value: {
@@ -201,7 +201,7 @@ export async function addTrigger(
     // Update Cloudformtion file
     const projectBackendDirPath = pathManager.getBackendDirPath();
     const storageCFNFilePath = path.join(projectBackendDirPath, categoryName, resourceName, 's3-cloudformation-template.json');
-    const { cfnTemplate: storageCFNFile }: { cfnTemplate: $TSAny } = await readCFNTemplate(storageCFNFilePath);
+    const { cfnTemplate: storageCFNFile }: { cfnTemplate: $TSAny } = readCFNTemplate(storageCFNFilePath);
     const amplifyMetaFile = stateManager.getMeta();
 
     // Remove reference for old triggerFunction

--- a/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
@@ -198,7 +198,7 @@ describe('roundtrip CFN Templates to object and back', () => {
 
     (fs_mock.readFile as unknown as jest.MockedFunction<TwoArgReadFile>).mockResolvedValueOnce(yamlContent);
 
-    const result = await readCFNTemplate(testPath);
+    const result = readCFNTemplate(testPath);
 
     await writeCFNTemplate(result.cfnTemplate, testPath, { templateFormat: CFNTemplateFormat.YAML });
 
@@ -206,7 +206,7 @@ describe('roundtrip CFN Templates to object and back', () => {
 
     (fs_mock.readFile as unknown as jest.MockedFunction<TwoArgReadFile>).mockResolvedValueOnce(writtenYaml);
 
-    const roundtrippedYaml = await readCFNTemplate(testPath);
+    const roundtrippedYaml = readCFNTemplate(testPath);
 
     expect(result).toMatchObject(roundtrippedYaml);
   });

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -23,6 +23,7 @@ export function readCFNTemplate(filePath: string, options: Partial<typeof defaul
   }
   //TODO:  somthing wrong with this call , work fine with readFileSync()
   const fileContent = fs.readFileSync(filePath, 'utf8');
+
   // We use the first character to determine if the content is json or yaml because historically the CLI could
   // have emitted JSON with YML extension, so we can't rely on filename extension.
   const isJson = isJsonFileContent(fileContent);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-diff.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-diff.ts
@@ -164,7 +164,7 @@ export class ResourceDiff {
 
   //helper: wrapper around readCFNTemplate type to handle expressions.
   private safeReadCFNTemplate = async (filePath: string) => {
-    const templateResult = await readCFNTemplate(filePath, { throwIfNotExist: false });
+    const templateResult = readCFNTemplate(filePath, { throwIfNotExist: false });
     return templateResult?.cfnTemplate || {};
   };
 

--- a/packages/amplify-cli/src/project-config-version-check.ts
+++ b/packages/amplify-cli/src/project-config-version-check.ts
@@ -104,7 +104,7 @@ async function checkLambdaCustomResourceNodeVersion(context: Context, projectPat
 }
 
 async function checkFileContent(filePath: string): Promise<boolean> {
-  const { cfnTemplate } = await readCFNTemplate(filePath);
+  const { cfnTemplate } = readCFNTemplate(filePath);
 
   const resources = _.get(cfnTemplate, 'Resources', {});
   const lambdaFunctions = _.filter(
@@ -117,7 +117,7 @@ async function checkFileContent(filePath: string): Promise<boolean> {
 }
 
 async function updateFileContent(filePath: string): Promise<void> {
-  const { templateFormat, cfnTemplate } = await readCFNTemplate(filePath);
+  const { templateFormat, cfnTemplate } = readCFNTemplate(filePath);
 
   const resources = _.get(cfnTemplate, 'Resources', {});
   const lambdaFunctions: Lambda.Function[] = _.filter(

--- a/packages/amplify-provider-awscloudformation/src/disconnect-dependent-resources/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/disconnect-dependent-resources/utils.ts
@@ -36,7 +36,7 @@ export const getDependentFunctions = async (
 export const generateTempFuncCFNTemplates = async (dependentFunctions: string[]) => {
   const tempPaths: string[] = [];
   for (const funcName of dependentFunctions) {
-    const { cfnTemplate, templateFormat } = await readCFNTemplate(
+    const { cfnTemplate, templateFormat } = readCFNTemplate(
       path.join(pathManager.getResourceDirectoryPath(undefined, 'function', funcName), `${funcName}-cloudformation-template.json`),
     );
     replaceFnImport(cfnTemplate);

--- a/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
+++ b/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
@@ -13,7 +13,7 @@ const buildDir = 'build';
  * @returns The file path of the modified template
  */
 export async function preProcessCFNTemplate(filePath: string): Promise<string> {
-  const { templateFormat, cfnTemplate } = await readCFNTemplate(filePath);
+  const { templateFormat, cfnTemplate } = readCFNTemplate(filePath);
 
   await prePushCfnTemplateModifier(cfnTemplate);
   const backendDir = pathManager.getBackendDirPath();
@@ -32,7 +32,7 @@ export async function writeCustomPoliciesToCFNTemplate(resourceName: string, ser
 
   const resourceDir = pathManager.getResourceDirectoryPath(undefined, category, resourceName);
   const cfnPath = path.join(resourceDir, cfnFile);
-  const { templateFormat, cfnTemplate } = await readCFNTemplate(cfnPath);
+  const { templateFormat, cfnTemplate } = readCFNTemplate(cfnPath);
   const newCfnTemplate = generateCustomPoliciesInTemplate(cfnTemplate, resourceName, service, category);
   await writeCFNTemplate(newCfnTemplate, cfnPath, { templateFormat });
 }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -665,7 +665,7 @@ async function prepareResource(context: $TSContext, resource: $TSAny) {
     const cfnParamsFilePath = path.normalize(path.join(resourceDir, 'parameters.json'));
     JSONUtilities.writeJson(cfnParamsFilePath, cfnParams);
   } else {
-    const { cfnTemplate } = await readCFNTemplate(cfnFilePath);
+    const { cfnTemplate } = readCFNTemplate(cfnFilePath);
     cfnTemplate.Parameters.deploymentBucketName = paramType;
     cfnTemplate.Parameters.s3Key = paramType;
     const deploymentBucketNameRef = 'deploymentBucketName';

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-export.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-export.ts
@@ -240,7 +240,7 @@ export class ResourceExport extends ResourcePackager {
   }
 
   private async processAndWriteCfn(cfnFile: string, destinationPath: string, deleteParameters: boolean = true) {
-    const { cfnTemplate, templateFormat } = await readCFNTemplate(cfnFile);
+    const { cfnTemplate, templateFormat } = readCFNTemplate(cfnFile);
     return await this.processAndWriteCfnTemplate(cfnTemplate, destinationPath, templateFormat, deleteParameters);
   }
 
@@ -307,7 +307,7 @@ export class ResourceExport extends ResourcePackager {
             };
           });
         } else if (resource.category === FUNCTION_CATEGORY.NAME && resource.service === FUNCTION_CATEGORY.SERVICE.LAMBDA_LAYER) {
-          const { cfnTemplate, templateFormat } = await readCFNTemplate(cfnFile);
+          const { cfnTemplate, templateFormat } = readCFNTemplate(cfnFile);
           Object.keys(cfnTemplate.Resources)
             .filter(key => cfnTemplate.Resources[key].Type === 'AWS::Lambda::LayerVersion')
             .forEach(layerVersionResourceKey => {
@@ -343,7 +343,7 @@ export class ResourceExport extends ResourcePackager {
       _.set(this.amplifyMeta, [PROVIDER, PROVIDER_NAME, NETWORK_STACK_S3_URL], this.createTemplateUrl(bucket, NETWORK_STACK_FILENAME));
     }
 
-    if(this.resourcesHasApiGatewaysButNotAdminQueries(resources)){
+    if (this.resourcesHasApiGatewaysButNotAdminQueries(resources)) {
       const apiGWAuthFile = path.join(pathManager.getBackendDirPath(), API_CATEGORY.NAME, APIGW_AUTH_STACK_FILE_NAME);
       // don't check for the api gateway rest api just check for the consolidated file
       if (fs.existsSync(apiGWAuthFile)) {
@@ -421,7 +421,7 @@ export class ResourceExport extends ResourcePackager {
    * @param template {Template}
    * @returns {Template}
    */
-   private async modifyRootStack(template: Template, deleteParameters: boolean): Promise<Template> {
+  private async modifyRootStack(template: Template, deleteParameters: boolean): Promise<Template> {
     Object.keys(template.Resources).map(resourceKey => {
       const resource = template.Resources[resourceKey];
       if (resource.Type === AWS_CLOUDFORMATION_STACK_TYPE) {

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -197,11 +197,9 @@ export abstract class ResourcePackager {
   }
 
   protected resourcesHasApiGatewaysButNotAdminQueries(packagedResources: PackagedResourceDefinition[]): boolean {
-    const { API_CATEGORY, } = Constants;
+    const { API_CATEGORY } = Constants;
     const resources = packagedResources.filter(r => r.resourceName !== 'AdminQueries');
-    return (
-      this.resourcesHasCategoryService(resources, API_CATEGORY.NAME, API_CATEGORY.SERVICE.API_GATEWAY)
-    );
+    return this.resourcesHasCategoryService(resources, API_CATEGORY.NAME, API_CATEGORY.SERVICE.API_GATEWAY);
   }
 
   /**
@@ -288,7 +286,7 @@ export abstract class ResourcePackager {
           resource.service !== API_CATEGORY.SERVICE.ELASTIC_CONTAINER &&
           resource.service !== FUNCTION_CATEGORY.SERVICE.LAMBDA_LAYER
         ) {
-          const { cfnTemplate, templateFormat } = await readCFNTemplate(cfnFile);
+          const { cfnTemplate, templateFormat } = readCFNTemplate(cfnFile);
           const paramType = { Type: 'String' };
           const deploymentBucketNameRef = 'deploymentBucketName';
           const s3KeyRef = 's3Key';


### PR DESCRIPTION
Cleanup await calls for sync read cfn calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
