### PR TITLE
fix: velocity list.indexOf method

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/value-mapper/array.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/value-mapper/array.test.ts
@@ -1,4 +1,5 @@
 import { JavaArray } from '../../../velocity/value-mapper/array';
+import { JavaString } from '../../../velocity/value-mapper/string';
 
 const identityMapper = jest.fn(v => v);
 
@@ -74,6 +75,19 @@ describe(' Velocity ValueMapper JavaArray', () => {
     const arr = new JavaArray(NEW_ARR, identityMapper);
     arr.removeAll([3, 2]);
     expect(arr.toJSON()).toEqual([1]);
+  });
+
+  it('indexOf', () => {
+    const obj = { prop: 1 };
+    const NEW_ARR = [1, 2, 3, 'someStr', true, obj];
+    const arr = new JavaArray(NEW_ARR, identityMapper);
+    expect(arr.indexOf(3)).toEqual(2);
+    expect(arr.indexOf(122)).toEqual(-1);
+    expect(arr.indexOf('someStr')).toEqual(3);
+    expect(arr.indexOf(new JavaString('someStr'))).toEqual(3);
+    expect(arr.indexOf(true)).toEqual(4);
+    expect(arr.indexOf(obj)).toEqual(5);
+    expect(arr.indexOf({ prop: 1 })).toEqual(-1);
   });
 
   // it('retainAll', () => {

--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/array.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/array.ts
@@ -65,4 +65,15 @@ export class JavaArray extends Array<any> {
   toJSON() {
     return Array.from(this).map(toJSON);
   }
+
+  indexOf(obj) {
+    const value = obj?.toJSON ? obj.toJSON() : obj;
+    for (let i = 0; i < this.length; i++) {
+      const item = this[i]?.toJson ? this[i]?.toJson() : this[i];
+      if (item === value) {
+        return i;
+      }
+    }
+    return -1;
+  }
 }

--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/string.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/string.ts
@@ -106,4 +106,7 @@ export class JavaString {
   length() {
     return this.value && this.value.length;
   }
+  toJson() {
+    return this.value;
+  }
 }


### PR DESCRIPTION
AppSync simulator did not implement indexOf method on list.  When the values were mapped to their Java equivalent JS implementation Array.indexOf method did always return -1. Implemented indexOf method in JavaArray class

fix #8830

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
