### PR TITLE
fix: migrate rest apis with protected routes on push

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/apigw-input-state.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/apigw-input-state.test.ts
@@ -1,5 +1,6 @@
 import { $TSContext, getMigrateResourceMessageForOverride, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
 import { prompter } from 'amplify-prompts';
+import * as fs from 'fs-extra';
 import { ApigwInputState } from '../../../provider-utils/awscloudformation/apigw-input-state';
 
 jest.mock('amplify-cli-core');
@@ -7,6 +8,7 @@ jest.mock('fs-extra');
 jest.mock('path');
 jest.mock('../../../provider-utils/awscloudformation/cdk-stack-builder');
 
+const fs_mock = fs as jest.Mocked<typeof fs>;
 const JSONUtilities_mock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
 const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
 const prompter_mock = prompter as jest.Mocked<typeof prompter>;
@@ -16,9 +18,6 @@ const context_mock = {
   amplify: {
     updateamplifyMetaAfterResourceAdd: jest.fn(),
     updateamplifyMetaAfterResourceUpdate: jest.fn(),
-  },
-  filesystem: {
-    remove: jest.fn(),
   },
 } as unknown as $TSContext;
 
@@ -131,7 +130,7 @@ describe('REST API input state', () => {
       paths: mockApiPaths,
     });
     expect(stateManager_mock.setResourceParametersJson).toHaveBeenCalled();
-    expect(context_mock.filesystem.remove).toHaveBeenCalledTimes(3);
+    expect(fs_mock.removeSync).toHaveBeenCalledTimes(3);
   });
 
   it('does nothing when choosing NOT to migrate a REST API', async () => {
@@ -145,7 +144,7 @@ describe('REST API input state', () => {
     expect(stateManager_mock.setResourceInputsJson).not.toHaveBeenCalled();
     expect(stateManager_mock.setResourceParametersJson).not.toHaveBeenCalled();
     expect(context_mock.amplify.updateamplifyMetaAfterResourceUpdate).not.toHaveBeenCalled();
-    expect(context_mock.filesystem.remove).not.toHaveBeenCalled();
+    expect(fs_mock.removeSync).not.toHaveBeenCalled();
   });
 
   it('generates expected artifacts when choosing to migrate an Admin Queries API', async () => {
@@ -162,7 +161,7 @@ describe('REST API input state', () => {
     expect(getMigrateResourceMessageForOverride).toHaveBeenCalled();
     expect(stateManager_mock.setResourceInputsJson).toHaveBeenCalled();
     expect(stateManager_mock.setResourceParametersJson).toHaveBeenCalled();
-    expect(context_mock.filesystem.remove).toHaveBeenCalledTimes(2);
+    expect(fs_mock.removeSync).toHaveBeenCalledTimes(2);
   });
 
   it('does nothing when choosing NOT to migrate an Admin Queries API', async () => {
@@ -181,7 +180,7 @@ describe('REST API input state', () => {
     expect(stateManager_mock.setResourceInputsJson).not.toHaveBeenCalled();
     expect(stateManager_mock.setResourceParametersJson).not.toHaveBeenCalled();
     expect(context_mock.amplify.updateamplifyMetaAfterResourceUpdate).not.toHaveBeenCalled();
-    expect(context_mock.filesystem.remove).not.toHaveBeenCalled();
+    expect(fs_mock.removeSync).not.toHaveBeenCalled();
   });
 
   it('generates expected artifacts when adding an Admin Queries API', async () => {

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -45,8 +45,8 @@ export async function console(context: $TSContext) {
 }
 
 export async function migrate(context: $TSContext, serviceName?: string) {
-  const { projectPath } = context.migrationInfo;
-  const amplifyMeta = stateManager.getMeta();
+  const { projectPath } = context?.migrationInfo ?? { projectPath: pathManager.findProjectRoot() };
+  const amplifyMeta = stateManager.getMeta(projectPath);
   const migrateResourcePromises = [];
   for (const categoryName of Object.keys(amplifyMeta)) {
     if (categoryName === category) {
@@ -54,7 +54,7 @@ export async function migrate(context: $TSContext, serviceName?: string) {
         try {
           if (amplifyMeta[category][resourceName].providerPlugin) {
             const providerController = await import(
-              path.join('.', 'provider-utils', amplifyMeta[category][resourceName].providerPlugin, 'index')
+              path.join(__dirname, 'provider-utils', amplifyMeta[category][resourceName].providerPlugin, 'index')
             );
             if (providerController) {
               if (!serviceName || serviceName === amplifyMeta[category][resourceName].service) {
@@ -125,7 +125,7 @@ export async function initEnv(context: $TSContext) {
     return;
   }
 
-  const providerController = await import(path.join('.', 'provider-utils', provider, 'index'));
+  const providerController = await import(path.join(__dirname, 'provider-utils', provider, 'index'));
 
   if (!providerController) {
     printer.error('Provider not configured for this category');

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/apigw-input-state.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/apigw-input-state.ts
@@ -108,8 +108,8 @@ export class ApigwInputState {
     }
     const resourceDirPath = pathManager.getResourceDirectoryPath(this.projectRootPath, AmplifyCategories.API, this.resourceName);
 
-    this.context.filesystem.remove(join(resourceDirPath, PathConstants.ParametersJsonFileName));
-    this.context.filesystem.remove(join(resourceDirPath, 'admin-queries-cloudformation-template.json'));
+    fs.removeSync(join(resourceDirPath, PathConstants.ParametersJsonFileName));
+    fs.removeSync(join(resourceDirPath, 'admin-queries-cloudformation-template.json'));
 
     return this.updateAdminQueriesResource(adminQueriesProps);
   };
@@ -199,9 +199,9 @@ export class ApigwInputState {
       };
     });
 
-    this.context.filesystem.remove(deprecatedParametersFilePath);
-    this.context.filesystem.remove(join(resourceDirPath, PathConstants.ParametersJsonFileName));
-    this.context.filesystem.remove(join(resourceDirPath, `${this.resourceName}-cloudformation-template.json`));
+    fs.removeSync(deprecatedParametersFilePath);
+    fs.removeSync(join(resourceDirPath, PathConstants.ParametersJsonFileName));
+    fs.removeSync(join(resourceDirPath, `${this.resourceName}-cloudformation-template.json`));
 
     await this.createApigwArtifacts();
   };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/apigw-walkthrough.ts
@@ -78,6 +78,11 @@ export async function updateWalkthrough(context: $TSContext) {
   if (!stateManager.resourceInputsJsonExists(projRoot, category, selectedApiName)) {
     // Not yet migrated
     await migrate(context, projRoot, selectedApiName);
+
+    // chose not to migrate
+    if (!stateManager.resourceInputsJsonExists(projRoot, category, selectedApiName)) {
+      exitOnNextTick(0);
+    }
   }
 
   const parameters = stateManager.getResourceInputsJson(projRoot, category, selectedApiName);

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -932,17 +932,15 @@ export async function formNestedStack(
         },
       },
     };
-    const apis = amplifyMeta?.api ?? {};
 
-    Object.keys(apis).forEach(apiName => {
-      const api = apis[apiName];
-
-      if (loadApiCliInputs(apiName, api)) {
+    const apis: $TSObject = amplifyMeta?.api ?? {};
+    for (const [apiName, api] of Object.entries(apis)) {
+      if (await loadApiCliInputs(context, apiName, api)) {
         stack.Properties.Parameters[apiName] = {
           'Fn::GetAtt': [api.providerMetadata.logicalId, 'Outputs.ApiId'],
         };
       }
-    });
+    }
 
     rootStack.Resources[APIGW_AUTH_STACK_LOGICAL_ID] = stack;
   }

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -230,7 +230,7 @@ export abstract class ResourcePackager {
     if (this.resourcesHasApiGatewaysButNotAdminQueries(resources)) {
       const { PROVIDER, PROVIDER_NAME } = Constants;
       const { StackName: stackName } = this.amplifyMeta[PROVIDER][PROVIDER_NAME];
-      consolidateApiGatewayPolicies(this.context, stackName);
+      await consolidateApiGatewayPolicies(this.context, stackName);
     }
     await prePushAuthTransform(this.context, resources);
     for await (const resource of resources) {

--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -263,7 +263,7 @@ export async function loadApiCliInputs(context: $TSContext, resourceName: string
       ]);
 
       // answered no to migration
-      if (fs.existsSync(legacyParamsFilePath)) {
+      if (!stateManager.resourceInputsJsonExists(undefined, AmplifyCategories.API, resourceName)) {
         exitOnNextTick(0);
       }
     }

--- a/packages/amplify-provider-awscloudformation/src/utils/env-level-constructs.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/env-level-constructs.ts
@@ -21,7 +21,7 @@ export async function createEnvLevelConstructs(context: $TSContext) {
   Object.assign(
     updatedMeta,
     await createNetworkResources(context, stackName, hasContainers),
-    consolidateApiGatewayPolicies(context, stackName),
+    await consolidateApiGatewayPolicies(context, stackName),
     await uploadAuthTriggerTemplate(context),
   );
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
REST APIs that have a consolidated policy stack which have not yet been migrated fail to regenerate the policy stack when pushing with 7.5.0 - 7.5.4.

To workaround, migrate the REST API with `amplify update api`.

Fixes https://github.com/aws-amplify/amplify-cli/issues/9104

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
