### PR TITLE
fix: generate list types will nullable elements

### DIFF
--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
@@ -101,7 +101,7 @@ enum ModelSortDirection {
 }
 
 type ModelTestConnection {
-  items: [Test!]!
+  items: [Test]!
   nextToken: String
 }
 
@@ -274,7 +274,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -368,7 +368,7 @@ function generateModelXConnectionType(config: IndexDirectiveConfiguration, ctx: 
   let connectionTypeExtension = blankObjectExtension(tableXConnectionName);
 
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
-    makeField('items', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(object.name.value))))),
+    makeField('items', [], makeNonNullType(makeListType(makeNamedType(object.name.value)))),
   ]);
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('nextToken', [], makeNamedType('String'))]);
 

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -107,7 +107,7 @@ enum ModelSortDirection {
 }
 
 type ModelTestConnection {
-  items: [Test!]!
+  items: [Test]!
   nextToken: String
 }
 
@@ -162,7 +162,7 @@ type Subscription {
 }
 
 type ModelEmailConnection {
-  items: [Email!]!
+  items: [Email]!
   nextToken: String
 }
 
@@ -356,7 +356,7 @@ input EntityMetadataInput {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -463,7 +463,7 @@ type Subscription {
 }
 
 type ModelAuthorConnection {
-  items: [Author!]!
+  items: [Author]!
   nextToken: String
 }
 
@@ -501,7 +501,7 @@ input DeleteAuthorInput {
 }
 
 type ModelRequireConnection {
-  items: [Require!]!
+  items: [Require]!
   nextToken: String
 }
 
@@ -539,7 +539,7 @@ input DeleteRequireInput {
 }
 
 type ModelCommentConnection {
-  items: [Comment!]!
+  items: [Comment]!
   nextToken: String
 }
 
@@ -12153,7 +12153,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -12690,7 +12690,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -13050,7 +13050,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -13404,7 +13404,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/query.ts
@@ -13,7 +13,7 @@ export const makeListQueryFilterInput = (
 export const makeListQueryModel = (type: ObjectTypeDefinitionNode, modelName: string, isSyncEnabled: boolean): ObjectTypeDefinitionNode => {
   const outputType = ObjectDefinitionWrapper.create(modelName);
 
-  outputType.addField(FieldWrapper.create('items', type.name.value, false, true));
+  outputType.addField(FieldWrapper.create('items', type.name.value, true, true));
   outputType.addField(FieldWrapper.create('nextToken', 'String', true, false));
 
   if (isSyncEnabled) {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -3277,7 +3277,7 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 1966,
+            "end": 1965,
             "start": 1951,
           },
           "name": Object {
@@ -3291,35 +3291,28 @@ Object {
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 1966,
+              "end": 1965,
               "start": 1958,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 1965,
+                "end": 1964,
                 "start": 1958,
               },
               "type": Object {
-                "kind": "NonNullType",
+                "kind": "NamedType",
                 "loc": Object {
-                  "end": 1964,
+                  "end": 1963,
                   "start": 1959,
                 },
-                "type": Object {
-                  "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
                   "loc": Object {
                     "end": 1963,
                     "start": 1959,
                   },
-                  "name": Object {
-                    "kind": "Name",
-                    "loc": Object {
-                      "end": 1963,
-                      "start": 1959,
-                    },
-                    "value": "Post",
-                  },
+                  "value": "Post",
                 },
               },
             },
@@ -3331,28 +3324,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 1986,
-            "start": 1969,
+            "end": 1985,
+            "start": 1968,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1978,
-              "start": 1969,
+              "end": 1977,
+              "start": 1968,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1986,
-              "start": 1980,
+              "end": 1985,
+              "start": 1979,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1986,
-                "start": 1980,
+                "end": 1985,
+                "start": 1979,
               },
               "value": "String",
             },
@@ -3362,7 +3355,7 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 1988,
+        "end": 1987,
         "start": 1922,
       },
       "name": Object {
@@ -3384,28 +3377,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2037,
-            "start": 2021,
+            "end": 2036,
+            "start": 2020,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2023,
-              "start": 2021,
+              "end": 2022,
+              "start": 2020,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2037,
-              "start": 2025,
+              "end": 2036,
+              "start": 2024,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2037,
-                "start": 2025,
+                "end": 2036,
+                "start": 2024,
               },
               "value": "ModelIDInput",
             },
@@ -3417,28 +3410,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2063,
-            "start": 2040,
+            "end": 2062,
+            "start": 2039,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2045,
-              "start": 2040,
+              "end": 2044,
+              "start": 2039,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2063,
-              "start": 2047,
+              "end": 2062,
+              "start": 2046,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2063,
-                "start": 2047,
+                "end": 2062,
+                "start": 2046,
               },
               "value": "ModelStringInput",
             },
@@ -3450,34 +3443,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2093,
-            "start": 2066,
+            "end": 2092,
+            "start": 2065,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2069,
-              "start": 2066,
+              "end": 2068,
+              "start": 2065,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2093,
-              "start": 2071,
+              "end": 2092,
+              "start": 2070,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2092,
-                "start": 2072,
+                "end": 2091,
+                "start": 2071,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2092,
-                  "start": 2072,
+                  "end": 2091,
+                  "start": 2071,
                 },
                 "value": "ModelPostFilterInput",
               },
@@ -3490,34 +3483,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2122,
-            "start": 2096,
+            "end": 2121,
+            "start": 2095,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2098,
-              "start": 2096,
+              "end": 2097,
+              "start": 2095,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2122,
-              "start": 2100,
+              "end": 2121,
+              "start": 2099,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2121,
-                "start": 2101,
+                "end": 2120,
+                "start": 2100,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2121,
-                  "start": 2101,
+                  "end": 2120,
+                  "start": 2100,
                 },
                 "value": "ModelPostFilterInput",
               },
@@ -3530,28 +3523,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2150,
-            "start": 2125,
+            "end": 2149,
+            "start": 2124,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2128,
-              "start": 2125,
+              "end": 2127,
+              "start": 2124,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2150,
-              "start": 2130,
+              "end": 2149,
+              "start": 2129,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2150,
-                "start": 2130,
+                "end": 2149,
+                "start": 2129,
               },
               "value": "ModelPostFilterInput",
             },
@@ -3560,14 +3553,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2152,
-        "start": 1990,
+        "end": 2151,
+        "start": 1989,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2016,
-          "start": 1996,
+          "end": 2015,
+          "start": 1995,
         },
         "value": "ModelPostFilterInput",
       },
@@ -3584,34 +3577,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2184,
-                "start": 2177,
+                "end": 2183,
+                "start": 2176,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2179,
-                  "start": 2177,
+                  "end": 2178,
+                  "start": 2176,
                 },
                 "value": "id",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2184,
-                  "start": 2181,
+                  "end": 2183,
+                  "start": 2180,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2183,
-                    "start": 2181,
+                    "end": 2182,
+                    "start": 2180,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2183,
-                      "start": 2181,
+                      "end": 2182,
+                      "start": 2180,
                     },
                     "value": "ID",
                   },
@@ -3623,28 +3616,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2191,
-            "start": 2169,
+            "end": 2190,
+            "start": 2168,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2176,
-              "start": 2169,
+              "end": 2175,
+              "start": 2168,
             },
             "value": "getPost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2191,
-              "start": 2187,
+              "end": 2190,
+              "start": 2186,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2191,
-                "start": 2187,
+                "end": 2190,
+                "start": 2186,
               },
               "value": "Post",
             },
@@ -3658,28 +3651,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2232,
-                "start": 2204,
+                "end": 2231,
+                "start": 2203,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2210,
-                  "start": 2204,
+                  "end": 2209,
+                  "start": 2203,
                 },
                 "value": "filter",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2232,
-                  "start": 2212,
+                  "end": 2231,
+                  "start": 2211,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2232,
-                    "start": 2212,
+                    "end": 2231,
+                    "start": 2211,
                   },
                   "value": "ModelPostFilterInput",
                 },
@@ -3691,28 +3684,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2244,
-                "start": 2234,
+                "end": 2243,
+                "start": 2233,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2239,
-                  "start": 2234,
+                  "end": 2238,
+                  "start": 2233,
                 },
                 "value": "limit",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2244,
-                  "start": 2241,
+                  "end": 2243,
+                  "start": 2240,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2244,
-                    "start": 2241,
+                    "end": 2243,
+                    "start": 2240,
                   },
                   "value": "Int",
                 },
@@ -3724,28 +3717,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2263,
-                "start": 2246,
+                "end": 2262,
+                "start": 2245,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2255,
-                  "start": 2246,
+                  "end": 2254,
+                  "start": 2245,
                 },
                 "value": "nextToken",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2263,
-                  "start": 2257,
+                  "end": 2262,
+                  "start": 2256,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2263,
-                    "start": 2257,
+                    "end": 2262,
+                    "start": 2256,
                   },
                   "value": "String",
                 },
@@ -3756,28 +3749,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2285,
-            "start": 2194,
+            "end": 2284,
+            "start": 2193,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2203,
-              "start": 2194,
+              "end": 2202,
+              "start": 2193,
             },
             "value": "listPosts",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2285,
-              "start": 2266,
+              "end": 2284,
+              "start": 2265,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2285,
-                "start": 2266,
+                "end": 2284,
+                "start": 2265,
               },
               "value": "ModelPostConnection",
             },
