### PR TITLE
fix(amplify-cli-core): parameter structure in hooks script

### DIFF
--- a/packages/amplify-cli-core/src/__tests__/hooks/hooksMeta.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/hooks/hooksMeta.test.ts
@@ -1,4 +1,14 @@
 import { HooksMeta } from '../../hooks/hooksMeta';
+import { stateManager } from '../../state-manager';
+
+const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
+jest.mock('../../state-manager');
+stateManager_mock.localEnvInfoExists.mockReturnValue(true);
+stateManager_mock.getLocalEnvInfo.mockReturnValue({
+  projectPath: '/project-path',
+  defaultEditor: 'vscode',
+  envName: 'production',
+});
 
 describe('HooksMeta tests', () => {
   beforeEach(async () => {
@@ -48,6 +58,16 @@ describe('HooksMeta tests', () => {
 
     expect(hooksMeta.getHookEvent()?.command).toEqual(undefined);
     expect(hooksMeta.getHookEvent()?.subCommand).toEqual(undefined);
+  });
+
+  test('should identify environment name', () => {
+    const input = { command: 'publish', plugin: 'core' };
+    const hooksMeta = HooksMeta.getInstance();
+    hooksMeta.setHookEventFromInput(input);
+
+    expect(hooksMeta.getHookEvent()?.command).toEqual('publish');
+    expect(hooksMeta.getHookEvent()?.subCommand).toEqual(undefined);
+    expect(hooksMeta.getDataParameter()?.amplify.environment).toEqual('production');
   });
 
   test('should return correct HooksMeta object - getInstance', () => {

--- a/packages/amplify-cli-core/src/hooks/hooksMeta.ts
+++ b/packages/amplify-cli-core/src/hooks/hooksMeta.ts
@@ -28,7 +28,7 @@ export class HooksMeta {
     }
     HooksMeta.instance.setEventPrefix(eventPrefix);
     if (stateManager.localEnvInfoExists()) {
-      HooksMeta.instance.setEnvironmentName(stateManager.getLocalEnvInfo());
+      HooksMeta.instance.setEnvironmentName(stateManager.getLocalEnvInfo().envName);
     }
     HooksMeta.instance.mergeDataParameter({
       amplify: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Make sure to access the current environment name with `amplify.environment`.
https://docs.amplify.aws/cli/project/command-hooks/#access-parameters-in-hook-scripts


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

fix #9346

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- yarn test
- Manual Testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
