### PR TITLE
fix: handle strings as custom subscription names

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1286,4 +1286,30 @@ describe('ModelTransformer: ', () => {
     const schema = parse(out.schema);
     validateModelSchema(schema);
   });
+
+  it('handles custom subscriptions passed as strings', () => {
+    const validSchema = `type Post @model(subscriptions: {
+          onCreate: "onFeedCreated",
+          onUpdate: "onFeedUpdated",
+          onDelete: "onFeedDeleted"
+      }) {
+        id: ID!
+    }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+      featureFlags,
+    });
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    const definition = out.schema;
+    expect(definition).toBeDefined();
+    const parsed = parse(definition);
+    validateModelSchema(parsed);
+
+    const subscriptionType = getObjectType(parsed, 'Subscription');
+    expect(subscriptionType).toBeDefined();
+    expect(subscriptionType!.fields!.length).toEqual(3);
+    expectFields(subscriptionType!, ['onFeedCreated', 'onFeedUpdated', 'onFeedDeleted']);
+  });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -247,6 +247,19 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
         updatedAt: 'updatedAt',
       },
     });
+
+    if (options.subscriptions?.onCreate && !Array.isArray(options.subscriptions.onCreate)) {
+      options.subscriptions.onCreate = [options.subscriptions.onCreate];
+    }
+
+    if (options.subscriptions?.onDelete && !Array.isArray(options.subscriptions.onDelete)) {
+      options.subscriptions.onDelete = [options.subscriptions.onDelete];
+    }
+
+    if (options.subscriptions?.onUpdate && !Array.isArray(options.subscriptions.onUpdate)) {
+      options.subscriptions.onUpdate = [options.subscriptions.onUpdate];
+    }
+
     this.modelDirectiveConfig.set(typeName, options);
     this.typesWithModelDirective.add(typeName);
   };


### PR DESCRIPTION
GraphQL allows a string where an array of strings is expected.
This commit ensures that custom subscription names are handled
as arrays of strings.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9199
