### PR TITLE
chore: improve graphql syntax error message

### DIFF
--- a/packages/graphql-transformer-core/src/collectDirectives.ts
+++ b/packages/graphql-transformer-core/src/collectDirectives.ts
@@ -12,7 +12,7 @@ import {
   parse,
   Kind,
 } from 'graphql';
-
+import { printer } from 'amplify-prompts';
 export function collectDirectiveNames(sdl: string): string[] {
   const dirs = collectDirectives(sdl);
   return dirs.map(d => d.name.value);
@@ -65,7 +65,15 @@ export function collectDirectivesByType(sdl: string): Object {
   if (!sdl) {
     return {};
   }
-  const doc = parse(sdl);
+  let doc;
+  try {
+    doc = parse(sdl);
+  } catch (e) {
+    if (e.message?.includes('Syntax Error')) {
+      printer.error('Your GraphQL schema is invalid. Update the schema to use proper syntax and try again.');
+    }
+    throw e;
+  }
   // defined types with directives list
   let types = {};
   for (const def of doc.definitions) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This commit improves the error messaging during `amplify update api` to be more clear when the developer's graphql syntax is invalid.

Currently, this is the error that the developer sees:

```
🛑 Syntax Error: Unexpected Name "haoentuhaoesnug9r234hbkjekhoasueoa"
GraphQLError: Syntax Error: Unexpected Name "haoentuhaoesnug9r234hbkjekhoasueoa"
    at syntaxError (/Users/xss/repos/amplify-cli-dec16/node_modules/graphql/error/syntaxError.js:15:10)
    at Parser.unexpected (/Users/xss/repos/amplify-cli-dec16/node_modules/graphql/language/parser.js:1463:41)
    at Parser.parseDefinition (/Users/xss/repos/amplify-cli-dec16/node_modules/graphql/language/parser.js:157:16)
    at Parser.many (/Users/xss/repos/amplify-cli-dec16/node_modules/graphql/language/parser.js:1518:26)
    at Parser.parseDocument (/Users/xss/repos/amplify-cli-dec16/node_modules/graphql/language/parser.js:111:25)
    at parse (/Users/xss/repos/amplify-cli-dec16/node_modules/graphql/language/parser.js:36:17)
```

After this commit, the user sees a more actionable error message:

```
Your GraphQL schema is invalid. Update the schema to use proper syntax and try again.
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/8079

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
