### PR TITLE
fix: use __dirname instead of '.' in import path

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -54,7 +54,7 @@ export async function migrate(context: $TSContext, serviceName?: string) {
         try {
           if (amplifyMeta[category][resourceName].providerPlugin) {
             const providerController = await import(
-              path.join('.', 'provider-utils', amplifyMeta[category][resourceName].providerPlugin, 'index')
+              path.join(__dirname, 'provider-utils', amplifyMeta[category][resourceName].providerPlugin, 'index')
             );
             if (providerController) {
               if (!serviceName || serviceName === amplifyMeta[category][resourceName].service) {
@@ -125,7 +125,7 @@ export async function initEnv(context: $TSContext) {
     return;
   }
 
-  const providerController = await import(path.join('.', 'provider-utils', provider, 'index'));
+  const providerController = await import(path.join(__dirname, 'provider-utils', provider, 'index'));
 
   if (!providerController) {
     printer.error('Provider not configured for this category');


### PR DESCRIPTION
I haven't been able to reproduce #9097, but this may be related. Even if this does not address #9097, I think we should make this change.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9097

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
