### PR TITLE
fix: prevent A <-> B @hasOne or @hasMany relationships with DS

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -1,6 +1,6 @@
 import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { ConflictHandlerType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { Kind, parse } from 'graphql';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
 
@@ -645,4 +645,51 @@ test('validates VTL of a complex schema', () => {
   const schema = parse(out.schema);
   validateModelSchema(schema);
   expect(out.resolvers).toMatchSnapshot();
+});
+
+test('@hasMany and @hasMany can point at each other if DataStore is not enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: [Post] @hasMany
+    }
+
+    type Post @model {
+      id: ID!
+      blog: [Blog] @hasMany
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new HasManyTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});
+
+test('@hasMany and @hasMany cannot point at each other if DataStore is enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: [Post] @hasMany
+    }
+
+    type Post @model {
+      id: ID!
+      blog: [Blog] @hasMany
+    }`;
+  const transformer = new GraphQLTransform({
+    resolverConfig: {
+      project: {
+        ConflictDetection: 'VERSION',
+        ConflictHandler: ConflictHandlerType.AUTOMERGE,
+      },
+    },
+    transformers: [new ModelTransformer(), new HasOneTransformer(), new HasManyTransformer()],
+  });
+
+  expect(() => transformer.transform(inputSchema)).toThrowError(
+    `Blog and Post cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
+  );
 });

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
@@ -1,8 +1,8 @@
 import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { ConflictHandlerType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { Kind, parse } from 'graphql';
-import { HasOneTransformer } from '..';
+import { HasManyTransformer, HasOneTransformer } from '..';
 
 test('fails if @hasOne was used on an object that is not a model type', () => {
   const inputSchema = `
@@ -349,4 +349,98 @@ test('creates has one relationship with composite sort key.', () => {
   expect(updateInput.fields.find((f: any) => f.name.value === 'id')).toBeDefined();
   expect(updateInput.fields.find((f: any) => f.name.value === 'email')).toBeDefined();
   expect(updateInput.fields.find((f: any) => f.name.value === 'name')).toBeDefined();
+});
+
+test('@hasOne and @hasMany can point at each other if DataStore is not enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: [Post] @hasMany
+    }
+
+    type Post @model {
+      id: ID!
+      blog: Blog @hasOne
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new HasOneTransformer(), new HasManyTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});
+
+test('@hasOne and @hasOne can point at each other if DataStore is not enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: Post @hasOne
+    }
+
+    type Post @model {
+      id: ID!
+      blog: Blog @hasOne
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new HasOneTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});
+
+test('@hasOne and @hasMany cannot point at each other if DataStore is enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: [Post] @hasMany
+    }
+
+    type Post @model {
+      id: ID!
+      blog: Blog @hasOne
+    }`;
+  const transformer = new GraphQLTransform({
+    resolverConfig: {
+      project: {
+        ConflictDetection: 'VERSION',
+        ConflictHandler: ConflictHandlerType.AUTOMERGE,
+      },
+    },
+    transformers: [new ModelTransformer(), new HasOneTransformer(), new HasManyTransformer()],
+  });
+
+  expect(() => transformer.transform(inputSchema)).toThrowError(
+    `Post and Blog cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
+  );
+});
+
+test('@hasOne and @hasOne cannot point at each other if DataStore is enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: Post @hasOne
+    }
+
+    type Post @model {
+      id: ID!
+      blog: Blog @hasOne
+    }`;
+  const transformer = new GraphQLTransform({
+    resolverConfig: {
+      project: {
+        ConflictDetection: 'VERSION',
+        ConflictHandler: ConflictHandlerType.AUTOMERGE,
+      },
+    },
+    transformers: [new ModelTransformer(), new HasOneTransformer()],
+  });
+
+  expect(() => transformer.transform(inputSchema)).toThrowError(
+    `Blog and Post cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
+  );
 });

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -14,6 +14,7 @@ import {
   getFieldsNodes,
   getRelatedType,
   getRelatedTypeIndex,
+  validateDisallowedDataStoreRelationships,
   validateModelDirective,
   validateRelatedModelDirective,
 } from './utils';
@@ -84,4 +85,5 @@ function validate(config: HasManyDirectiveConfiguration, ctx: TransformerContext
   config.relatedType = getRelatedType(config, ctx);
   config.connectionFields = [];
   validateRelatedModelDirective(config);
+  validateDisallowedDataStoreRelationships(config, ctx);
 }

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
@@ -14,6 +14,7 @@ import {
   getFieldsNodes,
   getRelatedType,
   getRelatedTypeIndex,
+  validateDisallowedDataStoreRelationships,
   validateModelDirective,
   validateRelatedModelDirective,
 } from './utils';
@@ -80,4 +81,5 @@ function validate(config: HasOneDirectiveConfiguration, ctx: TransformerContextP
   config.relatedType = getRelatedType(config, ctx);
   config.connectionFields = [];
   validateRelatedModelDirective(config);
+  validateDisallowedDataStoreRelationships(config, ctx);
 }

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -171,3 +171,37 @@ function getIndexName(directive: DirectiveNode): string | undefined {
 export function getConnectionAttributeName(type: string, field: string) {
   return toCamelCase([type, field, 'id']);
 }
+
+export function validateDisallowedDataStoreRelationships(
+  config: HasManyDirectiveConfiguration | HasOneDirectiveConfiguration,
+  ctx: TransformerContextProvider,
+) {
+  // If DataStore is enabled, the following scenario is not supported:
+  // Model A includes a @hasOne or @hasMany relationship with Model B, while
+  // Model B includes a @hasOne or @hasMany relationship back to Model A.
+
+  if (!ctx.isProjectUsingDataStore()) {
+    return;
+  }
+
+  const modelType = config.object.name.value;
+  const relatedType = ctx.output.getType(config.relatedType.name.value) as ObjectTypeDefinitionNode;
+  assert(relatedType);
+
+  const hasUnsupportedConnectionFields = relatedType.fields!.some(field => {
+    // If the related field has the same data type as this model, and @hasOne or @hasMany
+    // is present, then the connection is unsupported.
+    return (
+      getBaseType(field.type) === modelType &&
+      field.directives!.some(directive => {
+        return directive.name.value === 'hasOne' || directive.name.value === 'hasMany';
+      })
+    );
+  });
+
+  if (hasUnsupportedConnectionFields) {
+    throw new InvalidDirectiveError(
+      `${modelType} and ${relatedType.name.value} cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
+    );
+  }
+}

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -201,7 +201,7 @@ export function validateDisallowedDataStoreRelationships(
 
   if (hasUnsupportedConnectionFields) {
     throw new InvalidDirectiveError(
-      `${modelType} and ${relatedType.name.value} cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
+      `${modelType} and ${relatedType.name.value} cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead. See https://docs.amplify.aws/cli/graphql/data-modeling/#belongs-to-relationship`,
     );
   }
 }


### PR DESCRIPTION
If DataStore is enabled, Model A cannot have a `@hasOne` or `@hasMany` relationship with Model B if Model B also has a `@hasOne` or `@hasMany` relationship with Model A.
