### PR TITLE
fix: handle implicit primary keys in @manyToMany

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
@@ -319,6 +319,23 @@ test('join table inherits auth from tables with similar rules', () => {
   expect(out.resolvers['Mutation.updateFooBar.res.vtl']).toMatchSnapshot();
 });
 
+test('creates join table with implicitly defined primary keys', () => {
+  const inputSchema = `
+    type Foo @model {
+      fooName: String
+      bars: [Bar] @manyToMany(relationName: "FooBar")
+    }
+    type Bar @model {
+      barName: String
+      foos: [Foo] @manyToMany(relationName: "FooBar")
+    }`;
+  const transformer = createTransformer();
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});
+
 function createTransformer(authConfig?: AppSyncAuthConfiguration) {
   const transformerAuthConfig: AppSyncAuthConfiguration = authConfig ?? {
     defaultAuthentication: {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
@@ -127,8 +127,8 @@ export class ManyToManyTransformer extends TransformerPluginBase {
       const d2TypeName = directive2.object.name.value;
       const d1FieldName = d1TypeName.charAt(0).toLowerCase() + d1TypeName.slice(1);
       const d2FieldName = d2TypeName.charAt(0).toLowerCase() + d2TypeName.slice(1);
-      const d1PartitionKey = getPartitionKeyField(directive1.object);
-      const d2PartitionKey = getPartitionKeyField(directive2.object);
+      const d1PartitionKey = getPartitionKeyField(context, directive1.object);
+      const d2PartitionKey = getPartitionKeyField(context, directive2.object);
       const d1IndexName = `by${d1TypeName}`;
       const d2IndexName = `by${d2TypeName}`;
       const d1FieldNameId = `${d1FieldName}ID`;
@@ -166,7 +166,7 @@ export class ManyToManyTransformer extends TransformerPluginBase {
       directive1.indexName = d1IndexName;
       directive2.indexName = d2IndexName;
       directive1.fields = [d1PartitionKey.name.value];
-      directive2.fields = [d1PartitionKey.name.value];
+      directive2.fields = [d2PartitionKey.name.value];
       directive1.fieldNodes = [d1PartitionKey];
       directive2.fieldNodes = [d2PartitionKey];
       directive1.relatedType = joinType;

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -20,6 +20,7 @@ import {
   toCamelCase,
   toPascalCase,
   toUpper,
+  wrapNonNull,
 } from 'graphql-transformer-common';
 import {
   BelongsToDirectiveConfiguration,
@@ -410,11 +411,13 @@ function makeModelXFilterInputObject(
   };
 }
 
-export function getPartitionKeyField(object: ObjectTypeDefinitionNode): FieldDefinitionNode {
+export function getPartitionKeyField(ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode): FieldDefinitionNode {
+  const outputObject = ctx.output.getType(object.name.value) as ObjectTypeDefinitionNode;
+  assert(outputObject);
   const fieldMap = new Map<string, FieldDefinitionNode>();
   let name = 'id';
 
-  for (const field of object.fields!) {
+  for (const field of outputObject.fields!) {
     fieldMap.set(field.name.value, field);
 
     for (const directive of field.directives!) {
@@ -425,5 +428,5 @@ export function getPartitionKeyField(object: ObjectTypeDefinitionNode): FieldDef
     }
   }
 
-  return fieldMap.get(name)!;
+  return fieldMap.get(name) ?? makeField('id', [], wrapNonNull(makeNamedType('ID')));
 }


### PR DESCRIPTION
This commit updates the `@manyToMany` directive to handle implicit primary keys when creating the join table.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9110

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
