### PR TITLE
fix(graphql-relational-transformer): @belongsTo directive support for Int fields

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
@@ -1,8 +1,8 @@
-import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { Kind, parse } from 'graphql';
-import { BelongsToTransformer, HasOneTransformer } from '..';
+import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
 
 test('fails if @belongsTo was used on an object that is not a model type', () => {
   const inputSchema = `
@@ -327,4 +327,40 @@ test('regression test for implicit id field on related type', () => {
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
+});
+
+test('support for belongs to with Int fields', () => {
+  const inputSchema = `
+    type ItemBank @model {
+      bankId: Int! @primaryKey
+      bankName: String!
+      bankDescription: String!
+      bankItems: [ExamItem] @hasMany(indexName: "byBank", fields: ["bankId"])
+    }
+
+    type ExamItem @model {
+      examItemId: Int! @primaryKey
+      currentIterationId: Int!
+      owningBankId: Int! @index(name: "byBank", sortKeyFields: ["examItemId"])
+      owningBank: ItemBank @belongsTo(fields: ["owningBankId"])
+    }`;
+
+  const transformer = new GraphQLTransform({
+    transformers: [
+      new ModelTransformer(),
+      new PrimaryKeyTransformer(),
+      new IndexTransformer(),
+      new HasManyTransformer(),
+      new BelongsToTransformer(),
+    ],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+  expect(out.resolvers['ExamItem.owningBank.req.vtl']).toContain('$util.defaultIfNull($ctx.source.owningBankId, "___xamznone____"))');
+  expect(out.resolvers['ExamItem.owningBank.req.vtl']).not.toContain(
+    '$util.defaultIfNullOrBlank($ctx.source.owningBankId, "___xamznone____"))',
+  );
 });

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -1,9 +1,9 @@
-import assert from 'assert';
 import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
 import { Table } from '@aws-cdk/aws-dynamodb';
 import * as cdk from '@aws-cdk/core';
+import assert from 'assert';
 import { ObjectTypeDefinitionNode } from 'graphql';
 import {
   and,
@@ -47,6 +47,19 @@ import { getConnectionAttributeName } from './utils';
 const CONNECTION_STACK = 'ConnectionStack';
 const authFilter = ref('ctx.stash.authFilter');
 
+function buildKeyValueExpression(fieldName: string, object: ObjectTypeDefinitionNode) {
+  const field = object.fields?.find(it => it.name.value === fieldName);
+
+  // can be auto-generated
+  const attributeType = field ? attributeTypeFromScalar(field.type) : 'S';
+
+  return ref(
+    `util.parseJson($util.dynamodb.toDynamoDBJson($util.${
+      attributeType === 'S' ? 'defaultIfNullOrBlank' : 'defaultIfNull'
+    }($ctx.source.${fieldName}, "${NONE_VALUE}")))`,
+  );
+}
+
 export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider) {
   const { connectionFields, field, fields, object, relatedType, relatedTypeIndex } = config;
   assert(relatedTypeIndex.length > 0);
@@ -59,10 +72,9 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
   let totalExpressionNames: Record<string, Expression> = {
     [`#partitionKey`]: str(partitionKeyName),
   };
+
   let totalExpressionValues: Record<string, Expression> = {
-    [`:partitionValue`]: ref(
-      `util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${localFields[0]}, "${NONE_VALUE}")))`,
-    ),
+    [`:partitionValue`]: buildKeyValueExpression(localFields[0], object),
   };
 
   // Add a composite sort key or simple sort key if there is one.
@@ -80,9 +92,7 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
     const sortKeyName = keySchema[1].attributeName;
     totalExpressions.push(`#sortKeyName = :sortKeyName`);
     totalExpressionNames['#sortKeyName'] = str(sortKeyName);
-    totalExpressionValues[':sortKeyName'] = ref(
-      `util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.${localFields[1]}, "${NONE_VALUE}")))`,
-    );
+    totalExpressionValues[':sortKeyName'] = buildKeyValueExpression(localFields[1], object);
   }
 
   const resolver = ctx.resolvers.generateQueryResolver(


### PR DESCRIPTION
#### Description of changes
- added support for @belongsTo Int fields 

#### Description of how you validated changes
- manual testing
- unit test added
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
