### PR TITLE
fix(amplify-provider-awscloudformation): fixed path as file name

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -28,6 +28,7 @@ import {
   UploadedResourceDefinition,
   TransformedCfnResource,
 } from './types';
+import * as path from 'path';
 import { prePushTemplateDescriptionHandler } from '../template-description-utils';
 
 /**
@@ -307,7 +308,8 @@ export abstract class ResourcePackager {
           await writeCFNTemplate(cfnTemplate, cfnFile, { templateFormat });
         }
         const transformedCFNPath = await preProcessCFNTemplate(cfnFile);
-        await writeCustomPoliciesToCFNTemplate(resource.resourceName, resource.service, cfnFile, resource.category);
+
+        await writeCustomPoliciesToCFNTemplate(resource.resourceName, resource.service, path.basename(cfnFile), resource.category);
         transformedCfnPaths.push(transformedCFNPath);
       }
       transformedCfnResources.push({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Send file name instead of absolute file path to custom policies
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
