### PR TITLE
fix:(amplify-category-api) container name from services:key without container_name in service

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/docker-compose/converter.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/docker-compose/converter.test.ts
@@ -1,0 +1,48 @@
+import { getContainers } from '../../../../provider-utils/awscloudformation/docker-compose/converter';
+
+describe('getContainers', () => {
+  const containers = yaml => getContainers(yaml).containers;
+  describe('containers', () => {
+    it('returns 0 container if not exist containers in services', () => {
+      const yaml = `
+      version: "3.8"
+      services: []
+      `;
+      expect(containers(yaml).length).toEqual(0);
+    });
+    it('returns containers if exist containers in services', () => {
+      const yaml = `
+      version: "3.8"
+      services:
+        app: []
+        web: []
+      `;
+      expect(containers(yaml).length).toEqual(2);
+    });
+
+    describe('container', () => {
+      it('containers[].name is services.key', () => {
+        const yaml = `
+        version: "3.8"
+        services:
+          app: []
+          web: []
+        `;
+        expect(containers(yaml)[0].name).toMatch(/app/);
+        expect(containers(yaml)[1].name).toMatch(/web/);
+      });
+      it('containers[].name is container_name if container has container_name', () => {
+        const yaml = `
+        version: "3.8"
+        services:
+          app: 
+            container_name: 'awesome_app'
+          web:
+            container_name: 'awesome_web'
+        `;
+        expect(containers(yaml)[0].name).toMatch(/awesome_app/);
+        expect(containers(yaml)[1].name).toMatch(/awesome_web/);
+      });
+    });
+  });
+});

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/docker-compose/converter.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/docker-compose/converter.ts
@@ -19,8 +19,8 @@ function isV38Service(obj: any): obj is v38Types.DefinitionsService {
 const mapComposeEntriesToContainer = (record: [string, v1Types.DefinitionsService | v2Types.DefinitionsService]): Container => {
   const [k, v] = record;
 
-  const { image, ports, build, command, entrypoint, env_file, environment, working_dir, user } = v;
-  const { container_name: name = k } = v;
+  const { container_name, image, ports, build, command, entrypoint, env_file, environment, working_dir, user } = v;
+  const name = container_name || k;
 
   var healthcheck: v2Types.DefinitionsHealthcheck = {};
   if (hasHealthCheck(v)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When docker development is enabled and docker-compose.yml is used, if container_name is not defined,  `docker build -t $api_REPOSITORY_URI:latest ./.` command  will use prefixed `$api_` environment variable in auto-generated buildspec.yml, so if it is not defined, will use services:key.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Prepare `docker-compose.yml` like below: 
```
version: "3.8"
services:
  app: []
```

1. `amplify configure project` and enable container-based deployments
1. copy `docker-compose.yml` to amplify/backend/api/[container]/src/
1. `amplify push -y`
1. Check auto-generated buildspec.yml `cat amplify/backend/api/[container]/src/buldspec.yml`
1. build:commands: `docker build -t $api_REPOSITORY_URI:latest ./.` if not defined `container_name` 
1. `amplify-dev push -y`
1. Check auto-generated buildspec.yml `cat amplify/backend/api/[container]/src/buldspec.yml`
1. build:commands: `docker build -t $app_REPOSITORY_URI:latest ./.` if not defined `container_name` 

**About test**
`yarn test` dose not passed, but `cd packages/amplify-category-api && yarn run test` passed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
