### PR TITLE
fix: group response and request resolvers by slot

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -1,7 +1,7 @@
 import { print } from 'graphql';
 import { EXTRA_DIRECTIVES_DOCUMENT } from './transformation/validation';
 export { GraphQLTransform, GraphQLTransformOptions, SyncUtils } from './transformation';
-export { DeploymentResources, UserDefinedSlot } from './transformation/types';
+export { DeploymentResources, UserDefinedSlot, UserDefinedResolver } from './transformation/types';
 export { validateModelSchema } from './transformation/validation';
 export {
   ConflictDetectionType,

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -362,13 +362,17 @@ export class GraphQLTransform {
     const resolverEntries = context.resolvers.collectResolvers();
 
     for (const [resolverName, resolver] of resolverEntries) {
-      const userSlots = this.userDefinedSlots[resolverName];
+      const userSlots = this.userDefinedSlots[resolverName] || [];
 
-      if (userSlots) {
-        userSlots.forEach(({ slotName, template, fileName }: UserDefinedSlot) => {
-          resolver.addToSlot(slotName, MappingTemplate.s3MappingTemplateFromString(template, fileName));
-        });
-      }
+      userSlots.forEach(slot => {
+        const requestTemplate = slot.requestResolver
+          ? MappingTemplate.s3MappingTemplateFromString(slot.requestResolver.template, slot.requestResolver.fileName)
+          : undefined;
+        const responseTemplate = slot.responseResolver
+          ? MappingTemplate.s3MappingTemplateFromString(slot.responseResolver.template, slot.responseResolver.fileName)
+          : undefined;
+        resolver.addToSlot(slot.slotName, requestTemplate, responseTemplate);
+      });
 
       resolver.synthesize(context, api);
     }

--- a/packages/amplify-graphql-transformer-core/src/transformation/types.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/types.ts
@@ -50,9 +50,14 @@ export interface DeploymentResources extends ResolversFunctionsAndSchema, Nested
 }
 
 export type UserDefinedSlot = {
-  fileName: string;
   resolverTypeName: string;
   resolverFieldName: string;
   slotName: string;
+  requestResolver?: UserDefinedResolver;
+  responseResolver?: UserDefinedResolver;
+};
+
+export type UserDefinedResolver = {
+  fileName: string;
   template: string;
 };

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -18,7 +18,7 @@ import { IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from '../utils';
 import { StackManager } from './stack-manager';
 
 type Slot = {
-  requestMappingTemplate: MappingTemplateProvider;
+  requestMappingTemplate?: MappingTemplateProvider;
   responseMappingTemplate?: MappingTemplateProvider;
   dataSource?: DataSourceProvider;
 };
@@ -148,7 +148,7 @@ export class TransformerResolver implements TransformerResolverProvider {
   };
   addToSlot = (
     slotName: string,
-    requestMappingTemplate: MappingTemplateProvider,
+    requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
     dataSource?: DataSourceProvider,
   ): void => {
@@ -299,12 +299,13 @@ export class TransformerResolver implements TransformerResolverProvider {
         for (let slotItem of slotEntries!) {
           const name = `${this.typeName}${this.fieldName}${slotName}${index++}Function`;
           const { requestMappingTemplate, responseMappingTemplate, dataSource } = slotItem;
-          this.substitueSlotInfo(requestMappingTemplate, slotName, index);
+          // eslint-disable-next-line no-unused-expressions
+          requestMappingTemplate && this.substitueSlotInfo(requestMappingTemplate, slotName, index);
           // eslint-disable-next-line no-unused-expressions
           responseMappingTemplate && this.substitueSlotInfo(responseMappingTemplate, slotName, index);
           const fn = api.host.addAppSyncFunction(
             name,
-            requestMappingTemplate,
+            requestMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
             responseMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
             dataSource?.name || NONE_DATA_SOURCE_NAME,
             stack,

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -6,7 +6,7 @@ import { TransformerContextProvider } from './transformer-context-provider';
 export interface TransformerResolverProvider {
   addToSlot: (
     slotName: string,
-    requestMappingTemplate: MappingTemplateProvider,
+    requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
     dataSource?: DataSourceProvider,
   ) => void;

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/user-defined-slots.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/user-defined-slots.test.ts
@@ -1,4 +1,4 @@
-import { SLOT_NAMES, createUserDefinedSlot, parseUserDefinedSlots } from '../../graphql-transformer';
+import { SLOT_NAMES, parseUserDefinedSlots } from '../../graphql-transformer';
 
 describe('user defined slots', () => {
   describe('const SLOT_NAMES', () => {
@@ -20,22 +20,6 @@ describe('user defined slots', () => {
     });
   });
 
-  describe('createUserDefinedSlot', () => {
-    it('creates the expected object shape', () => {
-      const fileName = 'Query.listTodos.postAuth.1.req.vtl';
-      const slicedName = ['Query', 'listTodos', 'postAuth', '2', 'req', 'vtl'];
-      const template = '$util.unauthorized()';
-
-      expect(createUserDefinedSlot(fileName, slicedName, template)).toEqual({
-        fileName,
-        resolverTypeName: slicedName[0],
-        resolverFieldName: slicedName[1],
-        slotName: slicedName[2],
-        template,
-      });
-    });
-  });
-
   describe('parseUserDefinedSlots', () => {
     it('creates the user defined slots map', () => {
       const resolvers = {
@@ -48,36 +32,142 @@ describe('user defined slots', () => {
       expect(parseUserDefinedSlots(resolvers)).toEqual({
         'Query.listTodos': [
           {
-            fileName: 'Query.listTodos.auth.2.req.vtl',
+            requestResolver: {
+              fileName: 'Query.listTodos.auth.2.req.vtl',
+              template: 'template 1',
+            },
             resolverTypeName: 'Query',
             resolverFieldName: 'listTodos',
             slotName: 'auth',
-            template: 'template 1',
           },
         ],
         'Query.getTodo': [
           {
-            fileName: 'Query.getTodo.auth.2.req.vtl',
+            requestResolver: {
+              fileName: 'Query.getTodo.auth.2.req.vtl',
+              template: 'template 2',
+            },
             resolverTypeName: 'Query',
             resolverFieldName: 'getTodo',
             slotName: 'auth',
-            template: 'template 2',
           },
           {
-            fileName: 'Query.getTodo.postAuth.2.req.vtl',
+            requestResolver: {
+              fileName: 'Query.getTodo.postAuth.2.req.vtl',
+              template: 'template 3',
+            },
             resolverTypeName: 'Query',
             resolverFieldName: 'getTodo',
             slotName: 'postAuth',
-            template: 'template 3',
           },
         ],
         'Mutation.createTodo': [
           {
-            fileName: 'Mutation.createTodo.auth.2.req.vtl',
+            requestResolver: {
+              fileName: 'Mutation.createTodo.auth.2.req.vtl',
+              template: 'template 4',
+            },
             resolverTypeName: 'Mutation',
             resolverFieldName: 'createTodo',
             slotName: 'auth',
-            template: 'template 4',
+          },
+        ],
+      });
+    });
+
+    it('groups request and response resolvers in the same slot together', () => {
+      const resolvers = {
+        'Query.getTodo.auth.1.req.vtl': 'request resolver 1',
+        'Query.getTodo.auth.1.res.vtl': 'response resolver 1',
+        'Mutation.createTodo.postAuth.2.req.vtl': 'request resolver 2',
+        'Mutation.createTodo.postAuth.2.res.vtl': 'response resolver 2',
+      };
+
+      expect(parseUserDefinedSlots(resolvers)).toEqual({
+        'Query.getTodo': [
+          {
+            requestResolver: {
+              fileName: 'Query.getTodo.auth.1.req.vtl',
+              template: 'request resolver 1',
+            },
+            responseResolver: {
+              fileName: 'Query.getTodo.auth.1.res.vtl',
+              template: 'response resolver 1',
+            },
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'auth',
+          },
+        ],
+        'Mutation.createTodo': [
+          {
+            requestResolver: {
+              fileName: 'Mutation.createTodo.postAuth.2.req.vtl',
+              template: 'request resolver 2',
+            },
+            responseResolver: {
+              fileName: 'Mutation.createTodo.postAuth.2.res.vtl',
+              template: 'response resolver 2',
+            },
+            resolverTypeName: 'Mutation',
+            resolverFieldName: 'createTodo',
+            slotName: 'postAuth',
+          },
+        ],
+      });
+    });
+
+    it('orders multiple slot resolvers correctly', () => {
+      const resolvers = {
+        'Query.getTodo.auth.3.req.vtl': 'request resolver 3',
+        'Query.getTodo.auth.3.res.vtl': 'response resolver 3',
+        'Query.getTodo.auth.1.req.vtl': 'request resolver 1',
+        'Query.getTodo.auth.1.res.vtl': 'response resolver 1',
+        'Query.getTodo.auth.2.req.vtl': 'request resolver 2',
+        'Query.getTodo.auth.2.res.vtl': 'response resolver 2',
+      };
+
+      const result = parseUserDefinedSlots(resolvers);
+      expect(result).toEqual({
+        'Query.getTodo': [
+          {
+            requestResolver: {
+              fileName: 'Query.getTodo.auth.1.req.vtl',
+              template: 'request resolver 1',
+            },
+            responseResolver: {
+              fileName: 'Query.getTodo.auth.1.res.vtl',
+              template: 'response resolver 1',
+            },
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'auth',
+          },
+          {
+            requestResolver: {
+              fileName: 'Query.getTodo.auth.2.req.vtl',
+              template: 'request resolver 2',
+            },
+            responseResolver: {
+              fileName: 'Query.getTodo.auth.2.res.vtl',
+              template: 'response resolver 2',
+            },
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'auth',
+          },
+          {
+            requestResolver: {
+              fileName: 'Query.getTodo.auth.3.req.vtl',
+              template: 'request resolver 3',
+            },
+            responseResolver: {
+              fileName: 'Query.getTodo.auth.3.res.vtl',
+              template: 'response resolver 3',
+            },
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'auth',
           },
         ],
       });

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/user-defined-slots.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/user-defined-slots.ts
@@ -34,7 +34,7 @@ export function parseUserDefinedSlots(userDefinedTemplates: Record<string, strin
       const resolverType = slicedSlotName[slicedSlotName.length - 2] === 'res' ? 'responseResolver' : 'requestResolver';
       const resolverName = [slicedSlotName[0], slicedSlotName[1]].join('.');
       const slotName = slicedSlotName[2];
-      const resolverOrder = Number(slicedSlotName[3]) || 0;
+      const resolverOrder = `order${Number(slicedSlotName[3]) || 0}`;
       const resolver: UserDefinedResolver = {
         fileName,
         template,
@@ -60,5 +60,12 @@ export function parseUserDefinedSlots(userDefinedTemplates: Record<string, strin
         .map(([_, slot]) => slot),
       resolverName: resolverNameKey.split('#')[0],
     }))
-    .reduce((acc, { orderedSlots, resolverName }) => ({ ...acc, [resolverName]: orderedSlots }), {} as Record<string, UserDefinedSlot[]>);
+    .reduce((acc, { orderedSlots, resolverName }) => {
+      if (acc[resolverName]) {
+        acc[resolverName].push(...orderedSlots);
+      } else {
+        acc[resolverName] = orderedSlots;
+      }
+      return acc;
+    }, {} as Record<string, UserDefinedSlot[]>);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Updates the resolver slotting logic to support both request and response resolvers in each slot.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified and unit tested

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
