### PR TITLE
fix(amplify-util-mock): fix cleanup V2 resolvers on mock exit

### DIFF
--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -193,7 +193,7 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
           continue;
         }
         const pipelineFunctionPath = path.join(pipelineFunctionDirectory, pipelineFunctionFile);
-        pipelineFunctions[pipelineFunctionFile] = await fs.readFile(pipelineFunctionPath);
+        pipelineFunctions[pipelineFunctionFile] = await fs.readFile(pipelineFunctionPath, 'utf8');
       }
     }
   }
@@ -210,7 +210,7 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
           continue;
         }
         const resolverFilePath = path.join(resolverDirectory, resolverFile);
-        resolvers[resolverFile] = await fs.readFile(resolverFilePath);
+        resolvers[resolverFile] = await fs.readFile(resolverFilePath, 'utf8');
       }
     }
   }


### PR DESCRIPTION
#### Description of changes
- fixed readFile so it will return a string instead of a buffer to match the object definition
- fixes the object comparison in the mock in order to decide if template needs to be updated

#### Issue #9268 

#### Description of how you validated changes
- manual testing
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
