### PR TITLE
fix: don't use path.join() for s3 upload path

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/consolidate-apigw-policies.ts
@@ -37,7 +37,7 @@ type ApiGatewayPolicyCreationState = {
 export const APIGW_AUTH_STACK_LOGICAL_ID = 'APIGatewayAuthStack';
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const MAX_MANAGED_POLICY_SIZE = 6_144;
-const S3_UPLOAD_PATH = path.join(AmplifyCategories.API, `${APIGW_AUTH_STACK_LOGICAL_ID}.json`);
+const S3_UPLOAD_PATH = `${AmplifyCategories.API}/${APIGW_AUTH_STACK_LOGICAL_ID}.json`;
 const AUTH_ROLE_NAME = 'authRoleName';
 const UNAUTH_ROLE_NAME = 'unauthRoleName';
 


### PR DESCRIPTION
#### Description of changes
The S3 upload path is only used to construct a URL. On Windows,
this would use a backslash instead of the desired forward slash.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9091

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
