### PR TITLE
fix: reference table by logical id from cloudformation template outputs

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1230,17 +1230,17 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const streamArnOutputId = `GetAtt${ModelResourceIDs.ModelTableStreamArn(def!.name.value)}`;
     // eslint-disable-next-line no-new
     new cdk.CfnOutput(stack, streamArnOutputId, {
-      value: cdk.Fn.getAtt(tableLogicalName, 'StreamArn').toString(),
+      value: cdk.Fn.getAtt(cfnTable.logicalId, 'StreamArn').toString(),
       description: 'Your DynamoDB table StreamArn.',
-      exportName: cdk.Fn.join(':', [context.api.apiId, 'GetAtt', tableLogicalName, 'StreamArn']),
+      exportName: cdk.Fn.join(':', [context.api.apiId, 'GetAtt', cfnTable.logicalId, 'StreamArn']),
     });
 
     const tableNameOutputId = `GetAtt${tableLogicalName}Name`;
     // eslint-disable-next-line no-new
     new cdk.CfnOutput(stack, tableNameOutputId, {
-      value: cdk.Fn.ref(tableLogicalName),
+      value: cdk.Fn.ref(cfnTable.logicalId),
       description: 'Your DynamoDB table name.',
-      exportName: cdk.Fn.join(':', [context.api.apiId, 'GetAtt', tableLogicalName, 'Name']),
+      exportName: cdk.Fn.join(':', [context.api.apiId, 'GetAtt', cfnTable.logicalId, 'Name']),
     });
 
     const role = this.createIAMRole(context, def, stack, tableName);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

I came across this issue that sometimes the Outputs of the Cloudformation Templates generated based on Amplify GraphQL transformers are not referencing the right resource within the template. The resource name includes a hash suffix (generated by the CDK according to the references in this StackOverflow issue https://stackoverflow.com/a/59070762), while the reference here is using the table name. To make sure it covers this case when the logical ID is not the same as the resource name passed when the Table is created, I think it makes sense to always reference through the Table's `logicalId`. Let me know please if you think this change makes sense.

e.g. the resource would be defined like this:

```
  "Resources": {
    "UserTableBD4BF69E": {
      "Type": "AWS::DynamoDB::Table",
       ....
```

while the outputs will be:

```
  "Outputs": {
    "GetAttUserTableName": {
      "Description": "Your DynamoDB table name.",
      "Value": {
        "Ref": "UserTable" <--- no resource "UserTable" defined in this template
      },
      ....
```

**Note:** the issue in my case was caused by a AWS CDK version mismatch, but still I think it is a good idea to reference the resources by their `logicalId` to avoid eventual problems.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
