### PR TITLE
fix(amplify-category-geo): refactor auth warnings

### DIFF
--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -159,6 +159,11 @@ export const checkAuthConfig = async (context: $TSContext, parameters: Pick<Reso
       parameters.name,
     ]);
 
+    // If auth is not added, throw error
+    if (!checkResult.authEnabled) {
+      throw new Error(`Adding ${service} to your project requires the Auth category for managing authentication rules. Please add auth using "amplify add auth"`);
+    }
+
     // If auth is imported and configured, we have to throw the error instead of printing since there is no way to adjust the auth
     // configuration.
     if (checkResult.authImported === true && checkResult.errors && checkResult.errors.length > 0) {
@@ -170,9 +175,7 @@ export const checkAuthConfig = async (context: $TSContext, parameters: Pick<Reso
     }
 
     // If auth is not imported and there were errors, adjust or enable auth configuration
-    if (!checkResult.authEnabled || !checkResult.requirementsMet) {
-      printer.warn(`Adding ${service} to your project requires the Auth category for managing authentication rules.`);
-
+    if (!checkResult.requirementsMet) {
       try {
         await context.amplify.invokePluginMethod(context, 'auth', undefined, 'externalAuthEnable', [
           context,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When enabling UnAuth or Guest access to a Geo resource, a confusing warning message is shown that Auth is not added to the app even though it is. This change fixes it. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-cli/issues/9154

#### Description of how you validated changes
Manually tested the case in a JS app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
