### PR TITLE
fix: predictions lambda access policy type

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/types/amplify-api-resource-stack-types.ts
+++ b/packages/amplify-graphql-transformer-core/src/types/amplify-api-resource-stack-types.ts
@@ -83,7 +83,7 @@ export interface PredictionsDirectiveStack {
   TranslateDataSourceServiceRole: CfnRole;
   predictionsLambdaIAMRole: CfnRole;
   predictionsLambdaFunction: CfnFunction;
-  PredictionsLambdaAccess: CfnRole;
+  PredictionsLambdaAccess: CfnPolicy;
   predictionsIAMRole: CfnRole;
   PredictionsStorageAccess: CfnPolicy;
   identifyTextAccess: CfnPolicy;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- changed type exposed for prediction lambda access from CfnRole to CfnPolicy

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