@@ -3791,34 +3784,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2303,
-                "start": 2296,
+                "end": 2302,
+                "start": 2295,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2298,
-                  "start": 2296,
+                  "end": 2297,
+                  "start": 2295,
                 },
                 "value": "id",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2303,
-                  "start": 2300,
+                  "end": 2302,
+                  "start": 2299,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2302,
-                    "start": 2300,
+                    "end": 2301,
+                    "start": 2299,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2302,
-                      "start": 2300,
+                      "end": 2301,
+                      "start": 2299,
                     },
                     "value": "ID",
                   },
@@ -3830,28 +3823,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2310,
-            "start": 2288,
+            "end": 2309,
+            "start": 2287,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2295,
-              "start": 2288,
+              "end": 2294,
+              "start": 2287,
             },
             "value": "getUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2310,
-              "start": 2306,
+              "end": 2309,
+              "start": 2305,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2310,
-                "start": 2306,
+                "end": 2309,
+                "start": 2305,
               },
               "value": "User",
             },
@@ -3865,28 +3858,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2351,
-                "start": 2323,
+                "end": 2350,
+                "start": 2322,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2329,
-                  "start": 2323,
+                  "end": 2328,
+                  "start": 2322,
                 },
                 "value": "filter",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2351,
-                  "start": 2331,
+                  "end": 2350,
+                  "start": 2330,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2351,
-                    "start": 2331,
+                    "end": 2350,
+                    "start": 2330,
                   },
                   "value": "ModelUserFilterInput",
                 },
@@ -3898,28 +3891,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2363,
-                "start": 2353,
+                "end": 2362,
+                "start": 2352,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2358,
-                  "start": 2353,
+                  "end": 2357,
+                  "start": 2352,
                 },
                 "value": "limit",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2363,
-                  "start": 2360,
+                  "end": 2362,
+                  "start": 2359,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2363,
-                    "start": 2360,
+                    "end": 2362,
+                    "start": 2359,
                   },
                   "value": "Int",
                 },
@@ -3931,28 +3924,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2382,
-                "start": 2365,
+                "end": 2381,
+                "start": 2364,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2374,
-                  "start": 2365,
+                  "end": 2373,
+                  "start": 2364,
                 },
                 "value": "nextToken",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2382,
-                  "start": 2376,
+                  "end": 2381,
+                  "start": 2375,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2382,
-                    "start": 2376,
+                    "end": 2381,
+                    "start": 2375,
                   },
                   "value": "String",
                 },
@@ -3963,28 +3956,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2404,
-            "start": 2313,
+            "end": 2403,
+            "start": 2312,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2322,
-              "start": 2313,
+              "end": 2321,
+              "start": 2312,
             },
             "value": "listUsers",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2404,
-              "start": 2385,
+              "end": 2403,
+              "start": 2384,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2404,
-                "start": 2385,
+                "end": 2403,
+                "start": 2384,
               },
               "value": "ModelUserConnection",
             },
@@ -3994,14 +3987,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 2406,
-        "start": 2154,
+        "end": 2405,
+        "start": 2153,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2164,
-          "start": 2159,
+          "end": 2163,
+          "start": 2158,
         },
         "value": "Query",
       },
@@ -4016,28 +4009,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2465,
-            "start": 2442,
+            "end": 2464,
+            "start": 2441,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2447,
-              "start": 2442,
+              "end": 2446,
+              "start": 2441,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2465,
-              "start": 2449,
+              "end": 2464,
+              "start": 2448,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2465,
-                "start": 2449,
+                "end": 2464,
+                "start": 2448,
               },
               "value": "ModelStringInput",
             },
@@ -4049,34 +4042,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2498,
-            "start": 2468,
+            "end": 2497,
+            "start": 2467,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2471,
-              "start": 2468,
+              "end": 2470,
+              "start": 2467,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2498,
-              "start": 2473,
+              "end": 2497,
+              "start": 2472,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2497,
-                "start": 2474,
+                "end": 2496,
+                "start": 2473,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2497,
-                  "start": 2474,
+                  "end": 2496,
+                  "start": 2473,
                 },
                 "value": "ModelPostConditionInput",
               },
@@ -4089,34 +4082,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2530,
-            "start": 2501,
+            "end": 2529,
+            "start": 2500,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2503,
-              "start": 2501,
+              "end": 2502,
+              "start": 2500,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2530,
-              "start": 2505,
+              "end": 2529,
+              "start": 2504,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2529,
-                "start": 2506,
+                "end": 2528,
+                "start": 2505,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2529,
-                  "start": 2506,
+                  "end": 2528,
+                  "start": 2505,
                 },
                 "value": "ModelPostConditionInput",
               },
@@ -4129,28 +4122,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2561,
-            "start": 2533,
+            "end": 2560,
+            "start": 2532,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2536,
-              "start": 2533,
+              "end": 2535,
+              "start": 2532,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2561,
-              "start": 2538,
+              "end": 2560,
+              "start": 2537,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2561,
-                "start": 2538,
+                "end": 2560,
+                "start": 2537,
               },
               "value": "ModelPostConditionInput",
             },
@@ -4159,14 +4152,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2563,
-        "start": 2408,
+        "end": 2562,
+        "start": 2407,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2437,
-          "start": 2414,
+          "end": 2436,
+          "start": 2413,
         },
         "value": "ModelPostConditionInput",
       },
@@ -4181,28 +4174,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2597,
-            "start": 2591,
+            "end": 2596,
+            "start": 2590,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2593,
-              "start": 2591,
+              "end": 2592,
+              "start": 2590,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2597,
-              "start": 2595,
+              "end": 2596,
+              "start": 2594,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2597,
-                "start": 2595,
+                "end": 2596,
+                "start": 2594,
               },
               "value": "ID",
             },
@@ -4214,34 +4207,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2614,
-            "start": 2600,
+            "end": 2613,
+            "start": 2599,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2605,
-              "start": 2600,
+              "end": 2604,
+              "start": 2599,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 2614,
-              "start": 2607,
+              "end": 2613,
+              "start": 2606,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2613,
-                "start": 2607,
+                "end": 2612,
+                "start": 2606,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2613,
-                  "start": 2607,
+                  "end": 2612,
+                  "start": 2606,
                 },
                 "value": "String",
               },
@@ -4251,14 +4244,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2616,
-        "start": 2565,
+        "end": 2615,
+        "start": 2564,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2586,
-          "start": 2571,
+          "end": 2585,
+          "start": 2570,
         },
         "value": "CreatePostInput",
       },
@@ -4273,34 +4266,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2651,
-            "start": 2644,
+            "end": 2650,
+            "start": 2643,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2646,
-              "start": 2644,
+              "end": 2645,
+              "start": 2643,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 2651,
-              "start": 2648,
+              "end": 2650,
+              "start": 2647,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2650,
-                "start": 2648,
+                "end": 2649,
+                "start": 2647,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2650,
-                  "start": 2648,
+                  "end": 2649,
+                  "start": 2647,
                 },
                 "value": "ID",
               },
@@ -4313,28 +4306,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2667,
-            "start": 2654,
+            "end": 2666,
+            "start": 2653,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2659,
-              "start": 2654,
+              "end": 2658,
+              "start": 2653,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2667,
-              "start": 2661,
+              "end": 2666,
+              "start": 2660,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2667,
-                "start": 2661,
+                "end": 2666,
+                "start": 2660,
               },
               "value": "String",
             },
@@ -4343,14 +4336,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2669,
-        "start": 2618,
+        "end": 2668,
+        "start": 2617,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2639,
-          "start": 2624,
+          "end": 2638,
+          "start": 2623,
         },
         "value": "UpdatePostInput",
       },
@@ -4365,34 +4358,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2704,
-            "start": 2697,
+            "end": 2703,
+            "start": 2696,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2699,
-              "start": 2697,
+              "end": 2698,
+              "start": 2696,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 2704,
-              "start": 2701,
+              "end": 2703,
+              "start": 2700,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2703,
-                "start": 2701,
+                "end": 2702,
+                "start": 2700,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2703,
-                  "start": 2701,
+                  "end": 2702,
+                  "start": 2700,
                 },
                 "value": "ID",
               },
@@ -4402,14 +4395,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2706,
-        "start": 2671,
+        "end": 2705,
+        "start": 2670,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2692,
-          "start": 2677,
+          "end": 2691,
+          "start": 2676,
         },
         "value": "DeletePostInput",
       },
@@ -4426,34 +4419,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2760,
-                "start": 2737,
+                "end": 2759,
+                "start": 2736,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2742,
-                  "start": 2737,
+                  "end": 2741,
+                  "start": 2736,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2760,
-                  "start": 2744,
+                  "end": 2759,
+                  "start": 2743,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2759,
-                    "start": 2744,
+                    "end": 2758,
+                    "start": 2743,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2759,
-                      "start": 2744,
+                      "end": 2758,
+                      "start": 2743,
                     },
                     "value": "CreatePostInput",
                   },
@@ -4466,28 +4459,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2796,
-                "start": 2762,
+                "end": 2795,
+                "start": 2761,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2771,
-                  "start": 2762,
+                  "end": 2770,
+                  "start": 2761,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2796,
-                  "start": 2773,
+                  "end": 2795,
+                  "start": 2772,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2796,
-                    "start": 2773,
+                    "end": 2795,
+                    "start": 2772,
                   },
                   "value": "ModelPostConditionInput",
                 },
