### PR TITLE
feat: Add projectInfo and env to vm sandbox for override

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/override.ts.sample
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/override.ts.sample
@@ -1,6 +1,10 @@
 // This file is used to override the REST API resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyApiRestResourceStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyApiRestResourceStackTemplate) {
-
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/AppSync/override.ts.sample
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/AppSync/override.ts.sample
@@ -1,5 +1,10 @@
+// This file is used to override the AppSync API resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyApiGraphQlResourceStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyApiGraphQlResourceStackTemplate) {
-    
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-category-auth/resources/overrides-resource/auth/override.ts.sample
+++ b/packages/amplify-category-auth/resources/overrides-resource/auth/override.ts.sample
@@ -1,5 +1,10 @@
+// This file is used to override the Cognito Auth resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyAuthCognitoStackTemplate) {
-    
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/override.ts.sample
+++ b/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/override.ts.sample
@@ -1,5 +1,10 @@
+// This file is used to override the User Pool Group Auth resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyUserPoolGroupStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyUserPoolGroupStackTemplate) {
-    
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -1,3 +1,4 @@
+import { getVmSandbox } from '@aws-amplify/cli-extensibility-helper';
 import {
   AmplifyCategories,
   AmplifySupportedService,
@@ -111,10 +112,11 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
         return '';
       });
 
