### PR TITLE
fix: Parameters file path fix based on cli-inputs

### DIFF
--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -147,7 +147,11 @@ export class PathManager {
   getResourceParametersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string => {
     let isBuildParametersjson: boolean = false;
     const resourceDirPath = this.getResourceDirectoryPath(projectPath, category, resourceName);
-    if (!fs.existsSync(path.join(resourceDirPath, PathConstants.ParametersJsonFileName)) && overriddenCategories.includes(category)) {
+    if (
+      !fs.existsSync(path.join(resourceDirPath, PathConstants.ParametersJsonFileName)) &&
+      fs.existsSync(path.join(resourceDirPath, PathConstants.CLIInputsJsonFileName)) &&
+      overriddenCategories.includes(category)
+    ) {
       isBuildParametersjson = true;
     }
     const basePath = isBuildParametersjson ? path.join(resourceDirPath, PathConstants.BuildDirName) : resourceDirPath;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Fixes parameters.json path fetch based o previous parameters.json , cli-inputs and overridden categories

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
