### PR TITLE
fix(amplify-provider-awscloudformation): use in memory meta for export

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/export.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export.test.ts
@@ -1,0 +1,72 @@
+import {
+  addApiWithoutSchema,
+  addAuthWithMaxOptions,
+  addS3StorageWithIdpAuth,
+  amplifyPush,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  exportBackend,
+  getProjectConfig,
+  initJSProjectWithProfile,
+} from 'amplify-e2e-core';
+import * as path from 'path';
+import { JSONUtilities, readCFNTemplate } from 'amplify-cli-core';
+
+describe('amplify export backend', () => {
+  let projRoot: string;
+  const projName = 'exporttest';
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir(projName);
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('init a js project and export', async () => {
+    await initJSProjectWithProfile(projRoot, { envName: 'dev' });
+    await addAuthWithMaxOptions(projRoot, {});
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
+    await addS3StorageWithIdpAuth(projRoot);
+
+    const exportPath = path.join(projRoot, 'exportedBackend');
+    await exportBackend(projRoot, { exportPath });
+    await amplifyPush(projRoot);
+    const name = getProjectConfig(projRoot).projectName;
+    const pathToExport = path.join(exportPath, `amplify-export-${name}`);
+    const pathToStackMappings = path.join(pathToExport, 'category-stack-mapping.json');
+    const pathToManifest = path.join(pathToExport, 'amplify-export-manifest.json');
+    const stackMappings = JSONUtilities.readJson(pathToStackMappings) as { category: string; resourceName: string; service: string }[];
+    const manifest = JSONUtilities.readJson(pathToManifest) as { stackName: string; props: any };
+    const buildFolder = path.join(projRoot, 'amplify', 'backend', 'awscloudformation', 'build');
+    stackMappings.forEach(mapping => {
+      const template1 = getTemplateForMapping(mapping, buildFolder) 
+      const stack = manifest.props.loadNestedStacks[mapping.category + mapping.resourceName];
+      const template2 = readCFNTemplate(path.join(pathToExport, stack.templateFile)).cfnTemplate;
+      matchTemplates(template1, template2);      
+    });
+   
+  });
+});
+
+function matchTemplates(template: any, exporttemplate: any) {
+  expect(Object.keys(template.Parameters)).toEqual(Object.keys(exporttemplate.Parameters))
+  expect(Object.keys(template.Resources)).toEqual(Object.keys(exporttemplate.Resources))
+  expect(Object.keys(template.Outputs)).toEqual(Object.keys(exporttemplate.Outputs))
+  
+}
+
+function getTemplateForMapping(mapping:  { category: string; resourceName: string; service: string }, buildFolder: string) : any {
+  let cfnFileName = 'cloudformation-template.json';
+  if(mapping.service !== 'AppSync' && mapping.service !== 'S3'){
+    cfnFileName = mapping.resourceName + '-' + cfnFileName 
+  }
+  const templatePath = mapping.category === 'function' ? 
+  path.join(buildFolder, mapping.category, mapping.resourceName, cfnFileName) :
+    path.join(buildFolder, mapping.category, mapping.resourceName, 'build', cfnFileName)
+  return readCFNTemplate(templatePath).cfnTemplate;
+}
+
+

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1031,7 +1031,6 @@ export async function formNestedStack(
       if (resourceDetails.providerPlugin) {
         const parameters = <$TSObject>loadResourceParameters(context, category, resource);
         const { dependsOn } = resourceDetails;
-        console.log(resourceDetails);
         if (dependsOn) {
           for (let i = 0; i < dependsOn.length; ++i) {
             for (const attribute of dependsOn[i]?.attributes || []) {

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -869,6 +869,7 @@ export async function formNestedStack(
   resourceName?: string,
   serviceName?: string,
   skipEnv?: boolean,
+  useExistingMeta?: boolean
 ) {
   let rootStack;
   // CFN transform for Root stack
@@ -889,7 +890,7 @@ export async function formNestedStack(
   }
 
   const projectPath = pathManager.findProjectRoot();
-  const amplifyMeta = stateManager.getMeta(projectPath);
+  const amplifyMeta = useExistingMeta ? projectDetails.amplifyMeta : stateManager.getMeta(projectPath);
   // update amplify meta with updated root stack Info
   if (Object.keys(metaToBeUpdated).length) {
     context.amplify.updateProvideramplifyMeta(providerName, metaToBeUpdated);
@@ -1015,10 +1016,8 @@ export async function formNestedStack(
   let categories = Object.keys(amplifyMeta);
 
   categories = categories.filter(category => category !== 'providers');
-
   categories.forEach(category => {
     const resources = Object.keys(amplifyMeta[category]);
-
     resources.forEach(resource => {
       const resourceDetails = amplifyMeta[category][resource];
 
@@ -1032,7 +1031,7 @@ export async function formNestedStack(
       if (resourceDetails.providerPlugin) {
         const parameters = <$TSObject>loadResourceParameters(context, category, resource);
         const { dependsOn } = resourceDetails;
-
+        console.log(resourceDetails);
         if (dependsOn) {
           for (let i = 0; i < dependsOn.length; ++i) {
             for (const attribute of dependsOn[i]?.attributes || []) {
@@ -1141,7 +1140,6 @@ export async function formNestedStack(
             parameters.unauthRoleName = unauthRoleName;
           }
         }
-
         if (resourceDetails.providerMetadata) {
           templateURL = resourceDetails.providerMetadata.s3TemplateURL;
 

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -328,7 +328,7 @@ export abstract class ResourcePackager {
   }
 
   protected async generateRootStack(): Promise<Template> {
-    return await formNestedStack(this.context, { amplifyMeta: this.amplifyMeta });
+    return await formNestedStack(this.context, { amplifyMeta: this.amplifyMeta }, undefined, undefined, undefined, undefined, true);
   }
 
   private resourcesHasCategoryService = (resources: ResourceDefinition[], category: string, service?: string): boolean =>

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -209,6 +209,9 @@ export abstract class ResourcePackager {
    * @param bucketName
    */
   protected storeS3BucketInfo(packagedResource: PackagedResourceDefinition, bucketName: string): void {
+    if(!packagedResource.build){
+      return;
+    }
     const s3Info = {
       deploymentBucketName: bucketName,
       s3Key: packagedResource.packagerParams.zipFilename,
@@ -219,6 +222,7 @@ export abstract class ResourcePackager {
       [this.envInfo.envName, CATEGORIES, packagedResource.category, packagedResource.resourceName],
       s3Info,
     );
+    _.set(packagedResource, ['s3Bucket'], s3Info);
     _.set(this.amplifyMeta, [packagedResource.category, packagedResource.resourceName, S3_BUCKET], s3Info);
   }
 
@@ -312,6 +316,7 @@ export abstract class ResourcePackager {
         await writeCustomPoliciesToCFNTemplate(resource.resourceName, resource.service, path.basename(cfnFile), resource.category);
         transformedCfnPaths.push(transformedCFNPath);
       }
+      this.storeS3BucketInfo(resource, 'deploymentBucketRef');
       transformedCfnResources.push({
         ...resource,
         transformedCfnPaths,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Export relied on a non committed amplify meta to generate the root stack template
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
