### PR TITLE
fix: write CFN templates synchronously

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/cfnUtilities.test.ts
@@ -125,15 +125,15 @@ describe('writeCFNTemplate', () => {
   it('writes json templates by default', async () => {
     await writeCFNTemplate(testTemplate, testPath);
 
-    expect(fs_mock.writeFile.mock.calls[0][0]).toEqual(testPath);
-    expect(fs_mock.writeFile.mock.calls[0][1]).toEqual(jsonContent);
+    expect(fs_mock.writeFileSync.mock.calls[0][0]).toEqual(testPath);
+    expect(fs_mock.writeFileSync.mock.calls[0][1]).toEqual(jsonContent);
   });
 
   it('writes yaml templates if specified', async () => {
     await writeCFNTemplate(testTemplate, testPath, { templateFormat: CFNTemplateFormat.YAML });
 
-    expect(fs_mock.writeFile.mock.calls[0][0]).toEqual(testPath);
-    expect(fs_mock.writeFile.mock.calls[0][1]).toEqual(yamlContent);
+    expect(fs_mock.writeFileSync.mock.calls[0][0]).toEqual(testPath);
+    expect(fs_mock.writeFileSync.mock.calls[0][1]).toEqual(yamlContent);
   });
 });
 
@@ -202,7 +202,7 @@ describe('roundtrip CFN Templates to object and back', () => {
 
     await writeCFNTemplate(result.cfnTemplate, testPath, { templateFormat: CFNTemplateFormat.YAML });
 
-    const writtenYaml = fs_mock.writeFile.mock.calls[0][1];
+    const writtenYaml = fs_mock.writeFileSync.mock.calls[0][1];
 
     (fs_mock.readFile as unknown as jest.MockedFunction<TwoArgReadFile>).mockResolvedValueOnce(writtenYaml);
 

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -59,7 +59,7 @@ export async function writeCFNTemplate(template: object, filePath: string, optio
       throw new Error(`Unexpected CFN template format ${mergedOptions.templateFormat}`);
   }
   await fs.ensureDir(path.parse(filePath).dir);
-  return fs.writeFile(filePath, serializedTemplate);
+  return fs.writeFileSync(filePath, serializedTemplate);
 }
 
 // Register custom tags for yaml parser


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
