### PR TITLE
fix: use not equals for iam role check

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/api_2.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/api_2.test.ts.snap
@@ -53,7 +53,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #if( $util.authType() == \\"IAM Authorization\\" )
   #set( $adminRoles = [\\"myAdminRoleName\\"] )
   #foreach( $adminRole in $adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && !$ctx.identity.userArn == $ctx.stash.authRole && !$ctx.identity.userArn == $ctx.stash.unauthRole )
+    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
@@ -9,7 +9,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #if( $util.authType() == \\"IAM Authorization\\" )
   #set( $adminRoles = [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"] )
   #foreach( $adminRole in $adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && !$ctx.identity.userArn == $ctx.stash.authRole && !$ctx.identity.userArn == $ctx.stash.unauthRole )
+    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -45,7 +45,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #if( $util.authType() == \\"IAM Authorization\\" )
   #set( $adminRoles = [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"] )
   #foreach( $adminRole in $adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && !$ctx.identity.userArn == $ctx.stash.authRole && !$ctx.identity.userArn == $ctx.stash.unauthRole )
+    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -81,7 +81,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #if( $util.authType() == \\"IAM Authorization\\" )
   #set( $adminRoles = [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"] )
   #foreach( $adminRole in $adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && !$ctx.identity.userArn == $ctx.stash.authRole && !$ctx.identity.userArn == $ctx.stash.unauthRole )
+    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/multi-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/multi-auth.test.ts.snap
@@ -9,7 +9,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #if( $util.authType() == \\"IAM Authorization\\" )
   #set( $adminRoles = [\\"helloWorldFunction\\",\\"echoMessageFunction\\"] )
   #foreach( $adminRole in $adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && !$ctx.identity.userArn == $ctx.stash.authRole && !$ctx.identity.userArn == $ctx.stash.unauthRole )
+    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -20,6 +20,7 @@ import {
   or,
   and,
   parens,
+  notEquals,
 } from 'graphql-mapping-template';
 import { NONE_VALUE } from 'graphql-transformer-common';
 import {
@@ -164,8 +165,8 @@ export const iamAdminRoleCheckExpression = (adminRoles: Array<string>): Expressi
       iff(
         and([
           methodCall(ref('ctx.identity.userArn.contains'), ref('adminRole')),
-          not(equals(ref('ctx.identity.userArn'), ref(`ctx.stash.authRole`))),
-          not(equals(ref('ctx.identity.userArn'), ref(`ctx.stash.unauthRole`))),
+          notEquals(ref('ctx.identity.userArn'), ref(`ctx.stash.authRole`)),
+          notEquals(ref('ctx.identity.userArn'), ref(`ctx.stash.unauthRole`)),
         ]),
         raw('#return($util.toJson({}))'),
       ),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
