### PR TITLE
fix(graphql): make hash key as non null type for index transformer

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -198,6 +198,8 @@ test('@index with multiple sort keys adds a query field and GSI correctly', () =
   expect(queryField).toBeDefined();
   expect(queryField.arguments).toHaveLength(6);
   expect(queryField.arguments[0].name.value).toEqual('email');
+  expect(queryField.arguments[0].type.kind).toEqual('NonNullType');
+  expect(queryField.arguments[0].type.type.name.value).toEqual('String');
   expect(queryField.arguments[1].name.value).toEqual('kindDate');
   expect(queryField.arguments[2].name.value).toEqual('sortDirection');
   expect(queryField.arguments[2].type.name.value).toEqual('ModelSortDirection');

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -239,8 +239,8 @@ export function updateMutationConditionInput(
 
 function createHashField(config: PrimaryKeyDirectiveConfiguration | IndexDirectiveConfiguration): InputValueDefinitionNode {
   const { field } = config;
-
-  return makeInputValueDefinition(field.name.value, makeNonNullType(makeNamedType(getBaseType(field.type))));
+  const type = "queryField" in config ? makeNonNullType(makeNamedType(getBaseType(field.type))) : makeNamedType(getBaseType(field.type));
+  return makeInputValueDefinition(field.name.value, type);
 }
 
 function createSimpleSortField(

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -240,7 +240,7 @@ export function updateMutationConditionInput(
 function createHashField(config: PrimaryKeyDirectiveConfiguration | IndexDirectiveConfiguration): InputValueDefinitionNode {
   const { field } = config;
 
-  return makeInputValueDefinition(field.name.value, makeNamedType(getBaseType(field.type)));
+  return makeInputValueDefinition(field.name.value, makeNonNullType(makeNamedType(getBaseType(field.type))));
 }
 
 function createSimpleSortField(


### PR DESCRIPTION
#### Description of changes
Make hash key as non null type for index transformer v2.

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/7499

#### Description of how you validated changes
- yarn test
- manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
