### PR TITLE
fix: #9070 TOTP only auth configs are failing

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -374,12 +374,12 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       }
 
       this.userPool.mfaConfiguration = cdk.Fn.ref('mfaConfiguration');
-      if (props.useEnabledMfas && props.mfaConfiguration != 'OFF') {
+      if (props.useEnabledMfas && props.mfaConfiguration !== 'OFF') {
         if (configureSMS) {
           this.userPool.enabledMfas = ['SMS_MFA'];
         }
         if (!_.isEmpty(props.mfaTypes) && props.mfaTypes!.includes('TOTP')) {
-          this.userPool.enabledMfas!.push('SOFTWARE_TOKEN_MFA');
+          this.userPool.enabledMfas = [...(this.userPool.enabledMfas || []), 'SOFTWARE_TOKEN_MFA'];
         }
       }
 


### PR DESCRIPTION
#### Description of changes

When auth had only TOTP enabled stack building fails. This PR fixes that.

#### Issue #, if available

Fixes #9070 - at least this part: https://github.com/aws-amplify/amplify-cli/issues/9070#issuecomment-979104053

#### Description of how you validated changes

Manual testing

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