@@ -4498,28 +4491,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2803,
-            "start": 2726,
+            "end": 2802,
+            "start": 2725,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2736,
-              "start": 2726,
+              "end": 2735,
+              "start": 2725,
             },
             "value": "createPost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2803,
-              "start": 2799,
+              "end": 2802,
+              "start": 2798,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2803,
-                "start": 2799,
+                "end": 2802,
+                "start": 2798,
               },
               "value": "Post",
             },
@@ -4533,34 +4526,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2840,
-                "start": 2817,
+                "end": 2839,
+                "start": 2816,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2822,
-                  "start": 2817,
+                  "end": 2821,
+                  "start": 2816,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2840,
-                  "start": 2824,
+                  "end": 2839,
+                  "start": 2823,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2839,
-                    "start": 2824,
+                    "end": 2838,
+                    "start": 2823,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2839,
-                      "start": 2824,
+                      "end": 2838,
+                      "start": 2823,
                     },
                     "value": "UpdatePostInput",
                   },
@@ -4573,28 +4566,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2876,
-                "start": 2842,
+                "end": 2875,
+                "start": 2841,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2851,
-                  "start": 2842,
+                  "end": 2850,
+                  "start": 2841,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2876,
-                  "start": 2853,
+                  "end": 2875,
+                  "start": 2852,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2876,
-                    "start": 2853,
+                    "end": 2875,
+                    "start": 2852,
                   },
                   "value": "ModelPostConditionInput",
                 },
@@ -4605,28 +4598,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2883,
-            "start": 2806,
+            "end": 2882,
+            "start": 2805,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2816,
-              "start": 2806,
+              "end": 2815,
+              "start": 2805,
             },
             "value": "updatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2883,
-              "start": 2879,
+              "end": 2882,
+              "start": 2878,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2883,
-                "start": 2879,
+                "end": 2882,
+                "start": 2878,
               },
               "value": "Post",
             },
@@ -4640,34 +4633,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2920,
-                "start": 2897,
+                "end": 2919,
+                "start": 2896,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2902,
-                  "start": 2897,
+                  "end": 2901,
+                  "start": 2896,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2920,
-                  "start": 2904,
+                  "end": 2919,
+                  "start": 2903,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2919,
-                    "start": 2904,
+                    "end": 2918,
+                    "start": 2903,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2919,
-                      "start": 2904,
+                      "end": 2918,
+                      "start": 2903,
                     },
                     "value": "DeletePostInput",
                   },
@@ -4680,28 +4673,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2956,
-                "start": 2922,
+                "end": 2955,
+                "start": 2921,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2931,
-                  "start": 2922,
+                  "end": 2930,
+                  "start": 2921,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2956,
-                  "start": 2933,
+                  "end": 2955,
+                  "start": 2932,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2956,
-                    "start": 2933,
+                    "end": 2955,
+                    "start": 2932,
                   },
                   "value": "ModelPostConditionInput",
                 },
@@ -4712,28 +4705,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2963,
-            "start": 2886,
+            "end": 2962,
+            "start": 2885,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2896,
-              "start": 2886,
+              "end": 2895,
+              "start": 2885,
             },
             "value": "deletePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2963,
-              "start": 2959,
+              "end": 2962,
+              "start": 2958,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2963,
-                "start": 2959,
+                "end": 2962,
+                "start": 2958,
               },
               "value": "Post",
             },
@@ -4747,34 +4740,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3012,
-                "start": 2983,
+                "end": 3011,
+                "start": 2982,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2988,
-                  "start": 2983,
+                  "end": 2987,
+                  "start": 2982,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3012,
-                  "start": 2990,
+                  "end": 3011,
+                  "start": 2989,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3011,
-                    "start": 2990,
+                    "end": 3010,
+                    "start": 2989,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3011,
-                      "start": 2990,
+                      "end": 3010,
+                      "start": 2989,
                     },
                     "value": "CreatePostEditorInput",
                   },
@@ -4787,28 +4780,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3054,
-                "start": 3014,
+                "end": 3053,
+                "start": 3013,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3023,
-                  "start": 3014,
+                  "end": 3022,
+                  "start": 3013,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3054,
-                  "start": 3025,
+                  "end": 3053,
+                  "start": 3024,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3054,
-                    "start": 3025,
+                    "end": 3053,
+                    "start": 3024,
                   },
                   "value": "ModelPostEditorConditionInput",
                 },
@@ -4819,28 +4812,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3067,
-            "start": 2966,
+            "end": 3066,
+            "start": 2965,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2982,
-              "start": 2966,
+              "end": 2981,
+              "start": 2965,
             },
             "value": "createPostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3067,
-              "start": 3057,
+              "end": 3066,
+              "start": 3056,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3067,
-                "start": 3057,
+                "end": 3066,
+                "start": 3056,
               },
               "value": "PostEditor",
             },
@@ -4854,34 +4847,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3116,
-                "start": 3087,
+                "end": 3115,
+                "start": 3086,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3092,
-                  "start": 3087,
+                  "end": 3091,
+                  "start": 3086,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3116,
-                  "start": 3094,
+                  "end": 3115,
+                  "start": 3093,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3115,
-                    "start": 3094,
+                    "end": 3114,
+                    "start": 3093,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3115,
-                      "start": 3094,
+                      "end": 3114,
+                      "start": 3093,
                     },
                     "value": "UpdatePostEditorInput",
                   },
@@ -4894,28 +4887,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3158,
-                "start": 3118,
+                "end": 3157,
+                "start": 3117,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3127,
-                  "start": 3118,
+                  "end": 3126,
+                  "start": 3117,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3158,
-                  "start": 3129,
+                  "end": 3157,
+                  "start": 3128,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3158,
-                    "start": 3129,
+                    "end": 3157,
+                    "start": 3128,
                   },
                   "value": "ModelPostEditorConditionInput",
                 },
@@ -4926,28 +4919,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3171,
-            "start": 3070,
+            "end": 3170,
+            "start": 3069,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3086,
-              "start": 3070,
+              "end": 3085,
+              "start": 3069,
             },
             "value": "updatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3171,
-              "start": 3161,
+              "end": 3170,
+              "start": 3160,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3171,
-                "start": 3161,
+                "end": 3170,
+                "start": 3160,
               },
               "value": "PostEditor",
             },
@@ -4961,34 +4954,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3220,
-                "start": 3191,
+                "end": 3219,
+                "start": 3190,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3196,
-                  "start": 3191,
+                  "end": 3195,
+                  "start": 3190,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3220,
-                  "start": 3198,
+                  "end": 3219,
+                  "start": 3197,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3219,
-                    "start": 3198,
+                    "end": 3218,
+                    "start": 3197,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3219,
-                      "start": 3198,
+                      "end": 3218,
+                      "start": 3197,
                     },
                     "value": "DeletePostEditorInput",
                   },
@@ -5001,28 +4994,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3262,
-                "start": 3222,
+                "end": 3261,
+                "start": 3221,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3231,
-                  "start": 3222,
+                  "end": 3230,
+                  "start": 3221,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3262,
-                  "start": 3233,
+                  "end": 3261,
+                  "start": 3232,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3262,
-                    "start": 3233,
+                    "end": 3261,
+                    "start": 3232,
                   },
                   "value": "ModelPostEditorConditionInput",
                 },
@@ -5033,28 +5026,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3275,
-            "start": 3174,
+            "end": 3274,
+            "start": 3173,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3190,
-              "start": 3174,
+              "end": 3189,
+              "start": 3173,
             },
             "value": "deletePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3275,
-              "start": 3265,
+              "end": 3274,
+              "start": 3264,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3275,
-                "start": 3265,
+                "end": 3274,
+                "start": 3264,
               },
               "value": "PostEditor",
             },
@@ -5068,34 +5061,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3312,
-                "start": 3289,
+                "end": 3311,
+                "start": 3288,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3294,
-                  "start": 3289,
+                  "end": 3293,
+                  "start": 3288,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3312,
-                  "start": 3296,
+                  "end": 3311,
+                  "start": 3295,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3311,
-                    "start": 3296,
+                    "end": 3310,
+                    "start": 3295,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3311,
-                      "start": 3296,
+                      "end": 3310,
+                      "start": 3295,
                     },
                     "value": "CreateUserInput",
                   },
@@ -5108,28 +5101,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3348,
-                "start": 3314,
+                "end": 3347,
+                "start": 3313,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3323,
-                  "start": 3314,
+                  "end": 3322,
+                  "start": 3313,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3348,
-                  "start": 3325,
+                  "end": 3347,
+                  "start": 3324,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3348,
-                    "start": 3325,
+                    "end": 3347,
+                    "start": 3324,
                   },
                   "value": "ModelUserConditionInput",
                 },
@@ -5140,28 +5133,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3355,
-            "start": 3278,
+            "end": 3354,
+            "start": 3277,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3288,
-              "start": 3278,
+              "end": 3287,
+              "start": 3277,
             },
             "value": "createUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3355,
-              "start": 3351,
+              "end": 3354,
+              "start": 3350,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3355,
-                "start": 3351,
+                "end": 3354,
+                "start": 3350,
               },
               "value": "User",
             },
