### PR TITLE
fix: remove extra $ in vtl template

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -129,7 +129,7 @@ const generateAuthOnModelQueryExpression = (
               set(ref(`${role.entity}Claim`), claimExpression),
               ifElse(
                 ref(`util.isString($ctx.args.${role.entity})`),
-                set(ref(`${role.entity}Condition`), parens(equals(ref(`${role.entity}Claim`), ref(`$ctx.args.${role.entity}`)))),
+                set(ref(`${role.entity}Condition`), parens(equals(ref(`${role.entity}Claim`), ref(`ctx.args.${role.entity}`)))),
                 set(
                   ref(`${role.entity}Condition`),
                   parens(


### PR DESCRIPTION
AppSync handles duplicate $s, but mock does not.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9075