### PR TITLE
fix: global notification configuration is replaced with private/prote…

### DIFF
--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthrough-types/s3-user-input-types.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthrough-types/s3-user-input-types.ts
@@ -58,7 +58,7 @@ export interface S3UserInputTriggerFunctionParams{
     triggerFunction : string;
     permissions : S3PermissionType[];
     triggerEvents : S3TriggerEventType[];
-    triggerPrefix : S3TriggerPrefixType[];
+    triggerPrefix? : S3TriggerPrefixType[];
     //note:- this can be extended to add events/filters
 }
 

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state.ts
@@ -288,14 +288,16 @@ export class S3InputState {
   private _confirmLambdaTriggerPrefixUnique(triggerFunctionName: string, triggerPrefixList: S3TriggerPrefixType[]): boolean {
     if (this._inputPayload?.additionalTriggerFunctions) {
       for (const triggerParams of this._inputPayload.additionalTriggerFunctions) {
-        for (const configuredTriggerPrefix of triggerParams.triggerPrefix) {
-          if (
-            this.checkPrefixExists(triggerPrefixList, configuredTriggerPrefix.prefix) &&
-            triggerParams.triggerFunction !== triggerFunctionName
-          ) {
-            throw new Error(
-              `Error installing additional Lambda Trigger : trigger ${triggerParams.triggerFunction} already configured on prefix ${triggerParams.triggerPrefix}`,
-            );
+        if (triggerParams.triggerPrefix) {
+          for (const configuredTriggerPrefix of triggerParams.triggerPrefix) {
+            if (
+              this.checkPrefixExists(triggerPrefixList, configuredTriggerPrefix.prefix) &&
+              triggerParams.triggerFunction !== triggerFunctionName
+            ) {
+              throw new Error(
+                `Error installing additional Lambda Trigger : trigger ${triggerParams.triggerFunction} already configured on prefix ${triggerParams.triggerPrefix}`,
+              );
+            }
           }
         }
       }
@@ -334,7 +336,9 @@ export class S3InputState {
     if (!this._inputPayload) {
       throw new Error(`Error installing additional Lambda Trigger : Storage resource ${this._resourceName} not configured`);
     }
-    this._confirmLambdaTriggerPrefixUnique(triggerFunctionParams.triggerFunction, triggerFunctionParams.triggerPrefix);
+    if ( triggerFunctionParams.triggerPrefix ) {
+      this._confirmLambdaTriggerPrefixUnique(triggerFunctionParams.triggerFunction, triggerFunctionParams.triggerPrefix);
+    }
     if ((this._inputPayload as S3UserInputs).additionalTriggerFunctions) {
       let functionExists = false;
       const existingTriggerFunctions = (this._inputPayload as S3UserInputs).additionalTriggerFunctions;


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Problem:
The legacy behavior for S3 Notification triggers was to have a globally configured lambda trigger. However this precludes any new triggers being added to the S3 bucket for any subfolders (prefix clash - https://aws.amazon.com/premiumsupport/knowledge-center/lambda-s3-event-configuration-error/ ) . Hence applications like Predictions (for IdentitySearch) had to 'remove' the global  NotificationTrigger from S3 bucket and replace with a per-folder (public, private, protected folder) triggers.
To fix this problem ( of default configuration resulting in overlapping trigger prefixes ) , a code change was made to not include global triggers for S3 buckets. This resulted in legacy apps losing global triggers as the bug  #9089 states.

Fix:
Only create per-folder triggers if predictions is enabled, else retain global S3 triggers. 


 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#9089 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
1. (manual)  Add S3 bucket , add Trigger, Deploy to Cloud - validate 2- roles created. Validate uploading file results in Lambda trigger.
2. (manual) Add Predictions with identity flow , Deploy to Cloud - validate  6 - roles created + 2 for rekognitionLambda. Validate both StorageTrigger and RekognitionLambda are triggered when data is uploaded in respective folders.
3. (manual) Headless- Add S3 bucket with triggers , validate roles and  repeat test 1 and 2.
4. E2E  & Unit-test Storage
5. E2E test Predictions

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [*] PR description included
- [*] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
