### PR TITLE
fix(amplify-provider-awscloudformation): Ensure the right profile is used with SSO and with credential_process

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -1,5 +1,6 @@
 import { $TSContext } from 'amplify-cli-core';
 import fs from 'fs-extra';
+import * as aws from 'aws-sdk';
 import { getProfileCredentials, getProfiledAwsConfig } from '../system-config-manager';
 
 jest.setTimeout(15000);
@@ -32,6 +33,8 @@ describe('profile tests', () => {
     const getProfileCredentials_mock = jest.fn(getProfileCredentials);
     const profile_config = await getProfiledAwsConfig(context_stub, 'fake');
     expect(profile_config).toBeDefined();
+    expect(profile_config.credentialProvider).toBeDefined();
+    expect(profile_config.credentialProvider).toBeInstanceOf(aws.CredentialProviderChain);
     expect(getProfileCredentials_mock).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -88,6 +88,14 @@ export const getProfiledAwsConfig = async (context: $TSContext, profileName: str
         ...profileConfig,
         ...roleCredentials,
       };
+
+      if (profileConfig.credential_process) {
+        const chain = new aws.CredentialProviderChain();
+        const processProvider = () => new aws.ProcessCredentials({ profile: profileName });
+        chain.providers.push(processProvider);
+
+        awsConfigInfo.credentialProvider = chain;
+      }
     } else {
       logger('getProfiledAwsConfig.getProfileCredentials', [profileName]);
       const profileCredentials = getProfileCredentials(profileName);


### PR DESCRIPTION
#### Description of changes

When using credential_process in the AWS profile (to get SSO to work for example) the ProcessCredentials Provider is used.
When using the default chain from the aws-sdk no options are passed to it and it default to using AWS_PROFILE.

With this change, we detect ```credential_process``` and specifically pass the profile name into the credential chain to ensure it gets used.

The problem this solves for me is when using multiple environments.
When adding an environment with ```aws env add``` even though a profile is picked, if it is using credential_process it won't be used.

In my patrticular use case the environments are in multiple accounts.
I suspect most people are using environments in the same account and have an AWS_PROFILE set so the default fallback works.

I haven't added any tests but could attempt it given some guidance.

#### Issue

#4488 is an example where the workaround suggest setting AWS_PROFILE, which should be unnecessary.

#### Description of how you validated changes

```bash
# Configure two  AWS SSO profiles using separate accounts 
# Add a wrapped entries that uses credential_process with something like aws2wrap

unset AWS_PROFILE # Make sure we don't have any creds
# unset AWS_* # All the other standard export
amplify init 
# Choose the first profile

amplify env add
# Choose the other profil
```

Both environments are created without any auth errors 

#### Checklist
- [x ] PR description included
- [ x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.