### PR TITLE
fix: remove next template from destructive iterative update

### DIFF
--- a/packages/amplify-e2e-tests/schemas/simple_model_new_primary_key.graphql
+++ b/packages/amplify-e2e-tests/schemas/simple_model_new_primary_key.graphql
@@ -1,4 +1,4 @@
-type Todo @model @key(fields: ["content"]) {
+type Todo @model {
   id: ID!
-  content: String!
+  content: String! @primaryKey
 }

--- a/packages/amplify-e2e-tests/src/__tests__/api_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6.test.ts
@@ -20,7 +20,7 @@ let projRoot;
 beforeEach(async () => {
   projRoot = await createNewProjectDir(projName);
   await initJSProjectWithProfile(projRoot, { name: projName });
-  await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
+  await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
   await amplifyPush(projRoot);
 });
 afterEach(async () => {

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/amplify-graphql-resource-manager.ts
@@ -109,7 +109,7 @@ export class GraphQLResourceManager {
     if (!this.rebuildAllTables) {
       this.gsiManagement(gqlDiff.diff, gqlDiff.current, gqlDiff.next);
     }
-    this.tableRecreationManagement(gqlDiff.current, gqlDiff.next);
+    this.tableRecreationManagement(gqlDiff.current);
     return await this.getDeploymentSteps();
   };
 
@@ -273,7 +273,7 @@ export class GraphQLResourceManager {
     }
   };
 
-  private tableRecreationManagement = (currentState: DiffableProject, nextState: DiffableProject) => {
+  private tableRecreationManagement = (currentState: DiffableProject) => {
     this.getTablesBeingReplaced().forEach(tableMeta => {
       const ddbStack = this.getStack(tableMeta.stackName, currentState);
       this.dropTemplateResources(ddbStack);
@@ -281,7 +281,6 @@ export class GraphQLResourceManager {
       // clear any other states created by GSI updates as dropping and recreating supercedes those changes
       this.clearTemplateState(tableMeta.stackName);
       this.templateState.add(tableMeta.stackName, JSONUtilities.stringify(ddbStack));
-      this.templateState.add(tableMeta.stackName, JSONUtilities.stringify(this.getStack(tableMeta.stackName, nextState)));
     });
   };
 

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -200,7 +200,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
           modelsBeingReplaced,
           deploymentSteps,
         );
-        if (deploymentSteps.length > 1) {
+        if (deploymentSteps.length > 0) {
           iterativeDeploymentWasInvoked = true;
 
           // Initialize deployment state to signal a new iterative deployment
@@ -239,8 +239,8 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
       context.exeInfo.forcePush ||
       rebuild
     ) {
-      // If there is an API change, there will be one deployment step. But when there needs an iterative update the step count is > 1
-      if (deploymentSteps.length > 1) {
+      // if there are deploymentSteps, need to do an iterative update
+      if (deploymentSteps.length > 0) {
         // create deployment manager
         const deploymentManager = await DeploymentManager.createInstance(context, cloudformationMeta.DeploymentBucketName, spinner, {
           userAgent: formUserAgentParam(context, generateUserAgentAction(resourcesToBeCreated, resourcesToBeUpdated)),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a bug with destructive iterative updates where deploying the "nextState" as the second step of the iterative deployment was causing failures because the original resolvers are updated with the template rather than the new resolvers. This caused CFN failures when the new template tried to reference resolvers that didn't exist yet. Fixed by removing this step from the iterative deployment as it is not needed. Also fixed a bug in the iterative deployment logic where we were checking for steps.length > 1 instead of > 0. We had never run into this case before because we didn't have any single step iterative deployments (although there is a potential future optimization we can make to iterative GSI updates to skip the last step and have it be added in the final deployment step)

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/9151

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified and updated existing destructive updates e2e tests to exercise this case

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
