### PR TITLE
fix: velocity #break statement handling

### DIFF
--- a/packages/amplify-velocity-template/src/compile/blocks.js
+++ b/packages/amplify-velocity-template/src/compile/blocks.js
@@ -200,6 +200,8 @@ module.exports = function (Velocity, utils) {
           _from,
           function (val, i) {
             if (this._state.break) {
+              // reset break after breaking the loop
+              this._state.break = false;
               return;
             }
             // 构造临时变量
@@ -222,6 +224,8 @@ module.exports = function (Velocity, utils) {
           utils.keys(_from),
           function (key, i) {
             if (this._state.break) {
+              // reset break after breaking the loop
+              this._state.break = false;
               return;
             }
             local[_to] = _from[key];

--- a/packages/amplify-velocity-template/src/compile/compile.js
+++ b/packages/amplify-velocity-template/src/compile/compile.js
@@ -1,9 +1,9 @@
-module.exports = function(Velocity, utils) {
+module.exports = function (Velocity, utils) {
   /**
    * compile
    */
   utils.mixin(Velocity.prototype, {
-    init: function() {
+    init: function () {
       this.context = {};
       this.macros = {};
       this.defines = {};
@@ -14,7 +14,7 @@ module.exports = function(Velocity, utils) {
 
       var self = this;
       this.directive = {
-        stop: function() {
+        stop: function () {
           self._state.stop = true;
           return '';
         },
@@ -27,7 +27,7 @@ module.exports = function(Velocity, utils) {
      * @param silent {bool} 如果是true，$foo变量将原样输出
      * @return str
      */
-    render: function(context, macros, silence) {
+    render: function (context, macros, silence) {
       this._state = { stop: false, break: false, return: false };
       this.silence = !!silence;
       this.context = context || {};
@@ -49,7 +49,7 @@ module.exports = function(Velocity, utils) {
      * 取值，都放在一个this.local下，通过contextId查找
      * @return {string}解析后的字符串
      */
-    _render: function(asts, contextId) {
+    _render: function (asts, contextId) {
       var str = '';
       asts = asts || this.asts;
 
@@ -65,10 +65,15 @@ module.exports = function(Velocity, utils) {
 
       utils.forEach(
         asts,
-        function(ast) {
+        function (ast) {
           // 进入stop，直接退出
           if (this._state.stop === true) {
             return false;
+          }
+
+          // Don't process anything after the break is encountered.
+          if (this._state.break === true) {
+            return;
           }
 
           switch (ast.type) {
@@ -119,7 +124,7 @@ module.exports = function(Velocity, utils) {
 
       return str;
     },
-    format: function(value) {
+    format: function (value) {
       if (utils.isArray(value)) {
         return '[' + value.map(this.format.bind(this)).join(', ') + ']';
       }
@@ -129,16 +134,10 @@ module.exports = function(Velocity, utils) {
           return value;
         }
 
-        var kvJoin = function(k) {
+        var kvJoin = function (k) {
           return k + '=' + this.format(value[k]);
         }.bind(this);
-        return (
-          '{' +
-          Object.keys(value)
-            .map(kvJoin)
-            .join(', ') +
-          '}'
-        );
+        return '{' + Object.keys(value).map(kvJoin).join(', ') + '}';
       }
 
       return value;

--- a/packages/amplify-velocity-template/tests/foreach.test.js
+++ b/packages/amplify-velocity-template/tests/foreach.test.js
@@ -4,55 +4,55 @@ var Velocity = require('../src/velocity');
 var assert = require('assert');
 var render = Velocity.render;
 
-describe('Loops', function() {
-  it('#foreach', function() {
+describe('Loops', function () {
+  it('#foreach', function () {
     var vm = '#foreach( $product in $allProducts )<li>$product</li>#end';
     var data = { allProducts: ['book', 'phone'] };
     assert.equal('<li>book</li><li>phone</li>', render(vm, data));
   });
 
-  it('#foreach with map', function() {
+  it('#foreach with map', function () {
     var vm = '#foreach($key in $products) name => $products.name #end';
     var data = { products: { name: 'hanwen' } };
     assert.equal(' name => hanwen ', render(vm, data));
   });
 
-  it('#foreach with map hasNext', function() {
+  it('#foreach with map hasNext', function () {
     var vm = '#foreach($product in $products)$product.name#if($foreach.hasNext),#end#end';
     var data = { products: { product1: { name: 'hanwen1' }, product2: { name: 'hanwen2' }, product3: { name: 'hanwen3' } } };
     assert.equal('hanwen1,hanwen2,hanwen3', render(vm, data));
   });
 
-  it('#foreach with map hasNext as method', function() {
+  it('#foreach with map hasNext as method', function () {
     var vm = '#foreach($product in $products)$product.name#if($foreach.hasNext()),#end#end';
     var data = { products: { product1: { name: 'hanwen1' }, product2: { name: 'hanwen2' }, product3: { name: 'hanwen3' } } };
     assert.equal('hanwen1,hanwen2,hanwen3', render(vm, data));
   });
 
-  it('#foreach with map keySet', function() {
+  it('#foreach with map keySet', function () {
     var vm = '#foreach($key in $products.keySet())' + ' $key => $products.get($key) #end';
     var data = { products: { name: 'hanwen' } };
     assert.equal(' name => hanwen ', render(vm, data));
   });
 
-  it('#foreach with nest foreach', function() {
+  it('#foreach with nest foreach', function () {
     var vm = '#foreach($i in [1..2])${velocityCount}' + '#foreach($j in [2..3])${velocityCount}#end#end';
     assert.equal('112212', render(vm));
     var vm = '#foreach($i in [5..2])$i#end';
     assert.equal('5432', render(vm));
   });
 
-  it('#foreach with nest non-empty foreach', function() {
+  it('#foreach with nest non-empty foreach', function () {
     var vm = '#foreach($i in [1..2])' + '[#foreach($j in [1..2])$j#if($foreach.hasNext),#end#end]' + '#if($foreach.hasNext),#end#end';
     assert.equal('[1,2],[1,2]', render(vm));
   });
 
-  it('#foreach with nest empty foreach', function() {
+  it('#foreach with nest empty foreach', function () {
     var vm = '#foreach($i in [1..2])' + '[#foreach($j in [])$j#if($foreach.hasNext),#end#end]' + '#if($foreach.hasNext),#end#end';
     assert.equal('[],[]', render(vm));
   });
 
-  it('#foreach with map entrySet', function() {
+  it('#foreach with map entrySet', function () {
     var vm =
       '' +
       '#set($js_file = {\n' +
@@ -75,7 +75,7 @@ describe('Loops', function() {
 
     var data = {
       staticServer: {
-        getURI: function(url) {
+        getURI: function (url) {
           return '/path' + url;
         },
       },
@@ -84,29 +84,29 @@ describe('Loops', function() {
     assert.equal(ret.trim(), render(vm, data).trim());
   });
 
-  it('#foreach with #macro, $velocityCount should work, #25', function() {
+  it('#foreach with #macro, $velocityCount should work, #25', function () {
     var vm = '#macro(local) #end ' + '#foreach ($one in [1,2,4]) #local() $velocityCount #end';
     var ret = render(vm).replace(/\s+/g, '');
     assert.equal('123', ret);
   });
 
-  it('#break', function() {
+  it('#break', function () {
     var vm = '#foreach($num in [1..6])' + ' #if($foreach.count > 3) #break #end $num #end';
-    assert.equal('  1   2   3     4 ', render(vm));
+    assert.equal('  1   2   3     ', render(vm));
   });
 
-  it('#break for map', function() {
+  it('#break for map', function () {
     var vm = '#foreach($item in $map)' + ' #if($foreach.count > 2) #break #end $item #end';
     var data = { map: { item1: '1', item2: '2', item3: '3', item4: '4' } };
-    assert.equal('  1   2     3 ', render(vm, data));
+    assert.equal('  1   2   ', render(vm, data));
   });
 
-  it('foreach for null', function() {
+  it('foreach for null', function () {
     var vm = '#foreach($num in $bar) #end';
     assert.equal('', render(vm));
   });
 
-  it('support #foreach(${itemData} in ${defaultData})', function() {
+  it('support #foreach(${itemData} in ${defaultData})', function () {
     const vm = `#set($allProducts = [1, 2, 3])
         #foreach(\${product} in \${allProducts}) <li>$product</li> #end`;
     const html = render(vm);
@@ -114,7 +114,7 @@ describe('Loops', function() {
     html.should.containEql('<li>2</li>');
   });
 
-  it('issue 100', function() {
+  it('issue 100', function () {
     const vm = `
       #set($records = [[1], [2], [3]])
       #foreach($rec in $records)

--- a/packages/amplify-velocity-template/tests/runner/spec.js
+++ b/packages/amplify-velocity-template/tests/runner/spec.js
@@ -1,4 +1,4 @@
-describe('Compile', function() {
+describe('Compile', function () {
   var render = Velocity.render;
 
   function getContext(str, context, macros) {
@@ -7,8 +7,8 @@ describe('Compile', function() {
     return compile.context;
   }
 
-  describe('References', function() {
-    it('get/is method', function() {
+  describe('References', function () {
+    it('get/is method', function () {
       var vm = '$customer.getAddress()';
       var vm1 = '$customer.get("Address") $customer.isAddress()';
 
@@ -16,38 +16,38 @@ describe('Compile', function() {
       assert.equal('bar bar', render(vm1, { customer: { Address: 'bar' } }));
     });
 
-    it('method with attribute', function() {
+    it('method with attribute', function () {
       var vm = '$foo().bar\n${foo().bar}';
       assert.equal(
         'hello\nhello',
         render(vm, {
-          foo: function() {
+          foo: function () {
             return { bar: 'hello' };
           },
-        })
+        }),
       );
 
       assert.equal(
         'foo',
         render('${foo()}', {
-          foo: function() {
+          foo: function () {
             return 'foo';
           },
-        })
+        }),
       );
     });
 
-    it('index notation', function() {
+    it('index notation', function () {
       var vm = '$foo[0] $foo[$i] $foo.get(1)';
       assert.equal('bar haha haha', render(vm, { foo: ['bar', 'haha'], i: 1 }));
     });
 
-    it('set method', function() {
+    it('set method', function () {
       var vm = '$page.setTitle( "My Home Page" ).setname("haha")$page.Title $page.name';
       assert.equal('My Home Page haha', render(vm, { page: {} }));
     });
 
-    it('size method', function() {
+    it('size method', function () {
       var vm = '$foo.bar.size()';
       assert.equal('2', render(vm, { foo: { bar: [1, 2] } }));
       assert.equal('2', render(vm, { foo: { bar: { a: 1, b: 3 } } }));
@@ -57,27 +57,27 @@ describe('Compile', function() {
       assert.equal(' nosize ', render(vm2, { foo: {} }));
     });
 
-    it('quiet reference', function() {
+    it('quiet reference', function () {
       var vm = 'my email is $email';
       var vmquiet = 'my email is $!email';
       assert.equal(vm, render(vm));
       assert.equal('my email is ', render(vmquiet));
     });
 
-    it('silence all reference', function() {
+    it('silence all reference', function () {
       var vm = 'my email is $email';
 
       var compile = new Compile(Parser.parse(vm));
       assert.equal('my email is ', compile.render(null, null, true));
     });
 
-    it('this context keep correct, see #16', function() {
+    it('this context keep correct, see #16', function () {
       var data = 'a = $a.get()';
       Compile.Parser = Parser;
       function b(c) {
         this.c = c;
       }
-      b.prototype.get = function() {
+      b.prototype.get = function () {
         var t = this.eval(' hello $name', { name: 'hanwen' });
         return this.c + t;
       };
@@ -85,14 +85,14 @@ describe('Compile', function() {
       assert.equal('a = 1 hello hanwen', render(data, { a: new b(1) }));
     });
 
-    it('get variable form text', function() {
+    it('get variable form text', function () {
       var vm = 'hello $user.getName().getFullName("hanwen")';
       var data = { '$user.getName().getFullName("hanwen")': 'world' };
 
       assert.equal('hello world', render(vm, data));
     });
 
-    it('escape default', function() {
+    it('escape default', function () {
       var vm = '$name $name2 $cn $cn1';
       var data = {
         name: 'hello world',
@@ -105,7 +105,7 @@ describe('Compile', function() {
       assert.equal(ret, render(vm, data));
     });
 
-    it('add custom ignore escape function', function() {
+    it('add custom ignore escape function', function () {
       var vm = '$noIgnore($name), $ignore($name)';
       var expected = '&lt;i&gt;, <i>';
 
@@ -114,11 +114,11 @@ describe('Compile', function() {
 
       var context = {
         name: '<i>',
-        noIgnore: function(name) {
+        noIgnore: function (name) {
           return name;
         },
 
-        ignore: function(name) {
+        ignore: function (name) {
           return name;
         },
       };
@@ -127,14 +127,14 @@ describe('Compile', function() {
       assert.equal(expected, ret);
     });
 
-    it('config support', function() {
+    it('config support', function () {
       var vm = '$foo($name)';
       var expected = '<i>';
 
       var compile = new Compile(Parser.parse(vm), { escape: false });
       var context = {
         name: '<i>',
-        foo: function(name) {
+        foo: function (name) {
           return name;
         },
       };
@@ -148,33 +148,33 @@ describe('Compile', function() {
     });
   });
 
-  describe('Set && Expression', function() {
-    it('set equal to reference', function() {
+  describe('Set && Expression', function () {
+    it('set equal to reference', function () {
       var vm = '#set( $monkey = $bill ) ## variable reference';
       assert.equal('hello', getContext(vm, { bill: 'hello' }).monkey);
     });
 
-    it('empty map', function() {
+    it('empty map', function () {
       var vm = '#set($foo = {})';
       assert.deepEqual({}, getContext(vm).foo);
     });
 
-    it('#set array', function() {
+    it('#set array', function () {
       var vm = '#set($foo = []) #set($foo[0] = 12)';
       assert.equal(12, getContext(vm).foo[0]);
     });
 
-    it('set equal to literal', function() {
+    it('set equal to literal', function () {
       var vm = "#set( $monkey.Friend = 'monica' ) ## string literal\n" + '#set( $monkey.Number = 123 ) ##number literal';
       assert.equal('monica', getContext(vm).monkey.Friend);
       assert.equal('123', getContext(vm).monkey.Number);
     });
 
-    it('equal to method/property reference', function() {
+    it('equal to method/property reference', function () {
       var vm = '#set($monkey.Blame = $spindoctor.Leak) ## property \n' + '#set( $monkey.Plan = $spindoctor.weave($web) ) ## method';
       var obj = {
         spindoctor: {
-          weave: function(name) {
+          weave: function (name) {
             return name;
           },
           Leak: 'hello world',
@@ -186,7 +186,7 @@ describe('Compile', function() {
       assert.equal('name', getContext(vm, obj).monkey.Plan);
     });
 
-    it('equal to map/list', function() {
+    it('equal to map/list', function () {
       var vms = [
         '#set( $monkey.Say = ["Not", $my, "fault"] ) ## ArrayList',
         '#set( $monkey.Map = {"banana" : "good", "roast beef" : "bad"}) ## Map',
@@ -198,7 +198,7 @@ describe('Compile', function() {
       assert.deepEqual(map, getContext(vms[1]).monkey.Map);
     });
 
-    it('expression simple math', function() {
+    it('expression simple math', function () {
       assert.equal(10, getContext('#set($foo = 2 * 5)').foo);
       assert.equal(2, getContext('#set($foo = 4 / 2)').foo);
       assert.equal(-3, getContext('#set($foo = 2 - 5)').foo);
@@ -206,19 +206,19 @@ describe('Compile', function() {
       assert.equal(7, getContext('#set($foo = 7)').foo);
     });
 
-    it('math with decimal', function() {
+    it('math with decimal', function () {
       assert.equal(10.5, getContext('#set($foo = 2.1 * 5)').foo);
       assert.equal(2.1, getContext('#set($foo = 4.2 / 2)').foo);
       assert.equal(-7.5, getContext('#set($foo = - 2.5 - 5)').foo);
     });
 
-    it('expression complex math', function() {
+    it('expression complex math', function () {
       assert.equal(20, getContext('#set($foo = (7 + 3) * (10 - 8))').foo);
       assert.equal(-20, getContext('#set($foo = -(7 + 3) * (10 - 8))').foo);
       assert.equal(-1, getContext('#set($foo = -7 + 3 * (10 - 8))').foo);
     });
 
-    it('expression compare', function() {
+    it('expression compare', function () {
       assert.equal(false, getContext('#set($foo = 10 > 11)').foo);
       assert.equal(true, getContext('#set($foo = 10 < 11)').foo);
       assert.equal(true, getContext('#set($foo = 10 != 11)').foo);
@@ -229,7 +229,7 @@ describe('Compile', function() {
       assert.equal(false, getContext('#set($foo = 10 == 11)').foo);
     });
 
-    it('expression logic', function() {
+    it('expression logic', function () {
       assert.equal(false, getContext('#set($foo = 10 == 11 && 3 > 1)').foo);
       assert.equal(true, getContext('#set($foo = 10 < 11 && 3 > 1)').foo);
       assert.equal(true, getContext('#set($foo = 10 > 11 || 3 > 1)').foo);
@@ -239,15 +239,15 @@ describe('Compile', function() {
       assert.equal(true, getContext('#set($foo = $a || $b)', { a: 1, b: 0 }).foo);
     });
 
-    it('#set context should be global, #25', function() {
+    it('#set context should be global, #25', function () {
       var vm = '#macro(local) #set($val =1) $val #end #local() $val';
       var ret = render(vm).replace(/\s+/g, '');
       assert.equal('11', ret);
     });
   });
 
-  describe('Literals', function() {
-    it('eval string value', function() {
+  describe('Literals', function () {
+    it('eval string value', function () {
       var vm =
         '#set( $directoryRoot = "www" )' +
         '#set( $templateName = "index.vm")' +
@@ -257,17 +257,17 @@ describe('Compile', function() {
       assert.equal('www/index.vm', render(vm));
     });
 
-    it('not eval string', function() {
+    it('not eval string', function () {
       var vm = "#set( $blargh = '$foo' )$blargh";
       assert.equal('$foo', render(vm));
     });
 
-    it('not parse #[[ ]]#', function() {
+    it('not parse #[[ ]]#', function () {
       var vm = '#foreach ($woogie in $boogie) nothing to $woogie #end';
       assert.equal(vm, render('#[[' + vm + ']]#'));
     });
 
-    it('Range Operator', function() {
+    it('Range Operator', function () {
       var vm1 = '#set($foo = [-1..2])';
       var vm2 = '#set($foo = [-1..$bar])';
       var vm3 = '#set($foo = [$bar..2])';
@@ -277,7 +277,7 @@ describe('Compile', function() {
       assert.deepEqual([], getContext('#set($foo = [$bar..1])').foo);
     });
 
-    it('map and array nest', function() {
+    it('map and array nest', function () {
       var vm1 = '' + '#set($a = [\n' + '  {"name": 1},\n' + '  {"name": 2}\n' + '])\n' + ' ';
 
       var vm2 =
@@ -295,28 +295,28 @@ describe('Compile', function() {
     });
   });
 
-  describe('Conditionals', function() {
-    it('#if', function() {
+  describe('Conditionals', function () {
+    it('#if', function () {
       var vm = '#if($foo)Velocity#end';
       assert.equal('Velocity', render(vm, { foo: 1 }));
     });
 
-    it('#if not work', function() {
+    it('#if not work', function () {
       var vm = '#if($!css_pureui)hello world#end';
       assert.equal('', render(vm));
     });
 
-    it('#elseif & #else', function() {
+    it('#elseif & #else', function () {
       var vm = '#if($foo < 5)Go North#elseif($foo == 8)Go East#{else}Go South#end';
       assert.equal('Go North', render(vm, { foo: 4 }));
       assert.equal('Go East', render(vm, { foo: 8 }));
       assert.equal('Go South', render(vm, { foo: 9 }));
     });
 
-    it('#if with arguments', function() {
+    it('#if with arguments', function () {
       var vm = '#if($foo.isTrue(true))true#end';
       var foo = {
-        isTrue: function(str) {
+        isTrue: function (str) {
           return !!str;
         },
       };
@@ -325,33 +325,33 @@ describe('Compile', function() {
     });
   });
 
-  describe('Loops', function() {
-    it('#foreach', function() {
+  describe('Loops', function () {
+    it('#foreach', function () {
       var vm = '#foreach( $product in $allProducts )<li>$product</li>#end';
       var data = { allProducts: ['book', 'phone'] };
       assert.equal('<li>book</li><li>phone</li>', render(vm, data));
     });
 
-    it('#foreach with map', function() {
+    it('#foreach with map', function () {
       var vm = '#foreach($key in $products) name => $products.name #end';
       var data = { products: { name: 'hanwen' } };
       assert.equal(' name => hanwen ', render(vm, data));
     });
 
-    it('#foreach with map keySet', function() {
+    it('#foreach with map keySet', function () {
       var vm = '#foreach($key in $products.keySet()) $key => $products.get($key) #end';
       var data = { products: { name: 'hanwen' } };
       assert.equal(' name => hanwen ', render(vm, data));
     });
 
-    it('#foreach with nest foreach', function() {
+    it('#foreach with nest foreach', function () {
       var vm = '#foreach($i in [1..2])${velocityCount}#foreach($j in [2..3])${velocityCount}#end#end';
       assert.equal('112212', render(vm));
       var vm = '#foreach($i in [5..2])$i#end';
       assert.equal('5432', render(vm));
     });
 
-    it('#foreach with map entrySet', function() {
+    it('#foreach with map entrySet', function () {
       var vm =
         '' +
         '#set($js_file = {\n' +
@@ -374,7 +374,7 @@ describe('Compile', function() {
 
       var data = {
         staticServer: {
-          getURI: function(url) {
+          getURI: function (url) {
             return '/path' + url;
           },
         },
@@ -383,25 +383,25 @@ describe('Compile', function() {
       assert.equal(ret.trim(), render(vm, data).trim());
     });
 
-    it('#foreach with #macro, $velocityCount should work find, #25', function() {
+    it('#foreach with #macro, $velocityCount should work find, #25', function () {
       var vm = '#macro(local) #end #foreach ($one in [1,2,4]) #local() $velocityCount #end';
       var ret = render(vm).replace(/\s+/g, '');
       assert.equal('123', ret);
     });
 
-    it('#break', function() {
+    it('#break', function () {
       var vm = '#foreach($num in [1..6]) #if($foreach.count > 3) #break #end $num #end';
-      assert.equal('  1   2   3     4 ', render(vm));
+      assert.equal('  1   2   3', render(vm));
     });
   });
 
-  describe('Velocimacros', function() {
-    it('simple #macro', function() {
+  describe('Velocimacros', function () {
+    it('simple #macro', function () {
       var vm = '#macro( d )<tr><td></td></tr>#end #d()';
       assert.equal(' <tr><td></td></tr>', render(vm));
     });
 
-    it('compex #macro', function() {
+    it('compex #macro', function () {
       var vm = '#macro( d $name)<tr><td>$!name</td></tr>#end #d($foo)';
       var vm1 = '#macro( d $a $b)#if($b)$a#end#end #d ( $foo $bar )';
 
@@ -412,118 +412,118 @@ describe('Compile', function() {
       assert.equal(' haha', render(vm1, { foo: 'haha', bar: true }));
     });
 
-    it('#macro call arguments', function() {
+    it('#macro call arguments', function () {
       var vm = '#macro( d $a $b $d)$a$b$!d#end #d ( $foo , $bar, $dd )';
       assert.equal(' ab', render(vm, { foo: 'a', bar: 'b' }));
       assert.equal(' abd', render(vm, { foo: 'a', bar: 'b', dd: 'd' }));
     });
 
-    it('#macro map argument', function() {
+    it('#macro map argument', function () {
       var vm = '#macro( d $a)#foreach($_item in $a.entrySet())$_item.key = $_item.value #end#end #d ( {"foo": $foo,"bar":$bar} )';
       assert.equal(' foo = a bar = b ', render(vm, { foo: 'a', bar: 'b' }));
     });
 
-    it('#noescape', function() {
+    it('#noescape', function () {
       var vm = '#noescape()$hello#end';
       assert.equal('hello world', render(vm, { hello: 'hello world' }));
     });
   });
 
-  describe('Escaping', function() {
-    it('escape slash', function() {
+  describe('Escaping', function () {
+    it('escape slash', function () {
       var vm = '#set( $email = "foo" )$email \\$email';
       assert.equal('foo $email', render(vm));
     });
 
-    it('double slash', function() {
+    it('double slash', function () {
       var vm = '#set( $email = "foo" )\\\\$email \\\\\\$email';
       assert.equal('\\foo \\$email', render(vm));
     });
   });
 
-  describe('Error condiction', function() {
-    it('css color render', function() {
+  describe('Error condiction', function () {
+    it('css color render', function () {
       var vm = 'color: #666 height: 39px';
       assert.equal(vm, render(vm));
     });
 
-    it('jquery parse', function() {
+    it('jquery parse', function () {
       var vm = '$(function(){ $("a").click() $.post() })';
       assert.equal(vm, render(vm));
     });
 
-    it('issue #7: $ meet with #', function() {
+    it('issue #7: $ meet with #', function () {
       var vm = '$bar.foo()#if(1>0)...#end';
       assert.equal('$bar.foo()...', render(vm));
     });
 
-    it('issue #15', function() {
+    it('issue #15', function () {
       var vm = '#macro(a $b $list)#foreach($a in $list)${a}#end $b #end #a("hello", [1, 2])';
       assert.equal(' 12 hello ', render(vm));
     });
 
-    it('issue #18', function() {
+    it('issue #18', function () {
       var vm =
         '$!tradeDetailModel.goodsInfoModel.goodsTitle[<a href="$!personalModule.setTarget(\'/p.htm\').addQueryData("id",$!stringUtil.substringAfter($!tradeDetailModel.goodsInfoModel.goodsId,"guarantee."))" target="_blank">商品页面</a>]';
       var ret = '[<a href="" target="_blank">商品页面</a>]';
       assert.equal(ret, render(vm));
     });
 
-    it('issue #18, condiction 2', function() {
+    it('issue #18, condiction 2', function () {
       var vm = '$!a(**** **** **** $stringUtil.right($!b,4))';
       var ret = '(**** **** **** $stringUtil.right($!b,4))';
       assert.equal(ret, render(vm));
     });
 
-    it('# meet with css property', function() {
+    it('# meet with css property', function () {
       var vm = '#margin-top:2px';
       assert.equal(vm, render(vm));
     });
 
-    it('var end must in condiction var begin', function() {
+    it('var end must in condiction var begin', function () {
       var vm = 'stepFareNo:{$!result.getStepFareNo()}';
       assert.equal('stepFareNo:{}', render(vm));
     });
 
-    it('empty string condiction', function() {
+    it('empty string condiction', function () {
       assert.equal('', render(''));
       assert.equal('', render('##hello'));
       assert.equal('hello', render('hello'));
     });
   });
 
-  describe('throw friendly error message', function() {
-    it('print right posiont when error throw', function() {
+  describe('throw friendly error message', function () {
+    it('print right posiont when error throw', function () {
       var vm = '111\nsdfs\n$foo($name)';
       var expected = '<i>';
 
       var compile = new Compile(Parser.parse(vm), { escape: false });
       var context = {
         name: '<i>',
-        foo: function(name) {
+        foo: function (name) {
           throw new Error('Run error');
         },
       };
-      assert.throws(function() {
+      assert.throws(function () {
         compile.render(context);
       }, /\$foo\(\$name\)/);
 
-      assert.throws(function() {
+      assert.throws(function () {
         compile.render(context);
       }, /L\/N 3:0/);
     });
 
-    it('print error stack of user-defined macro', function() {
+    it('print error stack of user-defined macro', function () {
       var vm = '111\n\n#foo($name)';
       var vm1 = '\nhello#parse("vm.vm")';
       var files = { 'vm.vm': vm, 'vm1.vm': vm1 };
 
       var compile = new Compile(Parser.parse('\n\n#parse("vm1.vm")'));
       var macros = {
-        foo: function(name) {
+        foo: function (name) {
           throw new Error('Run error');
         },
-        parse: function(name) {
+        parse: function (name) {
           return this.eval(files[name]);
         },
       };
@@ -538,10 +538,10 @@ describe('Compile', function() {
     });
   });
 
-  describe('user-defined macro, such as #include, #parse', function() {
-    it('basic', function() {
+  describe('user-defined macro, such as #include, #parse', function () {
+    it('basic', function () {
       var macros = {
-        haha: function(a, b) {
+        haha: function (a, b) {
           a = a || '';
           b = b || '';
           return a + ' hello to ' + b;
@@ -553,15 +553,15 @@ describe('Compile', function() {
       assert.equal('Lily hello to ', render(vm, { a: 'Lily' }, macros));
     });
 
-    it('use eval', function() {
+    it('use eval', function () {
       //这一句非常重要，在node端无需处理，web端必须如此声明
       Compile.Parser = Parser;
 
       var macros = {
-        cmsparse: function(str) {
+        cmsparse: function (str) {
           return this.eval(str);
         },
-        d: function() {
+        d: function () {
           return 'I am d!';
         },
       };
@@ -575,24 +575,24 @@ describe('Compile', function() {
       assert.equal('hello world, I am d!', render(vm, o, macros));
     });
 
-    it('use eval with local variable', function() {
+    it('use eval with local variable', function () {
       //这一句非常重要，在node端无需处理，web端必须如此声明
       Compile.Parser = Parser;
 
       var macros = {
-        cmsparse: function(str) {
+        cmsparse: function (str) {
           return macros.include.apply(this, arguments);
         },
 
-        include: function(str) {
+        include: function (str) {
           return this.eval(str, { name: 'hanwen' });
         },
 
-        parse: function(file) {
+        parse: function (file) {
           return file;
         },
 
-        d: function($name) {
+        d: function ($name) {
           return this.eval('I am $name!');
         },
       };
@@ -609,12 +609,12 @@ describe('Compile', function() {
       assert.equal('a.vm', render(vm1, o, macros));
     });
 
-    it('eval work with #set', function() {
+    it('eval work with #set', function () {
       //这一句非常重要，在node端无需处理，web端必须如此声明
       Compile.Parser = Parser;
 
       var macros = {
-        cmsparse: function(str) {
+        cmsparse: function (str) {
           return this.eval(str);
         },
       };
@@ -628,18 +628,18 @@ describe('Compile', function() {
     });
   });
 
-  describe('self defined function', function() {
-    it('$control.setTemplate', function() {
+  describe('self defined function', function () {
+    it('$control.setTemplate', function () {
       var control = {
-        setTemplate: function(vm) {
+        setTemplate: function (vm) {
           this.vm = vm;
           return this;
         },
-        toString: function() {
+        toString: function () {
           return this.eval(this.vm, this.__temp);
         },
         __temp: {},
-        setParameter: function(key, value) {
+        setParameter: function (key, value) {
           this.__temp[key] = value;
           return this;
         },
@@ -652,81 +652,81 @@ describe('Compile', function() {
     });
   });
 
-  describe('issues', function() {
-    it('#29', function() {
+  describe('issues', function () {
+    it('#29', function () {
       var vm = '#set($total = 0) #foreach($i in [1,2,3]) #set($total = $total + $i) #end $total';
       assert.equal(render(vm).trim(), '6');
     });
-    it('#30', function() {
+    it('#30', function () {
       var vm = '$foo.setName';
       assert.equal(render(vm, { foo: { setName: 'foo' } }).trim(), 'foo');
     });
   });
 
-  describe('multiline', function() {
-    it('#set multiline', function() {
+  describe('multiline', function () {
+    it('#set multiline', function () {
       var vm = '$bar.foo()\n#set($foo=$bar)\n...';
       assert.equal('$bar.foo()\n...', render(vm));
     });
 
-    it('#if multiline', function() {
+    it('#if multiline', function () {
       var vm = '$bar.foo()\n#if(1>0)\n...#end';
       assert.equal('$bar.foo()\n...', render(vm));
     });
 
-    it('#set #set', function() {
+    it('#set #set', function () {
       var vm = '$bar.foo()\n...\n#set($foo=$bar)\n#set($foo=$bar)';
       assert.equal('$bar.foo()\n...\n', render(vm));
     });
 
-    it('#if multiline #set', function() {
+    it('#if multiline #set', function () {
       var vm = '$bar.foo()\n#if(1>0)\n#set($foo=$bar)\n...#end';
       assert.equal('$bar.foo()\n...', render(vm));
     });
 
-    it('#if multiline #set #end', function() {
+    it('#if multiline #set #end', function () {
       var vm = '$bar.foo()\n#if(1>0)...\n#set($foo=$bar)\n#end';
       assert.equal('$bar.foo()\n...\n', render(vm));
     });
 
-    it('with references', function() {
+    it('with references', function () {
       var vm = ['a', '#foreach($b in $nums)', '#if($b) ', 'b', 'e $b.alm', '#end', '#end', 'c'].join('\n');
       var expected = ['a', 'b', 'e 1', 'b', 'e 2', 'b', 'e 3', 'c'].join('\n');
 
       assert.equal(expected, render(vm, { nums: [{ alm: 1 }, { alm: 2 }, { alm: 3 }], bar: '' }));
     });
 
-    it('multiple newlines after statement', function() {
+    it('multiple newlines after statement', function () {
       var vm = '#if(1>0)\n\nb#end';
       assert.equal('\nb', render(vm));
     });
   });
 
-  describe('define support', function() {
-    it('basic', function() {
+  describe('define support', function () {
+    it('basic', function () {
       var vm = '#define( $block )\nHello $who#end\n#set( $who = "World!" )\n$block';
       assert.equal('Hello World!', render(vm));
     });
   });
 });
 
-describe('Helper', function() {
+describe('Helper', function () {
   var getRefText = Velocity.Helper.getRefText;
   var parse = Velocity.Parser.parse;
-  describe('getRefText', function() {
-    it('simple reference', function() {
+  describe('getRefText', function () {
+    it('simple reference', function () {
       var foo = '$a.b';
       var ast = parse(foo)[0];
       assert.equal(getRefText(ast), foo);
     });
 
-    it('reference method', function() {
+    it('reference method', function () {
       var foo = '$a.b()';
       var ast = parse(foo)[0];
       assert.equal(getRefText(ast), foo);
     });
 
-    it('reference method with arguments', function() {
+    it('reference method with arguments', function () {
       var foo = '$a.b("hello")';
       var ast = parse(foo)[0];
       assert.equal(getRefText(ast), foo);
@@ -740,7 +740,7 @@ describe('Helper', function() {
       assert.equal(getRefText(ast), foo);
     });
 
-    it('reference method with arguments array', function() {
+    it('reference method with arguments array', function () {
       var foo = '$a.b(["hello"])';
       var ast = parse(foo)[0];
       assert.equal(getRefText(ast), foo);
@@ -750,7 +750,7 @@ describe('Helper', function() {
       assert.equal(getRefText(ast), foo);
     });
 
-    it('reference index', function() {
+    it('reference index', function () {
       var foo = '$a.b[1]';
       var ast = parse(foo)[0];
       assert.equal(getRefText(ast), foo);
@@ -765,9 +765,9 @@ describe('Helper', function() {
     });
   });
 });
-describe('Parser', function() {
-  describe('simple references', function() {
-    it('simple references', function() {
+describe('Parser', function () {
+  describe('simple references', function () {
+    it('simple references', function () {
       var vm = 'hello world: $foo';
       var ret = Parser.parse(vm);
 
@@ -777,27 +777,27 @@ describe('Parser', function() {
       assert.equal('foo', ret[1].id);
     });
 
-    it('valid variable references', function() {
+    it('valid variable references', function () {
       var vm = '$mud-Slinger_1';
       assert.equal('mud-Slinger_1', Parser.parse(vm)[0].id);
     });
 
-    it('wraped references', function() {
+    it('wraped references', function () {
       var vm = '${mudSlinger}';
       var ast = Parser.parse(vm)[0];
       assert.equal(true, ast.isWraped);
       assert.equal('mudSlinger', ast.id);
     });
 
-    it('function call references', function() {
+    it('function call references', function () {
       var ast = Parser.parse('$foo()')[0];
       assert.equal(false, ast.args);
       assert.equal('references', ast.type);
     });
   });
 
-  describe('Properties', function() {
-    it('simple property', function() {
+  describe('Properties', function () {
+    it('simple property', function () {
       var vm = '$customer.Address';
       var asts = Parser.parse(vm);
       assert.deepEqual(asts[0], {
@@ -811,8 +811,8 @@ describe('Parser', function() {
     });
   });
 
-  describe('Methods ', function() {
-    it('with no arguments', function() {
+  describe('Methods ', function () {
+    it('with no arguments', function () {
       var vm = '$foo.bar()';
       var ast = Parser.parse(vm)[0];
 
@@ -825,7 +825,7 @@ describe('Parser', function() {
       ]);
     });
 
-    it('with arguments integer', function() {
+    it('with arguments integer', function () {
       var vm = '$foo.bar(10)';
       var ast = Parser.parse(vm)[0];
 
@@ -843,7 +843,7 @@ describe('Parser', function() {
       ]);
     });
 
-    it('with arguments references', function() {
+    it('with arguments references', function () {
       var vm = '$foo.bar($bar)';
       var ast = Parser.parse(vm)[0];
 
@@ -859,8 +859,8 @@ describe('Parser', function() {
     });
   });
 
-  describe('Index', function() {
-    it('all kind of indexs', function() {
+  describe('Index', function () {
+    it('all kind of indexs', function () {
       var vm = '$foo[0] $foo[$i] $foo["bar"]';
       var asts = Parser.parse(vm);
 
@@ -886,8 +886,8 @@ describe('Parser', function() {
     });
   });
 
-  describe('complex references', function() {
-    it('property + index + property', function() {
+  describe('complex references', function () {
+    it('property + index + property', function () {
       var vm = '$foo.bar[1].junk';
       var ast = Parser.parse(vm)[0];
 
@@ -901,7 +901,7 @@ describe('Parser', function() {
       assert.equal('property', paths[2].type);
     });
 
-    it('method + index', function() {
+    it('method + index', function () {
       var vm = '$foo.callMethod()[1]';
       var ast = Parser.parse(vm)[0];
 
@@ -915,7 +915,7 @@ describe('Parser', function() {
       assert.equal('integer', ast.path[1].id.type);
     });
 
-    it('property should not start with alphabet', function() {
+    it('property should not start with alphabet', function () {
       var asts = Parser.parse('$foo.124');
       var ast2 = Parser.parse('$foo.-24')[0];
 
@@ -926,15 +926,15 @@ describe('Parser', function() {
       assert.equal(undefined, ast2.path);
     });
 
-    it('index should end with close bracket', function() {
-      assert.throws(function() {
+    it('index should end with close bracket', function () {
+      assert.throws(function () {
         Parser.parse("$foo.bar['a'12]");
       }, /Parse error/);
     });
   });
 
-  describe('Directives', function() {
-    it('#macro', function() {
+  describe('Directives', function () {
+    it('#macro', function () {
       var vm = '#macro( d $a $b)#if($b)$a#end#end #d($foo $bar)';
       var asts = Parser.parse(vm);
 
@@ -953,8 +953,8 @@ describe('Parser', function() {
     });
   });
 
-  describe('comment identify', function() {
-    it('one line comment', function() {
+  describe('comment identify', function () {
+    it('one line comment', function () {
       var asts = Parser.parse('#set( $monkey.Number = 123)##number literal');
 
       assert.equal(2, asts.length);


### PR DESCRIPTION
Velocity template renderer implemented in Amplify CLI was continuing execution of statements that were after the `#break` statement and breaking of loop happened only at the end of the `#foreach` loop. Updated the code to not to run any statements that are after `#break` statement

fix #8779

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