@@ -5175,34 +5168,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3392,
-                "start": 3369,
+                "end": 3391,
+                "start": 3368,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3374,
-                  "start": 3369,
+                  "end": 3373,
+                  "start": 3368,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3392,
-                  "start": 3376,
+                  "end": 3391,
+                  "start": 3375,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3391,
-                    "start": 3376,
+                    "end": 3390,
+                    "start": 3375,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3391,
-                      "start": 3376,
+                      "end": 3390,
+                      "start": 3375,
                     },
                     "value": "UpdateUserInput",
                   },
@@ -5215,28 +5208,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3428,
-                "start": 3394,
+                "end": 3427,
+                "start": 3393,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3403,
-                  "start": 3394,
+                  "end": 3402,
+                  "start": 3393,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3428,
-                  "start": 3405,
+                  "end": 3427,
+                  "start": 3404,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3428,
-                    "start": 3405,
+                    "end": 3427,
+                    "start": 3404,
                   },
                   "value": "ModelUserConditionInput",
                 },
@@ -5247,28 +5240,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3435,
-            "start": 3358,
+            "end": 3434,
+            "start": 3357,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3368,
-              "start": 3358,
+              "end": 3367,
+              "start": 3357,
             },
             "value": "updateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3435,
-              "start": 3431,
+              "end": 3434,
+              "start": 3430,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3435,
-                "start": 3431,
+                "end": 3434,
+                "start": 3430,
               },
               "value": "User",
             },
@@ -5282,34 +5275,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3472,
-                "start": 3449,
+                "end": 3471,
+                "start": 3448,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3454,
-                  "start": 3449,
+                  "end": 3453,
+                  "start": 3448,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3472,
-                  "start": 3456,
+                  "end": 3471,
+                  "start": 3455,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3471,
-                    "start": 3456,
+                    "end": 3470,
+                    "start": 3455,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3471,
-                      "start": 3456,
+                      "end": 3470,
+                      "start": 3455,
                     },
                     "value": "DeleteUserInput",
                   },
@@ -5322,28 +5315,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3508,
-                "start": 3474,
+                "end": 3507,
+                "start": 3473,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3483,
-                  "start": 3474,
+                  "end": 3482,
+                  "start": 3473,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3508,
-                  "start": 3485,
+                  "end": 3507,
+                  "start": 3484,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3508,
-                    "start": 3485,
+                    "end": 3507,
+                    "start": 3484,
                   },
                   "value": "ModelUserConditionInput",
                 },
@@ -5354,28 +5347,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3515,
-            "start": 3438,
+            "end": 3514,
+            "start": 3437,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3448,
-              "start": 3438,
+              "end": 3447,
+              "start": 3437,
             },
             "value": "deleteUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3515,
-              "start": 3511,
+              "end": 3514,
+              "start": 3510,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3515,
-                "start": 3511,
+                "end": 3514,
+                "start": 3510,
               },
               "value": "User",
             },
@@ -5385,14 +5378,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 3517,
-        "start": 2708,
+        "end": 3516,
+        "start": 2707,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2721,
-          "start": 2713,
+          "end": 2720,
+          "start": 2712,
         },
         "value": "Mutation",
       },
@@ -5410,30 +5403,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3600,
-                    "start": 3575,
+                    "end": 3599,
+                    "start": 3574,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3584,
-                      "start": 3575,
+                      "end": 3583,
+                      "start": 3574,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3600,
-                      "start": 3586,
+                      "end": 3599,
+                      "start": 3585,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3599,
-                          "start": 3587,
+                          "end": 3598,
+                          "start": 3586,
                         },
                         "value": "createPost",
                       },
@@ -5443,14 +5436,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3601,
-                "start": 3560,
+                "end": 3600,
+                "start": 3559,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3574,
-                  "start": 3561,
+                  "end": 3573,
+                  "start": 3560,
                 },
                 "value": "aws_subscribe",
               },
@@ -5458,28 +5451,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3601,
-            "start": 3541,
+            "end": 3600,
+            "start": 3540,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3553,
-              "start": 3541,
+              "end": 3552,
+              "start": 3540,
             },
             "value": "onCreatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3559,
-              "start": 3555,
+              "end": 3558,
+              "start": 3554,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3559,
-                "start": 3555,
+                "end": 3558,
+                "start": 3554,
               },
               "value": "Post",
             },
@@ -5494,30 +5487,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3663,
-                    "start": 3638,
+                    "end": 3662,
+                    "start": 3637,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3647,
-                      "start": 3638,
+                      "end": 3646,
+                      "start": 3637,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3663,
-                      "start": 3649,
+                      "end": 3662,
+                      "start": 3648,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3662,
-                          "start": 3650,
+                          "end": 3661,
+                          "start": 3649,
                         },
                         "value": "updatePost",
                       },
@@ -5527,14 +5520,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3664,
-                "start": 3623,
+                "end": 3663,
+                "start": 3622,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3637,
-                  "start": 3624,
+                  "end": 3636,
+                  "start": 3623,
                 },
                 "value": "aws_subscribe",
               },
@@ -5542,28 +5535,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3664,
-            "start": 3604,
+            "end": 3663,
+            "start": 3603,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3616,
-              "start": 3604,
+              "end": 3615,
+              "start": 3603,
             },
             "value": "onUpdatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3622,
-              "start": 3618,
+              "end": 3621,
+              "start": 3617,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3622,
-                "start": 3618,
+                "end": 3621,
+                "start": 3617,
               },
               "value": "Post",
             },
@@ -5578,30 +5571,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3726,
-                    "start": 3701,
+                    "end": 3725,
+                    "start": 3700,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3710,
-                      "start": 3701,
+                      "end": 3709,
+                      "start": 3700,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3726,
-                      "start": 3712,
+                      "end": 3725,
+                      "start": 3711,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3725,
-                          "start": 3713,
+                          "end": 3724,
+                          "start": 3712,
                         },
                         "value": "deletePost",
                       },
@@ -5611,14 +5604,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3727,
-                "start": 3686,
+                "end": 3726,
+                "start": 3685,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3700,
-                  "start": 3687,
+                  "end": 3699,
+                  "start": 3686,
                 },
                 "value": "aws_subscribe",
               },
@@ -5626,28 +5619,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3727,
-            "start": 3667,
+            "end": 3726,
+            "start": 3666,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3679,
-              "start": 3667,
+              "end": 3678,
+              "start": 3666,
             },
             "value": "onDeletePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3685,
-              "start": 3681,
+              "end": 3684,
+              "start": 3680,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3685,
-                "start": 3681,
+                "end": 3684,
+                "start": 3680,
               },
               "value": "Post",
             },
@@ -5662,30 +5655,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3807,
-                    "start": 3776,
+                    "end": 3806,
+                    "start": 3775,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3785,
-                      "start": 3776,
+                      "end": 3784,
+                      "start": 3775,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3807,
-                      "start": 3787,
+                      "end": 3806,
+                      "start": 3786,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3806,
-                          "start": 3788,
+                          "end": 3805,
+                          "start": 3787,
                         },
                         "value": "createPostEditor",
                       },
@@ -5695,14 +5688,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3808,
-                "start": 3761,
+                "end": 3807,
+                "start": 3760,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3775,
-                  "start": 3762,
+                  "end": 3774,
+                  "start": 3761,
                 },
                 "value": "aws_subscribe",
               },
@@ -5710,28 +5703,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3808,
-            "start": 3730,
+            "end": 3807,
+            "start": 3729,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3748,
-              "start": 3730,
+              "end": 3747,
+              "start": 3729,
             },
             "value": "onCreatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3760,
-              "start": 3750,
+              "end": 3759,
+              "start": 3749,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3760,
-                "start": 3750,
+                "end": 3759,
+                "start": 3749,
               },
               "value": "PostEditor",
             },
@@ -5746,30 +5739,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3888,
-                    "start": 3857,
+                    "end": 3887,
+                    "start": 3856,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3866,
-                      "start": 3857,
+                      "end": 3865,
+                      "start": 3856,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3888,
-                      "start": 3868,
+                      "end": 3887,
+                      "start": 3867,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3887,
-                          "start": 3869,
+                          "end": 3886,
+                          "start": 3868,
                         },
                         "value": "updatePostEditor",
                       },
@@ -5779,14 +5772,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3889,
-                "start": 3842,
+                "end": 3888,
+                "start": 3841,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3856,
-                  "start": 3843,
+                  "end": 3855,
+                  "start": 3842,
                 },
                 "value": "aws_subscribe",
               },
@@ -5794,28 +5787,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3889,
-            "start": 3811,
+            "end": 3888,
+            "start": 3810,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3829,
-              "start": 3811,
+              "end": 3828,
+              "start": 3810,
             },
             "value": "onUpdatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3841,
-              "start": 3831,
+              "end": 3840,
+              "start": 3830,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3841,
-                "start": 3831,
+                "end": 3840,
+                "start": 3830,
               },
               "value": "PostEditor",
             },
@@ -5830,30 +5823,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3969,
-                    "start": 3938,
+                    "end": 3968,
+                    "start": 3937,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3947,
-                      "start": 3938,
+                      "end": 3946,
+                      "start": 3937,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3969,
-                      "start": 3949,
+                      "end": 3968,
+                      "start": 3948,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3968,
-                          "start": 3950,
+                          "end": 3967,
+                          "start": 3949,
                         },
                         "value": "deletePostEditor",
                       },
