### PR TITLE
fix(amplify-provider-awscloudformation): validate IDP roles on import (ref #9286)

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
@@ -84,6 +84,10 @@ export class IdentityPoolService implements IIdentityPoolService {
       })
       .promise();
 
+    if (!response.Roles || !response.Roles['authenticated'] || !response.Roles['unauthenticated']) {
+      throw new Error(`Cannot import Identity Pool without roles.`);
+    }
+
     return {
       authRoleArn: response.Roles['authenticated'],
       authRoleName: this.getResourceNameFromArn(response.Roles['authenticated']),


### PR DESCRIPTION
#### Description of changes
- validate imported IdentityPool for assigned Roles

#### Issue #, if available
- [9286](https://github.com/aws-amplify/amplify-cli/issues/9286)

#### Description of how you validated changes
- manual testing
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
