### PR TITLE
Pin npx create-react-app

### DIFF
--- a/packages/amplify-console-integration-tests/src/consoleHosting/utils.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/utils.ts
@@ -82,7 +82,7 @@ export async function createTestProject(): Promise<string> {
   const projectName = path.basename(projRoot);
   const projectDir = path.dirname(projRoot);
 
-  spawnSync('npx', ['create-react-app', projectName], { cwd: projectDir });
+  spawnSync('npx', ['create-react-app@4.0.3', projectName], { cwd: projectDir });
 
   return projRoot;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
npx pulls latest by default, but the latest version of create-react-app dropped node 12 support


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Validated that create-react-app does not support 12 and 12 is in use, ran npx locally using the new command format with version

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