@@ -5863,14 +5856,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3970,
-                "start": 3923,
+                "end": 3969,
+                "start": 3922,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3937,
-                  "start": 3924,
+                  "end": 3936,
+                  "start": 3923,
                 },
                 "value": "aws_subscribe",
               },
@@ -5878,28 +5871,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3970,
-            "start": 3892,
+            "end": 3969,
+            "start": 3891,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3910,
-              "start": 3892,
+              "end": 3909,
+              "start": 3891,
             },
             "value": "onDeletePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3922,
-              "start": 3912,
+              "end": 3921,
+              "start": 3911,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3922,
-                "start": 3912,
+                "end": 3921,
+                "start": 3911,
               },
               "value": "PostEditor",
             },
@@ -5914,30 +5907,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4032,
-                    "start": 4007,
+                    "end": 4031,
+                    "start": 4006,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4016,
-                      "start": 4007,
+                      "end": 4015,
+                      "start": 4006,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4032,
-                      "start": 4018,
+                      "end": 4031,
+                      "start": 4017,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4031,
-                          "start": 4019,
+                          "end": 4030,
+                          "start": 4018,
                         },
                         "value": "createUser",
                       },
@@ -5947,14 +5940,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4033,
-                "start": 3992,
+                "end": 4032,
+                "start": 3991,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4006,
-                  "start": 3993,
+                  "end": 4005,
+                  "start": 3992,
                 },
                 "value": "aws_subscribe",
               },
@@ -5962,28 +5955,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4033,
-            "start": 3973,
+            "end": 4032,
+            "start": 3972,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3985,
-              "start": 3973,
+              "end": 3984,
+              "start": 3972,
             },
             "value": "onCreateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3991,
-              "start": 3987,
+              "end": 3990,
+              "start": 3986,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3991,
-                "start": 3987,
+                "end": 3990,
+                "start": 3986,
               },
               "value": "User",
             },
@@ -5998,30 +5991,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4095,
-                    "start": 4070,
+                    "end": 4094,
+                    "start": 4069,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4079,
-                      "start": 4070,
+                      "end": 4078,
+                      "start": 4069,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4095,
-                      "start": 4081,
+                      "end": 4094,
+                      "start": 4080,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4094,
-                          "start": 4082,
+                          "end": 4093,
+                          "start": 4081,
                         },
                         "value": "updateUser",
                       },
@@ -6031,14 +6024,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4096,
-                "start": 4055,
+                "end": 4095,
+                "start": 4054,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4069,
-                  "start": 4056,
+                  "end": 4068,
+                  "start": 4055,
                 },
                 "value": "aws_subscribe",
               },
@@ -6046,28 +6039,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4096,
-            "start": 4036,
+            "end": 4095,
+            "start": 4035,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4048,
-              "start": 4036,
+              "end": 4047,
+              "start": 4035,
             },
             "value": "onUpdateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4054,
-              "start": 4050,
+              "end": 4053,
+              "start": 4049,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4054,
-                "start": 4050,
+                "end": 4053,
+                "start": 4049,
               },
               "value": "User",
             },
@@ -6082,30 +6075,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4158,
-                    "start": 4133,
+                    "end": 4157,
+                    "start": 4132,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4142,
-                      "start": 4133,
+                      "end": 4141,
+                      "start": 4132,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4158,
-                      "start": 4144,
+                      "end": 4157,
+                      "start": 4143,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4157,
-                          "start": 4145,
+                          "end": 4156,
+                          "start": 4144,
                         },
                         "value": "deleteUser",
                       },
@@ -6115,14 +6108,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4159,
-                "start": 4118,
+                "end": 4158,
+                "start": 4117,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4132,
-                  "start": 4119,
+                  "end": 4131,
+                  "start": 4118,
                 },
                 "value": "aws_subscribe",
               },
@@ -6130,28 +6123,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4159,
-            "start": 4099,
+            "end": 4158,
+            "start": 4098,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4111,
-              "start": 4099,
+              "end": 4110,
+              "start": 4098,
             },
             "value": "onDeleteUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4117,
-              "start": 4113,
+              "end": 4116,
+              "start": 4112,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4117,
-                "start": 4113,
+                "end": 4116,
+                "start": 4112,
               },
               "value": "User",
             },
@@ -6161,14 +6154,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 4161,
-        "start": 3519,
+        "end": 4160,
+        "start": 3518,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 3536,
-          "start": 3524,
+          "end": 3535,
+          "start": 3523,
         },
         "value": "Subscription",
       },
@@ -6183,28 +6176,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4223,
-            "start": 4203,
+            "end": 4222,
+            "start": 4202,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4209,
-              "start": 4203,
+              "end": 4208,
+              "start": 4202,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4223,
-              "start": 4211,
+              "end": 4222,
+              "start": 4210,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4223,
-                "start": 4211,
+                "end": 4222,
+                "start": 4210,
               },
               "value": "ModelIDInput",
             },
@@ -6216,28 +6209,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4248,
-            "start": 4226,
+            "end": 4247,
+            "start": 4225,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4234,
-              "start": 4226,
+              "end": 4233,
+              "start": 4225,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4248,
-              "start": 4236,
+              "end": 4247,
+              "start": 4235,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4248,
-                "start": 4236,
+                "end": 4247,
+                "start": 4235,
               },
               "value": "ModelIDInput",
             },
@@ -6249,34 +6242,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4287,
-            "start": 4251,
+            "end": 4286,
+            "start": 4250,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4254,
-              "start": 4251,
+              "end": 4253,
+              "start": 4250,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4287,
-              "start": 4256,
+              "end": 4286,
+              "start": 4255,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4286,
-                "start": 4257,
+                "end": 4285,
+                "start": 4256,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4286,
-                  "start": 4257,
+                  "end": 4285,
+                  "start": 4256,
                 },
                 "value": "ModelPostEditorConditionInput",
               },
@@ -6289,34 +6282,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4325,
-            "start": 4290,
+            "end": 4324,
+            "start": 4289,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4292,
-              "start": 4290,
+              "end": 4291,
+              "start": 4289,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4325,
-              "start": 4294,
+              "end": 4324,
+              "start": 4293,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4324,
-                "start": 4295,
+                "end": 4323,
+                "start": 4294,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4324,
-                  "start": 4295,
+                  "end": 4323,
+                  "start": 4294,
                 },
                 "value": "ModelPostEditorConditionInput",
               },
@@ -6329,28 +6322,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4362,
-            "start": 4328,
+            "end": 4361,
+            "start": 4327,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4331,
-              "start": 4328,
+              "end": 4330,
+              "start": 4327,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4362,
-              "start": 4333,
+              "end": 4361,
+              "start": 4332,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4362,
-                "start": 4333,
+                "end": 4361,
+                "start": 4332,
               },
               "value": "ModelPostEditorConditionInput",
             },
@@ -6359,14 +6352,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4364,
-        "start": 4163,
+        "end": 4363,
+        "start": 4162,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4198,
-          "start": 4169,
+          "end": 4197,
+          "start": 4168,
         },
         "value": "ModelPostEditorConditionInput",
       },
@@ -6381,28 +6374,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4404,
-            "start": 4398,
+            "end": 4403,
+            "start": 4397,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4400,
-              "start": 4398,
+              "end": 4399,
+              "start": 4397,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4404,
-              "start": 4402,
+              "end": 4403,
+              "start": 4401,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4404,
-                "start": 4402,
+                "end": 4403,
+                "start": 4401,
               },
               "value": "ID",
             },
@@ -6414,34 +6407,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4418,
-            "start": 4407,
+            "end": 4417,
+            "start": 4406,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4413,
-              "start": 4407,
+              "end": 4412,
+              "start": 4406,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4418,
-              "start": 4415,
+              "end": 4417,
+              "start": 4414,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4417,
-                "start": 4415,
+                "end": 4416,
+                "start": 4414,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4417,
-                  "start": 4415,
+                  "end": 4416,
+                  "start": 4414,
                 },
                 "value": "ID",
               },
@@ -6454,34 +6447,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4434,
-            "start": 4421,
+            "end": 4433,
+            "start": 4420,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4429,
-              "start": 4421,
+              "end": 4428,
+              "start": 4420,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4434,
-              "start": 4431,
+              "end": 4433,
+              "start": 4430,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4433,
-                "start": 4431,
+                "end": 4432,
+                "start": 4430,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4433,
-                  "start": 4431,
+                  "end": 4432,
+                  "start": 4430,
                 },
                 "value": "ID",
               },
@@ -6491,14 +6484,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4436,
-        "start": 4366,
+        "end": 4435,
+        "start": 4365,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4393,
-          "start": 4372,
+          "end": 4392,
+          "start": 4371,
         },
         "value": "CreatePostEditorInput",
       },
@@ -6513,34 +6506,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4477,
-            "start": 4470,
+            "end": 4476,
+            "start": 4469,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4472,
-              "start": 4470,
+              "end": 4471,
+              "start": 4469,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4477,
-              "start": 4474,
+              "end": 4476,
+              "start": 4473,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4476,
-                "start": 4474,
+                "end": 4475,
+                "start": 4473,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4476,
-                  "start": 4474,
+                  "end": 4475,
+                  "start": 4473,
                 },
                 "value": "ID",
               },
