### PR TITLE
fix: support recursive @hasOne/@hasMany with DataStore

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -693,3 +693,25 @@ test('@hasMany and @hasMany cannot point at each other if DataStore is enabled',
     `Blog and Post cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
   );
 });
+
+test('recursive @hasMany relationships are supported if DataStore is enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: [Blog] @hasMany
+    }`;
+  const transformer = new GraphQLTransform({
+    resolverConfig: {
+      project: {
+        ConflictDetection: 'VERSION',
+        ConflictHandler: ConflictHandlerType.AUTOMERGE,
+      },
+    },
+    transformers: [new ModelTransformer(), new HasManyTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
@@ -444,3 +444,25 @@ test('@hasOne and @hasOne cannot point at each other if DataStore is enabled', (
     `Blog and Post cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead.`,
   );
 });
+
+test('recursive @hasOne relationships are supported if DataStore is enabled', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      posts: Blog @hasOne
+    }`;
+  const transformer = new GraphQLTransform({
+    resolverConfig: {
+      project: {
+        ConflictDetection: 'VERSION',
+        ConflictHandler: ConflictHandlerType.AUTOMERGE,
+      },
+    },
+    transformers: [new ModelTransformer(), new HasOneTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+});

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -188,6 +188,11 @@ export function validateDisallowedDataStoreRelationships(
   const relatedType = ctx.output.getType(config.relatedType.name.value) as ObjectTypeDefinitionNode;
   assert(relatedType);
 
+  // Recursive relationships on the same type are allowed.
+  if (modelType === relatedType.name.value) {
+    return;
+  }
+
   const hasUnsupportedConnectionFields = relatedType.fields!.some(field => {
     // If the related field has the same data type as this model, and @hasOne or @hasMany
     // is present, then the connection is unsupported.


### PR DESCRIPTION
This commit allows recursive @hasOne and @hasMany relationships
on the same model when DataStore is enabled.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9335
