### PR TITLE
fix: add support for IAM roles in mock

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/utils/auth-helpers/current-auth-mode.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/auth-helpers/current-auth-mode.test.ts
@@ -1,5 +1,10 @@
 import { getAuthorizationMode } from '../../../utils/auth-helpers/current-auth-mode';
-import { extractHeader, getAllowedAuthTypes, isValidOIDCToken, extractJwtToken } from '../../../utils/auth-helpers/helpers';
+import {
+  extractHeader,
+  getAllowedAuthTypes,
+  isValidOIDCToken,
+  extractJwtToken,
+} from '../../../utils/auth-helpers/helpers';
 import { AmplifyAppSyncSimulatorAuthenticationType, AmplifyAppSyncAPIConfig } from '../../../type-definition';
 
 jest.mock('../../../utils/auth-helpers/helpers');
@@ -151,3 +156,5 @@ describe('getAuthorizationMode', () => {
     expect(() => getAuthorizationMode({}, APPSYNC_CONFIG)).toThrow('UnauthorizedException: Missing authorization');
   });
 });
+
+

--- a/packages/amplify-appsync-simulator/src/__tests__/utils/auth-helpers/helper.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/auth-helpers/helper.test.ts
@@ -1,0 +1,33 @@
+import { AmplifyAppSyncAPIConfig, AmplifyAppSyncSimulatorAuthenticationType } from '../../../type-definition';
+import { extractIamToken } from '../../../utils/auth-helpers/helpers';
+describe('extractIamToken', () => {
+  const appSyncConfig: AmplifyAppSyncAPIConfig = {
+    name: 'testApi',
+    additionalAuthenticationProviders: [],
+    authRoleName: 'myAuthRole',
+    unAuthRoleName: 'myUnAuthRole',
+    defaultAuthenticationType: { authenticationType: AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM },
+    authAccessKeyId: 'testAccessKeyId',
+    accountId: 'testAccount',
+  };
+  it('should return authRole when the accessKeyId matches', () => {
+    const iamToken = extractIamToken(
+      `AWS4-HMAC-SHA256 Credential=${appSyncConfig.authAccessKeyId}/${new Date().toISOString()}/someService/aaa`,
+      appSyncConfig,
+    );
+    expect(iamToken.userArn).toEqual(`arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.authRoleName}`);
+  });
+
+  it('should return unAuth user when accessKeyId does not match', () => {
+    const iamToken = extractIamToken(
+      `AWS4-HMAC-SHA256 Credential=AKIUNAUTHAcceeKeyId/${new Date().toISOString()}/someService/aaa`,
+      appSyncConfig,
+    );
+    expect(iamToken.userArn).toEqual(`arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.unAuthRoleName}`);
+  });
+
+  it('should throw accessKeyId error when IAM token is not in the right format', () => {
+    expect(() => extractIamToken(`AWS4-HMAC-SHA256 `, appSyncConfig)).toThrowError('missing accessKeyId');
+  });
+  
+});

--- a/packages/amplify-appsync-simulator/src/index.ts
+++ b/packages/amplify-appsync-simulator/src/index.ts
@@ -23,6 +23,14 @@ export { AppSyncGraphQLExecutionContext, JWTToken, IAMToken } from './utils';
 export * from './type-definition';
 export * from './velocity';
 