@@ -6553,28 +6546,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4490,
-            "start": 4480,
+            "end": 4489,
+            "start": 4479,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4486,
-              "start": 4480,
+              "end": 4485,
+              "start": 4479,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4490,
-              "start": 4488,
+              "end": 4489,
+              "start": 4487,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4490,
-                "start": 4488,
+                "end": 4489,
+                "start": 4487,
               },
               "value": "ID",
             },
@@ -6586,28 +6579,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4505,
-            "start": 4493,
+            "end": 4504,
+            "start": 4492,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4501,
-              "start": 4493,
+              "end": 4500,
+              "start": 4492,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4505,
-              "start": 4503,
+              "end": 4504,
+              "start": 4502,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4505,
-                "start": 4503,
+                "end": 4504,
+                "start": 4502,
               },
               "value": "ID",
             },
@@ -6616,14 +6609,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4507,
-        "start": 4438,
+        "end": 4506,
+        "start": 4437,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4465,
-          "start": 4444,
+          "end": 4464,
+          "start": 4443,
         },
         "value": "UpdatePostEditorInput",
       },
@@ -6638,34 +6631,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4548,
-            "start": 4541,
+            "end": 4547,
+            "start": 4540,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4543,
-              "start": 4541,
+              "end": 4542,
+              "start": 4540,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4548,
-              "start": 4545,
+              "end": 4547,
+              "start": 4544,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4547,
-                "start": 4545,
+                "end": 4546,
+                "start": 4544,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4547,
-                  "start": 4545,
+                  "end": 4546,
+                  "start": 4544,
                 },
                 "value": "ID",
               },
@@ -6675,14 +6668,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4550,
-        "start": 4509,
+        "end": 4549,
+        "start": 4508,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4536,
-          "start": 4515,
+          "end": 4535,
+          "start": 4514,
         },
         "value": "DeletePostEditorInput",
       },
@@ -6697,49 +6690,42 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4596,
-            "start": 4581,
+            "end": 4594,
+            "start": 4580,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4586,
-              "start": 4581,
+              "end": 4585,
+              "start": 4580,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4596,
-              "start": 4588,
+              "end": 4594,
+              "start": 4587,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 4595,
-                "start": 4588,
+                "end": 4593,
+                "start": 4587,
               },
               "type": Object {
-                "kind": "NonNullType",
+                "kind": "NamedType",
                 "loc": Object {
-                  "end": 4594,
-                  "start": 4589,
+                  "end": 4592,
+                  "start": 4588,
                 },
-                "type": Object {
-                  "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
                   "loc": Object {
-                    "end": 4593,
-                    "start": 4589,
+                    "end": 4592,
+                    "start": 4588,
                   },
-                  "name": Object {
-                    "kind": "Name",
-                    "loc": Object {
-                      "end": 4593,
-                      "start": 4589,
-                    },
-                    "value": "User",
-                  },
+                  "value": "User",
                 },
               },
             },
@@ -6751,28 +6737,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4616,
-            "start": 4599,
+            "end": 4614,
+            "start": 4597,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4608,
-              "start": 4599,
+              "end": 4606,
+              "start": 4597,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4616,
-              "start": 4610,
+              "end": 4614,
+              "start": 4608,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4616,
-                "start": 4610,
+                "end": 4614,
+                "start": 4608,
               },
               "value": "String",
             },
@@ -6782,14 +6768,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 4618,
-        "start": 4552,
+        "end": 4616,
+        "start": 4551,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4576,
-          "start": 4557,
+          "end": 4575,
+          "start": 4556,
         },
         "value": "ModelUserConnection",
       },
@@ -6804,28 +6790,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4667,
-            "start": 4651,
+            "end": 4665,
+            "start": 4649,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4653,
-              "start": 4651,
+              "end": 4651,
+              "start": 4649,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4667,
-              "start": 4655,
+              "end": 4665,
+              "start": 4653,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4667,
-                "start": 4655,
+                "end": 4665,
+                "start": 4653,
               },
               "value": "ModelIDInput",
             },
@@ -6837,28 +6823,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4696,
-            "start": 4670,
+            "end": 4694,
+            "start": 4668,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4678,
-              "start": 4670,
+              "end": 4676,
+              "start": 4668,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4696,
-              "start": 4680,
+              "end": 4694,
+              "start": 4678,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4696,
-                "start": 4680,
+                "end": 4694,
+                "start": 4678,
               },
               "value": "ModelStringInput",
             },
@@ -6870,34 +6856,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4726,
-            "start": 4699,
+            "end": 4724,
+            "start": 4697,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4702,
-              "start": 4699,
+              "end": 4700,
+              "start": 4697,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4726,
-              "start": 4704,
+              "end": 4724,
+              "start": 4702,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4725,
-                "start": 4705,
+                "end": 4723,
+                "start": 4703,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4725,
-                  "start": 4705,
+                  "end": 4723,
+                  "start": 4703,
                 },
                 "value": "ModelUserFilterInput",
               },
@@ -6910,34 +6896,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4755,
-            "start": 4729,
+            "end": 4753,
+            "start": 4727,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4731,
-              "start": 4729,
+              "end": 4729,
+              "start": 4727,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4755,
-              "start": 4733,
+              "end": 4753,
+              "start": 4731,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4754,
-                "start": 4734,
+                "end": 4752,
+                "start": 4732,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4754,
-                  "start": 4734,
+                  "end": 4752,
+                  "start": 4732,
                 },
                 "value": "ModelUserFilterInput",
               },
@@ -6950,28 +6936,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4783,
-            "start": 4758,
+            "end": 4781,
+            "start": 4756,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4761,
-              "start": 4758,
+              "end": 4759,
+              "start": 4756,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4783,
-              "start": 4763,
+              "end": 4781,
+              "start": 4761,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4783,
-                "start": 4763,
+                "end": 4781,
+                "start": 4761,
               },
               "value": "ModelUserFilterInput",
             },
@@ -6980,14 +6966,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4785,
-        "start": 4620,
+        "end": 4783,
+        "start": 4618,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4646,
-          "start": 4626,
+          "end": 4644,
+          "start": 4624,
         },
         "value": "ModelUserFilterInput",
       },
@@ -7002,28 +6988,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4847,
-            "start": 4821,
+            "end": 4845,
+            "start": 4819,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4829,
-              "start": 4821,
+              "end": 4827,
+              "start": 4819,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4847,
-              "start": 4831,
+              "end": 4845,
+              "start": 4829,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4847,
-                "start": 4831,
+                "end": 4845,
+                "start": 4829,
               },
               "value": "ModelStringInput",
             },
@@ -7035,34 +7021,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4880,
-            "start": 4850,
+            "end": 4878,
+            "start": 4848,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4853,
-              "start": 4850,
+              "end": 4851,
+              "start": 4848,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4880,
-              "start": 4855,
+              "end": 4878,
+              "start": 4853,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4879,
-                "start": 4856,
+                "end": 4877,
+                "start": 4854,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4879,
-                  "start": 4856,
+                  "end": 4877,
+                  "start": 4854,
                 },
                 "value": "ModelUserConditionInput",
               },
@@ -7075,34 +7061,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4912,
-            "start": 4883,
+            "end": 4910,
+            "start": 4881,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4885,
-              "start": 4883,
+              "end": 4883,
+              "start": 4881,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4912,
-              "start": 4887,
+              "end": 4910,
+              "start": 4885,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4911,
-                "start": 4888,
+                "end": 4909,
+                "start": 4886,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4911,
-                  "start": 4888,
+                  "end": 4909,
+                  "start": 4886,
                 },
                 "value": "ModelUserConditionInput",
               },
@@ -7115,28 +7101,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4943,
-            "start": 4915,
+            "end": 4941,
+            "start": 4913,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4918,
-              "start": 4915,
+              "end": 4916,
+              "start": 4913,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4943,
-              "start": 4920,
+              "end": 4941,
+              "start": 4918,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4943,
-                "start": 4920,
+                "end": 4941,
+                "start": 4918,
               },
               "value": "ModelUserConditionInput",
             },
@@ -7145,14 +7131,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4945,
-        "start": 4787,
+        "end": 4943,
+        "start": 4785,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4816,
-          "start": 4793,
+          "end": 4814,
+          "start": 4791,
         },
         "value": "ModelUserConditionInput",
       },
@@ -7167,28 +7153,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4979,
-            "start": 4973,
+            "end": 4977,
+            "start": 4971,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4975,
-              "start": 4973,
+              "end": 4973,
+              "start": 4971,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4979,
-              "start": 4977,
+              "end": 4977,
+              "start": 4975,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4979,
-                "start": 4977,
+                "end": 4977,
+                "start": 4975,
               },
               "value": "ID",
             },
@@ -7200,34 +7186,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4999,
-            "start": 4982,
+            "end": 4997,
+            "start": 4980,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4990,
-              "start": 4982,
+              "end": 4988,
+              "start": 4980,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4999,
-              "start": 4992,
+              "end": 4997,
+              "start": 4990,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4998,
-                "start": 4992,
+                "end": 4996,
+                "start": 4990,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4998,
-                  "start": 4992,
+                  "end": 4996,
+                  "start": 4990,
                 },
                 "value": "String",
               },
@@ -7237,14 +7223,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5001,
-        "start": 4947,
+        "end": 4999,
+        "start": 4945,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4968,
-          "start": 4953,
+          "end": 4966,
+          "start": 4951,
         },
         "value": "CreateUserInput",
       },
