### PR TITLE
fix(amplify-util-mock): correct mock env variable name to match name …

### DIFF
--- a/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts
@@ -43,7 +43,7 @@ const getStaticDefaults = (): Record<string, string> => ({
   AWS_LAMBDA_FUNCTION_VERSION: '1',
   AWS_LAMBDA_INITIALIZATION_TYPE: 'on-demand',
   AWS_LAMBDA_LOG_GROUP_NAME: 'amplify-mock-aws-lambda-log-group-name',
-  AWS_LAMBDA_LOG_GROUP_STREAM_NAME: 'amplify-mock-aws-lambda-log-group-stream-name',
+  AWS_LAMBDA_LOG_STREAM_NAME: 'amplify-mock-aws-lambda-log-stream-name',
   TZ: 'UTC',
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Updates the mock static environment variable AWS_LAMBDA_LOG_GROUP_STREAM_NAME to match the runtime environment variable AWS_LAMBDA_LOG_STREAM_NAME. The naming mismatch can lead to unexpected errors while mocking or at runtime if the function expects the env variable to have a value.

There is no indication that the current variable name was ever used except in this mocking context.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

No existing issue.

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Compared value of process.env from mock execution with value of process.env from deployed execution. Mock env variable names now match and error is not thrown in code that relies on the existence of AWS_LAMBDA_LOG_STREAM_NAME.

Executed yarn test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