+      const sandbox = getVmSandbox();
       const sandboxNode = new vm.NodeVM({
         console: 'inherit',
         timeout: 5000,
-        sandbox: {},
+        sandbox,
         require: {
           context: 'sandbox',
           builtin: ['path'],

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -1,3 +1,4 @@
+import { getVmSandbox } from '@aws-amplify/cli-extensibility-helper';
 import {
   $TSContext,
   AmplifyCategories,
@@ -183,10 +184,11 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
         formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override auth`]);
         return '';
       });
+      const sandbox = getVmSandbox();
       const sandboxNode = new vm.NodeVM({
         console: 'inherit',
         timeout: 5000,
-        sandbox: {},
+        sandbox,
       });
       try {
         sandboxNode.run(overrideCode).override(this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate);

--- a/packages/amplify-category-storage/Readme.md
+++ b/packages/amplify-category-storage/Readme.md
@@ -10,4 +10,4 @@ The following table lists the current set of commands supported by the Amplify S
 | amplify storage update | Takes you through steps in the CLI to update a storage resource.  |
 | amplify storage push | Provisions only storage cloud resources with the latest local developments.  |
 | amplify storage remove | Removes storage resource from your local backend. The resources are removed from the cloud on the next push command. |
-| amplify storage override | Generates 'overrides.ts' for storage resource in your local backend. The resource properties can be overridden by editing this file. The resource is overridden in the cloud on the next push command. |
+| amplify storage override | Generates 'override.ts' for storage resource in your local backend. The resource properties can be overridden by editing this file. The resource is overridden in the cloud on the next push command. |

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts.sample
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts.sample
@@ -1,5 +1,10 @@
+// This file is used to override the DynamoDB Storage resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyDDBResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyDDBResourceTemplate) {
-    
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts.sample
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts.sample
@@ -1,5 +1,10 @@
+// This file is used to override the S3 Storage resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyS3ResourceTemplate) {
-    
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
@@ -3,7 +3,7 @@
 import { DDBStackTransform } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform';
 import {
   DynamoDBCLIInputs,
-  FieldType,
+  FieldType
 } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/dynamoDB-user-input-types';
 import { DynamoDBInputState } from '../../../../provider-utils/awscloudformation/service-walkthroughs/dynamoDB-input-state';
 
@@ -27,13 +27,21 @@ jest.mock('fs-extra', () => ({
 jest.mock('path', () => ({
   join: jest.fn().mockReturnValue('mockjoinedpath'),
   resolve: jest.fn().mockReturnValue('mockjoinedpath'),
+  normalize: jest.fn().mockReturnValue('mockjoinedpath')
 }));
 
 jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/dynamoDB-input-state');
 
+const getVmSandbox = jest.fn();
+jest.mock('@aws-amplify/cli-extensibility-helper', () => {
+  return {
+    getVmSandbox: () => getVmSandbox(),
+  }
+});
+
 describe('Test DDB transform generates correct CFN template', () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('Generated ddb template with all CLI configurations set with no overrides', async () => {
@@ -77,5 +85,7 @@ describe('Test DDB transform generates correct CFN template', () => {
 
     expect(ddbTransform._cfn).toMatchSnapshot();
     expect(ddbTransform._cfnInputParams).toMatchSnapshot();
+    // no override.ts
+    expect(getVmSandbox).toBeCalledTimes(0);
   });
 });

--- a/packages/amplify-category-storage/src/commands/storage.ts
+++ b/packages/amplify-category-storage/src/commands/storage.ts
@@ -40,7 +40,7 @@ export async function run(context: $TSContext) {
     },
     {
       name: 'override',
-      description: `Generates 'overrides.ts' for ${categoryName} resource in your local backend. The resource properties can be overridden by editing this file. The resource is overridden in the cloud on the next push command. `,
+      description: `Generates 'override.ts' for ${categoryName} resource in your local backend. The resource properties can be overridden by editing this file. The resource is overridden in the cloud on the next push command. `,
     },
   ];
 

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
@@ -1,4 +1,4 @@
-import { AmplifyDDBResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { getVmSandbox, AmplifyDDBResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from '@aws-cdk/core';
 import { App } from '@aws-cdk/core';
 import { $TSAny, buildOverrideDir, JSONUtilities, pathManager } from 'amplify-cli-core';
@@ -182,20 +182,21 @@ export class DDBStackTransform {
     // skip if packageManager or override.ts not found
     if (isBuild) {
       const { override } = await import(overrideJSFilePath).catch(error => {
-        formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override auth ${this._resourceName} `]);
+        formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override storage ${this._resourceName} `]);
         return undefined;
       });
 
       if (typeof override === 'function' && override) {
         const overrideCode: string = await fs.readFile(overrideJSFilePath, 'utf-8').catch(() => {
-          formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override auth`]);
+          formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override storage`]);
           return '';
         });
 
+        const sandbox = getVmSandbox();
         const sandboxNode = new vm.NodeVM({
           console: 'inherit',
           timeout: 5000,
-          sandbox: {},
+          sandbox,
           require: {
             context: 'sandbox',
             builtin: ['path'],

--- a/packages/amplify-cli-extensibility-helper/package.json
+++ b/packages/amplify-cli-extensibility-helper/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "test": "jest",
     "clean": "rimraf ./lib"
   },
   "dependencies": {

--- a/packages/amplify-cli-extensibility-helper/src/__tests__/helpers/project-info.test.ts
+++ b/packages/amplify-cli-extensibility-helper/src/__tests__/helpers/project-info.test.ts
@@ -1,0 +1,30 @@
+import { $TSAny, GetOptions, stateManager } from 'amplify-cli-core';
+import { getProjectInfo } from '../../helpers/project-info';
+import { AmplifyProjectInfo } from '../../types';
+
+describe('project-info', () => {
+  let getLocalEnvInfoMock: jest.SpyInstance<$TSAny, [projectPath?: string, options?: GetOptions<any>]>;
+  let getProjectConfigMock: jest.SpyInstance<$TSAny, [projectPath?: string, options?: GetOptions<any>]>;
+
+  beforeEach(() => {
+    getLocalEnvInfoMock = jest.spyOn(stateManager, 'getLocalEnvInfo').mockImplementation(() => {
+      return {
+        envName: 'mockEnvironment',
+      };
+    });
+    getProjectConfigMock = jest.spyOn(stateManager, 'getProjectConfig').mockImplementation(() => {
+      return {
+        projectName: 'mockProject',
+      };
+    });
+  });
+
+
+  it('returns projectInfo', () => {
+    const projectInfo: AmplifyProjectInfo = getProjectInfo();
+    expect(projectInfo.envName).toStrictEqual<string>('mockEnvironment');
+    expect(projectInfo.projectName).toStrictEqual<string>('mockProject');
+    expect(getLocalEnvInfoMock).toHaveBeenCalledTimes(1);
+    expect(getProjectConfigMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/amplify-cli-extensibility-helper/src/__tests__/helpers/vm-sandbox.test.ts
+++ b/packages/amplify-cli-extensibility-helper/src/__tests__/helpers/vm-sandbox.test.ts
@@ -1,0 +1,70 @@
+import * as mocked from '../../helpers/project-info';
+import { getVmSandbox } from '../../helpers/vm-sandbox';
+
+describe('vm-sandbox', () => {
+  const realProcessEnv: NodeJS.ProcessEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...realProcessEnv };
+    jest.spyOn(mocked, 'getProjectInfo').mockImplementation(() => {
+      return {
+        envName: 'mockEnvironment',
+        projectName: 'mockProject',
+      };
+    });
+  });
+
+  afterAll(() => {
+    process.env = { ...realProcessEnv };
+  });
+
+  for (const testEnv of [
+    'TEST_SECRET_TEST',
+    'TEST_SECRET',
+    'SECRET_TEST',
+    'AMPLIFY_AMAZON_CLIENT_SECRET',
+    'AMPLIFY_FACEBOOK_CLIENT_SECRET',
+    'AMPLIFY_GOOGLE_CLIENT_SECRET',
+  ]) {
+    it(`returns filtered environment given key ${ testEnv }`, () => {
+      process.env[testEnv] = testEnv;
+      const sandbox = getVmSandbox();
+      expect(sandbox.amplify.env[testEnv]).toBeUndefined();
+    });
+  }
+
+  const amplifyDefinedEnvironmentVariables: string[] = [
+    // excludes variables containing 'SECRET'
+    '_BUILD_TIMEOUT',
+    '_LIVE_UPDATES',
+    'AMPLIFY_AMAZON_CLIENT_ID',
+    'AMPLIFY_BACKEND_APP_ID',
+    'AMPLIFY_BACKEND_PULL_ONLY',
+    'AMPLIFY_DIFF_BACKEND',
+    'AMPLIFY_DIFF_DEPLOY',
+    'AMPLIFY_DIFF_DEPLOY_ROOT',
+    'AMPLIFY_FACEBOOK_CLIENT_ID',
+    'AMPLIFY_GOOGLE_CLIENT_ID',
+    'AMPLIFY_IDENTITYPOOL_ID',
+    'AMPLIFY_MONOREPO_APP_ROOT',
+    'AMPLIFY_NATIVECLIENT_ID',
+    'AMPLIFY_SKIP_BACKEND_BUILD',
+    'AMPLIFY_USERPOOL_ID',
+    'AMPLIFY_WEBCLIENT_ID',
+    'AWS_APP_ID',
+    'AWS_BRANCH',
+    'AWS_BRANCH_ARN',
+    'AWS_CLONE_URL',
+    'AWS_COMMIT_ID',
+    'AWS_JOB_ID',
+  ];
+  for (const testEnv of amplifyDefinedEnvironmentVariables) {
+    it(`returns environment given amplify defined key ${ testEnv }`, () => {
+      const expected = `value_${ testEnv }`;
+      process.env[testEnv] = expected;
+      const sandbox = getVmSandbox();
+      expect(sandbox.amplify.env[testEnv]).toStrictEqual(expected);
+    });
+  }
+});

--- a/packages/amplify-cli-extensibility-helper/src/helpers/vm-sandbox.ts
+++ b/packages/amplify-cli-extensibility-helper/src/helpers/vm-sandbox.ts
@@ -1,0 +1,73 @@
+import { printer } from 'amplify-prompts';
+import { AmplifyVmSandboxEnv, VmSandbox } from '../types';
+import { getProjectInfo } from './project-info';
+
+/**
+ * @description Provides a sandbox configuration for use in overrides within vm2.
+ * @returns sandbox object for use in overrides vm sandbox
+ */
+export function getVmSandbox(): VmSandbox {
+  const sandbox = {
+    amplify: {
+      env: getAmplifyEnvironment(),
+      projectInfo: getProjectInfo()
+    }
+  }
+  printer.debug(`override: vm sandbox: ${ JSON.stringify(sandbox) }`);
+  return sandbox;
+}
+
+/**
+ * @description Filters process.env to keys matching output of AmplifyVmSandboxEnvKeys().
+ * @returns Filtered process.env
+ */
+function getAmplifyEnvironment(): AmplifyVmSandboxEnv {
+  const amplifyEnv: AmplifyVmSandboxEnv = {};
+  const amplifyVmSandboxEnvKeys: (string | RegExp)[] = [
+    // https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html#amplify-console-environment-variables
+    '_BUILD_TIMEOUT',
+    '_LIVE_UPDATES',
+    /^AMPLIFY_/,
+    /^AWS_/,
+  ];
+
+  // environment keys that should never be available to the override
+  const forbiddenKeys: (string | RegExp)[] = [
+    'AWS_ACCESS_KEY_ID',
+    /SECRET/i,
+  ];
+
+  // set of process.env keys that are not forbidden
+  const allowedKeys: Set<string> = new Set(Object.keys(process.env).filter(key => {
+    return !forbiddenKeys.some(forbiddenKey => {
+      const isForbiddenKey = ((typeof forbiddenKey === 'string' && forbiddenKey === key) || (forbiddenKey instanceof RegExp && forbiddenKey.test(key)));
+      if (isForbiddenKey) {
+        // todo: Replace printer.debug() with printer.trace() if it is added
+        printer.debug(`override: Excluding forbidden environment key: ${ key }`);
+      }
+      return isForbiddenKey;
+    })
+  }));
+
+  // build the new env with k/v pairs from the allowedKeys where the key names match the rules specified in amplifyVmSandboxEnvKeys
+  amplifyVmSandboxEnvKeys.forEach(key => {
+    if (typeof key === 'string' && allowedKeys.has(key)) {
+      // todo: Replace printer.debug() with printer.trace() if it is added
+      printer.debug(`override: Adding environment key from exact match: ${key}`);
+      Object.assign(amplifyEnv, {[key]: process.env[key]});
+      allowedKeys.delete(key);
+    } else if (key instanceof RegExp) {
+      for (const allowedKey of allowedKeys) {
+        if (key.test(allowedKey)) {
+          // todo: Replace printer.debug() with printer.trace() if it is added
+          printer.debug(`override: Adding environment key from RegExp match: ${allowedKey}`);
+          Object.assign(amplifyEnv, { [allowedKey]: process.env[allowedKey] });
+          allowedKeys.delete(allowedKey);
+        }
+      }
+    }
+  });
+
+  // ensure that we are returning a new copy of the environment variables
+  return JSON.parse(JSON.stringify(amplifyEnv)) as AmplifyVmSandboxEnv;
+}

--- a/packages/amplify-cli-extensibility-helper/src/index.ts
+++ b/packages/amplify-cli-extensibility-helper/src/index.ts
@@ -1,8 +1,10 @@
 import { addCDKResourceDependency, AmplifyResourceProps } from '@aws-amplify/amplify-category-custom';
 import { getProjectInfo } from './helpers/project-info';
+import { getVmSandbox } from './helpers/vm-sandbox';
 export { AmplifyApiGraphQlResourceStackTemplate } from './types/api/amplify-api-resource-stack-types';
 export { AmplifyApiRestResourceStackTemplate, ApigwPathPolicy } from './types/api/types';
 export { AmplifyAuthCognitoStackTemplate, AmplifyUserPoolGroupStackTemplate } from './types/auth/types';
 export { AmplifyRootStackTemplate } from './types/project/types';
 export { AmplifyCDKL1, AmplifyDDBResourceTemplate, AmplifyS3ResourceTemplate } from './types/storage/types';
-export { getProjectInfo, addCDKResourceDependency as addResourceDependency, AmplifyResourceProps };
+export { getVmSandbox, getProjectInfo, addCDKResourceDependency as addResourceDependency, AmplifyResourceProps };
+export type { AmplifyProjectInfo } from './types';

--- a/packages/amplify-cli-extensibility-helper/src/types.ts
+++ b/packages/amplify-cli-extensibility-helper/src/types.ts
@@ -2,3 +2,38 @@ export type AmplifyProjectInfo = {
   envName: string;
   projectName: string;
 };
+
+export type AmplifyVmSandboxEnv = {
+  _BUILD_TIMEOUT?: string;
+  _LIVE_UPDATES?: string;
+  AMPLIFY_AMAZON_CLIENT_ID?: string;
+  AMPLIFY_BACKEND_APP_ID?: string;
+  AMPLIFY_BACKEND_PULL_ONLY?: string;
+  AMPLIFY_DIFF_BACKEND?: string;
+  AMPLIFY_DIFF_DEPLOY?: string;
+  AMPLIFY_DIFF_DEPLOY_ROOT?: string;
+  AMPLIFY_FACEBOOK_CLIENT_ID?: string;
+  AMPLIFY_GOOGLE_CLIENT_ID?: string;
+  AMPLIFY_IDENTITYPOOL_ID?: string;
+  AMPLIFY_MONOREPO_APP_ROOT?: string;
+  AMPLIFY_NATIVECLIENT_ID?: string;
+  AMPLIFY_SKIP_BACKEND_BUILD?: string;
+  AMPLIFY_USERPOOL_ID?: string;
+  AMPLIFY_WEBCLIENT_ID?: string;
+  AWS_APP_ID?: string;
+  AWS_BRANCH?: string;
+  AWS_BRANCH_ARN?: string;
+  AWS_CLONE_URL?: string;
+  AWS_COMMIT_ID?: string;
+  AWS_JOB_ID?: string;
+  [key: string]: string | undefined;
+}
+
+export type AmplifyVmSandbox = {
+  env: AmplifyVmSandboxEnv,
+  projectInfo: AmplifyProjectInfo
+}
+
+export type VmSandbox = {
+  amplify: AmplifyVmSandbox
+}

--- a/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer-override.test.ts
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer-override.test.ts
@@ -2,6 +2,18 @@ import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
 import * as path from 'path';
 import { FunctionTransformer } from '..';
+
+const getVmSandbox = jest.fn();
+jest.mock('@aws-amplify/cli-extensibility-helper', () => {
+  return {
+    getVmSandbox: () => getVmSandbox(),
+  }
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
 test('it ovderrides the expected resources', () => {
   const validSchema = `
     type Query {
@@ -24,4 +36,5 @@ test('it ovderrides the expected resources', () => {
   const stack = out.stacks.FunctionDirectiveStack;
   expect(stack).toBeDefined();
   expect(stack).toMatchSnapshot();
+  expect(getVmSandbox).toHaveBeenCalledTimes(1);
 });

--- a/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer-override.test.ts
+++ b/packages/amplify-graphql-http-transformer/src/__tests__/amplify-graphql-http-transformer-override.test.ts
@@ -1,7 +1,19 @@
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
-import { HttpTransformer } from '..';
 import path from 'path';
+import { HttpTransformer } from '..';
+
+const getVmSandbox = jest.fn();
+jest.mock('@aws-amplify/cli-extensibility-helper', () => {
+  return {
+    getVmSandbox: () => getVmSandbox(),
+  }
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
 test('it generates the overrided resources', () => {
   const validSchema = /* GraphQL */ `
     type Comment {
@@ -27,4 +39,5 @@ test('it generates the overrided resources', () => {
   parse(out.schema);
   const stack = out.stacks.HttpStack;
   expect(stack).toMatchSnapshot();
+  expect(getVmSandbox).toBeCalledTimes(1);
 });

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer-override.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer-override.test.ts
@@ -9,7 +9,18 @@ const featureFlags = {
   getString: jest.fn(),
 };
 
+const getVmSandbox = jest.fn();
+jest.mock('@aws-amplify/cli-extensibility-helper', () => {
+  return {
+    getVmSandbox: () => getVmSandbox(),
+  }
+});
+
 describe('ModelTransformer: ', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should override  model objects when given override config', () => {
     const validSchema = `
       type Post @model {
@@ -37,5 +48,6 @@ describe('ModelTransformer: ', () => {
 
     expect(postStack).toMatchSnapshot();
     expect(commentStack).toMatchSnapshot();
+    expect(getVmSandbox).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer-override.test.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer-override.test.ts
@@ -2,6 +2,17 @@ import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import * as path from 'path';
 import { PredictionsTransformer } from '..';
 
+const getVmSandbox = jest.fn();
+jest.mock('@aws-amplify/cli-extensibility-helper', () => {
+  return {
+    getVmSandbox: () => getVmSandbox(),
+  }
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
 test('it generates resources with overrides', () => {
   const validSchema = /* GraphQL */ `
     type Query {
@@ -21,4 +32,5 @@ test('it generates resources with overrides', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   expect(out.stacks).toMatchSnapshot();
+  expect(getVmSandbox).toHaveBeenCalledTimes(1);
 });

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
@@ -16,7 +16,19 @@ const featureFlags = {
   getString: jest.fn(),
 };
 
+
+const getVmSandbox = jest.fn();
+jest.mock('@aws-amplify/cli-extensibility-helper', () => {
+  return {
+    getVmSandbox: () => getVmSandbox(),
+  }
+});
+
 test('it overrides expected resources', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   const validSchema = `
     type Post @model @searchable {
         id: ID!
@@ -111,4 +123,5 @@ test('it overrides expected resources', () => {
       ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
     }),
   );
+  expect(getVmSandbox).toHaveBeenCalledTimes(1);
 });

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -27,6 +27,7 @@
         "test": "jest"
     },
     "dependencies": {
+        "@aws-amplify/cli-extensibility-helper": "^2.3.3",
         "@aws-amplify/graphql-transformer-interfaces": "1.12.3",
         "@aws-cdk/assets": "~1.124.0",
         "@aws-cdk/aws-applicationautoscaling": "~1.124.0",

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts.sample
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts.sample
@@ -1,5 +1,10 @@
+// This file is used to override the Root Stack resources configuration
+import type { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyRootStackTemplate) {
-    
+  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
+  if (projectInfo.envName === 'production') {
+    // ... override for production
+  }
 }

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -1,4 +1,4 @@
-import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyRootStackTemplate, getVmSandbox } from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from '@aws-cdk/core';
 import { $TSAny, $TSContext, buildOverrideDir, CFNTemplateFormat, pathManager, Template, writeCFNTemplate } from 'amplify-cli-core';
 import { printer, formatter } from 'amplify-prompts';
@@ -59,10 +59,12 @@ export class AmplifyRootStackTransform {
         formatter.list(['No override File Found', `To override ${this._resourceName} run amplify override auth`]);
         return '';
       });
+
+      const sandbox = getVmSandbox();
       const sandboxNode = new vm.NodeVM({
         console: 'inherit',
         timeout: 5000,
-        sandbox: {},
+        sandbox,
         require: {
           context: 'sandbox',
           builtin: ['path'],


### PR DESCRIPTION
#### Description of changes

Calling `getProjectInfo()` with the current sandbox implementation is currently not possible.  
> TL;DR It looks like it would require removal of the sandbox and a proxy.

I went ahead and attempted to add in the required builtins info to the vm2 sandbox, starting with `os` and ended at `events` which has has [an open issue](https://github.com/patriksimek/vm2/issues/216) that has existed for a couple of years without a proper solution.  The full list that I ended with, before running into the issue with events was: `[ 'assert', 'events', 'fs', 'os', 'path', 'tty', 'util' ]`

As an alternative to removing the vm2 sandbox and proxying I am proposing to provide the output of getProjectInfo() into the vm, making it available within `global.amplify`.

These changes will:

- Provide the output of `getProjectInfo()` available within `override.ts` for each category that currently supports it.
- Provide a filtered `process.env`
    - Limited to `AWS_*`, `AMPLIFY_*`
    - Excludes `AWS_ACCESS_KEY_ID`
    - Excludes variables that contain `SECRET` in their name (case insensitive)


#### Issue #, if available

#9063 

#### Description of how you validated changes

Locally ran `amplify-dev build` to validate that the newly added information was available within `override.ts` of an AppSync api.

<details>
<summary><code>override.ts</code></summary>

```typescript
import { AmplifyApiGraphQlResourceStackTemplate, getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
import { AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper/lib/types';

export function override(resources: AmplifyApiGraphQlResourceStackTemplate): void {
  const projectInfo: AmplifyProjectInfo = global.amplify.projectInfo;
  const env = global.amplify.env;
  console.log(`projectInfo: ${JSON.stringify(projectInfo)}`);
  console.log(`env: ${JSON.stringify(env)}`);
}
```
</details>

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
    - coming soon
- ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
