### PR TITLE
fix: migration flow and cfn params when user pool groups are present, types

### DIFF
--- a/packages/amplify-category-api/resources/schemas/aPIGateway/APIGatewayCLIInputs.schema.json
+++ b/packages/amplify-category-api/resources/schemas/aPIGateway/APIGatewayCLIInputs.schema.json
@@ -37,15 +37,12 @@
                 }
               },
               "groups": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "enum": ["create", "delete", "read", "update"],
-                      "type": "string"
-                    }
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "enum": ["create", "delete", "read", "update"],
+                    "type": "string"
                   }
                 }
               }

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/apigw-input-state.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/apigw-input-state.ts
@@ -163,6 +163,7 @@ export class ApigwInputState {
 
       let auth;
       let guest;
+      let groups;
       // convert deprecated permissions to CRUD structure
       if (typeof path.privacy.auth === 'string' && ['r', 'rw'].includes(path.privacy.auth)) {
         auth = _convertDeprecatedPermissionStringToCRUD(path.privacy.auth);
@@ -176,11 +177,23 @@ export class ApigwInputState {
         guest = _convertDeprecatedPermissionArrayToCRUD(path.privacy.unauth);
       }
 
+      if (path.privacy?.userPoolGroups) {
+        groups = {};
+        for (const [userPoolGroupName, crudOperations] of Object.entries(path.privacy.userPoolGroups)) {
+          if (typeof crudOperations === 'string' && ['r', 'rw'].includes(crudOperations)) {
+            groups[userPoolGroupName] = _convertDeprecatedPermissionStringToCRUD(crudOperations);
+          } else if (Array.isArray(crudOperations)) {
+            groups[userPoolGroupName] = _convertDeprecatedPermissionArrayToCRUD(crudOperations);
+          }
+        }
+      }
+
       this.paths[path.name] = {
         permissions: {
           setting: pathPermissionSetting,
           auth,
           guest,
+          groups,
         },
         lambdaFunction: path.lambdaFunction,
       };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -91,7 +91,7 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
     this._constructCfnPaths(resourceName);
 
     this.restApi = new apigw.CfnRestApi(this, resourceName, {
-      description: '', // TODO - left blank in current CLI
+      description: '',
       name: resourceName,
       body: {
         swagger: '2.0',
@@ -146,7 +146,7 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
     this._constructCfnPaths(resourceName);
 
     this.restApi = new apigw.CfnRestApi(this, resourceName, {
-      description: '', // TODO - left blank in current CLI
+      description: '',
       failOnWarnings: true,
       name: resourceName,
       body: {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -1,5 +1,6 @@
 import * as apigw from '@aws-cdk/aws-apigateway';
 import * as lambda from '@aws-cdk/aws-lambda';
+import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
 import { $TSObject, JSONUtilities } from 'amplify-cli-core';
 import { AmplifyApigwResourceTemplate, ApigwInputs, ApigwPathPolicy } from './types';
@@ -22,6 +23,7 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
     this._scope = scope;
     this._props = props;
     this.paths = {};
+    this.policies = {};
     this.templateOptions.templateFormatVersion = CFN_TEMPLATE_FORMAT_VERSION;
     this.templateOptions.description = ROOT_CFN_DESCRIPTION;
   }
@@ -81,6 +83,58 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
       throw new Error(`logical id "${logicalId}" already exists`);
     }
     this._cfnParameterMap.set(logicalId, new cdk.CfnParameter(this, logicalId, props));
+  }
+
+  private _craftPolicyDocument(apiResourceName: string, pathName: string, supportedOperations: string[]) {
+    const resources = [pathName, `${pathName}/*`].flatMap(path =>
+      supportedOperations.map(op =>
+        cdk.Fn.join('', [
+          'arn:aws:execute-api:',
+          cdk.Fn.ref('AWS::Region'),
+          ':',
+          cdk.Fn.ref('AWS::AccountId'),
+          ':',
+          cdk.Fn.ref(apiResourceName),
+          '/',
+          cdk.Fn.conditionIf('ShouldNotCreateEnvResources', 'Prod', cdk.Fn.ref('env')).toString(),
+          op,
+          path,
+        ]),
+      ),
+    );
+
+    return new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          actions: ['execute-api:Invoke'],
+          effect: iam.Effect.ALLOW,
+          resources,
+        }),
+      ],
+    });
+  }
+
+  addIamPolicyResourceForUserPoolGroup(
+    apiResourceName: string,
+    authRoleLogicalId: string,
+    groupName: string,
+    pathName: string,
+    supportedOperations: string[],
+  ): void {
+    const alphanumericPathName = pathName.replace(/[^-a-z0-9]/g, '');
+
+    const policyName = [apiResourceName, alphanumericPathName, groupName, 'group', 'policy'].join('-');
+
+    const iamPolicy = new iam.CfnPolicy(this, `${groupName}Group${alphanumericPathName}Policy`, {
+      policyDocument: this._craftPolicyDocument(apiResourceName, pathName, supportedOperations),
+      policyName,
+      roles: [cdk.Fn.join('-', [cdk.Fn.ref(authRoleLogicalId), 'UsersGroupRole'])],
+    });
+    this.policies[pathName] = {
+      groups: {
+        [groupName]: iamPolicy,
+      },
+    };
   }
 
   renderCloudFormationTemplate = (): string => {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
@@ -47,7 +47,7 @@ export type AmplifyApigwResourceTemplate = {
 } & AmplifyCDKL1;
 
 export type ApigwPathPolicy = {
-  auth: iamCdk.CfnPolicy;
+  auth?: iamCdk.CfnPolicy;
   guest?: iamCdk.CfnPolicy;
   groups?: { [groupName: string]: iamCdk.CfnPolicy };
 };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
@@ -4,7 +4,7 @@ import * as iamCdk from '@aws-cdk/aws-iam';
 
 export type ApigwInputs = {
   version: number;
-  paths: Path[];
+  paths: { [pathName: string]: Path };
 };
 
 export type Path = {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/aPIGateway-user-input-types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/aPIGateway-user-input-types.ts
@@ -19,7 +19,7 @@ type Path = {
     setting: PermissionSetting;
     auth?: CrudOperation[];
     guest?: CrudOperation[];
-    groups?: { [groupName: string]: CrudOperation[] }[];
+    groups?: { [groupName: string]: CrudOperation[] };
   };
 };
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/apigw-types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/apigw-types.ts
@@ -7,7 +7,7 @@ export type ApigwPath = {
     setting: PermissionSetting;
     auth?: CrudOperation[];
     unauth?: CrudOperation[];
-    userPoolGroups?: {
+    groups?: {
       [userPoolGroupName: string]: CrudOperation[];
     };
   };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -265,8 +265,8 @@ async function askPermissions(
 
       let defaultSelectedGroups: string[] = [];
 
-      if (currentPath?.permissions?.userPoolGroups) {
-        defaultSelectedGroups = Object.keys(currentPath.permissions.userPoolGroups);
+      if (currentPath?.permissions?.groups) {
+        defaultSelectedGroups = Object.keys(currentPath.permissions.groups);
       }
 
       const selectedUserPoolGroupList = await prompter.pick<'many', string>('Select groups:', userPoolGroupList, {
@@ -277,13 +277,13 @@ async function askPermissions(
 
       for (const selectedUserPoolGroup of selectedUserPoolGroupList) {
         let defaults = [];
-        if (currentPath?.permissions?.userPoolGroups?.[selectedUserPoolGroup]) {
-          defaults = currentPath.permissions.userPoolGroups[selectedUserPoolGroup];
+        if (currentPath?.permissions?.groups?.[selectedUserPoolGroup]) {
+          defaults = currentPath.permissions.groups[selectedUserPoolGroup];
         }
-        if (!permissions.userPoolGroups) {
-          permissions.userPoolGroups = {};
+        if (!permissions.groups) {
+          permissions.groups = {};
         }
-        permissions.userPoolGroups[selectedUserPoolGroup] = await askCRUD(selectedUserPoolGroup, defaults);
+        permissions.groups[selectedUserPoolGroup] = await askCRUD(selectedUserPoolGroup, defaults);
       }
 
       if (!permissions.setting) {
@@ -431,8 +431,8 @@ async function findDependsOn(paths: $TSObject[]) {
       });
     }
 
-    if (path?.permissions?.userPoolGroups) {
-      const userPoolGroups = Object.keys(path.permissions.userPoolGroups);
+    if (path?.permissions?.groups) {
+      const userPoolGroups = Object.keys(path.permissions.groups);
       if (userPoolGroups.length > 0) {
         // Get auth resource name
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixed some missing gaps and type errors regarding user pool group permissions for REST API extensibility.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
e2e test `apigw.test.ts` passes, `amplify-cli` and `amplify-category-api` unit tests pass

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
