### PR TITLE
Searchable mock start

### DIFF
--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer-override.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer-override.test.ts.snap
@@ -40,7 +40,7 @@ Object {
           "LambdaConfig": Object {
             "LambdaFunctionArn": Object {
               "Fn::GetAtt": Array [
-                "predictionsLambdahandlerC696C27E",
+                "predictionsLambda8B880A74",
                 "Arn",
               ],
             },
@@ -82,7 +82,7 @@ Object {
                 "Effect": "Allow",
                 "Resource": Object {
                   "Fn::GetAtt": Array [
-                    "predictionsLambdahandlerC696C27E",
+                    "predictionsLambda8B880A74",
                     "Arn",
                   ],
                 },
@@ -108,7 +108,7 @@ Object {
                 "Effect": "Allow",
                 "Resource": Object {
                   "Fn::GetAtt": Array [
-                    "predictionsLambdahandlerC696C27E",
+                    "predictionsLambda8B880A74",
                     "Arn",
                   ],
                 },
@@ -660,6 +660,40 @@ $utils.error($ctx.result.body)
         },
         "Type": "AWS::IAM::Role",
       },
+      "predictionsLambda8B880A74": Object {
+        "DependsOn": Array [
+          "predictionsLambdaIAMRoleB8AC96D3",
+        ],
+        "Properties": Object {
+          "Code": Object {
+            "S3Bucket": Object {
+              "Ref": "referencetotransformerrootstackS3DeploymentBucket7592718ARef",
+            },
+            "S3Key": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "referencetotransformerrootstackS3DeploymentRootKeyA71EA735Ref",
+                  },
+                  "/functions/predictionsLambdaFunction.zip",
+                ],
+              ],
+            },
+          },
+          "FunctionName": "predictionsLambda",
+          "Handler": "predictionsLambda.handler",
+          "Role": Object {
+            "Fn::GetAtt": Array [
+              "predictionsLambdaIAMRoleB8AC96D3",
+              "Arn",
+            ],
+          },
+          "Runtime": "nodejs12.x",
+          "Timeout": 60,
+        },
+        "Type": "AWS::Lambda::Function",
+      },
       "predictionsLambdaIAMRoleB8AC96D3": Object {
         "Properties": Object {
           "AssumeRolePolicyDocument": Object {
@@ -721,39 +755,6 @@ $utils.error($ctx.result.body)
           },
         },
         "Type": "AWS::IAM::Role",
-      },
-      "predictionsLambdahandlerC696C27E": Object {
-        "DependsOn": Array [
-          "predictionsLambdaIAMRoleB8AC96D3",
-        ],
-        "Properties": Object {
-          "Code": Object {
-            "S3Bucket": Object {
-              "Ref": "referencetotransformerrootstackS3DeploymentBucket7592718ARef",
-            },
-            "S3Key": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  Object {
-                    "Ref": "referencetotransformerrootstackS3DeploymentRootKeyA71EA735Ref",
-                  },
-                  "/functions/predictionsLambdaFunction.zip",
-                ],
-              ],
-            },
-          },
-          "Handler": "predictionsLambda.handler",
-          "Role": Object {
-            "Fn::GetAtt": Array [
-              "predictionsLambdaIAMRoleB8AC96D3",
-              "Arn",
-            ],
-          },
-          "Runtime": "nodejs12.x",
-          "Timeout": 60,
-        },
-        "Type": "AWS::Lambda::Function",
       },
       "translateTextAccess74D3AE90": Object {
         "Properties": Object {

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -142,7 +142,7 @@ Object {
         "LambdaConfig": Object {
           "LambdaFunctionArn": Object {
             "Fn::GetAtt": Array [
-              "predictionsLambdahandlerC696C27E",
+              "predictionsLambda8B880A74",
               "Arn",
             ],
           },
@@ -184,7 +184,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "predictionsLambdahandlerC696C27E",
+                  "predictionsLambda8B880A74",
                   "Arn",
                 ],
               },
@@ -210,7 +210,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "predictionsLambdahandlerC696C27E",
+                  "predictionsLambda8B880A74",
                   "Arn",
                 ],
               },
@@ -1260,6 +1260,40 @@ $utils.error($ctx.result.body)
       },
       "Type": "AWS::IAM::Role",
     },
