### PR TITLE
fix: pass updated args between pipeline function in mock

### DIFF
--- a/packages/amplify-appsync-simulator/src/resolvers/function.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/function.ts
@@ -17,7 +17,7 @@ export class AmplifySimulatorFunction extends AppSyncBaseResolver {
     }
   }
 
-  async resolve(source, args, stash, prevResult, context, info): Promise<{ result: any; stash: any; hadException: boolean }> {
+  async resolve(source, args, stash, prevResult, context, info): Promise<{ result: any; stash: any; hadException: boolean; args: any }> {
     let result = null;
     let error = null;
     const requestMappingTemplate = this.getRequestMappingTemplate();
@@ -32,6 +32,7 @@ export class AmplifySimulatorFunction extends AppSyncBaseResolver {
       return {
         result: requestTemplateResult.result,
         stash: requestTemplateResult.stash,
+        args: requestTemplateResult.args,
         hadException: requestTemplateResult.hadException,
       };
     }
@@ -53,6 +54,7 @@ export class AmplifySimulatorFunction extends AppSyncBaseResolver {
       stash: responseMappingResult.stash,
       result: responseMappingResult.result,
       hadException: responseMappingResult.hadException,
+      args: requestTemplateResult.args,
     };
   }
 }

--- a/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/pipeline-resolver.ts
@@ -28,11 +28,14 @@ export class AppSyncPipelineResolver extends AppSyncBaseResolver {
     let hadException: boolean;
 
     // Pipeline request mapping template
-    ({ result, stash, errors: templateErrors, isReturn, hadException } = requestMappingTemplate.render(
-      { source, arguments: args, stash },
-      context,
-      info,
-    ));
+    ({
+      result,
+      stash,
+      errors: templateErrors,
+      isReturn,
+      hadException,
+      args,
+    } = requestMappingTemplate.render({ source, arguments: args, stash }, context, info));
 
     context.appsyncErrors = [...context.appsyncErrors, ...(templateErrors || [])];
 
@@ -44,7 +47,7 @@ export class AppSyncPipelineResolver extends AppSyncBaseResolver {
     let prevResult = result;
     for (let fnName of this.config.functions) {
       const fnResolver = this.simulatorContext.getFunction(fnName);
-      ({ result: prevResult, stash, hadException } = await fnResolver.resolve(source, args, stash, prevResult, context, info));
+      ({ result: prevResult, stash, hadException, args } = await fnResolver.resolve(source, args, stash, prevResult, context, info));
 
       // If an exception occurred, do not continue processing.
       if (hadException) {


### PR DESCRIPTION
Updated amplify-graphql-simulator to pass changes made to the arguments in pipeline function to next function.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
