### PR TITLE
feat(amplify-category-geo): add ability to grant permissions for Maps and Search to cognito groups

### DIFF
--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/mapStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/mapStack.test.ts.snap
@@ -47,6 +47,12 @@ Object {
     "authRoleName": Object {
       "Type": "String",
     },
+    "authmockAuthUserPoolId": Object {
+      "Type": "String",
+    },
+    "authuserPoolGroupsadminGroupGroupRole": Object {
+      "Type": "String",
+    },
     "env": Object {
       "Type": "String",
     },
@@ -325,6 +331,17 @@ exports.handler = async function (event, context) {
           Object {
             "Ref": "unauthRoleName",
           },
+          Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                Object {
+                  "Ref": "authmockAuthUserPoolId",
+                },
+                "adminGroupGroupRole",
+              ],
+            ],
+          },
         ],
       },
       "Type": "AWS::IAM::Policy",
@@ -378,6 +395,12 @@ Object {
   },
   "Parameters": Object {
     "authRoleName": Object {
+      "Type": "String",
+    },
+    "authmockAuthUserPoolId": Object {
+      "Type": "String",
+    },
+    "authuserPoolGroupsadminGroupGroupRole": Object {
       "Type": "String",
     },
     "env": Object {
@@ -654,6 +677,17 @@ exports.handler = async function (event, context) {
         "Roles": Array [
           Object {
             "Ref": "authRoleName",
+          },
+          Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                Object {
+                  "Ref": "authmockAuthUserPoolId",
+                },
+                "adminGroupGroupRole",
+              ],
+            ],
           },
         ],
       },

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/placeIndexStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/placeIndexStack.test.ts.snap
@@ -42,6 +42,12 @@ Object {
     "authRoleName": Object {
       "Type": "String",
     },
+    "authmockAuthUserPoolId": Object {
+      "Type": "String",
+    },
+    "authuserPoolGroupsadminGroupGroupRole": Object {
+      "Type": "String",
+    },
     "dataProvider": Object {
       "Type": "String",
     },
@@ -331,6 +337,17 @@ exports.handler = async function (event, context) {
           Object {
             "Ref": "unauthRoleName",
           },
+          Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                Object {
+                  "Ref": "authmockAuthUserPoolId",
+                },
+                "adminGroupGroupRole",
+              ],
+            ],
+          },
         ],
       },
       "Type": "AWS::IAM::Policy",
@@ -379,6 +396,12 @@ Object {
   },
   "Parameters": Object {
     "authRoleName": Object {
+      "Type": "String",
+    },
+    "authmockAuthUserPoolId": Object {
+      "Type": "String",
+    },
+    "authuserPoolGroupsadminGroupGroupRole": Object {
       "Type": "String",
     },
     "dataProvider": Object {
@@ -666,6 +689,17 @@ exports.handler = async function (event, context) {
         "Roles": Array [
           Object {
             "Ref": "authRoleName",
+          },
+          Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                Object {
+                  "Ref": "authmockAuthUserPoolId",
+                },
+                "adminGroupGroupRole",
+              ],
+            ],
           },
         ],
       },

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/mapStack.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/mapStack.test.ts
@@ -15,6 +15,8 @@ describe('cdk stack creation for map service', () => {
           locationServiceRegion: 'eu-central-1',
         },
       },
+      groupPermissions: ['adminGroup'],
+      authResourceName: 'mockAuth'
     };
     const mapStack = new MapStack(new App(), 'MapStack', stackProps);
     expect(mapStack.toCloudFormation()).toMatchSnapshot();
@@ -28,6 +30,8 @@ describe('cdk stack creation for map service', () => {
           locationServiceRegion: 'eu-central-1',
         },
       },
+      groupPermissions: ['adminGroup'],
+      authResourceName: 'mockAuth'
     };
     const mapStack = new MapStack(new App(), 'MapStack', stackProps);
     expect(mapStack.toCloudFormation()).toMatchSnapshot();

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/placeIndexStack.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/placeIndexStack.test.ts
@@ -15,6 +15,8 @@ describe('cdk stack creation for place index service', () => {
           locationServiceRegion: 'eu-central-1',
         },
       },
