### PR TITLE
fix: single userpoolgroup name is iterated instead of being used

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -269,11 +269,16 @@ async function askPermissions(
         defaultSelectedGroups = Object.keys(currentPath.permissions.groups);
       }
 
-      const selectedUserPoolGroupList = await prompter.pick<'many', string>('Select groups:', userPoolGroupList, {
+      let selectedUserPoolGroupList = await prompter.pick<'many', string>('Select groups:', userPoolGroupList, {
         initial: byValues(defaultSelectedGroups)(userPoolGroupList),
         returnSize: 'many',
         pickAtLeast: 1,
       });
+
+      //if single user pool group is selected, convert to array
+      if ( selectedUserPoolGroupList &&  !Array.isArray(selectedUserPoolGroupList)){
+        selectedUserPoolGroupList = [ selectedUserPoolGroupList ];
+      }
 
       for (const selectedUserPoolGroup of selectedUserPoolGroupList) {
         let defaults = [];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
