### PR TITLE
fix: populating custom resource stack with account/region placeholders

### DIFF
--- a/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts
+++ b/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts
@@ -14,7 +14,11 @@ export async function generateCloudFormationFromCDK(resourceName: string) {
 
   const amplifyResourceProps: AmplifyResourceProps = { category: categoryName, resourceName };
 
-  const customStack: cdk.Stack = new cdkStack(undefined, undefined, undefined, amplifyResourceProps);
+  const env = {
+    region: 'Aws.region',
+    account: 'Aws.accountId',
+  };
+  const customStack: cdk.Stack = new cdkStack(undefined, undefined, { env }, amplifyResourceProps);
 
   // @ts-ignore
   JSONUtilities.writeJson(path.join(targetDir, 'build', `${resourceName}-cloudformation-template.json`), customStack._toCloudFormation());


### PR DESCRIPTION
#### Description of changes

Custom stacks build with CDK now populated with environment containing account and region placeholders

#### Issue #, if available

refs #9360

#### Description of how you validated changes

Using tests

#### Checklist

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
