### PR TITLE
test(graphql-transformers-e2e-tests): add spelling of voice test in German

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
@@ -126,7 +126,7 @@ test('test translate and convert text to speech', async () => {
 });
 
 test('test translate text individually', async () => {
-  const germanTranslation = /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b))/i;
+  const germanTranslation = /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b)|(\bStimmetest\b))/i;
   const response = await GRAPHQL_CLIENT.query(
     `query TranslateThis($input: TranslateThisInput!) {
       translateThis(input: $input)

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
@@ -106,7 +106,7 @@ test('test translate and convert text to speech', async () => {
 });
 
 test('test translate text individually', async () => {
-  const germanTranslation = /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b))/i;
+  const germanTranslation = /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b)|(\bStimmetest\b))/i;
   const response = await GRAPHQL_CLIENT.query(
     `query TranslateThis($input: TranslateThisInput!) {
       translateThis(input: $input)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
 
The transformer e2e tests started failing when a query is done to turn "this is a voice test" to German in both the V1 and V2 tests. Upon some investigation, it looks like the value that was expected, `Stimmetest`, is a correct translation for `voice test`.

#### Description of how you validated changes

Google translator and running e2e tests locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
