### PR TITLE
fix: add missing salt to deployment logicalId

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -4,6 +4,7 @@ import * as lambda from '@aws-cdk/aws-lambda';
 import * as cdk from '@aws-cdk/core';
 import { $TSObject, JSONUtilities } from 'amplify-cli-core';
 import _ from 'lodash';
+import { v4 as uuid } from 'uuid';
 import { ADMIN_QUERIES_NAME } from '../../../category-constants';
 import { AmplifyApigwResourceTemplate, ApigwInputs, ApigwPathPolicy, Path, PermissionSetting } from './types';
 
@@ -284,7 +285,8 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
   }
 
   private _setDeploymentResource = (resourceName: string) => {
-    this.deploymentResource = new apigw.CfnDeployment(this, `DeploymentAPIGW${resourceName}`, {
+    const [shortId] = uuid().split('-');
+    this.deploymentResource = new apigw.CfnDeployment(this, `DeploymentAPIGW${resourceName}${shortId}`, {
       description: 'The Development stage deployment of your API.',
       stageName: cdk.Fn.conditionIf('ShouldNotCreateEnvResources', 'Prod', cdk.Fn.ref('env')).toString(),
       restApiId: cdk.Fn.ref(resourceName),

--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -30,6 +30,7 @@
     "graphql-transformer-core": "7.3.0",
     "jest-environment-node": "^26.6.2",
     "lodash": "^4.17.21",
+    "node-fetch": "^2.6.1",
     "node-pty-prebuilt-multiarch": "^0.9.0",
     "retimer": "2.0.0",
     "rimraf": "^3.0.0",

--- a/packages/amplify-e2e-core/src/utils/request.ts
+++ b/packages/amplify-e2e-core/src/utils/request.ts
@@ -1,4 +1,5 @@
 const https = require('https');
+import fetch from 'node-fetch';
 
 export function post({ body, ...options }) {
   return new Promise((resolve, reject) => {
@@ -26,4 +27,8 @@ export function post({ body, ...options }) {
     }
     req.end();
   });
+}
+
+export async function get(url: string) {
+  return fetch(url);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The deployment resource needs a new logical id for each push to work properly. This PR adds a shortened uuid to make the logical id unique.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes #9142
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually added an additional route with the latest changes and confirmed it was properly deployed and returned the expected response.

`apigw.test.ts` and `api_5.test.ts` pass locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
