### PR TITLE
fix: api7 and api-migration tests

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/api_7.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_7.test.ts
@@ -66,19 +66,6 @@ describe('amplify add api (GraphQL)', () => {
     expect(error).toBeDefined();
     expect(error.message).toContain(`${tableName} not found`);
 
-    // dont migrate project here
-    await amplifyOverrideApi(projRoot, { isMigratedProject: false });
-    updateApiSchema(projRoot, projName, 'simple_model_override.graphql');
-    await amplifyPushOverride(projRoot);
-    // check overidden config
-    const overridenAppsyncApi = await getAppSyncApi(GraphQLAPIIdOutput, region);
-    expect(overridenAppsyncApi.graphqlApi).toBeDefined();
-    expect(overridenAppsyncApi.graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
-    expect(overridenAppsyncApi.graphqlApi.xrayEnabled).toEqual(false);
-
-    // override with FF flag
-    addFeatureFlag(projRoot, 'graphqltransformer', 'transformerversion', 2);
-    addFeatureFlag(projRoot, 'graphqltransformer', 'useexperimentalpipelinedtransformer', true);
     await amplifyOverrideApi(projRoot, { isMigratedProject: true });
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-api.ts');
     const destOverrideFilePath = path.join(projRoot, 'amplify', 'backend', 'api', `${projName}`, 'override.ts');

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/api-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/api-migration.test.ts
@@ -33,7 +33,7 @@ describe('api migration update test', () => {
   afterEach(async () => {
     const metaFilePath = join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
     if (fs.existsSync(metaFilePath)) {
-      await deleteProject(projRoot);
+      await deleteProject(projRoot, undefined, true);
     }
     deleteProjectDir(projRoot);
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

-fixes e2e api_7.test.ts since V2 flag is merged with flag on
- fixes api-migration by deleting project with newer version

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
