### PR TITLE
feat: provide helpful error message when GQL schema validation fails

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/__tests__/errors/index.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/errors/index.test.ts
@@ -1,0 +1,62 @@
+import { parse } from 'graphql';
+import { SchemaValidationError } from '../../errors';
+import { validateModelSchema } from '../../transformation/validation';
+
+describe('SchemaValidationError', () => {
+  describe('when schema has V1 directive', () => {
+    it('should print migration related doc when the schema has @hasOne and @hasMany @primaryKey @index directives', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post @key {
+          id: ID!
+          title: String!
+          blog: Blog! @connection
+        }
+
+        type Blog @versioned {
+          id: ID!
+          name: String!
+          posts: [Post]! @connection
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toEqual(
+        'Your GraphQL Schema is using "@key", "@connection", "@versioned" directives from an older version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.',
+      );
+    });
+  });
+
+  describe('schema with general error', () => {
+    it('should show normal error message when the schema does not have v1 directive error', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post {
+          id: ID!
+          title: MissingType
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toContain(`Unknown type "MissingType".`);
+      expect(schemaValidationError.message).not.toContain(
+        `Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.'`,
+      );
+    });
+  });
+
+  describe('schema with general error and v1 directives', () => {
+    it('should show normal error message when the schema does not have v1 directive error', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post {
+          id: ID! @connection
+          title: MissingType
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toContain(`Unknown type "MissingType".`);
+      expect(schemaValidationError.message).toContain(
+        `Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.`,
+      );
+    });
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/transformation/validation.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/validation.ts
@@ -56,6 +56,7 @@ import { UniqueDirectivesPerLocation } from 'graphql/validation/rules/UniqueDire
 
 // AuthMode Types
 import { AppSyncAuthConfiguration, AppSyncAuthMode } from '@aws-amplify/graphql-transformer-interfaces';
+import { validateSDL } from 'graphql/validation/validate';
 
 /**
  * This set includes all validation rules defined by the GraphQL spec.
@@ -141,8 +142,12 @@ export const validateModelSchema = (doc: DocumentNode) => {
   if (!existingQueryType) {
     fullDocument.definitions.push(...NOOP_QUERY.definitions);
   }
-
-  const schema = buildASTSchema(fullDocument);
+  let schema;
+  const errors = validateSDL(fullDocument);
+  if (errors.length > 0) {
+    return errors;
+  }
+  schema = buildASTSchema(fullDocument, { assumeValid: true });
   return validate(schema, fullDocument, specifiedRules);
 };
 

--- a/packages/graphql-function-transformer/src/__tests__/FunctionTransformer.test.ts
+++ b/packages/graphql-function-transformer/src/__tests__/FunctionTransformer.test.ts
@@ -100,10 +100,5 @@ test('@function directive applied to Object should throw Error', () => {
   const transformer = new GraphQLTransform({
     transformers: [new FunctionTransformer()],
   });
-  try {
-    transformer.transform(invalidSchema);
-    fail('Error is expected to be thrown');
-  } catch (error) {
-    expect(error.message).toEqual('Directive "function" may not be used on OBJECT.');
-  }
+    expect(() => transformer.transform(invalidSchema)).toThrowError(/Directive "function" may not be used on OBJECT/);
 });

--- a/packages/graphql-transformer-core/src/__tests__/GraphQLTransform.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/GraphQLTransform.test.ts
@@ -68,11 +68,7 @@ test('Test graphql transformer validation. Unknown directive.', () => {
   const transformer = new GraphQLTransform({
     transformers: [new InvalidObjectTransformer()],
   });
-  try {
-    transformer.transform(invalidSchema);
-  } catch (e) {
-    expect(e.message).toEqual('Unknown directive "UnknownDirective".');
-  }
+  expect(() => transformer.transform(invalidSchema)).toThrowError(/Unknown directive/);
 });
 
 class PingTransformer extends Transformer {

--- a/packages/graphql-transformer-core/src/__tests__/errors.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/errors.test.ts
@@ -1,0 +1,76 @@
+import { parse } from 'graphql';
+import { SchemaValidationError } from '../errors';
+import { validateModelSchema } from '../validation';
+
+describe('SchemaValidationError', () => {
+  describe('Schema has only V2 directive errors', () => {
+    it('should print migration related doc when the schema has @hasOne and @hasMany @primaryKey @index directives', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post {
+          id: ID! @primaryKey
+          title: String! @index
+          blog: Blog! @hasOne
+        }
+
+        type Blog {
+          id: ID!
+          name: String!
+          posts: [Post]! @hasMany
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toEqual(
+        'Your GraphQL Schema is using "@primaryKey", "@index", "@hasOne", "@hasMany" directives from the newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.',
+      );
+    });
+
+    it('should print migration related doc when the schema has @default directive', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post {
+          id: ID!
+          title: String! @default
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toEqual(
+        'Your GraphQL Schema is using "@default" directive from the newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.',
+      );
+    });
+  });
+
+  describe('schema with general error', () => {
+    it('should show normal error message when the schema does not have v1 directive error', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post {
+          id: ID!
+          title: MissingType
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toContain(`Unknown type "MissingType".`);
+      expect(schemaValidationError.message).not.toContain(
+        `Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.'`,
+      );
+    });
+  });
+
+  describe('schema with general error and v2 directive error', () => {
+    it('should show normal error message when the schema does not have v1 directive error', () => {
+      const schema = parse(/* GraphQL */ `
+        type Post {
+          id: ID! @primaryKey
+          title: MissingType
+        }
+      `);
+      const errors = validateModelSchema(schema);
+      const schemaValidationError = new SchemaValidationError(errors);
+      expect(schemaValidationError.message).toContain(`Unknown type "MissingType".`);
+      expect(schemaValidationError.message).toContain(
+        `Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.`,
+      );
+    });
+  });
+});

