### PR TITLE
[Fix] OpenSearch 7.10+ Removal of mapping types

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -1044,7 +1044,7 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Query.searchPosts.req.vtl": "#set( $indexPath = \\"/post/doc/_search\\" )
+  "Query.searchPosts.req.vtl": "#set( $indexPath = \\"/post/_doc/_search\\" )
 #set( $allowedAggFields = $util.defaultIfNull($ctx.stash.allowedAggFields, []) )
 #set( $aggFieldsFilterMap = $util.defaultIfNull($ctx.stash.aggFieldsFilterMap, {}) )
 #set( $nonKeywordFields = [] )

--- a/packages/amplify-graphql-searchable-transformer/src/generate-resolver-vtl.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/generate-resolver-vtl.ts
@@ -31,7 +31,7 @@ const allowedAggFieldsList = 'allowedAggFields';
 export function requestTemplate(primaryKey: string, nonKeywordFields: Expression[], includeVersion: boolean = false, type: string, keyFields: Expression[] = []): string {
   return print(
     compoundExpression([
-      set(ref('indexPath'), str(`/${type.toLowerCase()}/doc/_search`)),
+      set(ref('indexPath'), str(`/${type.toLowerCase()}/_doc/_search`)),
       set(ref('allowedAggFields'), methodCall(ref('util.defaultIfNull'), ref('ctx.stash.allowedAggFields'), list([]))),
       set(ref('aggFieldsFilterMap'), methodCall(ref('util.defaultIfNull'), ref('ctx.stash.aggFieldsFilterMap'), obj({}))),
       set(ref('nonKeywordFields'), list(nonKeywordFields)),

--- a/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
+++ b/packages/amplify-graphql-searchable-transformer/streaming-lambda/python_streaming_function.py
@@ -20,8 +20,8 @@ OPENSEARCH_REGION = os.environ['OPENSEARCH_REGION']
 DEBUG = True if os.environ['DEBUG'] == "1" else False
 OPENSEARCH_USE_EXTERNAL_VERSIONING = True if os.environ['OPENSEARCH_USE_EXTERNAL_VERSIONING'] == "true" else False
 
-# Multiple mapping types in an index is deprecated. Default to doc.
-DOC_TYPE = 'doc'
+# Multiple mapping types in an index is deprecated in OpenSearch ver 7.10+. Default to _doc.
+DOC_TYPE = '_doc'
 OPENSEARCH_MAX_RETRIES = 3 # Max number of retries for exponential backoff
 
 logger = logging.getLogger()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Indices created in Elasticsearch 7.0.0 or later no longer accept a _default_ mapping. Indices created in 6.x will continue to function as before in Elasticsearch 6.x. Types are deprecated in APIs in 7.0, with breaking changes to the index creation, put mapping, get mapping, put template, get template and get field mappings APIs.

Specifying types in requests is deprecated. For instance, indexing a document no longer requires a document type. The new index APIs are PUT {index}/_doc/{id} in case of explicit ids and POST {index}/_doc for auto-generated ids. Note that in 7.0, _doc is a permanent part of the path, and represents the endpoint name rather than the document type.

[Removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/7.1/removal-of-types.html)

- Updated the searchable resolver template index path to `{indexName}/_doc/_search`
- Updated OpenSearch Streaming Lambda default `DOC_TYPE` to `_doc`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

#9263 
https://github.com/aws-amplify/amplify-cli/issues/9263#issue-1074877947

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
