### PR TITLE
test: fix test to match resource type count

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/export.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export.test.ts
@@ -52,10 +52,27 @@ describe('amplify export backend', () => {
 });
 
 function matchTemplates(template: any, exporttemplate: any) {
+  // matches count and parameters
   expect(Object.keys(template.Parameters)).toEqual(Object.keys(exporttemplate.Parameters))
-  expect(Object.keys(template.Resources)).toEqual(Object.keys(exporttemplate.Resources))
+
+  // matches the types and counts of resources since logical ids not idempotent
+  expect(getTypeCountMap(template.Resources)).toEqual(getTypeCountMap(exporttemplate.Resources));
+
+  // matches count and name of outputs
   expect(Object.keys(template.Outputs)).toEqual(Object.keys(exporttemplate.Outputs))
-  
+}
+
+function getTypeCountMap(resources: { [key: string] : any }) : Map<string, number> {
+  return Object.keys(resources).reduce((map, key) => {
+    const resourceType = resources[key].Type;
+    if(map.has(resourceType)){
+      map.set(resourceType, map.get(resourceType) + 1);
+    } else {
+      map.set(resourceType, 1);
+    }
+
+    return map;
+  }, new Map<string, number>());
 }
 
 function getTemplateForMapping(mapping:  { category: string; resourceName: string; service: string }, buildFolder: string) : any {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Changed the way the export test validates resources between push and export command. It relies on  the count of specific resources than the resource's logical id

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