+    "predictionsLambda8B880A74": Object {
+      "DependsOn": Array [
+        "predictionsLambdaIAMRoleB8AC96D3",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "referencetotransformerrootstackS3DeploymentBucket7592718ARef",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Ref": "referencetotransformerrootstackS3DeploymentRootKeyA71EA735Ref",
+                },
+                "/functions/predictionsLambdaFunction.zip",
+              ],
+            ],
+          },
+        },
+        "FunctionName": "predictionsLambda",
+        "Handler": "predictionsLambda.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "predictionsLambdaIAMRoleB8AC96D3",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs12.x",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
     "predictionsLambdaIAMRoleB8AC96D3": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -1321,39 +1355,6 @@ $utils.error($ctx.result.body)
         },
       },
       "Type": "AWS::IAM::Role",
-    },
-    "predictionsLambdahandlerC696C27E": Object {
-      "DependsOn": Array [
-        "predictionsLambdaIAMRoleB8AC96D3",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Ref": "referencetotransformerrootstackS3DeploymentBucket7592718ARef",
-          },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Ref": "referencetotransformerrootstackS3DeploymentRootKeyA71EA735Ref",
-                },
-                "/functions/predictionsLambdaFunction.zip",
-              ],
-            ],
-          },
-        },
-        "Handler": "predictionsLambda.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "predictionsLambdaIAMRoleB8AC96D3",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs12.x",
-        "Timeout": 60,
-      },
-      "Type": "AWS::Lambda::Function",
     },
     "translateTextAccess74D3AE90": Object {
       "Properties": Object {

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -411,7 +411,7 @@ function createPredictionsLambda(context: TransformerContextProvider, stack: cdk
   // Update the runtime to Node 14 once the following issue is resolved:
   // https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/80#issuecomment-831796699
   return context.api.host.addLambdaFunction(
-    PredictionsResourceIDs.lambdaHandlerName,
+    PredictionsResourceIDs.lambdaName,
     `functions/${functionId}.zip`,
     PredictionsResourceIDs.lambdaHandlerName,
     path.join(__dirname, '..', 'lib', 'predictionsLambdaFunction.zip'),

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -205,6 +205,7 @@ export class DefaultTransformHost implements TransformHostProvider {
     const dummycode = `if __name__ == "__main__":`; // assing dummy code so as to be overriden later
     const fn = new Function(stack || this.api, functionName, {
       code: Code.fromInline(dummycode),
+      functionName,
       handler: handlerName,
       runtime,
       role,

--- a/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
@@ -1,0 +1,79 @@
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { deploy, launchDDBLocal, logDebug, GraphQLClient, terminateDDB } from '../__e2e__/utils';
+import { AmplifyAppSyncSimulator } from 'amplify-appsync-simulator';
+
+jest.setTimeout(2000000);
+
+let GRAPHQL_ENDPOINT: string;
+let GRAPHQL_CLIENT: GraphQLClient;
+let ddbEmulator = null;
+let dbPath = null;
+let server: AmplifyAppSyncSimulator;
+
+describe('@searchable transformer', () => {
+  beforeAll(async () => {
+    const validSchema = `
+      type Todo @model @searchable {
+        id: ID!
+      }`;
+
+    try {
+      const transformer = new GraphQLTransform({
+        transformers: [new ModelTransformer(), new SearchableModelTransformer()],
+        sandboxModeEnabled: true,
+      });
+      const out = await transformer.transform(validSchema);
+      let ddbClient;
+      ({ dbPath, emulator: ddbEmulator, client: ddbClient } = await launchDDBLocal());
+      const result = await deploy(out, ddbClient);
+      server = result.simulator;
+
+      GRAPHQL_ENDPOINT = server.url + '/graphql';
+      logDebug(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
+
+      const apiKey = result.config.appSync.apiKey;
+      logDebug(apiKey);
+      GRAPHQL_CLIENT = new GraphQLClient(GRAPHQL_ENDPOINT, {
+        'x-api-key': apiKey,
+      });
+    } catch (e) {
+      logDebug('error when setting up test');
+      logDebug(e);
+      expect(true).toEqual(false);
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      if (server) {
+        await server.stop();
+      }
+
+      await terminateDDB(ddbEmulator, dbPath);
+    } catch (e) {
+      console.error(e);
+      expect(true).toEqual(false);
+    }
+  });
+
+  /**
+   * Test queries below
+   */
+  test('@searchable allows the mock server to run', async () => {
+    const response = await GRAPHQL_CLIENT.query(
+      `query {
+        searchTodos {
+          items {
+            id
+          }
+        }
+      }`,
+      {},
+    );
+
+    logDebug(JSON.stringify(response, null, 4));
+    expect(response.data.searchTodos.items).toEqual([]);
+  });
+});


### PR DESCRIPTION
This commit updates GraphQL transformer v2 to attach a function name to Lambdas that it creates. The function name is required by the mock server.

This also updates the function name used by `@predictions` to the correct value.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9253