### PR TITLE
fix(graphql-model-transformer): add id field to update input objects

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1312,4 +1312,30 @@ describe('ModelTransformer: ', () => {
     expect(subscriptionType!.fields!.length).toEqual(3);
     expectFields(subscriptionType!, ['onFeedCreated', 'onFeedUpdated', 'onFeedDeleted']);
   });
+
+  it('should generate id for the update input object', async () => {
+    const validSchema = `
+      type Todo @model {
+        uid: String!
+        username: String
+      }
+    `;
+
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer()],
+      featureFlags,
+    });
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    const definition = out.schema;
+    expect(definition).toBeDefined();
+
+    const parsed = parse(definition);
+    validateModelSchema(parsed);
+
+    const updateTodoInput = getInputType(parsed, 'UpdateTodoInput');
+    expect(updateTodoInput).toBeDefined();
+
+    expectFieldsOnInputType(updateTodoInput!, ['id']);
+  });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
@@ -44,8 +44,10 @@ export const makeUpdateInputField = (
   // make all the fields optional
   input.fields.forEach(f => f.makeNullable());
 
-  // Add id field and make it optional
-  if (hasIdField) {
+  if (!hasIdField) {
+    // Add id field and make it optional
+    input.addField(InputFieldWrapper.create('id', 'ID', true));
+  } else {
     const idField = input.fields.find(f => f.name === 'id');
     if (idField) {
       idField.makeNonNullable();

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -736,15 +736,41 @@ test('Should not validate reserved type names when validateTypeNameReservedWords
   `;
   const transformer = new GraphQLTransform({
     transformers: [new DynamoDBModelTransformer()],
-    featureFlags: ({
+    featureFlags: {
       getBoolean: jest.fn().mockImplementation(name => (name === 'validateTypeNameReservedWords' ? false : undefined)),
-    } as unknown) as FeatureFlagProvider,
+    } as unknown as FeatureFlagProvider,
   });
   const out = transformer.transform(schema);
   expect(out).toBeDefined();
   const parsed = parse(out.schema);
   const subscriptionType = getObjectType(parsed, 'Subscription');
   expect(subscriptionType).toBeDefined();
+});
+
+it('should generate id for the update input object', async () => {
+  const validSchema = `
+    type Todo @model {
+      uid: String!
+      username: String
+    }
+  `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new DynamoDBModelTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+
+  const definition = out.schema;
+  expect(definition).toBeDefined();
+
+  const parsed = parse(definition);
+
+  const updateTodoInput = getInputType(parsed, 'UpdateTodoInput');
+  expect(updateTodoInput).toBeDefined();
+
+  expectFieldsOnInputType(updateTodoInput!, ['id']);
 });
 
 function transformerVersionSnapshot(version: number): string {

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -227,6 +227,7 @@ export function makeUpdateInputObject(
   isSync: boolean = false,
 ): InputObjectTypeDefinitionNode {
   const name = ModelResourceIDs.ModelUpdateInputObjectName(obj.name.value);
+  const hasIdField = obj.fields.find(f => f.name.value === 'id');
   const fields: InputValueDefinitionNode[] = obj.fields
     .filter(f => {
       const fieldType = ctx.getType(getBaseType(f.type));
@@ -272,7 +273,11 @@ export function makeUpdateInputObject(
       kind: 'Name',
       value: name,
     },
-    fields,
+    fields: [
+      // add default id field and expose that
+      ...(hasIdField ? [] : [makeInputValueDefinition('id', makeNamedType('ID'))]),
+      ...fields,
+    ],
     directives: [],
   };
 }


### PR DESCRIPTION
#### Description of changes
- add id field to update input objects

#### Issue #[9136](https://github.com/aws-amplify/amplify-cli/issues/9136)

#### Description of how you validated changes
- manually
- added unit tests
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
