### PR TITLE
chore: improve `add env` error handling

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/env.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/env.test.ts
@@ -2,13 +2,23 @@ describe('amplify env: ', () => {
   const mockExit = jest.fn();
   jest.mock('amplify-cli-core', () => ({
     exitOnNextTick: mockExit,
+    pathManager: { getAmplifyMetaFilePath: jest.fn().mockReturnValue('test_file_does_not_exist') },
   }));
   const { run: runEnvCmd } = require('../../commands/env');
+  const { run: runAddEnvCmd } = require('../../commands/env/add');
   const envList = require('../../commands/env/list');
   jest.mock('../../commands/env/list');
 
   it('env run method should exist', () => {
     expect(runEnvCmd).toBeDefined();
+  });
+
+  it('env add method should exist', () => {
+    expect(runAddEnvCmd).toBeDefined();
+  });
+
+  it('env add method should throw if meta file does not exist', () => {
+    expect(async () => await runAddEnvCmd()).rejects.toThrow();
   });
 
   it('env ls is an alias for env list', async () => {
@@ -31,21 +41,21 @@ describe('amplify env: ', () => {
   it('invalid env subcommand should give a warning', async () => {
     const mockContextInvalidEnvSubcommand = {
       amplify: {
-        showHelp: jest.fn()
+        showHelp: jest.fn(),
       },
       parameters: {},
       input: {
         subCommands: ['test12345'],
       },
-      print:{
+      print: {
         warning: jest.fn(),
         info: jest.fn(),
-      }
+      },
     };
     await runEnvCmd(mockContextInvalidEnvSubcommand);
     expect(mockContextInvalidEnvSubcommand.amplify.showHelp).toBeCalled();
     expect(mockContextInvalidEnvSubcommand.print.warning.mock.calls[0][0]).toMatchInlineSnapshot(
       `"Cannot find command: 'amplify env test12345'"`,
     );
-  })
+  });
 });

--- a/packages/amplify-cli/src/commands/env/add.ts
+++ b/packages/amplify-cli/src/commands/env/add.ts
@@ -1,6 +1,13 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext, pathManager } from 'amplify-cli-core';
 import { run as init } from '../init';
+import fs from 'fs-extra';
 
 export const run = async (context: $TSContext) => {
+  const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
+  if (!fs.existsSync(amplifyMetaFilePath)) {
+    throw new Error(
+      'Your workspace is not configured to modify the backend. If you wish to change this configuration, remove your `amplify` directory and pull the project again.',
+    );
+  }
   await init(context);
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This addresses confusion caused for developers who respond `no` to `Do you plan on modifying this backend?` during `amplify pull`.

Since they've made this choice, the necessary meta files are not in place to run commands like `amplify add env`, and when they attempt to do so, they see an error like:

```
File at path: '/Users/xss/tmp/amplify/backend/amplify-meta.json' does not exist
Error: File at path: '/Users/xss/tmp/amplify/backend/amplify-meta.json' does not exist
    at Function.JSONUtilities.readJson (/Users/xss/repos/amplify-cli-dec16/packages/amplify-cli-core/lib/jsonUtilities.js:40:19)
    at StateManager.getData (/Users/xss/repos/amplify-cli-dec16/packages/amplify-cli-core/lib/state-manager/stateManager.js:298:56)
    at StateManager.getMeta (/Users/xss/repos/amplify-cli-dec16/packages/amplify-cli-core/lib/state-manager/stateManager.js:42:31)
```

This commit replaces that confusing error with a more actionable one:

```
Your workspace is not configured to modify the backend. If you wish to change this configuration, remove your `amplify` directory and pull the project again.
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/8257

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
