### PR TITLE
fix: change describeStackResources() call to listStackResources()

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -328,7 +328,6 @@ class CloudFormation {
     const { amplifyMeta } = projectDetails;
     logger('updateamplifyMetaFileWithStackOutputs.cfn.listStackResources', [cfnParentStackParams])();
     const result = await this.cfn.listStackResources(cfnParentStackParams).promise();
-    console.log(result);
     const resources = result.StackResourceSummaries.filter(
       resource =>
         ![

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -326,9 +326,10 @@ class CloudFormation {
     };
     const projectDetails = this.context.amplify.getProjectDetails();
     const { amplifyMeta } = projectDetails;
-    logger('updateamplifyMetaFileWithStackOutputs.cfn.describeStackResources', [cfnParentStackParams])();
-    const result = await this.cfn.describeStackResources(cfnParentStackParams).promise();
-    const resources = result.StackResources.filter(
+    logger('updateamplifyMetaFileWithStackOutputs.cfn.listStackResources', [cfnParentStackParams])();
+    const result = await this.cfn.listStackResources(cfnParentStackParams).promise();
+    console.log(result);
+    const resources = result.StackResourceSummaries.filter(
       resource =>
         ![
           'DeploymentBucket',
@@ -342,7 +343,7 @@ class CloudFormation {
     /**
      * Update root stack overrides
      */
-    const rootStackResources = result.StackResources.filter(
+    const rootStackResources = result.StackResourceSummaries.filter(
       resource =>
         !['UpdateRolesWithIDPFunction', 'UpdateRolesWithIDPFunctionOutputs', 'UpdateRolesWithIDPFunctionRole'].includes(
           resource.LogicalResourceId,


### PR DESCRIPTION


#### Description of changes



#### Issue #, if available
fixes #9037

#### Description of how you validated changes

AWS.CloudFormation.DescribeStackResources() only returns 100 resources (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStackResources.html) due to it's limits and it is recommended to use ListStackResources() instead. This is causing projects with > 100 Amplify resources to fail to fetch outputs from the nested cloudformation stacks and populate it in the amplify-meta.json file.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
