### PR TITLE
fix: update @primaryKey get/list queries for lowercase models

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
@@ -679,3 +679,38 @@ test('list queries use correct pluralization', () => {
   expect(out.resolvers['Query.listBosses.req.vtl']).toBeDefined();
   expect(out.resolvers['Query.listBosses.res.vtl']).toBeDefined();
 });
+
+test('lowercase model names generate the correct get/list query arguments', () => {
+  const inputSchema = `
+    type test @model {
+      email: String! @primaryKey(sortKeyFields: ["lastName"])
+      lastName: String!
+      firstName: String
+    }`;
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+  });
+
+  const out = transformer.transform(inputSchema);
+  const schema = parse(out.schema);
+
+  validateModelSchema(schema);
+
+  const query: any = schema.definitions.find((d: any) => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === 'Query');
+  const getQuery = query.fields.find((f: any) => f.name.value === 'getTest');
+  const listQuery = query.fields.find((f: any) => f.name.value === 'listTests');
+
+  expect(getQuery).toBeDefined();
+  expect(getQuery.arguments.length).toEqual(2);
+  expect(getQuery.arguments[0].name.value).toEqual('email');
+  expect(getQuery.arguments[1].name.value).toEqual('lastName');
+
+  expect(listQuery).toBeDefined();
+  expect(listQuery.arguments.length).toEqual(6);
+  expect(listQuery.arguments[0].name.value).toEqual('email');
+  expect(listQuery.arguments[1].name.value).toEqual('lastName');
+  expect(listQuery.arguments[2].name.value).toEqual('filter');
+  expect(listQuery.arguments[3].name.value).toEqual('limit');
+  expect(listQuery.arguments[4].name.value).toEqual('nextToken');
+  expect(listQuery.arguments[5].name.value).toEqual('sortDirection');
+});

--- a/packages/amplify-graphql-index-transformer/src/utils.ts
+++ b/packages/amplify-graphql-index-transformer/src/utils.ts
@@ -1,6 +1,6 @@
 import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { plurality } from 'graphql-transformer-common';
+import { plurality, toUpper } from 'graphql-transformer-common';
 import { IndexDirectiveConfiguration, PrimaryKeyDirectiveConfiguration } from './types';
 
 export function lookupResolverName(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider, op: string): string | null {
@@ -28,10 +28,12 @@ export function lookupResolverName(config: PrimaryKeyDirectiveConfiguration, ctx
   }
 
   if (!resolverName) {
+    const capitalizedName = toUpper(object.name.value);
+
     if (op === 'list' || op === 'sync') {
-      resolverName = `${op}${plurality(object.name.value, true)}`;
+      resolverName = `${op}${plurality(capitalizedName, true)}`;
     } else {
-      resolverName = `${op}${object.name.value}`;
+      resolverName = `${op}${capitalizedName}`;
     }
   }
 


### PR DESCRIPTION
This commit updates the get and list queries generated by `@primaryKey` to handle the case where the model name is all lowercase characters.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9402
Fixes: https://github.com/aws-amplify/amplify-cli/issues/9392
