### PR TITLE
fix: #9363 - additional checks in case of previously failed add auth

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
@@ -217,8 +217,9 @@ export function getResourcesToBeCreated(amplifyMeta, currentAmplifyMeta, categor
           (!amplifyMeta[dependsOnCategory][dependsOnResourcename]?.lastPushTimeStamp ||
             !currentAmplifyMeta[dependsOnCategory] ||
             !currentAmplifyMeta[dependsOnCategory][dependsOnResourcename]) &&
-          amplifyMeta[dependsOnCategory][dependsOnResourcename].serviceType !== 'imported' &&
-          !resources.includes(amplifyMeta[dependsOnCategory][dependsOnResourcename])
+          amplifyMeta[dependsOnCategory][dependsOnResourcename]?.serviceType !== 'imported' &&
+          !resources.includes(amplifyMeta[dependsOnCategory][dependsOnResourcename]) &&
+          amplifyMeta[dependsOnCategory][dependsOnResourcename]
         ) {
           resources.push(amplifyMeta[dependsOnCategory][dependsOnResourcename]);
         }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
@@ -217,9 +217,9 @@ export function getResourcesToBeCreated(amplifyMeta, currentAmplifyMeta, categor
           (!amplifyMeta[dependsOnCategory][dependsOnResourcename]?.lastPushTimeStamp ||
             !currentAmplifyMeta[dependsOnCategory] ||
             !currentAmplifyMeta[dependsOnCategory][dependsOnResourcename]) &&
+          amplifyMeta[dependsOnCategory][dependsOnResourcename] && 
           amplifyMeta[dependsOnCategory][dependsOnResourcename]?.serviceType !== 'imported' &&
-          !resources.includes(amplifyMeta[dependsOnCategory][dependsOnResourcename]) &&
-          amplifyMeta[dependsOnCategory][dependsOnResourcename]
+          !resources.includes(amplifyMeta[dependsOnCategory][dependsOnResourcename])
         ) {
           resources.push(amplifyMeta[dependsOnCategory][dependsOnResourcename]);
         }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
@@ -217,7 +217,7 @@ export function getResourcesToBeCreated(amplifyMeta, currentAmplifyMeta, categor
           (!amplifyMeta[dependsOnCategory][dependsOnResourcename]?.lastPushTimeStamp ||
             !currentAmplifyMeta[dependsOnCategory] ||
             !currentAmplifyMeta[dependsOnCategory][dependsOnResourcename]) &&
-          amplifyMeta[dependsOnCategory][dependsOnResourcename] && 
+          amplifyMeta[dependsOnCategory][dependsOnResourcename] &&
           amplifyMeta[dependsOnCategory][dependsOnResourcename]?.serviceType !== 'imported' &&
           !resources.includes(amplifyMeta[dependsOnCategory][dependsOnResourcename])
         ) {


### PR DESCRIPTION
#### Description of changes

#9214 is a duplicate of #9363, this PR fix the 2nd part of #9363 which helps with already corrupted project files, where User Pool Groups are already present in meta file, but Cognito addition failed.

#### Issue #, if available

Fixes #9363 

#### Description of how you validated changes

#### Checklist

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
