### PR TITLE
fix: improve api migration logic, update migration prompt

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -73,8 +73,9 @@ export async function migrate(context: $TSContext, serviceName?: string) {
       }
     }
   }
-
-  await Promise.all(migrateResourcePromises);
+  for (const migrateResourcePromise of migrateResourcePromises) {
+    await migrateResourcePromise;
+  }
 }
 
 export async function initEnv(context: $TSContext) {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/apigw-input-state.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/apigw-input-state.ts
@@ -153,11 +153,15 @@ export class ApigwInputState {
       return Array.from(new Set(deprecatedPrivacyArray.map(op => opMap[op])));
     }
 
+    if (!Array.isArray(deprecatedParameters.paths) || deprecatedParameters.paths.length < 1) {
+      throw new Error(`Expected paths to be defined in "${deprecatedParametersFilePath}", but none found.`);
+    }
+
     deprecatedParameters.paths.forEach((path: $TSObject) => {
       let pathPermissionSetting =
-        path.privacy.open === true
+        path.privacy?.open === true
           ? PermissionSetting.OPEN
-          : path.privacy.private === true
+          : path.privacy?.private === true
           ? PermissionSetting.PRIVATE
           : PermissionSetting.PROTECTED;
 
@@ -165,15 +169,15 @@ export class ApigwInputState {
       let guest;
       let groups;
       // convert deprecated permissions to CRUD structure
-      if (typeof path.privacy.auth === 'string' && ['r', 'rw'].includes(path.privacy.auth)) {
+      if (typeof path.privacy?.auth === 'string' && ['r', 'rw'].includes(path.privacy.auth)) {
         auth = _convertDeprecatedPermissionStringToCRUD(path.privacy.auth);
-      } else if (Array.isArray(path.privacy.auth)) {
+      } else if (Array.isArray(path.privacy?.auth)) {
         auth = _convertDeprecatedPermissionArrayToCRUD(path.privacy.auth);
       }
 
-      if (typeof path.privacy.unauth === 'string' && ['r', 'rw'].includes(path.privacy.unauth)) {
+      if (typeof path.privacy?.unauth === 'string' && ['r', 'rw'].includes(path.privacy.unauth)) {
         guest = _convertDeprecatedPermissionStringToCRUD(path.privacy.unauth);
-      } else if (Array.isArray(path.privacy.unauth)) {
+      } else if (Array.isArray(path.privacy?.unauth)) {
         guest = _convertDeprecatedPermissionArrayToCRUD(path.privacy.unauth);
       }
 

--- a/packages/amplify-cli-core/src/overrides-manager/migration-message.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/migration-message.ts
@@ -6,14 +6,19 @@ export function getMigrateResourceMessageForOverride(categoryName: string, resou
 
   if (isUpdate) {
     return [
+      '',
       `A migration is needed to support latest updates on ${categoryName} resources.`,
       chalk.red(`Recommended to try in a non-production environment first. Run "amplify env add" to create or clone an environment.`),
+      chalk.red(
+        `Custom cloudformation changes will NOT be preserved. Custom changes can be made with "amplify ${categoryName} override" after migration.`,
+      ),
       `Learn more about this migration: ${docsLink}`,
       `Do you want to migrate ${categoryName} resource "${resourceName}"?`,
     ].join(EOL);
   }
 
   return [
+    '',
     `A migration is needed to override ${categoryName} resources.`,
     chalk.red(`Recommended to try in a non-production environment first. Run "amplify env add" to create or clone an environment.`),
     `Learn more about this migration: ${docsLink}`,

--- a/packages/amplify-cli-core/src/overrides-manager/migration-message.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/migration-message.ts
@@ -10,7 +10,7 @@ export function getMigrateResourceMessageForOverride(categoryName: string, resou
       `A migration is needed to support latest updates on ${categoryName} resources.`,
       chalk.red(`Recommended to try in a non-production environment first. Run "amplify env add" to create or clone an environment.`),
       chalk.red(
-        `Custom cloudformation changes will NOT be preserved. Custom changes can be made with "amplify ${categoryName} override" after migration.`,
+        `Custom CloudFormation changes will NOT be preserved. Custom changes can be made with "amplify ${categoryName} override" after migration.`,
       ),
       `Learn more about this migration: ${docsLink}`,
       `Do you want to migrate ${categoryName} resource "${resourceName}"?`,
@@ -21,6 +21,7 @@ export function getMigrateResourceMessageForOverride(categoryName: string, resou
     '',
     `A migration is needed to override ${categoryName} resources.`,
     chalk.red(`Recommended to try in a non-production environment first. Run "amplify env add" to create or clone an environment.`),
+    chalk.red(`Custom CloudFormation changes will NOT be preserved, but they can be reintroduced in the override.ts file.`),
     `Learn more about this migration: ${docsLink}`,
     `Do you want to migrate ${categoryName} resource "${resourceName}" to support overrides?`,
   ].join(EOL);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Update extensibility migration message to include a note that custom modifications to a CloudFormation template will not be preserved.
- Make REST API migration logic more robust to variable input from `api-params.json` and provide a better error message when no paths are defined.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/9225

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`apigw-ext-migration.test.ts`  passes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
