### PR TITLE
fix: #8997 - auth trigger detached after push

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/generate-auth-trigger-template.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/generate-auth-trigger-template.ts
@@ -8,6 +8,7 @@ import { prepareApp } from '@aws-cdk/core/lib/private/prepare-app';
 import { AuthTriggerConnection, CognitoStackOptions } from '../service-walkthrough-types/cognito-user-input-types';
 import { CustomResource } from '@aws-cdk/core';
 import { authTriggerAssetFilePath } from '../constants';
+import { v4 as uuid } from 'uuid';
 
 type CustomResourceAuthStackProps = Readonly<{
   description: string;
@@ -48,7 +49,7 @@ export class CustomResourceAuthStack extends cdk.Stack {
       config.lambdaFunctionArn = fnArn.valueAsString;
     });
 
-    createCustomResource(this, props.authTriggerConnections, userpoolId, userpoolArn);
+    createCustomResource(this, props.authTriggerConnections, userpoolId);
   }
 
   toCloudFormation() {
@@ -84,12 +85,7 @@ async function createCustomResourceforAuthTrigger(authTriggerConnections: AuthTr
   return cfn;
 }
 
-function createCustomResource(
-  stack: cdk.Stack,
-  authTriggerConnections: AuthTriggerConnection[],
-  userpoolId: cdk.CfnParameter,
-  userpoolArn: cdk.CfnParameter,
-) {
+function createCustomResource(stack: cdk.Stack, authTriggerConnections: AuthTriggerConnection[], userpoolId: cdk.CfnParameter) {
   const triggerCode = fs.readFileSync(authTriggerAssetFilePath, 'utf-8');
   const authTriggerFn = new lambda.Function(stack, 'authTriggerFn', {
     runtime: lambda.Runtime.NODEJS_12_X,
@@ -107,10 +103,12 @@ function createCustomResource(
       }),
     );
   }
+
   // The custom resource that uses the provider to supply value
+  // Passing in a nonce parameter to ensure that the custom resource is triggered on every deployment
   new CustomResource(stack, 'CustomAuthTriggerResource', {
     serviceToken: authTriggerFn.functionArn,
-    properties: { userpoolId: userpoolId.valueAsString, lambdaConfig: authTriggerConnections },
+    properties: { userpoolId: userpoolId.valueAsString, lambdaConfig: authTriggerConnections, nonce: uuid() },
     resourceType: 'Custom::CustomAuthTriggerResourceOutputs',
   });
 }

--- a/packages/amplify-e2e-tests/src/__tests__/auth_9.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_9.test.ts
@@ -1,0 +1,109 @@
+import {
+  addAuthWithRecaptchaTrigger,
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getCLIPath,
+  getProjectMeta,
+  getUserPool,
+  initJSProjectWithProfile,
+  nspawn as spawn,
+} from 'amplify-e2e-core';
+import { CognitoIdentityServiceProvider } from 'aws-sdk';
+
+const defaultsSettings = {
+  name: 'authTest',
+};
+
+describe('amplify auth with trigger', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('auth');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('add auth with trigger, push, update auth, push, verify trigger attachment', async () => {
+    await initJSProjectWithProfile(projRoot, defaultsSettings);
+    await addAuthWithRecaptchaTrigger(projRoot, {});
+    await amplifyPushAuth(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    const userPoolId = Object.keys(meta.auth).map(key => meta.auth[key])[0].output.UserPoolId;
+    let userPool = (await getUserPool(
+      userPoolId,
+      meta.providers.awscloudformation.Region,
+    )) as CognitoIdentityServiceProvider.DescribeUserPoolResponse;
+
+    expect(userPool.UserPool).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig.CreateAuthChallenge).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig.DefineAuthChallenge).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig.VerifyAuthChallengeResponse).toBeDefined();
+
+    await updateAuthChangeToUserPoolOnlyAndSetCodeMessages(projRoot, {});
+
+    await amplifyPushAuth(projRoot);
+
+    userPool = (await getUserPool(
+      userPoolId,
+      meta.providers.awscloudformation.Region,
+    )) as CognitoIdentityServiceProvider.DescribeUserPoolResponse;
+
+    expect(userPool.UserPool).toBeDefined();
+    expect(userPool.UserPool.EmailVerificationSubject).toBe('New code');
+    expect(userPool.UserPool.EmailVerificationMessage).toBe('New code is {####}');
+    expect(userPool.UserPool.LambdaConfig).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig.CreateAuthChallenge).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig.DefineAuthChallenge).toBeDefined();
+    expect(userPool.UserPool.LambdaConfig.VerifyAuthChallengeResponse).toBeDefined();
+  });
+
+  const updateAuthChangeToUserPoolOnlyAndSetCodeMessages = async (cwd: string, settings: any): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const chain = spawn(getCLIPath(), ['update', 'auth'], { cwd, stripColors: true });
+
+      chain
+        .wait('What do you want to do')
+        .sendKeyDown()
+        .sendCarriageReturn()
+        .wait('Select the authentication/authorization services that you want to use')
+        .sendKeyDown()
+        .sendCarriageReturn()
+        .wait('Do you want to add User Pool Groups')
+        .sendKeyDown()
+        .sendCarriageReturn() // No
+        .wait('Do you want to add an admin queries API')
+        .sendKeyDown()
+        .sendCarriageReturn() // No
+        .wait('Multifactor authentication (MFA) user login options')
+        .sendCarriageReturn() // Select Off
+        .wait('Email based user registration/forgot password')
+        .sendCarriageReturn() // Enabled
+        .wait('Specify an email verification subject')
+        .sendLine('New code') // New code
+        .wait('Specify an email verification message')
+        .sendLine('New code is {####}') // New code is {####}
+        .wait('Do you want to override the default password policy')
+        .sendConfirmNo()
+        .wait("Specify the app's refresh token expiration period")
+        .sendCarriageReturn() // 30
+        .wait('Do you want to specify the user attributes this app can read and write')
+        .sendConfirmNo()
+        .wait('Do you want to enable any of the following capabilities')
+        .sendCarriageReturn() // Preserve recaptcha trigger
+        .wait('Do you want to use an OAuth flow')
+        .sendKeyDown()
+        .sendCarriageReturn() // No
+        .wait('Do you want to configure Lambda Triggers for Cognito')
+        .sendConfirmNo()
+        .sendEof()
+        .run((err: Error) => (err ? reject(err) : resolve()));
+    });
+  };
+});


### PR DESCRIPTION
#### Description of changes

This PR fixes #8997. A Lambda trigger was detached after subsequent updates to the `auth` resource.

#### Issue #, if available

fixes: #8997 

#### Description of how you validated changes

Manually and new e2e test is added

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
