### PR TITLE
feat(amplify-category-api): enable default 4xx and 5xx api gateway cors response

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@aws-amplify/graphql-transformer-migrator": "1.2.9",
-    "@aws-cdk/assertions": "~1.124.0",
     "@aws-cdk/assets": "~1.124.0",
     "@aws-cdk/aws-apigateway": "~1.124.0",
     "@aws-cdk/aws-apigatewayv2": "~1.124.0",
@@ -87,6 +86,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@aws-cdk/assertions": "~1.124.0",
     "@types/js-yaml": "^4.0.0"
   },
   "jest": {

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@aws-amplify/graphql-transformer-migrator": "1.2.9",
+    "@aws-cdk/assertions": "~1.124.0",
     "@aws-cdk/assets": "~1.124.0",
     "@aws-cdk/aws-apigateway": "~1.124.0",
     "@aws-cdk/aws-apigatewayv2": "~1.124.0",

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
@@ -19,7 +19,6 @@ describe('AmplifyApigwResourceStack', () => {
     });
     amplifyApigwStack.generateStackResources('myapi');
     const template = Template.fromStack(amplifyApigwStack);
-    console.log(template.toJSON());
     template.hasResourceProperties('AWS::ApiGateway::GatewayResponse', {
       ResponseType: 'DEFAULT_4XX',
       ResponseParameters: {

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
@@ -1,0 +1,48 @@
+import * as cdk from '@aws-cdk/core';
+import { Template } from '@aws-cdk/assertions';
+import { AmplifyApigwResourceStack } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder';
+import { PermissionSetting } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/types';
+
+describe('AmplifyApigwResourceStack', () => {
+  test('generateStackResources should synthesize the way we expected', () => {
+    const app = new cdk.App();
+    const amplifyApigwStack = new AmplifyApigwResourceStack(app, 'amplifyapigwstack', {
+      version: 1,
+      paths: {
+        '/path': {
+          lambdaFunction: 'lambdaFunction',
+          permissions: {
+            setting: PermissionSetting.OPEN,
+          },
+        },
+      },
+    });
+    amplifyApigwStack.generateStackResources('myapi');
+    const template = Template.fromStack(amplifyApigwStack);
+    console.log(template.toJSON());
+    template.hasResourceProperties('AWS::ApiGateway::GatewayResponse', {
+      ResponseType: 'DEFAULT_4XX',
+      ResponseParameters: {
+        'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+        'gatewayresponse.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+        'gatewayresponse.header.Access-Control-Allow-Methods': "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+        'gatewayresponse.header.Access-Control-Expose-Headers': "'Date,X-Amzn-ErrorType'",
+      },
+      RestApiId: {
+        Ref: 'myapi',
+      },
+    });
+    template.hasResourceProperties('AWS::ApiGateway::GatewayResponse', {
+      ResponseType: 'DEFAULT_5XX',
+      ResponseParameters: {
+        'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+        'gatewayresponse.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+        'gatewayresponse.header.Access-Control-Allow-Methods': "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+        'gatewayresponse.header.Access-Control-Expose-Headers': "'Date,X-Amzn-ErrorType'",
+      },
+      RestApiId: {
+        Ref: 'myapi',
+      },
+    });
+  });
+});

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -243,6 +243,16 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
         },
       },
     });
+    new apigw.CfnGatewayResponse(this, `${resourceName}Default4XXResponse`, {
+      responseType: 'DEFAULT_4XX',
+      restApiId: cdk.Fn.ref(resourceName),
+      responseParameters: defaultCorsGatewayResponseParams,
+    });
+    new apigw.CfnGatewayResponse(this, `${resourceName}Default5XXResponse`, {
+      responseType: 'DEFAULT_5XX',
+      restApiId: cdk.Fn.ref(resourceName),
+      responseParameters: defaultCorsGatewayResponseParams,
+    });
 
     this._setDeploymentResource(resourceName);
   };
@@ -453,6 +463,13 @@ const defaultCorsResponseObject = {
       "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'",
     'method.response.header.Access-Control-Allow-Origin': "'*'",
   },
+};
+
+const defaultCorsGatewayResponseParams = {
+  'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+  'gatewayresponse.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+  'gatewayresponse.header.Access-Control-Allow-Methods': "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+  'gatewayresponse.header.Access-Control-Expose-Headers': "'Date,X-Amzn-ErrorType'",
 };
 
 const response200 = {

--- a/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
@@ -9,6 +9,8 @@ import {
   addAuthWithGroupsAndAdminAPI,
 } from 'amplify-e2e-core';
 import { v4 as uuid } from 'uuid';
+import { get } from 'lodash';
+import fetch from 'node-fetch';
 
 const [shortId] = uuid().split('-');
 const projName = `apigwtest${shortId}`;
@@ -42,5 +44,24 @@ describe('API Gateway e2e tests', () => {
     const projMeta = getProjectMeta(projRoot);
     expect(projMeta).toBeDefined();
     expect(projMeta.api).toBeDefined();
+  });
+
+  it('adds rest api and verify the default 4xx response', async () => {
+    const apiName = 'integtest';
+    await addRestApi(projRoot, {
+      apiName,
+    });
+    await amplifyPushAuth(projRoot);
+    const projMeta = getProjectMeta(projRoot);
+    expect(projMeta).toBeDefined();
+    expect(projMeta.api).toBeDefined();
+    const apiPath = get(projMeta, `api.${apiName}.output.RootUrl`);
+    expect(apiPath).toBeDefined();
+    const res = await fetch(apiPath);
+    expect(res.status).toEqual(403);
+    expect(res.headers.get('access-control-allow-headers')).toEqual('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+    expect(res.headers.get('access-control-allow-methods')).toEqual('DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT');
+    expect(res.headers.get('access-control-allow-origin')).toEqual('*');
+    expect(res.headers.get('access-control-expose-headers')).toEqual('Date,X-Amzn-ErrorType');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,21 @@
     "@aws-cdk/cx-api" "1.124.0"
     constructs "^3.3.69"
 
+"@aws-cdk/assertions@~1.124.0":
+  version "1.124.0"
+  resolved "https://registry.npmjs.org/@aws-cdk/assertions/-/assertions-1.124.0.tgz#4d61226f341cf4f8ba66238cf46fa9150cc87afb"
+  integrity sha512-jvJf701HizOu3gZHFeC0YQHED2P9aRzKuBk76kA07pAVxxLN7AWTbPrMBtC0ToCVnhazZ1sftxjnLOkxLyyloA==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "1.124.0"
+    "@aws-cdk/core" "1.124.0"
+    "@aws-cdk/cx-api" "1.124.0"
+    colors "^1.4.0"
+    constructs "^3.3.69"
+    diff "^5.0.0"
+    fast-deep-equal "^3.1.3"
+    string-width "^4.2.2"
+    table "^6.7.1"
+
 "@aws-cdk/assets@1.124.0", "@aws-cdk/assets@~1.124.0":
   version "1.124.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.124.0.tgz#eaeacef8f2c03b93e3b742b6fe767b69e3cad4b3"


### PR DESCRIPTION
fix #5183

#### Description of changes
Enables CORS for default 4xx and 5xx api gateway for easier debugging.
It also allows `Amplify.API` to auto correct clockskew, see: https://github.com/aws-amplify/amplify-js/issues/6494

#### Issue #, if available
#5183

#### Description of how you validated changes
Manually tested.
Would be happy to add unit test if you can point me to where I should add the unit tests.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
