### PR TITLE
fix: append missing env vars in team provider on push

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
@@ -1,31 +1,27 @@
-import { $TSContext } from 'amplify-cli-core';
 import {
+  ensureEnvironmentVariableValues,
   getStoredEnvironmentVariables,
   saveEnvironmentVariables,
 } from '../../../../provider-utils/awscloudformation/utils/environmentVariablesHelper';
 
-const context_stub = {
-  amplify: {
-    getEnvInfo: () => ({ envName: 'dev' }),
-  },
-} as $TSContext;
+import { stateManager, pathManager, JSONUtilities, $TSContext } from 'amplify-cli-core';
+import { prompter } from 'amplify-prompts';
 
-jest.mock('amplify-cli-core', () => ({
-  stateManager: {
-    getTeamProviderInfo: jest.fn().mockReturnValue(''),
-    setTeamProviderInfo: jest.fn().mockReturnValue(''),
-    getLocalEnvInfo: jest.fn().mockReturnValue({ envName: 'testenv' }),
-  },
-  pathManager: {
-    findProjectRoot: jest.fn().mockReturnValue(''),
-    getBackendDirPath: jest.fn().mockReturnValue(''),
-    getTeamProviderInfoFilePath: jest.fn().mockReturnValue(''),
-  },
-  JSONUtilities: {
-    readJson: jest.fn().mockRejectedValue(''),
-    writeJson: jest.fn().mockRejectedValue(''),
-  },
-}));
+jest.mock('amplify-cli-core');
+jest.mock('amplify-prompts');
+
+const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
+const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
+const JSONUtilities_mock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
+const prompter_mock = prompter as jest.Mocked<typeof prompter>;
+
+stateManager_mock.getLocalEnvInfo.mockReturnValue({ envName: 'testenv' });
+
+pathManager_mock.findProjectRoot.mockReturnValue('');
+pathManager_mock.getBackendDirPath.mockReturnValue('');
+pathManager_mock.getTeamProviderInfoFilePath.mockReturnValue('');
+
+beforeEach(() => jest.clearAllMocks());
 
 describe('getStoredEnvironmentVariables', () => {
   it('does not throw error', () => {
@@ -36,7 +32,49 @@ describe('getStoredEnvironmentVariables', () => {
 describe('deleteEnvironmentVariable', () => {
   it('does not throw error', () => {
     expect(() => {
-      saveEnvironmentVariables(context_stub, 'name', { test: 'test' });
+      saveEnvironmentVariables('name', { test: 'test' });
     }).not.toThrow();
+  });
+});
+
+describe('ensureEnvironmentVariableValues', () => {
+  it('appends to existing env vars', async () => {
+    stateManager_mock.getTeamProviderInfo.mockReturnValue({
+      testenv: {
+        categories: {
+          function: {
+            testfunc: {
+              envVarOne: 'testval1',
+            },
+          },
+        },
+      },
+    });
+
+    JSONUtilities_mock.readJson.mockReturnValueOnce({
+      environmentVariableList: [
+        {
+          cloudFormationParameterName: 'envVarOne',
+          environmentVariableName: 'envVarOne',
+        },
+        {
+          cloudFormationParameterName: 'envVarTwo',
+          environmentVariableName: 'envVarTwo',
+        },
+        {
+          cloudFormationParameterName: 'envVarThree',
+          environmentVariableName: 'envVarThree',
+        },
+      ],
+    });
+
+    prompter_mock.input.mockResolvedValueOnce('testVal2').mockResolvedValueOnce('testVal3');
+
+    await ensureEnvironmentVariableValues({ usageData: { emitError: jest.fn() } } as $TSContext);
+    expect(stateManager_mock.setTeamProviderInfo.mock.calls[0][1].testenv.categories.function.testfunc).toEqual({
+      envVarOne: 'testval1',
+      envVarTwo: 'testVal2',
+      envVarThree: 'testVal3',
+    });
   });
 });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import _ from 'lodash';
 import uuid from 'uuid';
 import inquirer from 'inquirer';
-import { $TSContext, stateManager, pathManager, JSONUtilities, exitOnNextTick } from 'amplify-cli-core';
+import { $TSContext, stateManager, pathManager, JSONUtilities, exitOnNextTick, isCI } from 'amplify-cli-core';
 import { functionParametersFileName } from './constants';
 import { categoryName } from '../../../constants';
 import { formatter, maxLength, printer, prompter } from 'amplify-prompts';
@@ -190,7 +190,7 @@ export const ensureEnvironmentVariableValues = async (context: $TSContext) => {
 
   // there are some missing env vars
 
-  if (yesFlagSet) {
+  if (yesFlagSet || isCI()) {
     // in this case, we can't prompt for missing values, so fail gracefully
     const errMessage = `Cannot push Amplify environment "${currentEnvName}" due to missing Lambda function environment variable values. Rerun 'amplify push' without '--yes' to fix.`;
     printer.error(errMessage);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
@@ -5,6 +5,7 @@ import inquirer from 'inquirer';
 import { $TSContext, stateManager, pathManager, JSONUtilities, exitOnNextTick } from 'amplify-cli-core';
 import { functionParametersFileName } from './constants';
 import { categoryName } from '../../../constants';
+import { formatter, maxLength, printer, prompter } from 'amplify-prompts';
 
 export const validKey = new RegExp(/^[a-zA-Z0-9_]+$/);
 
@@ -34,13 +35,13 @@ export const getStoredEnvironmentVariables = (resourceName: string, currentEnvNa
   return environmentVariables;
 };
 
-export const saveEnvironmentVariables = (context: $TSContext, resourceName: string, newEnvironmentVariables: Record<string, string>) => {
+export const saveEnvironmentVariables = (resourceName: string, newEnvironmentVariables: Record<string, string>) => {
   const currentEnvironmentVariables = getStoredEnvironmentVariables(resourceName);
   _.each(currentEnvironmentVariables, (_, key) => {
     deleteEnvironmentVariable(resourceName, key);
   });
   _.each(newEnvironmentVariables, (value, key) => {
-    setEnvironmentVariable(context, resourceName, key, value);
+    setEnvironmentVariable(resourceName, key, value);
   });
 };
 
@@ -170,55 +171,52 @@ export const ensureEnvironmentVariableValues = async (context: $TSContext) => {
   if (functionNames.length === 0) {
     return;
   }
-  let printedMessage = false;
 
-  for (const functionName of functionNames) {
-    const storedList = getStoredList(functionName);
-    const storedKeyValue = getStoredKeyValue(functionName);
-    for (const item of storedList) {
-      const envName = item.environmentVariableName;
-      const keyName = item.cloudFormationParameterName;
-      if (storedKeyValue.hasOwnProperty(keyName)) continue;
-      if (!printedMessage) {
-        if (yesFlagSet) {
-          const errMessage = `An error occurred pushing an env "${currentEnvName}" due to missing environment variable values`;
-          context.print.error(errMessage);
-          await context.usageData.emitError(new Error(errMessage));
-          exitOnNextTick(1);
-        } else {
-          context.print.info('');
-          context.print.info('Some Lambda function environment variables are defined but missing values.');
-          context.print.info('');
-        }
-        printedMessage = true;
-      }
-
-      const newValueQuestion: inquirer.InputQuestion = {
-        type: 'input',
-        name: 'newValue',
-        message: `Enter the missing environment variable value of ${envName} in ${functionName}:`,
-        validate: input => {
-          if (input.length >= 2048) {
-            return 'The value must be 2048 characters or less';
-          }
-          return true;
-        },
+  const funcConfigMissingEnvVars = functionNames
+    .map(funcName => {
+      const storedList = getStoredList(funcName);
+      const keyValues = getStoredKeyValue(funcName);
+      return {
+        funcName,
+        existingKeyValues: keyValues,
+        missingEnvVars: storedList.filter(({ cloudFormationParameterName: keyName }) => !keyValues.hasOwnProperty(keyName)),
       };
-      const { newValue } = await inquirer.prompt(newValueQuestion);
-      setStoredKeyValue(functionName, {
-        ...storedKeyValue,
-        [keyName]: newValue,
+    })
+    .filter(envVars => envVars.missingEnvVars.length);
+
+  if (!funcConfigMissingEnvVars.length) {
+    return;
+  }
+
+  // there are some missing env vars
+
+  if (yesFlagSet) {
+    // in this case, we can't prompt for missing values, so fail gracefully
+    const errMessage = `Cannot push Amplify environment "${currentEnvName}" due to missing Lambda function environment variable values. Rerun 'amplify push' without '--yes' to fix.`;
+    printer.error(errMessage);
+    const missingEnvVarsMessage = funcConfigMissingEnvVars
+      .flatMap(({ missingEnvVars, funcName }) => missingEnvVars.map(missing => ({ ...missing, funcName: funcName })))
+      .map(({ funcName, environmentVariableName: envName }) => `Missing value for ${envName} in ${funcName} function`);
+    formatter.list(missingEnvVarsMessage);
+    await context.usageData.emitError(new Error(errMessage));
+    exitOnNextTick(1);
+  }
+
+  printer.info('Some Lambda function environment variables are missing values in this Amplify environment.');
+
+  // prompt for the missing env vars
+  for (const { funcName, existingKeyValues: keyValues, missingEnvVars } of funcConfigMissingEnvVars) {
+    for (const { cloudFormationParameterName: cfnName, environmentVariableName: envName } of missingEnvVars) {
+      const newValue = await prompter.input(`Enter the missing environment variable value of ${envName} in ${funcName}:`, {
+        validate: maxLength(2048),
       });
+      keyValues[cfnName] = newValue;
     }
+    setStoredKeyValue(funcName, keyValues);
   }
 };
 
-const setEnvironmentVariable = (
-  context: $TSContext,
-  resourceName: string,
-  newEnvironmentVariableKey: string,
-  newEnvironmentVariableValue: string,
-): void => {
+const setEnvironmentVariable = (resourceName: string, newEnvironmentVariableKey: string, newEnvironmentVariableValue: string): void => {
   const newList = getStoredList(resourceName);
   const newReferences = getStoredReferences(resourceName);
   const newParameters = getStoredParameters(resourceName);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -103,7 +103,7 @@ export async function saveMutableState(
     | FunctionTriggerParameters,
 ) {
   createParametersFile(buildParametersFileObj(parameters), parameters.resourceName || parameters.functionName, functionParametersFileName);
-  saveEnvironmentVariables(context, parameters.resourceName, parameters.environmentVariables);
+  saveEnvironmentVariables(parameters.resourceName, parameters.environmentVariables);
   await syncSecrets(context, parameters);
 }
 

--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -15,6 +15,7 @@ export * from './tags';
 export * from './errors';
 export * from './exitOnNextTick';
 export * from './isPackaged';
+export * from './isCI';
 export * from './cliConstants';
 export * from './deploymentSecretsHelper';
 export * from './deploymentState';

--- a/packages/amplify-cli-core/src/isCI.ts
+++ b/packages/amplify-cli-core/src/isCI.ts
@@ -1,0 +1,9 @@
+import ci from 'ci-info';
+
+/**
+ * Determine if the CLI is running in a CI/CD environment or not.
+ * Currently this is just a proxy to ci-info but we may want to include other signals in the future
+ */
+export const isCI = () => {
+  return ci.isCI;
+};

--- a/packages/amplify-cli-core/src/utils/open.ts
+++ b/packages/amplify-cli-core/src/utils/open.ts
@@ -1,5 +1,5 @@
 import opn from 'open';
-import ciInfo from 'ci-info';
+import { isCI } from '..';
 import { ChildProcess } from 'child_process';
 
 /**
@@ -9,7 +9,7 @@ import { ChildProcess } from 'child_process';
  * @param options
  */
 export const open = (target: string, options: opn.Options): Promise<ChildProcess | void> => {
-  if (ciInfo.isCI) {
+  if (isCI()) {
     return Promise.resolve();
   }
   return opn(target, options);

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import { Input } from '../input';
 import { getLatestPayloadVersion } from './VersionManager';
-import ci from 'ci-info';
+import { isCI } from 'amplify-cli-core';
 export class UsageDataPayload {
   sessionUuid: string;
   installationUuid: string;
@@ -42,7 +42,7 @@ export class UsageDataPayload {
     this.state = state;
     this.payloadVersion = getLatestPayloadVersion();
     this.accountId = accountId;
-    this.isCi = ci.isCI;
+    this.isCi = isCI();
     this.projectSetting = project;
     this.inputOptions = inputOptions;
     this.record = record;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a bug in the logic to fill in missing function env vars during push. The existing logic would only write the last env var to team provider rather than all of them. Also cleaned up some low-hanging fruit in the surrounding code.
#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/8111
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
manually tested and added unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