+const DEFAULT_API_CONFIG: Partial<AmplifyAppSyncAPIConfig> = {
+  authRoleName: 'assumed-role/authRole/CognitoIdentityCredentials',
+  unAuthRoleName: 'assumed-role/unAuthRole/CognitoIdentityCredentials',
+  authAccessKeyId: 'ASIAVJKIAM-AuthRole', // when accessKeyId matches assume the authRole. Otherwise, use unAuthRole
+  accountId: '12345678910',
+  apiKey: 'DA-FAKEKEY',
+};
+
 export class AmplifyAppSyncSimulator {
   private resolvers;
   private dataSources: Map<string, AmplifyAppSyncSimulatorDataLoader>;
@@ -64,7 +72,7 @@ export class AmplifyAppSyncSimulator {
     const lastFunctions = this.functions;
     const lastDataSources = this.dataSources;
     try {
-      this._appSyncConfig = config.appSync;
+      this._appSyncConfig = { ...DEFAULT_API_CONFIG, ...config.appSync };
       this.mappingTemplates = (config.mappingTemplates || []).reduce((map, template) => {
         const normalizedTemplate: AppSyncSimulatorMappingTemplate = { content: template.content };
         if (template.path) {

--- a/packages/amplify-appsync-simulator/src/type-definition.ts
+++ b/packages/amplify-appsync-simulator/src/type-definition.ts
@@ -78,7 +78,7 @@ export enum AmplifyAppSyncSimulatorAuthenticationType {
   AWS_IAM = 'AWS_IAM',
   AMAZON_COGNITO_USER_POOLS = 'AMAZON_COGNITO_USER_POOLS',
   OPENID_CONNECT = 'OPENID_CONNECT',
-  AWS_LAMBDA = 'AWS_LAMBDA'
+  AWS_LAMBDA = 'AWS_LAMBDA',
 }
 
 export type AmplifyAppSyncAuthenticationProviderAPIConfig = {
@@ -122,6 +122,10 @@ export type AmplifyAppSyncAuthenticationProviderConfig =
 export type AmplifyAppSyncAPIConfig = {
   name: string;
   defaultAuthenticationType: AmplifyAppSyncAuthenticationProviderConfig;
+  authRoleName?: string; // assumed-role/authRole/CognitoIdentityCredentials
+  unAuthRoleName?: string; // assumed-role/unAuthRole/CognitoIdentityCredentials
+  authAccessKeyId?: string; // when accessKeyId matches assume the authRole. Otherwise, use unAuthRole
+  accountId?: string;
   apiKey?: string;
   additionalAuthenticationProviders: AmplifyAppSyncAuthenticationProviderConfig[];
 };

--- a/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
+++ b/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
@@ -41,6 +41,30 @@ export function extractJwtToken(authorization: string): JWTToken {
   }
 }
 
+export function extractIamToken(authorization: string, appSyncConfig: AmplifyAppSyncAPIConfig): IAMToken {
+  try {
+    const accessKeyId = authorization.split('Credential=')[1]?.split('/')[0];
+    if (!accessKeyId) {
+      throw new Error('Invalid accessKeyId');
+    }
+    if (accessKeyId === appSyncConfig.authAccessKeyId) {
+      return {
+        accountId: appSyncConfig.accountId,
+        userArn: `arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.authRoleName}`,
+        username: 'auth-user',
+      };
+    } else {
+      return {
+        accountId: appSyncConfig.accountId,
+        userArn: `arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.unAuthRoleName}`,
+        username: 'unauth-user',
+      };
+    }
+  } catch (_) {
+    throw new Error('Invalid accessKeyId');
+  }
+}
+
 export function isValidOIDCToken(token: JWTToken, configuredAuthTypes: AmplifyAppSyncAuthenticationProviderConfig[]): boolean {
   const oidcIssuers = configuredAuthTypes
     .filter(authType => authType.authenticationType === AmplifyAppSyncSimulatorAuthenticationType.OPENID_CONNECT)

--- a/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
+++ b/packages/amplify-appsync-simulator/src/utils/auth-helpers/helpers.ts
@@ -42,26 +42,22 @@ export function extractJwtToken(authorization: string): JWTToken {
 }
 
 export function extractIamToken(authorization: string, appSyncConfig: AmplifyAppSyncAPIConfig): IAMToken {
-  try {
-    const accessKeyId = authorization.split('Credential=')[1]?.split('/')[0];
-    if (!accessKeyId) {
-      throw new Error('Invalid accessKeyId');
-    }
-    if (accessKeyId === appSyncConfig.authAccessKeyId) {
-      return {
-        accountId: appSyncConfig.accountId,
-        userArn: `arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.authRoleName}`,
-        username: 'auth-user',
-      };
-    } else {
-      return {
-        accountId: appSyncConfig.accountId,
-        userArn: `arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.unAuthRoleName}`,
-        username: 'unauth-user',
-      };
-    }
-  } catch (_) {
-    throw new Error('Invalid accessKeyId');
+  const accessKeyId = authorization.includes('Credential=') ? authorization.split('Credential=')[1]?.split('/')[0] : undefined;
+  if (!accessKeyId) {
+    throw new Error('missing accessKeyId');
+  }
+  if (accessKeyId === appSyncConfig.authAccessKeyId) {
+    return {
+      accountId: appSyncConfig.accountId,
+      userArn: `arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.authRoleName}`,
+      username: 'auth-user',
+    };
+  } else {
+    return {
+      accountId: appSyncConfig.accountId,
+      userArn: `arn:aws:sts::${appSyncConfig.accountId}:${appSyncConfig.unAuthRoleName}`,
+      username: 'unauth-user',
+    };
   }
 }
 

--- a/packages/amplify-graphiql-explorer/src/AuthModal.tsx
+++ b/packages/amplify-graphiql-explorer/src/AuthModal.tsx
@@ -24,6 +24,7 @@ type State = {
   isOpen: boolean;
   supportedAuthModes: AUTH_MODE[];
   oidcTokenError: string;
+  iamRole: 'auth' | 'unAuth';
 };
 
 type Props = {
@@ -32,6 +33,7 @@ type Props = {
   selectedAuthMode: AUTH_MODE;
   currentCognitoToken?: string;
   currentOIDCToken?: string;
+  iamRole?: 'Auth' | 'UnAuth';
   apiKey?: string;
 };
 export class AuthModal extends Component<Props, State> {
@@ -49,6 +51,7 @@ export class AuthModal extends Component<Props, State> {
     isOpen: true,
     currentAuthMode: AUTH_MODE.API_KEY,
     oidcTokenError: '',
+    iamRole: 'auth',
   };
 
   constructor(props) {
@@ -90,6 +93,7 @@ export class AuthModal extends Component<Props, State> {
       apiKey: props.apiKey || '',
       supportedAuthModes: this.props.authModes,
       currentAuthMode: props.selectedAuthMode,
+      iamRole: props.iamRole || 'Auth',
     };
 
     this.onClose = this.onClose.bind(this);
@@ -111,6 +115,7 @@ export class AuthModal extends Component<Props, State> {
       OIDCToken: this.state.currentAuthMode === AUTH_MODE.OPENID_CONNECT ? this.state.currentOIDCToken : null,
       // We have no data for IAM to store, so we just store a constant string for now
       iam: this.state.currentAuthMode === AUTH_MODE.AWS_IAM ? 'AWS4-HMAC-SHA256 IAMAuthorized' : null,
+      iamRole: this.state.iamRole,
     };
 
     if (this.props.onClose) {
@@ -143,6 +148,12 @@ export class AuthModal extends Component<Props, State> {
   onAuthModeChange(ev, data) {
     this.setState({
       currentAuthMode: data.value,
+    });
+  }
+
+  onIAMRoleChange(ev, data) {
+    this.setState({
+      iamRole: data.value,
     });
   }
 
@@ -244,7 +255,18 @@ export class AuthModal extends Component<Props, State> {
     } else if (this.state.currentAuthMode === AUTH_MODE.AWS_IAM) {
       formContent = (
         <>
-          <label>IAM authentication mode has no settings.</label>
+          <label>Role:</label>
+          <br />
+          <Dropdown
+            placeholder='Role'
+            selection
+            options={[
+              { value: 'Auth', text: 'Auth' },
+              { value: 'UnAuth', text: 'UnAuth' },
+            ]}
+            value={this.state.iamRole}
+            onChange={this.onIAMRoleChange.bind(this)}
+          />
         </>
       );
     }


### PR DESCRIPTION
Amplify Mock did not support selecting the roles that should be assumed when making GraphQL request
to mock server using GraphiQL explorer. Added option to select the role to be assumed when making
the request using IAM auth mode

fix #9107

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
