### PR TITLE
fix: removing old FF logic for extensibility

### DIFF
--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -40,32 +40,6 @@ export function isContainersEnabled(context) {
 }
 
 async function selectPluginForExecution(context: Context, pluginCandidates: PluginInfo[]): Promise<PluginInfo> {
-  const pluginCandidatesCategorySet = new Set<string>();
-
-  pluginCandidates.forEach(plugin => {
-    pluginCandidatesCategorySet.add(plugin.manifest.name);
-  });
-
-  // overrided packageName format : @aws-amplify/amplify-category-<catgoryName>
-  const pluginName = pluginCandidatesCategorySet.values().next().value;
-  if (pluginCandidatesCategorySet.size == 1 && overriddenCategories.includes(pluginName)) {
-    if (FeatureFlags.getBoolean(`overrides.${pluginName}`)) {
-      const pluginWithOverrides = pluginCandidates.find(plugin => {
-        return plugin.packageName === `@aws-amplify/amplify-category-${pluginName}`;
-      });
-      if (pluginWithOverrides !== undefined) {
-        return pluginWithOverrides;
-      }
-    } else {
-      const pluginWithOutOverrides = pluginCandidates.find(plugin => {
-        return plugin.packageName === `amplify-category-${pluginName}`;
-      });
-      if (pluginCandidates.length === 2 && pluginWithOutOverrides !== undefined) {
-        return pluginWithOutOverrides;
-      }
-    }
-  }
-
   let result = pluginCandidates[0];
 
   let promptForSelection = true;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Removing the logic selecting overrides package for extensibility since  we changed the actual package to contain overrides.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #9165

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- tested manually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
