### PR TITLE
fix: update amplify configure to use AdministratorAccess-Amplify

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/setup-new-user.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/setup-new-user.test.ts
@@ -1,7 +1,7 @@
 import { $TSContext, open } from 'amplify-cli-core';
 import { run } from '../setup-new-user';
 
-const context_stub = ({
+const context_stub = {
   print: {
     info: jest.fn(),
     warning: jest.fn(),
@@ -13,7 +13,7 @@ const context_stub = ({
       run: jest.fn().mockReturnValue(new Promise(resolve => resolve(true))),
     },
   },
-} as unknown) as jest.Mocked<$TSContext>;
+} as unknown as jest.Mocked<$TSContext>;
 
 jest.mock('amplify-cli-core', () => ({
   open: jest.fn().mockReturnValue(Promise.resolve()),
@@ -44,10 +44,8 @@ describe('setupNewUser.run', () => {
   });
   it('should print deepLinkURL', async () => {
     await run(context_stub);
-    expect(
-      open,
-    ).toBeCalledWith(
-      'https://console.aws.amazon.com/iam/home?region=test#/users$new?step=final&accessKey&userNames=test&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess',
+    expect(open).toBeCalledWith(
+      'https://console.aws.amazon.com/iam/home?region=test#/users$new?step=final&accessKey&userNames=test&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess-Amplify',
       { wait: false },
     );
   });
@@ -56,10 +54,8 @@ describe('setupNewUser.run', () => {
       value: 'win32',
     });
     await run(context_stub);
-    expect(
-      open,
-    ).toBeCalledWith(
-      'https://console.aws.amazon.com/iam/home?region=test#/users`$new?step=final&accessKey&userNames=test&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess',
+    expect(open).toBeCalledWith(
+      'https://console.aws.amazon.com/iam/home?region=test#/users`$new?step=final&accessKey&userNames=test&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess-Amplify',
       { wait: false },
     );
   });

--- a/packages/amplify-provider-awscloudformation/src/constants.js
+++ b/packages/amplify-provider-awscloudformation/src/constants.js
@@ -11,7 +11,7 @@ module.exports = {
   DefaultAWSRegion: 'us-east-1',
   AWSAmazonConsoleUrl: 'https://console.aws.amazon.com/',
   AWSCreateIAMUsersUrl:
-    'https://console.aws.amazon.com/iam/home?region={region}#/users$new?step=final&accessKey&userNames={userName}&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess',
+    'https://console.aws.amazon.com/iam/home?region={region}#/users$new?step=final&accessKey&userNames={userName}&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess-Amplify',
   FunctionCategoryName: 'function',
   // keep in sync with ServiceName in amplify-category-function, but probably it will not change
   FunctionServiceNameLambdaLayer: 'LambdaLayer',


### PR DESCRIPTION
This commit updates the IAM policy used by amplify configure to
be one controlled by the Amplify team.

Refs: https://github.com/aws-amplify/amplify-cli/pull/7571