--- a/packages/graphql-transformer-core/src/__tests__/validation.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/validation.test.ts
@@ -1,0 +1,46 @@
+import { parse } from 'graphql';
+import { validateModelSchema } from '../validation';
+
+describe('validateModelSchema', () => {
+  it('should return no error when the schema is valid', () => {
+    const schema = parse(/* GraphQL */ `
+      type Post {
+        id: ID!
+        title: String!
+        content: String!
+      }
+    `);
+    const errors = validateModelSchema(schema);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should return error when the document fails to parse due to missing type', () => {
+    const schema = parse(/* GraphQL */ `
+      type Post {
+        id: ID!
+        title: String!
+        content: MissingType
+      }
+    `);
+    const errors = validateModelSchema(schema);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Unknown type "MissingType".');
+  });
+
+  it('should return helpful error when parsing fails due to typo in typename', () => {
+    const schema = parse(/* GraphQL */ `
+      type Post {
+        id: ID!
+        title: String!
+        content: CustomType1
+      }
+
+      type CustomType {
+        content: String
+      }
+    `);
+    const errors = validateModelSchema(schema);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Unknown type "CustomType1". Did you mean "CustomType"?');
+  });
+});

--- a/packages/graphql-transformer-core/src/errors.ts
+++ b/packages/graphql-transformer-core/src/errors.ts
@@ -1,6 +1,7 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError, printError } from 'graphql';
 import * as os from 'os';
 
+const GRAPHQL_TRANSFORMER_V2_DIRECTIVES = ['hasOne', 'index', 'primaryKey', 'belongsTo', 'manyToMany', 'hasMany'];
 export class InvalidTransformerError extends Error {
   constructor(message: string) {
     super(message);
@@ -14,7 +15,36 @@ export class InvalidTransformerError extends Error {
 
 export class SchemaValidationError extends Error {
   constructor(errors: Readonly<GraphQLError[]>) {
-    super(`Schema Errors:\n\n${errors.join('\n')}`);
+    const v2DirectivesInUse = new Set<string>();
+    const newErrors = errors.filter(error => {
+      if (!error.message.startsWith('Unknown directive')) {
+        return true;
+      }
+      const dir = GRAPHQL_TRANSFORMER_V2_DIRECTIVES.find(d => error.message.endsWith(`"${d}".`));
+      if (!dir) {
+        return true;
+      }
+      v2DirectivesInUse.add(dir);
+      return false;
+    });
+
+    if (v2DirectivesInUse.size > 0) {
+      const v2DirectiveErrorMessage = `Your GraphQL Schema is using ${Array.from(v2DirectivesInUse.values())
+        .map(d => `"@${d}"`)
+        .join(', ')} ${
+        v2DirectivesInUse.size > 1 ? 'directives' : 'directive'
+      } from the newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.`;
+      if (newErrors.length === 0) {
+        super(v2DirectiveErrorMessage);
+      } else {
+        super(
+          v2DirectiveErrorMessage +
+            ` There are additional validation errors listed below: \n\n ${newErrors.map(error => printError(error)).join('\n\n')}`,
+        );
+      }
+    } else {
+      super(`Schema validation failed.\n\n${newErrors.map(error => printError(error)).join('\n\n')} `);
+    }
     Object.setPrototypeOf(this, SchemaValidationError.prototype);
     this.name = 'SchemaValidationError';
     if ((Error as any).captureStackTrace) {
@@ -22,7 +52,6 @@ export class SchemaValidationError extends Error {
     }
   }
 }
-
 /**
  * Thrown by transformers when a user provided schema breaks some contract expected by the transformer.
  *

--- a/packages/graphql-transformer-core/src/errors.ts
+++ b/packages/graphql-transformer-core/src/errors.ts
@@ -1,7 +1,7 @@
 import { GraphQLError, printError } from 'graphql';
 import * as os from 'os';
 
-const GRAPHQL_TRANSFORMER_V2_DIRECTIVES = ['hasOne', 'index', 'primaryKey', 'belongsTo', 'manyToMany', 'hasMany'];
+const GRAPHQL_TRANSFORMER_V2_DIRECTIVES = ['hasOne', 'index', 'primaryKey', 'belongsTo', 'manyToMany', 'hasMany', 'default'];
 export class InvalidTransformerError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/graphql-transformer-core/src/validation.ts
+++ b/packages/graphql-transformer-core/src/validation.ts
@@ -53,6 +53,7 @@ import { UniqueVariableNames } from 'graphql/validation/rules/UniqueVariableName
 import { NoUndefinedVariables } from 'graphql/validation/rules/NoUndefinedVariables';
 import { NoUnusedVariables } from 'graphql/validation/rules/NoUnusedVariables';
 import { UniqueDirectivesPerLocation } from 'graphql/validation/rules/UniqueDirectivesPerLocation';
+import { validateSDL } from 'graphql/validation/validate';
 
 /**
  * This set includes all validation rules defined by the GraphQL spec.
@@ -140,6 +141,10 @@ export const validateModelSchema = (doc: DocumentNode) => {
     fullDocument.definitions.push(...NOOP_QUERY.definitions);
   }
 
-  const schema = buildASTSchema(fullDocument);
+const errors = validateSDL(fullDocument);
+if (errors.length > 0) {
+  return errors;
+}
+  const schema = buildASTSchema(fullDocument, { assumeValid: true });
   return validate(schema, fullDocument, specifiedRules);
 };


### PR DESCRIPTION
Updated the GraphQL transformer V1 and V2 to provide helpful error message when an incompitable
directive is used in the schema. The error message points to migration docs to provide clear
guidelines as how the error can be fixed

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