@@ -7259,34 +7245,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5036,
-            "start": 5029,
+            "end": 5034,
+            "start": 5027,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5031,
-              "start": 5029,
+              "end": 5029,
+              "start": 5027,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5036,
-              "start": 5033,
+              "end": 5034,
+              "start": 5031,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5035,
-                "start": 5033,
+                "end": 5033,
+                "start": 5031,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5035,
-                  "start": 5033,
+                  "end": 5033,
+                  "start": 5031,
                 },
                 "value": "ID",
               },
@@ -7299,28 +7285,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5055,
-            "start": 5039,
+            "end": 5053,
+            "start": 5037,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5047,
-              "start": 5039,
+              "end": 5045,
+              "start": 5037,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5055,
-              "start": 5049,
+              "end": 5053,
+              "start": 5047,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5055,
-                "start": 5049,
+                "end": 5053,
+                "start": 5047,
               },
               "value": "String",
             },
@@ -7329,14 +7315,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5057,
-        "start": 5003,
+        "end": 5055,
+        "start": 5001,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5024,
-          "start": 5009,
+          "end": 5022,
+          "start": 5007,
         },
         "value": "UpdateUserInput",
       },
@@ -7351,34 +7337,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5092,
-            "start": 5085,
+            "end": 5090,
+            "start": 5083,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5087,
-              "start": 5085,
+              "end": 5085,
+              "start": 5083,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5092,
-              "start": 5089,
+              "end": 5090,
+              "start": 5087,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5091,
-                "start": 5089,
+                "end": 5089,
+                "start": 5087,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5091,
-                  "start": 5089,
+                  "end": 5089,
+                  "start": 5087,
                 },
                 "value": "ID",
               },
@@ -7388,14 +7374,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5094,
-        "start": 5059,
+        "end": 5092,
+        "start": 5057,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5080,
-          "start": 5065,
+          "end": 5078,
+          "start": 5063,
         },
         "value": "DeleteUserInput",
       },
@@ -7410,28 +7396,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5137,
-            "start": 5131,
+            "end": 5135,
+            "start": 5129,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5133,
-              "start": 5131,
+              "end": 5131,
+              "start": 5129,
             },
             "value": "eq",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5137,
-              "start": 5135,
+              "end": 5135,
+              "start": 5133,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5137,
-                "start": 5135,
+                "end": 5135,
+                "start": 5133,
               },
               "value": "ID",
             },
@@ -7443,28 +7429,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5146,
-            "start": 5140,
+            "end": 5144,
+            "start": 5138,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5142,
-              "start": 5140,
+              "end": 5140,
+              "start": 5138,
             },
             "value": "le",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5146,
-              "start": 5144,
+              "end": 5144,
+              "start": 5142,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5146,
-                "start": 5144,
+                "end": 5144,
+                "start": 5142,
               },
               "value": "ID",
             },
@@ -7476,28 +7462,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5155,
-            "start": 5149,
+            "end": 5153,
+            "start": 5147,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5151,
-              "start": 5149,
+              "end": 5149,
+              "start": 5147,
             },
             "value": "lt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5155,
-              "start": 5153,
+              "end": 5153,
+              "start": 5151,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5155,
-                "start": 5153,
+                "end": 5153,
+                "start": 5151,
               },
               "value": "ID",
             },
@@ -7509,28 +7495,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5164,
-            "start": 5158,
+            "end": 5162,
+            "start": 5156,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5160,
-              "start": 5158,
+              "end": 5158,
+              "start": 5156,
             },
             "value": "ge",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5164,
-              "start": 5162,
+              "end": 5162,
+              "start": 5160,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5164,
-                "start": 5162,
+                "end": 5162,
+                "start": 5160,
               },
               "value": "ID",
             },
@@ -7542,28 +7528,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5173,
-            "start": 5167,
+            "end": 5171,
+            "start": 5165,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5169,
-              "start": 5167,
+              "end": 5167,
+              "start": 5165,
             },
             "value": "gt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5173,
-              "start": 5171,
+              "end": 5171,
+              "start": 5169,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5173,
-                "start": 5171,
+                "end": 5171,
+                "start": 5169,
               },
               "value": "ID",
             },
@@ -7575,34 +7561,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5189,
-            "start": 5176,
+            "end": 5187,
+            "start": 5174,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5183,
-              "start": 5176,
+              "end": 5181,
+              "start": 5174,
             },
             "value": "between",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5189,
-              "start": 5185,
+              "end": 5187,
+              "start": 5183,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5188,
-                "start": 5186,
+                "end": 5186,
+                "start": 5184,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5188,
-                  "start": 5186,
+                  "end": 5186,
+                  "start": 5184,
                 },
                 "value": "ID",
               },
@@ -7615,28 +7601,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5206,
-            "start": 5192,
+            "end": 5204,
+            "start": 5190,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5202,
-              "start": 5192,
+              "end": 5200,
+              "start": 5190,
             },
             "value": "beginsWith",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5206,
-              "start": 5204,
+              "end": 5204,
+              "start": 5202,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5206,
-                "start": 5204,
+                "end": 5204,
+                "start": 5202,
               },
               "value": "ID",
             },
@@ -7645,14 +7631,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5208,
-        "start": 5096,
+        "end": 5206,
+        "start": 5094,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5126,
-          "start": 5102,
+          "end": 5124,
+          "start": 5100,
         },
         "value": "ModelIDKeyConditionInput",
       },
@@ -7667,49 +7653,42 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 5266,
-            "start": 5245,
+            "end": 5263,
+            "start": 5243,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5250,
-              "start": 5245,
+              "end": 5248,
+              "start": 5243,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5266,
-              "start": 5252,
+              "end": 5263,
+              "start": 5250,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 5265,
-                "start": 5252,
+                "end": 5262,
+                "start": 5250,
               },
               "type": Object {
-                "kind": "NonNullType",
+                "kind": "NamedType",
                 "loc": Object {
-                  "end": 5264,
-                  "start": 5253,
+                  "end": 5261,
+                  "start": 5251,
                 },
-                "type": Object {
-                  "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
                   "loc": Object {
-                    "end": 5263,
-                    "start": 5253,
+                    "end": 5261,
+                    "start": 5251,
                   },
-                  "name": Object {
-                    "kind": "Name",
-                    "loc": Object {
-                      "end": 5263,
-                      "start": 5253,
-                    },
-                    "value": "PostEditor",
-                  },
+                  "value": "PostEditor",
                 },
               },
             },
@@ -7721,28 +7700,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 5286,
-            "start": 5269,
+            "end": 5283,
+            "start": 5266,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5278,
-              "start": 5269,
+              "end": 5275,
+              "start": 5266,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5286,
-              "start": 5280,
+              "end": 5283,
+              "start": 5277,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5286,
-                "start": 5280,
+                "end": 5283,
+                "start": 5277,
               },
               "value": "String",
             },
@@ -7752,14 +7731,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 5288,
-        "start": 5210,
+        "end": 5285,
+        "start": 5208,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5240,
-          "start": 5215,
+          "end": 5238,
+          "start": 5213,
         },
         "value": "ModelPostEditorConnection",
       },
@@ -7774,28 +7753,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5343,
-            "start": 5327,
+            "end": 5340,
+            "start": 5324,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5329,
-              "start": 5327,
+              "end": 5326,
+              "start": 5324,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5343,
-              "start": 5331,
+              "end": 5340,
+              "start": 5328,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5343,
-                "start": 5331,
+                "end": 5340,
+                "start": 5328,
               },
               "value": "ModelIDInput",
             },
@@ -7807,28 +7786,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5366,
-            "start": 5346,
+            "end": 5363,
+            "start": 5343,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5352,
-              "start": 5346,
+              "end": 5349,
+              "start": 5343,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5366,
-              "start": 5354,
+              "end": 5363,
+              "start": 5351,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5366,
-                "start": 5354,
+                "end": 5363,
+                "start": 5351,
               },
               "value": "ModelIDInput",
             },
@@ -7840,28 +7819,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5391,
-            "start": 5369,
+            "end": 5388,
+            "start": 5366,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5377,
-              "start": 5369,
+              "end": 5374,
+              "start": 5366,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5391,
-              "start": 5379,
+              "end": 5388,
+              "start": 5376,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5391,
-                "start": 5379,
+                "end": 5388,
+                "start": 5376,
               },
               "value": "ModelIDInput",
             },
@@ -7873,34 +7852,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5427,
-            "start": 5394,
+            "end": 5424,
+            "start": 5391,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5397,
-              "start": 5394,
+              "end": 5394,
+              "start": 5391,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5427,
-              "start": 5399,
+              "end": 5424,
+              "start": 5396,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5426,
-                "start": 5400,
+                "end": 5423,
+                "start": 5397,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5426,
-                  "start": 5400,
+                  "end": 5423,
+                  "start": 5397,
                 },
                 "value": "ModelPostEditorFilterInput",
               },
@@ -7913,34 +7892,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5462,
-            "start": 5430,
+            "end": 5459,
+            "start": 5427,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5432,
-              "start": 5430,
+              "end": 5429,
+              "start": 5427,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5462,
-              "start": 5434,
+              "end": 5459,
+              "start": 5431,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5461,
-                "start": 5435,
+                "end": 5458,
+                "start": 5432,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5461,
-                  "start": 5435,
+                  "end": 5458,
+                  "start": 5432,
                 },
                 "value": "ModelPostEditorFilterInput",
               },
