### PR TITLE
fix: #9061 secret migration could fail and --yes was not working

### DIFF
--- a/packages/amplify-cli-core/src/deploymentSecretsHelper.ts
+++ b/packages/amplify-cli-core/src/deploymentSecretsHelper.ts
@@ -9,8 +9,11 @@ export const mergeDeploymentSecrets = (deploymentSecretsModifier: deploymentSecr
     environments: {},
   };
   _.set(newDeploymentAppSecret, ['environments', envName, category, resource, keyName], value);
+
+  const filteredSecrets = currentDeploymentSecrets.appSecrets?.filter(appSecret => appSecret.rootStackId !== rootStackId) || [];
+
   return {
-    appSecrets: [...currentDeploymentSecrets.appSecrets.filter(appSecret => appSecret.rootStackId !== rootStackId), newDeploymentAppSecret],
+    appSecrets: [...filteredSecrets, newDeploymentAppSecret],
   };
 };
 
@@ -20,7 +23,8 @@ export const removeFromDeploymentSecrets = (deploymentSecretsModifier: deploymen
   if (secretsByAppId) {
     recursiveOmit(secretsByAppId.environments, [envName, category, resource, keyName]);
     if (Object.keys(secretsByAppId.environments).length === 0) {
-      currentDeploymentSecrets.appSecrets = currentDeploymentSecrets.appSecrets.filter(r => r.rootStackId !== rootStackId);
+      currentDeploymentSecrets.appSecrets =
+        currentDeploymentSecrets.appSecrets?.filter(appSecret => appSecret.rootStackId !== rootStackId) || [];
     }
   }
   return currentDeploymentSecrets;

--- a/packages/amplify-cli/src/input-params-manager.ts
+++ b/packages/amplify-cli/src/input-params-manager.ts
@@ -1,6 +1,6 @@
-import { $TSAny, $TSContext, JSONUtilities } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSObject, JSONUtilities } from 'amplify-cli-core';
 
-export function normalizeInputParams(context: $TSContext) {
+export function normalizeInputParams(context: $TSContext): $TSObject {
   const inputParams = {};
   Object.keys(context.parameters.options).forEach(key => {
     const normalizedKey = normalizeKey(key);

--- a/packages/amplify-cli/src/utils/headless-input-utils.ts
+++ b/packages/amplify-cli/src/utils/headless-input-utils.ts
@@ -1,5 +1,4 @@
 import readline from 'readline';
-import _ from 'lodash';
 import { Context } from '../domain/context';
 import { normalizeInputParams } from '../input-params-manager';
 import { $TSContext } from 'amplify-cli-core';

--- a/packages/amplify-cli/src/utils/headless-input-utils.ts
+++ b/packages/amplify-cli/src/utils/headless-input-utils.ts
@@ -1,5 +1,8 @@
 import readline from 'readline';
+import _ from 'lodash';
 import { Context } from '../domain/context';
+import { normalizeInputParams } from '../input-params-manager';
+import { $TSContext } from 'amplify-cli-core';
 
 const headlessPayloadReadTimeoutMillis = 2000;
 
@@ -29,4 +32,13 @@ export const readHeadlessPayload = async (): Promise<string> => {
   });
 };
 
-export const isYesFlagSet = (context: Context): boolean => context?.exeInfo?.inputParams?.yes;
+export const isYesFlagSet = (context: Context): boolean => {
+  if (context?.exeInfo?.inputParams) {
+    return context.exeInfo.inputParams.yes;
+  }
+
+  // No exeInfo is constructed, get the yes flag from the input directly.
+  const inputParams = normalizeInputParams(context as unknown as $TSContext);
+
+  return inputParams?.yes;
+};

--- a/packages/amplify-cli/src/utils/team-provider-migrate.ts
+++ b/packages/amplify-cli/src/utils/team-provider-migrate.ts
@@ -9,7 +9,7 @@ import { moveSecretsFromTeamProviderToDeployment } from './move-secrets-to-deplo
 const message = `Amplify has been upgraded to handle secrets more securely by migrating some values in ${chalk.red(
   PathConstants.TeamProviderInfoFileName,
 )} to ${chalk.green(PathConstants.DeploymentSecretsFileName)}
-You can create a back up of the ${chalk.red(PathConstants.TeamProviderInfoFileName)} file before proceeding.`;
+You can create a backup of the ${chalk.red(PathConstants.TeamProviderInfoFileName)} file before proceeding.`;
 const hostedUIProviderCredsField = 'hostedUIProviderCreds';
 
 // return true if the current state of the app does not contain secrets in the team provider info


### PR DESCRIPTION
#### Description of changes

Fix an issue when secret migration could fail when `~/.aws/amplify/deployment-secrets.json` does not have an `appSecrets` property persisted.
Fix the `--yes` flag usage as `exeInfo` is not initialized when this prompt was executing.

#### Issue #, if available

Fixes #9061

#### Description of how you validated changes

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
