### PR TITLE
perf(cli): get AccountId from meta instead of sts

### DIFF
--- a/packages/amplify-cli/src/__tests__/context-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/context-manager.test.ts
@@ -6,7 +6,7 @@ import { Context } from '../domain/context';
 import { PluginInfo } from '../domain/plugin-info';
 import { PluginManifest } from '../domain/plugin-manifest';
 import * as UsageData from '../domain/amplify-usageData';
-
+import { stateManager } from 'amplify-cli-core';
 jest.mock('../domain/amplify-usageData/', () => {
   return {
     UsageData: {
@@ -22,6 +22,7 @@ jest.mock('../domain/amplify-usageData/', () => {
   };
 });
 jest.mock('../app-config');
+jest.mock('amplify-cli-core');
 
 describe('test attachUsageData', () => {
   const version = 'latestversion';
@@ -35,14 +36,15 @@ describe('test attachUsageData', () => {
   mockContext.pluginPlatform = new PluginPlatform();
   mockContext.pluginPlatform.plugins['core'] = [new PluginInfo('', version, '', new PluginManifest('', ''))];
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    const amplifyToolkit = jest.createMockFromModule<any>('../domain/amplify-toolkit').AmplifyToolkit;
-    amplifyToolkit['executeProviderUtils'] = jest.fn().mockReturnValue('accountId');
-    mockContext.amplify = amplifyToolkit;
-    jest.clearAllMocks();
+  const stateManagerMocked = stateManager as jest.Mocked<typeof stateManager>;
+  stateManagerMocked.metaFileExists.mockReturnValue(true);
+  stateManagerMocked.getMeta.mockReturnValue({
+    providers: {
+      awscloudformation: {
+        StackId: 'arn:aws:cloudformation:us-east-1:accountId:stack/amplify/8b4ba810-5208-11ec-bb0f-12f4d8376f67',
+      },
+    },
   });
-  afterEach(() => {});
 
   it('constructContext', () => {
     const context = constructContext(mockContext.pluginPlatform, mockContext.input);

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -26,7 +26,6 @@ export async function attachUsageData(context: Context) {
     context.usageData = NoUsageData.Instance;
   }
   const accountId = getSafeAccountId();
-  console.log(accountId);
   context.usageData.init(config.usageDataConfig.installationUuid, getVersion(context), context.input, accountId, getProjectSettings());
 }
 

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -35,7 +35,7 @@ const getSafeAccountId = () => {
     const stackId = _.get(amplifyMeta, ['providers','awscloudformation', 'StackId']) as string;
     if(stackId) {
       const splitString = stackId.split(':');
-      if(splitString.length >= 4) {
+      if(splitString.length > 4) {
         return splitString[4];
       }
     }

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -6,6 +6,7 @@ import { ProjectSettings } from './domain/amplify-usageData/UsageDataPayload';
 import { Context } from './domain/context';
 import { Input } from './domain/input';
 import { PluginPlatform } from './domain/plugin-platform';
+import * as _ from 'lodash';
 
 export function constructContext(pluginPlatform: PluginPlatform, input: Input): Context {
   const context = new Context(pluginPlatform, input);
@@ -24,9 +25,24 @@ export async function attachUsageData(context: Context) {
   } else {
     context.usageData = NoUsageData.Instance;
   }
-
-  const accountId = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getAccountId');
+  const accountId = getSafeAccountId();
+  console.log(accountId);
   context.usageData.init(config.usageDataConfig.installationUuid, getVersion(context), context.input, accountId, getProjectSettings());
+}
+
+const getSafeAccountId = () => {
+  if(stateManager.metaFileExists()){
+    const amplifyMeta = stateManager.getMeta();
+    const stackId = _.get(amplifyMeta, ['providers','awscloudformation', 'StackId']) as string;
+    if(stackId) {
+      const splitString = stackId.split(':');
+      if(splitString.length >= 4) {
+        return splitString[4];
+      }
+    }
+  }
+
+  return '';
 }
 
 const getVersion = (context: Context) => context.pluginPlatform.plugins.core[0].packageVersion;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Removed sts call which was taking a while and replaced it with meta

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