+      groupPermissions: ['adminGroup'],
+      authResourceName: 'mockAuth'
     };
     const mapStack = new PlaceIndexStack(new App(), 'PlaceIndexStack', stackProps);
     expect(mapStack.toCloudFormation()).toMatchSnapshot();
@@ -28,6 +30,8 @@ describe('cdk stack creation for place index service', () => {
           locationServiceRegion: 'eu-central-1',
         },
       },
+      groupPermissions: ['adminGroup'],
+      authResourceName: 'mockAuth'
     };
     const mapStack = new PlaceIndexStack(new App(), 'PlaceIndexStack', stackProps);
     expect(mapStack.toCloudFormation()).toMatchSnapshot();

--- a/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
@@ -65,13 +65,22 @@ describe('Test Map resource utility functions', () => {
 
 
     it('gets current map parameters from meta file', async() => {
+        const groupPermissions = {
+            mockCognitoGroup: [
+                "Read geofence",
+                "Create/Update geofence"
+            ]
+        }
+        JSONUtilities.readJson = jest.fn().mockReturnValue({groupPermissions: groupPermissions});
+        pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         const getCurrentMapParameters = require('../../service-utils/mapUtils').getCurrentMapParameters;
         const mapParams = await getCurrentMapParameters('map1');
         expect({
             ...getMapStyleComponents(map1Params.mapStyle),
             pricingPlan: map1Params.pricingPlan,
             accessType: map1Params.accessType,
-            isDefault: map1Params.isDefault
+            isDefault: map1Params.isDefault,
+            groupPermissions: groupPermissions
         }).toEqual(mapParams);
     });
 
@@ -85,6 +94,14 @@ describe('Test Map resource utility functions', () => {
     });
 
     it('gets current place index parameters from meta file', async() => {
+        const groupPermissions = {
+            mockCognitoGroup: [
+                "Read geofence",
+                "Create/Update geofence"
+            ]
+        }
+        JSONUtilities.readJson = jest.fn().mockReturnValue({groupPermissions: groupPermissions});
+        pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         const getCurrentPlaceIndexParameters = require('../../service-utils/placeIndexUtils').getCurrentPlaceIndexParameters;
         const placeIndexParams = await getCurrentPlaceIndexParameters('placeIndex1');
         expect({
@@ -92,7 +109,8 @@ describe('Test Map resource utility functions', () => {
             dataSourceIntendedUse: placeIndex1Params.dataSourceIntendedUse,
             pricingPlan: placeIndex1Params.pricingPlan,
             accessType: placeIndex1Params.accessType,
-            isDefault: placeIndex1Params.isDefault
+            isDefault: placeIndex1Params.isDefault,
+            groupPermissions: groupPermissions
         }).toEqual(placeIndexParams);
     });
 

--- a/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
@@ -64,13 +64,8 @@ describe('Test Map resource utility functions', () => {
     });
 
 
-    it('gets current map parameters from meta file', async() => {
-        const groupPermissions = {
-            mockCognitoGroup: [
-                "Read geofence",
-                "Create/Update geofence"
-            ]
-        }
+    it('gets current map parameters', async() => {
+        const groupPermissions = ['mockCognitoGroup'];
         JSONUtilities.readJson = jest.fn().mockReturnValue({groupPermissions: groupPermissions});
         pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         const getCurrentMapParameters = require('../../service-utils/mapUtils').getCurrentMapParameters;
@@ -93,13 +88,8 @@ describe('Test Map resource utility functions', () => {
         ]);
     });
 
-    it('gets current place index parameters from meta file', async() => {
-        const groupPermissions = {
-            mockCognitoGroup: [
-                "Read geofence",
-                "Create/Update geofence"
-            ]
-        }
+    it('gets current place index parameters', async() => {
+        const groupPermissions = ['mockCognitoGroup'];
         JSONUtilities.readJson = jest.fn().mockReturnValue({groupPermissions: groupPermissions});
         pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         const getCurrentPlaceIndexParameters = require('../../service-utils/placeIndexUtils').getCurrentPlaceIndexParameters;
@@ -114,7 +104,7 @@ describe('Test Map resource utility functions', () => {
         }).toEqual(placeIndexParams);
     });
 
-    it('gets current geofence collection parameters from meta file', async() => {
+    it('gets current geofence collection parameters', async() => {
         const groupPermissions = {
             mockCognitoGroup: [
                 "Read geofence",

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
@@ -4,7 +4,6 @@ import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resou
 import { provider, ServiceName, apiDocs } from '../../service-utils/constants';
 import { category } from '../../constants';
 import { printer, prompter } from 'amplify-prompts';
-import { updateDefaultMapWalkthrough } from '../../service-walkthroughs/mapWalkthrough';
 
 jest.mock('amplify-cli-core');
 jest.mock('amplify-prompts');
@@ -14,6 +13,7 @@ describe('Map walkthrough works as expected', () => {
     const service = ServiceName.Map;
     const mockMapName = 'mockmap12345';
     const secondaryMapName = 'secondarymap12345';
+    const mockUserPoolGroup: string = 'mockCognitoGroup';
     const mockMapResource = {
         resourceName: mockMapName,
         service: service,
@@ -44,7 +44,8 @@ describe('Map walkthrough works as expected', () => {
         dataProvider: DataProvider.Esri,
         pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedUsers,
-        isDefault: false
+        isDefault: false,
+        groupPermissions: [mockUserPoolGroup]
     };
 
     const mockContext = ({
@@ -80,6 +81,8 @@ describe('Map walkthrough works as expected', () => {
                 });
             });
         });
+        mockContext.amplify.getUserPoolGroupList = jest.fn().mockReturnValue([mockUserPoolGroup]);
+
         pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         JSONUtilities.readJson = jest.fn().mockReturnValue({});
         JSONUtilities.writeJson = jest.fn().mockReturnValue('');
@@ -99,6 +102,12 @@ describe('Map walkthrough works as expected', () => {
         });
         prompter.pick = jest.fn().mockImplementation((message: string): Promise<any> => {
             let mockUserInput = 'mock';
+            if (message === 'Select one or more cognito groups to give access:') {
+                mockUserInput = mockUserPoolGroup;
+            }
+            if (message === 'Restrict access by?') {
+                mockUserInput = 'Both';
+            }
             if (message === `Specify the map style. Refer ${apiDocs.mapStyles}`) {
                 mockUserInput = getGeoMapStyle(mockMapParameters.dataProvider, mockMapParameters.mapStyleType);
             }

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
@@ -4,7 +4,6 @@ import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resou
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
 import { printer, prompter } from 'amplify-prompts';
-import { updateDefaultPlaceIndexWalkthrough } from '../../service-walkthroughs/placeIndexWalkthrough';
 
 jest.mock('amplify-cli-core');
 jest.mock('amplify-prompts');
@@ -14,6 +13,7 @@ describe('Search walkthrough works as expected', () => {
     const service = ServiceName.PlaceIndex;
     const mockPlaceIndexName = 'mockindex12345';
     const secondaryPlaceIndexName = 'secondaryindex12345';
+    const mockUserPoolGroup: string = 'mockCognitoGroup';
     const mockMapResource = {
         resourceName: 'map12345',
         service: ServiceName.Map,
@@ -40,7 +40,8 @@ describe('Search walkthrough works as expected', () => {
         dataSourceIntendedUse: DataSourceIntendedUse.SingleUse,
         pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedUsers,
-        isDefault: false
+        isDefault: false,
+        groupPermissions: [mockUserPoolGroup]
     };
 
     const mockContext = ({
@@ -76,6 +77,8 @@ describe('Search walkthrough works as expected', () => {
                 });
             });
         });
+        mockContext.amplify.getUserPoolGroupList = jest.fn().mockReturnValue([mockUserPoolGroup]);
+
         pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         JSONUtilities.readJson = jest.fn().mockReturnValue({});
         JSONUtilities.writeJson = jest.fn().mockReturnValue('');
@@ -95,6 +98,12 @@ describe('Search walkthrough works as expected', () => {
         });
         prompter.pick = jest.fn().mockImplementation((message: string): Promise<any> => {
             let mockUserInput = 'mock';
+            if (message === 'Select one or more cognito groups to give access:') {
+                mockUserInput = mockUserPoolGroup;
+            }
+            if (message === 'Restrict access by?') {
+                mockUserInput = 'Both';
+            }
             if (message === 'Who can access this search index?') {
                 mockUserInput = mockPlaceIndexParameters.accessType;
             }

--- a/packages/amplify-category-geo/src/provider-controllers/map.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/map.ts
@@ -111,9 +111,9 @@ export const updateMapResourceWithParams = async (
   mapParams: Partial<MapParameters>
 ): Promise<string> => {
   const completeParameters: MapParameters = convertToCompleteMapParams(mapParams);
-  
+
   await modifyMapResource(context, completeParameters);
-  
+
   printer.success(`Successfully updated resource ${mapParams.name} locally.`);
   printNextStepsSuccessMessage(context);
   return completeParameters.name;

--- a/packages/amplify-category-geo/src/provider-controllers/map.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/map.ts
@@ -110,17 +110,11 @@ export const updateMapResourceWithParams = async (
   context: $TSContext,
   mapParams: Partial<MapParameters>
 ): Promise<string> => {
-  if (mapParams.name && mapParams.isDefault !== undefined && mapParams.accessType && mapParams.pricingPlan) {
-    modifyMapResource(context, {
-      accessType: mapParams.accessType,
-      name: mapParams.name,
-      isDefault: mapParams.isDefault,
-      pricingPlan: mapParams.pricingPlan
-    });
-  } else {
-    throw insufficientInfoForUpdateError(ServiceName.Map);
-  }
+  const completeParameters: MapParameters = convertToCompleteMapParams(mapParams);
+  
+  await modifyMapResource(context, completeParameters);
+  
   printer.success(`Successfully updated resource ${mapParams.name} locally.`);
   printNextStepsSuccessMessage(context);
-  return mapParams.name;
+  return completeParameters.name;
 }

--- a/packages/amplify-category-geo/src/provider-controllers/placeIndex.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/placeIndex.ts
@@ -35,21 +35,12 @@ export const updatePlaceIndexResource = async (
   // populate the parameters for the resource
   await updatePlaceIndexWalkthrough(context, placeIndexParams);
 
-  if (placeIndexParams.name && placeIndexParams.isDefault !== undefined && placeIndexParams.accessType && placeIndexParams.pricingPlan) {
-    modifyPlaceIndexResource(context, {
-      accessType: placeIndexParams.accessType,
-      name: placeIndexParams.name,
-      isDefault: placeIndexParams.isDefault,
-      pricingPlan: placeIndexParams.pricingPlan
-    });
-  }
-  else {
-    throw insufficientInfoForUpdateError(ServiceName.PlaceIndex);
-  }
+  const completeParameters: PlaceIndexParameters = convertToCompletePlaceIndexParams(placeIndexParams);
+  modifyPlaceIndexResource(context, completeParameters);
 
   printer.success(`Successfully updated resource ${placeIndexParams.name} locally.`);
   printNextStepsSuccessMessage(context);
-  return placeIndexParams.name;
+  return completeParameters.name;
 };
 
 export const removePlaceIndexResource = async (

--- a/packages/amplify-category-geo/src/provider-controllers/placeIndex.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/placeIndex.ts
@@ -36,7 +36,7 @@ export const updatePlaceIndexResource = async (
   await updatePlaceIndexWalkthrough(context, placeIndexParams);
 
   const completeParameters: PlaceIndexParameters = convertToCompletePlaceIndexParams(placeIndexParams);
-  modifyPlaceIndexResource(context, completeParameters);
+  await modifyPlaceIndexResource(context, completeParameters);
 
   printer.success(`Successfully updated resource ${placeIndexParams.name} locally.`);
   printNextStepsSuccessMessage(context);

--- a/packages/amplify-category-geo/src/service-stacks/mapStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/mapStack.ts
@@ -10,7 +10,7 @@ import { Runtime } from '@aws-cdk/aws-lambda';
 import { customMapLambdaCodePath } from '../service-utils/constants';
 import * as fs from 'fs-extra';
 
-type MapStackProps = Pick<MapParameters, 'accessType' | 'groupPermissions'> & 
+type MapStackProps = Pick<MapParameters, 'accessType' | 'groupPermissions'> &
   TemplateMappings & { authResourceName: string };
 
 export class MapStack extends BaseStack {
@@ -126,7 +126,7 @@ export class MapStack extends BaseStack {
     });
 
     let cognitoRoles: Array<string> = new Array();
-    if (this.accessType === AccessType.AuthorizedUsers || 
+    if (this.accessType === AccessType.AuthorizedUsers ||
       this.accessType === AccessType.AuthorizedAndGuestUsers) {
       cognitoRoles.push(this.parameters.get('authRoleName')!.valueAsString);
     }

--- a/packages/amplify-category-geo/src/service-stacks/placeIndexStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/placeIndexStack.ts
@@ -10,21 +10,30 @@ import { customPlaceIndexLambdaCodePath } from '../service-utils/constants';
 import * as fs from 'fs-extra';
 import { Runtime } from '@aws-cdk/aws-lambda';
 
-type PlaceIndexStackProps = Pick<PlaceIndexParameters, 'accessType'> & TemplateMappings;
+type PlaceIndexStackProps = Pick<PlaceIndexParameters, 'accessType' | 'groupPermissions'> & 
+  TemplateMappings & { authResourceName: string };
 
 export class PlaceIndexStack extends BaseStack {
+  protected readonly groupPermissions: string[];
   protected readonly accessType: string;
   protected readonly placeIndexResource: cdk.CustomResource;
   protected readonly placeIndexRegion: string;
   protected readonly placeIndexName: string;
+  protected readonly authResourceName: string;
 
   constructor(scope: cdk.Construct, id: string, private readonly props: PlaceIndexStackProps) {
     super(scope, id, props);
 
     this.accessType = this.props.accessType;
+    this.groupPermissions = this.props.groupPermissions;
+    this.authResourceName = this.props.authResourceName;
     this.placeIndexRegion = this.regionMapping.findInMap(cdk.Fn.ref('AWS::Region'), 'locationServiceRegion');
 
-    this.parameters = this.constructInputParameters([
+    const inputParameters: string[] = this.props.groupPermissions.map(
+      (group: string) => `authuserPoolGroups${group}GroupRole`
+    );
+    inputParameters.push(
+      `auth${this.authResourceName}UserPoolId`,
       'authRoleName',
       'unauthRoleName',
       'indexName',
@@ -32,8 +41,9 @@ export class PlaceIndexStack extends BaseStack {
       'dataSourceIntendedUse',
       'pricingPlan',
       'env',
-      'isDefault',
-    ]);
+      'isDefault'
+    );
+    this.parameters = this.constructInputParameters(inputParameters);
 
     this.placeIndexName = Fn.join('-', [this.parameters.get('indexName')!.valueAsString, this.parameters.get('env')!.valueAsString]);
 
@@ -118,9 +128,23 @@ export class PlaceIndexStack extends BaseStack {
     });
 
     let cognitoRoles: Array<string> = new Array();
-    cognitoRoles.push(this.parameters.get('authRoleName')!.valueAsString);
+    if (this.accessType === AccessType.AuthorizedUsers || 
+      this.accessType === AccessType.AuthorizedAndGuestUsers) {
+      cognitoRoles.push(this.parameters.get('authRoleName')!.valueAsString);
+    }
     if (this.accessType == AccessType.AuthorizedAndGuestUsers) {
       cognitoRoles.push(this.parameters.get('unauthRoleName')!.valueAsString);
+    }
+    if (this.groupPermissions && this.authResourceName) {
+      this.groupPermissions.forEach((group: string) => {
+        cognitoRoles.push(
+          cdk.Fn.join('-',
+          [
+            this.parameters.get(`auth${this.authResourceName}UserPoolId`)!.valueAsString,
+            `${group}GroupRole`
+          ])
+        );
+      });
     }
 
     return new iam.CfnPolicy(this, 'PlaceIndexPolicy', {

--- a/packages/amplify-category-geo/src/service-stacks/placeIndexStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/placeIndexStack.ts
@@ -10,7 +10,7 @@ import { customPlaceIndexLambdaCodePath } from '../service-utils/constants';
 import * as fs from 'fs-extra';
 import { Runtime } from '@aws-cdk/aws-lambda';
 
-type PlaceIndexStackProps = Pick<PlaceIndexParameters, 'accessType' | 'groupPermissions'> & 
+type PlaceIndexStackProps = Pick<PlaceIndexParameters, 'accessType' | 'groupPermissions'> &
   TemplateMappings & { authResourceName: string };
 
 export class PlaceIndexStack extends BaseStack {
@@ -128,7 +128,7 @@ export class PlaceIndexStack extends BaseStack {
     });
 
     let cognitoRoles: Array<string> = new Array();
-    if (this.accessType === AccessType.AuthorizedUsers || 
+    if (this.accessType === AccessType.AuthorizedUsers ||
       this.accessType === AccessType.AuthorizedAndGuestUsers) {
       cognitoRoles.push(this.parameters.get('authRoleName')!.valueAsString);
     }

--- a/packages/amplify-category-geo/src/service-utils/geofenceCollectionUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/geofenceCollectionUtils.ts
@@ -10,7 +10,8 @@ import {
   updateDefaultResource,
   readResourceMetaParameters,
   getAuthResourceName,
-  updateGeoPricingPlan
+  updateGeoPricingPlan,
+  ResourceDependsOn
 } from './resourceUtils';
 import { App } from '@aws-cdk/core';
 import { getTemplateMappings } from '../provider-controllers';
@@ -122,12 +123,6 @@ export const constructGeofenceCollectionMetaParameters = (params: GeofenceCollec
     dependsOn: dependsOnResources
   };
   return result;
-};
-
-export type ResourceDependsOn = {
-  category: string;
-  resourceName: string;
-  attributes: string[];
 };
 
 /**

--- a/packages/amplify-category-geo/src/service-utils/mapParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapParams.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
  */
 export type MapParameters = ResourceParameters & {
     mapStyleType: MapStyleType;
+    groupPermissions: string[];
 };
 
 /**

--- a/packages/amplify-category-geo/src/service-utils/placeIndexParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/placeIndexParams.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
  */
 export type PlaceIndexParameters = ResourceParameters & {
   dataSourceIntendedUse: DataSourceIntendedUse;
+  groupPermissions: string[];
 };
 
 /**

--- a/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
@@ -116,7 +116,7 @@ export const constructPlaceIndexMetaParameters = (params: PlaceIndexParameters, 
       attributes: [`${group}GroupRole`]
     });
   });
-  
+
   let result: PlaceIndexMetaParameters = {
     isDefault: params.isDefault,
     providerPlugin: provider,

--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -234,3 +234,9 @@ export const getAuthResourceName = async (context: $TSContext): Promise<string> 
   }
   return authResources[0].resourceName;
 }
+
+export type ResourceDependsOn = {
+  category: string;
+  resourceName: string;
+  attributes: string[];
+};

--- a/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
@@ -6,7 +6,7 @@ import { apiDocs, ServiceName } from '../service-utils/constants';
 import { $TSContext } from 'amplify-cli-core';
 import { getCurrentMapParameters, getMapFriendlyNames } from '../service-utils/mapUtils';
 import { getGeoServiceMeta, updateDefaultResource, geoServiceExists, getGeoPricingPlan, checkGeoResourceExists} from '../service-utils/resourceUtils';
-import { authAndGuestAccessWalkthrough, pricingPlanWalkthrough, defaultResourceQuestion } from './resourceWalkthrough';
+import { resourceAccessWalkthrough, pricingPlanWalkthrough, defaultResourceQuestion } from './resourceWalkthrough';
 import { DataProvider, PricingPlan } from '../service-utils/resourceParams';
 import { printer, formatter, prompter, alphanumeric } from 'amplify-prompts';
 
@@ -23,7 +23,7 @@ export const createMapWalkthrough = async (
   parameters = merge(parameters, await mapNameWalkthrough(context));
 
   // get the access
-  parameters = merge(parameters, await authAndGuestAccessWalkthrough(parameters, ServiceName.Map));
+  parameters = merge(parameters, await resourceAccessWalkthrough(context, parameters, ServiceName.Map));
 
   // initiate pricing plan walkthrough if this is the first Map added
   let includePricingPlanInAdvancedWalkthrough = true;
@@ -157,7 +157,9 @@ export const updateMapWalkthrough = async (
     parameters = merge(parameters, await getCurrentMapParameters(resourceToUpdate));
 
     // overwrite the parameters based on user input
-    parameters.accessType = (await authAndGuestAccessWalkthrough(parameters, ServiceName.Map)).accessType;
+    const mapAccessSettings = (await resourceAccessWalkthrough(context, parameters, ServiceName.Map));
+    parameters.accessType = mapAccessSettings.accessType;
+    parameters.groupPermissions = mapAccessSettings.groupPermissions;
 
     // enable flow to update the pricing plan for Map
     printer.info('Available advanced settings:');

--- a/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
@@ -6,7 +6,7 @@ import { apiDocs, ServiceName } from '../service-utils/constants';
 import { $TSContext } from 'amplify-cli-core';
 import { getCurrentPlaceIndexParameters } from '../service-utils/placeIndexUtils';
 import { getGeoServiceMeta, updateDefaultResource, geoServiceExists, getGeoPricingPlan, checkGeoResourceExists } from '../service-utils/resourceUtils';
-import { authAndGuestAccessWalkthrough, pricingPlanWalkthrough, dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
+import { resourceAccessWalkthrough, pricingPlanWalkthrough, dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
 import { DataProvider, PricingPlan } from '../service-utils/resourceParams';
 import { printer, formatter, prompter, alphanumeric } from 'amplify-prompts';
 
@@ -24,7 +24,7 @@ export const createPlaceIndexWalkthrough = async (
   parameters = merge(parameters, await placeIndexNameWalkthrough(context));
 
   // get the access
-  parameters = merge(parameters, await authAndGuestAccessWalkthrough(parameters, ServiceName.PlaceIndex));
+  parameters = merge(parameters, await resourceAccessWalkthrough(context, parameters, ServiceName.PlaceIndex));
 
   // initiate pricing plan walkthrough if this is the first Place Index added
   let includePricingPlanInAdvancedWalkthrough = true;
@@ -155,7 +155,9 @@ export const updatePlaceIndexWalkthrough = async (
     parameters = merge(parameters, await getCurrentPlaceIndexParameters(resourceToUpdate));
 
     // overwrite the parameters based on user input
-    parameters.accessType = (await authAndGuestAccessWalkthrough(parameters, ServiceName.PlaceIndex)).accessType;
+    const placeIndexAccessSettings = (await resourceAccessWalkthrough(context, parameters, ServiceName.PlaceIndex));
+    parameters.accessType = placeIndexAccessSettings.accessType;
+    parameters.groupPermissions = placeIndexAccessSettings.groupPermissions;
 
     // enable flow to update the pricing plan for Place Index
     printer.info('Available advanced settings:');

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -26,8 +26,8 @@ export async function resourceAccessWalkthrough<T extends ResourceParameters & {
             if (parameters.accessType === AccessType.CognitoGroups) {
                 defaultPermission = 'Individual Groups'
             }
-            else if (parameters.groupPermissions && 
-                parameters.groupPermissions.length > 0 && 
+            else if (parameters.groupPermissions &&
+                parameters.groupPermissions.length > 0 &&
                 parameters.accessType !== AccessType.CognitoGroups) {
                 defaultPermission = 'Both'
             }
@@ -48,7 +48,7 @@ export async function resourceAccessWalkthrough<T extends ResourceParameters & {
         if (parameters.accessType === AccessType.AuthorizedAndGuestUsers) {
             accessTypeDefaultIndex = 1;
         }
-    
+
         parameters.accessType = await prompter.pick<'one', string>(
             `Who can access this ${getServiceFriendlyName(service)}?`,
             accessChoices,

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -2,26 +2,87 @@ import { AccessType, DataProvider, ResourceParameters } from "../service-utils/r
 import { ServiceName, choosePricingPlan, apiDocs } from "../service-utils/constants";
 import { PricingPlan } from "../service-utils/resourceParams";
 import { $TSContext, open } from "amplify-cli-core";
-import { printer, prompter } from 'amplify-prompts';
+import { byValue, byValues, printer, prompter } from 'amplify-prompts';
 
-export async function authAndGuestAccessWalkthrough<T extends ResourceParameters>(
+export async function resourceAccessWalkthrough<T extends ResourceParameters & { groupPermissions: string[] }>(
+    context: $TSContext,
     parameters: Partial<T>,
     service: ServiceName
 ): Promise<Partial<T>> {
-    const accessChoices = [
-        { name: 'Authorized users only', value: AccessType.AuthorizedUsers },
-        { name: 'Authorized and Guest users', value: AccessType.AuthorizedAndGuestUsers }
-    ];
-    let accessTypeDefaultIndex = 0;
-    if (parameters.accessType === AccessType.AuthorizedAndGuestUsers) {
-        accessTypeDefaultIndex = 1;
+    let permissionSelected = 'Auth/Guest Users';
+    const LearnMore = 'Learn more';
+    const userPoolGroupList = context.amplify.getUserPoolGroupList();
+
+    if (userPoolGroupList.length > 0) {
+        do {
+            if (permissionSelected === LearnMore) {
+                printer.info('');
+                printer.info(
+                    'You can restrict access using CRUD policies for Authenticated Users, Guest Users, or on individual Group that users belong to in a User Pool. If a user logs into your application and is not a member of any group they will use policy set for “Authenticated Users”, however if they belong to a group they will only get the policy associated with that specific group.',
+                );
+                printer.info('');
+            }
+            let defaultPermission = 'Auth/Guest Users';
+            if (parameters.accessType === AccessType.CognitoGroups) {
+                defaultPermission = 'Individual Groups'
+            }
+            else if (parameters.groupPermissions && 
+                parameters.groupPermissions.length > 0 && 
+                parameters.accessType !== AccessType.CognitoGroups) {
+                defaultPermission = 'Both'
+            }
+            permissionSelected = await prompter.pick<'one', string>(
+                `Restrict access by?`,
+                ['Auth/Guest Users', 'Individual Groups', 'Both', LearnMore],
+                { initial: byValue(defaultPermission) }
+            );
+        } while (permissionSelected === 'Learn more');
     }
 
-    parameters.accessType = await prompter.pick<'one', string>(
-        `Who can access this ${getServiceFriendlyName(service)}?`,
-        accessChoices,
-        { initial: accessTypeDefaultIndex }
-    ) as AccessType;
+    if (permissionSelected === 'Both' || permissionSelected === 'Auth/Guest Users') {
+        const accessChoices = [
+            { name: 'Authorized users only', value: AccessType.AuthorizedUsers },
+            { name: 'Authorized and Guest users', value: AccessType.AuthorizedAndGuestUsers }
+        ];
+        let accessTypeDefaultIndex = 0;
+        if (parameters.accessType === AccessType.AuthorizedAndGuestUsers) {
+            accessTypeDefaultIndex = 1;
+        }
+    
+        parameters.accessType = await prompter.pick<'one', string>(
+            `Who can access this ${getServiceFriendlyName(service)}?`,
+            accessChoices,
+            { initial: accessTypeDefaultIndex }
+        ) as AccessType;
+
+        if (permissionSelected === 'Auth/Guest Users') {
+            parameters.groupPermissions = [];
+        }
+    }
+
+    if (permissionSelected === 'Both' || permissionSelected === 'Individual Groups') {
+        let defaultSelectedGroups: string[] = [];
+        if (parameters.groupPermissions) {
+            defaultSelectedGroups = parameters.groupPermissions;
+        }
+
+        const selectedUserPoolGroups = await prompter.pick<'many', string>(
+            'Select one or more cognito groups to give access:',
+            userPoolGroupList,
+            { returnSize: 'many', initial: byValues(defaultSelectedGroups) }
+        );
+
+        if(typeof selectedUserPoolGroups === 'string') {
+            parameters.groupPermissions = [selectedUserPoolGroups];
+        }
+        else {
+            parameters.groupPermissions = selectedUserPoolGroups;
+        }
+
+        if (permissionSelected === 'Individual Groups') {
+            parameters.accessType = AccessType.CognitoGroups;
+        }
+    }
     return parameters;
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds Walkthrough to enable developer to grant permissions for Maps, Search to users of cognito groups.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/7850

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit tests and tested in a JS app

#### Screenshots and updated DX
When adding a Map or Search Index, if the Amplify backend already has one or more cognito groups added, we will give the developer choice to grant Read only permissions to cognito groups in addition to the Auth/UnAuth roles. This is necessary since Geofencing capability of geo only supports Group based access aimed to be used by Geofence Admin users and they might also need to access the Map and/or Search capabilities.
The Walkthrough will look like this for `update` and is the same for `add` command:
![image](https://user-images.githubusercontent.com/55896475/147965690-9614dca0-49f0-4e3c-aa4f-71acae2763ad.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
