### PR TITLE
fix(graphql-auth-transformer): fix datastore fields auth

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/conflict-resolution.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/conflict-resolution.test.ts.snap
@@ -31,6 +31,46 @@ $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
 
+exports[`test multi auth model with field auth with conflict resolution 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+#set( $inputFields = $util.parseJson($util.toJson($ctx.args.input.keySet())) )
+#set( $isAuthorized = false )
+#set( $allowedFields = [] )
+#set( $nullAllowedFields = [] )
+#set( $deniedFields = {} )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #if( $ctx.identity.userArn == $ctx.stash.authRole )
+    #set( $isAuthorized = true )
+  #end
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  $util.qr($allowedFields.addAll([\\"id\\",\\"writeable\\",\\"_version\\",\\"_deleted\\",\\"_lastChangedAt\\"]))
+  $util.qr($nullAllowedFields.addAll([]))
+#end
+#if( !$isAuthorized && $allowedFields.isEmpty() && $nullAllowedFields.isEmpty() )
+$util.unauthorized()
+#end
+#if( !$isAuthorized )
+  #foreach( $entry in $util.map.copyAndRetainAllKeys($ctx.args.input, $inputFields).entrySet() )
+    #if( $util.isNull($entry.value) && !$nullAllowedFields.contains($entry.key) )
+      $util.qr($deniedFields.put($entry.key, \\"\\"))
+    #end
+  #end
+  #foreach( $deniedField in $util.list.copyAndRemoveAll($inputFields, $allowedFields) )
+    $util.qr($deniedFields.put($deniedField, \\"\\"))
+  #end
+#end
+#if( $deniedFields.keySet().size() > 0 )
+  $util.error(\\"Unauthorized on \${deniedFields.keySet()}\\", \\"Unauthorized\\")
+#end
+$util.toJson({})
+## [End] Authorization Steps. **"
+`;
+
 exports[`test single auth model is enabled with conflict resolution 1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))


### PR DESCRIPTION
#### Description of changes
- add datastore fields to allowed list

#### Issue #, if available
- https://github.com/aws-amplify/amplify-cli/issues/9101

#### Description of how you validated changes
- manual testing the issue graphql.schema
- `yarn tests` passes
- unit test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