@@ -7953,28 +7932,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5496,
-            "start": 5465,
+            "end": 5493,
+            "start": 5462,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5468,
-              "start": 5465,
+              "end": 5465,
+              "start": 5462,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5496,
-              "start": 5470,
+              "end": 5493,
+              "start": 5467,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5496,
-                "start": 5470,
+                "end": 5493,
+                "start": 5467,
               },
               "value": "ModelPostEditorFilterInput",
             },
@@ -7983,14 +7962,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5498,
-        "start": 5290,
+        "end": 5495,
+        "start": 5287,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5322,
-          "start": 5296,
+          "end": 5319,
+          "start": 5293,
         },
         "value": "ModelPostEditorFilterInput",
       },
@@ -7998,7 +7977,7 @@ Object {
   ],
   "kind": "Document",
   "loc": Object {
-    "end": 5500,
+    "end": 5497,
     "start": 0,
   },
 }

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -1069,7 +1069,7 @@ enum ModelSortDirection {
 }
 
 type ModelFooConnection {
-  items: [Foo!]!
+  items: [Foo]!
   nextToken: String
 }
 
@@ -1132,7 +1132,7 @@ type Subscription {
 }
 
 type ModelBarConnection {
-  items: [Bar!]!
+  items: [Bar]!
   nextToken: String
 }
 
@@ -1162,7 +1162,7 @@ input DeleteBarInput {
 }
 
 type ModelFooBarConnection {
-  items: [FooBar!]!
+  items: [FooBar]!
   nextToken: String
 }
 

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -72,7 +72,7 @@ function generateModelXConnectionType(
   let connectionTypeExtension = blankObjectExtension(tableXConnectionName);
 
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
-    makeField('items', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(relatedType.name.value))))),
+    makeField('items', [], makeNonNullType(makeListType(makeNamedType(relatedType.name.value)))),
   ]);
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('nextToken', [], makeNamedType('String'))]);
 

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -17,10 +17,10 @@ enum EmploymentType {
 }
 
 type SearchableEmployeeConnection {
-  items: [Employee!]!
+  items: [Employee]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 type SearchableAggregateResult {
@@ -141,7 +141,7 @@ enum ModelSortDirection {
 }
 
 type ModelEmployeeConnection {
-  items: [Employee!]!
+  items: [Employee]!
   nextToken: String
 }
 
@@ -324,10 +324,10 @@ type Post {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 type SearchableAggregateResult {
@@ -448,7 +448,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1238,10 +1238,10 @@ type User {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 type SearchableAggregateResult {
@@ -1274,10 +1274,10 @@ type Query {
 }
 
 type SearchableUserConnection {
-  items: [User!]!
+  items: [User]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 input ModelStringInput {
@@ -1372,7 +1372,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1432,7 +1432,7 @@ type Subscription {
 }
 
 type ModelUserConnection {
-  items: [User!]!
+  items: [User]!
   nextToken: String
 }
 
@@ -1620,10 +1620,10 @@ type Post {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 type SearchableAggregateResult {
@@ -1744,7 +1744,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1902,10 +1902,10 @@ type Post {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 type SearchableAggregateResult {
@@ -2026,7 +2026,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -2199,10 +2199,10 @@ type Post {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
-  aggregateItems: [SearchableAggregateResult!]!
+  aggregateItems: [SearchableAggregateResult]!
 }
 
 type SearchableAggregateResult {
@@ -2323,7 +2323,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -245,12 +245,12 @@ export class SearchableModelTransformer extends TransformerPluginBase {
     // Create TableXConnection type with items and nextToken
     let connectionTypeExtension = blankObjectExtension(searchableXConnectionName);
     connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
-      makeField('items', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(definition.name.value))))),
+      makeField('items', [], makeNonNullType(makeListType(makeNamedType(definition.name.value)))),
     ]);
     connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
       makeField('nextToken', [], makeNamedType('String')),
       makeField('total', [], makeNamedType('Int')),
-      makeField('aggregateItems', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(`SearchableAggregateResult`))))),
+      makeField('aggregateItems', [], makeNonNullType(makeListType(makeNamedType(`SearchableAggregateResult`)))),
     ]);
     ctx.output.addObjectExtension(connectionTypeExtension);
   }

--- a/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
+++ b/packages/graphql-auth-transformer/src/__tests__/__snapshots__/SearchableAuthTransformer.test.ts.snap
@@ -15,7 +15,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection @aws_api_key @aws_iam {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -198,7 +198,7 @@ input SearchablePostSortInput {
 }
 
 type SearchablePostConnection @aws_api_key @aws_iam {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
 }

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/ModelConnectionTransformer.test.ts.snap
@@ -17,7 +17,7 @@ type Comment {
 }
 
 type ModelCommentConnection {
-  items: [Comment!]!
+  items: [Comment]!
   nextToken: String
 }
 
@@ -144,7 +144,7 @@ enum PRODUCT_TYPE {
 }
 
 type ModelCartItemConnection {
-  items: [CartItem!]!
+  items: [CartItem]!
   nextToken: String
 }
 

--- a/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
+++ b/packages/graphql-connection-transformer/src/__tests__/__snapshots__/NewConnectionTransformer.test.ts.snap
@@ -42,7 +42,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   startedAt: AWSTimestamp
 }
@@ -200,7 +200,7 @@ type Subscription {
 }
 
 type ModelPostEditorConnection {
-  items: [PostEditor!]!
+  items: [PostEditor]!
   nextToken: String
   startedAt: AWSTimestamp
 }
@@ -242,7 +242,7 @@ input ModelPostEditorConditionInput {
 }
 
 type ModelUserConnection {
-  items: [User!]!
+  items: [User]!
   nextToken: String
   startedAt: AWSTimestamp
 }
@@ -324,7 +324,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -499,7 +499,7 @@ input ModelPostEditorConditionInput {
 }
 
 type ModelUserConnection {
-  items: [User!]!
+  items: [User]!
   nextToken: String
 }
 
@@ -543,7 +543,7 @@ input ModelIDKeyConditionInput {
 }
 
 type ModelPostEditorConnection {
-  items: [PostEditor!]!
+  items: [PostEditor]!
   nextToken: String
 }
 

--- a/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/__snapshots__/DynamoDBModelTransformer.test.ts.snap
@@ -14,7 +14,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -224,7 +224,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -538,7 +538,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -855,7 +855,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1164,7 +1164,7 @@ enum ModelSortDirection {
 }
 
 type ModelEntityConnection {
-  items: [Entity!]!
+  items: [Entity]!
   nextToken: String
 }
 
@@ -1283,7 +1283,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1593,7 +1593,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1703,7 +1703,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -739,7 +739,7 @@ export function makeModelConnectionType(typeName: string, isSync: Boolean = fals
   const connectionName = ModelResourceIDs.ModelConnectionTypeName(typeName);
   let connectionTypeExtension = blankObjectExtension(connectionName);
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
-    makeField('items', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(typeName))))),
+    makeField('items', [], makeNonNullType(makeListType(makeNamedType(typeName)))),
   ]);
   connectionTypeExtension = extensionWithFields(connectionTypeExtension, [makeField('nextToken', [], makeNamedType('String'))]);
   if (isSync) {

--- a/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
+++ b/packages/graphql-elasticsearch-transformer/src/SearchableModelTransformer.ts
@@ -163,7 +163,7 @@ export class SearchableModelTransformer extends Transformer {
     // Create TableXConnection type with items and nextToken
     let connectionTypeExtension = blankObjectExtension(searchableXConnectionName);
     connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
-      makeField('items', [], makeNonNullType(makeListType(makeNonNullType(makeNamedType(def.name.value))))),
+      makeField('items', [], makeNonNullType(makeListType(makeNamedType(def.name.value)))),
     ]);
     connectionTypeExtension = extensionWithFields(connectionTypeExtension, [
       makeField('nextToken', [], makeNamedType('String')),

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/__snapshots__/SearchableModelTransformer.test.ts.snap
@@ -69,7 +69,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -257,7 +257,7 @@ input SearchablePostSortInput {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
 }
@@ -285,7 +285,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -396,7 +396,7 @@ type Subscription {
 }
 
 type ModelUserConnection {
-  items: [User!]!
+  items: [User]!
   nextToken: String
 }
 
@@ -509,7 +509,7 @@ input SearchablePostSortInput {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
 }
@@ -533,7 +533,7 @@ input SearchableUserSortInput {
 }
 
 type SearchableUserConnection {
-  items: [User!]!
+  items: [User]!
   nextToken: String
   total: Int
 }
@@ -554,7 +554,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -727,7 +727,7 @@ input SearchablePostSortInput {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
 }
@@ -748,7 +748,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -936,7 +936,7 @@ input SearchablePostSortInput {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
 }
@@ -957,7 +957,7 @@ enum ModelSortDirection {
 }
 
 type ModelPostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
 }
 
@@ -1145,7 +1145,7 @@ input SearchablePostSortInput {
 }
 
 type SearchablePostConnection {
-  items: [Post!]!
+  items: [Post]!
   nextToken: String
   total: Int
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Partially reverts the behavior that was added in https://github.com/aws-amplify/amplify-cli/pull/8166. The array itself in the list type is still non-null but the elements are generated as nullable. This is because individual elements can come back as null if there is an error in the VTL resolver for that record

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified and updated unit test snapshots

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
