### PR TITLE
fix: update dep and use node test environment

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -71,7 +71,7 @@
     "amplify-cli-core": "2.4.5",
     "amplify-headless-interface": "1.13.1",
     "amplify-prompts": "1.6.0",
-    "amplify-provider-awscloudformation": "4.61.1",
+    "amplify-provider-awscloudformation": "5.8.5",
     "amplify-util-headless-input": "1.8.1",
     "chalk": "^4.1.1",
     "constructs": "^3.3.125",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -124,6 +124,7 @@
     "nock": "^12.0.3"
   },
   "jest": {
+    "testEnvironment": "node",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -134,6 +134,7 @@
     "@types/node": "^12.12.6"
   },
   "jest": {
+    "testEnvironment": "node",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,200 +177,6 @@
     prettier "^1.19.1"
     yargs "^15.1.0"
 
-"@aws-amplify/graphql-function-transformer@0.4.4":
-  version "0.4.4"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-function-transformer/-/graphql-function-transformer-0.4.4.tgz#56464e9cdbc86d8951a165eeae71725a7d28aadb"
-  integrity sha512-ZTbivT8wiM8whlggSiVOvCllhEN4JMISPq1kUKVOA1Fzg+TBxciuBmgIoEdreYDNi2nQo6+i2udMGiKJ/CjvMg==
-  dependencies:
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-
-"@aws-amplify/graphql-http-transformer@0.5.4":
-  version "0.5.4"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-http-transformer/-/graphql-http-transformer-0.5.4.tgz#374cadfa01b6b1c069b083fb986bd6fc6f0fa47e"
-  integrity sha512-LisG3s8Cf4DvzdGMUKCXRA0tsZuFgLyp1W6z+LHP1IZjlWwTVOG6CSc33ZWX6nWFf5kfosorWIkluP+jchxzvQ==
-  dependencies:
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/core" "~1.124.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-
-"@aws-amplify/graphql-index-transformer@0.3.3":
-  version "0.3.3"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-index-transformer/-/graphql-index-transformer-0.3.3.tgz#6d07bed54b20f72cf7bed617e45a1ce94512da50"
-  integrity sha512-ZAnQAeMHXQMIO3/DkvUzDN7F/agPd0JIP+UV91iaaA8Kv5DfPySrQbUBv7GprRkfWKr01gxbYL12iCm9VoAilQ==
-  dependencies:
-    "@aws-amplify/graphql-model-transformer" "0.6.3"
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-dynamodb" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-
-"@aws-amplify/graphql-model-transformer@0.6.3":
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-model-transformer/-/graphql-model-transformer-0.6.3.tgz#283f440ac4c97d6aceb55f31d6d657143eb35fe2"
-  integrity sha512-wZuxQnM7WdSq75DtbY0czDszC9pU0JM96xESX3Unf/B++EklWW5z9wkzs05bPSHQxrYW6dFCpJEIsdcee5LIIw==
-  dependencies:
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/assets" "~1.124.0"
-    "@aws-cdk/aws-applicationautoscaling" "~1.124.0"
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-autoscaling-common" "~1.124.0"
-    "@aws-cdk/aws-cloudformation" "~1.124.0"
-    "@aws-cdk/aws-cloudwatch" "~1.124.0"
-    "@aws-cdk/aws-codeguruprofiler" "~1.124.0"
-    "@aws-cdk/aws-dynamodb" "~1.124.0"
-    "@aws-cdk/aws-ec2" "~1.124.0"
-    "@aws-cdk/aws-efs" "~1.124.0"
-    "@aws-cdk/aws-events" "~1.124.0"
-    "@aws-cdk/aws-iam" "~1.124.0"
-    "@aws-cdk/aws-kms" "~1.124.0"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/aws-logs" "~1.124.0"
-    "@aws-cdk/aws-s3" "~1.124.0"
-    "@aws-cdk/aws-s3-assets" "~1.124.0"
-    "@aws-cdk/aws-sns" "~1.124.0"
-    "@aws-cdk/aws-sqs" "~1.124.0"
-    "@aws-cdk/aws-ssm" "~1.124.0"
-    "@aws-cdk/cloud-assembly-schema" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    "@aws-cdk/custom-resources" "~1.124.0"
-    "@aws-cdk/cx-api" "~1.124.0"
-    "@aws-cdk/region-info" "~1.124.0"
-    constructs "^3.3.125"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    lodash "^4.17.21"
-    md5 "^2.3.0"
-
-"@aws-amplify/graphql-predictions-transformer@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-predictions-transformer/-/graphql-predictions-transformer-0.3.4.tgz#88feca0db4c60a553bd83cbe97dec8ea8680bc17"
-  integrity sha512-+Yi2gJ7sCEhqb+ZFGUHHW66xhpohb82yYGPwk+XNUZyo1nvKkYaAdb4S0N4fr75/I9xQc3rPF3NScKEuCDdhhg==
-  dependencies:
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-iam" "~1.124.0"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-
-"@aws-amplify/graphql-relational-transformer@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-relational-transformer/-/graphql-relational-transformer-0.3.0.tgz#c6560842796afa8bbed30077e166ef6950d52d54"
-  integrity sha512-0XlH+A/8HWhTqtdIf+izkfg8iFCKPwTGRmPT+plZ1uz899PqyLKXzDZyPxnf+BRb2D7wP8NgAUK1qLlt7zh8gA==
-  dependencies:
-    "@aws-amplify/graphql-index-transformer" "0.3.3"
-    "@aws-amplify/graphql-model-transformer" "0.6.3"
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-dynamodb" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-
-"@aws-amplify/graphql-searchable-transformer@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-searchable-transformer/-/graphql-searchable-transformer-0.6.2.tgz#6ae35ecd702ffa676fe547e7ccbf040e010be256"
-  integrity sha512-CGwfXedp+vbEXTufX4aSqctE+idjUUL+AI/Sziyv84bGt2P602YaJtlZfx9JH6H+yfuxGRDE+rva8bAUcFrTYg==
-  dependencies:
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-dynamodb" "~1.124.0"
-    "@aws-cdk/aws-ec2" "~1.124.0"
-    "@aws-cdk/aws-elasticsearch" "~1.124.0"
-    "@aws-cdk/aws-iam" "~1.124.0"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-
-"@aws-amplify/graphql-transformer-core@0.9.1":
-  version "0.9.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.9.1.tgz#7172c2053300026fb0c9b8e33731f1cdd5870151"
-  integrity sha512-hzMuA4FHe+EbUPATQrTUabaJ2ETGmHaf+JMsAllw3BkZLcicbwzvBA4iUvgyllkOXXCur3p7gWkdsOndiY0qGw==
-  dependencies:
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/assets" "~1.124.0"
-    "@aws-cdk/aws-applicationautoscaling" "~1.124.0"
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-certificatemanager" "~1.124.0"
-    "@aws-cdk/aws-cloudwatch" "~1.124.0"
-    "@aws-cdk/aws-codeguruprofiler" "~1.124.0"
-    "@aws-cdk/aws-cognito" "~1.124.0"
-    "@aws-cdk/aws-dynamodb" "~1.124.0"
-    "@aws-cdk/aws-ec2" "~1.124.0"
-    "@aws-cdk/aws-efs" "~1.124.0"
-    "@aws-cdk/aws-events" "~1.124.0"
-    "@aws-cdk/aws-iam" "~1.124.0"
-    "@aws-cdk/aws-kms" "~1.124.0"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/aws-logs" "~1.124.0"
-    "@aws-cdk/aws-route53" "~1.124.0"
-    "@aws-cdk/aws-s3" "~1.124.0"
-    "@aws-cdk/aws-s3-assets" "~1.124.0"
-    "@aws-cdk/aws-sqs" "~1.124.0"
-    "@aws-cdk/aws-ssm" "~1.124.0"
-    "@aws-cdk/cloud-assembly-schema" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    "@aws-cdk/custom-resources" "~1.124.0"
-    "@aws-cdk/cx-api" "~1.124.0"
-    "@aws-cdk/region-info" "~1.124.0"
-    change-case "^4.1.1"
-    constructs "^3.3.125"
-    deep-diff "^1.0.2"
-    fs-extra "^8.1.0"
-    glob "^7.1.6"
-    graphql "^14.5.8"
-    graphql-transformer-common "4.19.10"
-    lodash "^4.17.21"
-    md5 "^2.3.0"
-    ts-dedent "^2.0.0"
-
-"@aws-amplify/graphql-transformer-interfaces@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-1.9.1.tgz#b0c394d7ed8be1344cbd974d29fa428d8202d999"
-  integrity sha512-8gMCLK6nzBfehPo2shEIeYqytB6Vn2+vtA3TAAlI0tkJFPY5NfWd5agcmXtXh15n6UZay1QQPUBmDVKAWUXk3Q==
-  dependencies:
-    "@aws-cdk/aws-appsync" "~1.124.0"
-    "@aws-cdk/aws-cloudwatch" "~1.124.0"
-    "@aws-cdk/aws-dynamodb" "~1.124.0"
-    "@aws-cdk/aws-ec2" "~1.124.0"
-    "@aws-cdk/aws-elasticsearch" "~1.124.0"
-    "@aws-cdk/aws-events" "~1.124.0"
-    "@aws-cdk/aws-iam" "~1.124.0"
-    "@aws-cdk/aws-kms" "~1.124.0"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/aws-logs" "~1.124.0"
-    "@aws-cdk/aws-rds" "~1.124.0"
-    "@aws-cdk/aws-s3" "~1.124.0"
-    "@aws-cdk/aws-sam" "~1.124.0"
-    "@aws-cdk/aws-secretsmanager" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    "@aws-cdk/custom-resources" "~1.124.0"
-    constructs "^3.3.125"
-    graphql "^14.5.8"
-
 "@aws-amplify/graphql-types-generator@2.8.6":
   version "2.8.6"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-2.8.6.tgz#1fcccb13a96523f12daa0364d811e2ae5c6fe37c"
@@ -6345,11 +6151,6 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@panva/asn1.js@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
-  integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
-
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
   resolved "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -7794,30 +7595,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-cli-core@1.30.0:
-  version "1.30.0"
-  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-1.30.0.tgz#dcfc7555c3194c91cfd89c7edfdf6495e9f6fd70"
-  integrity sha512-G9JK8eFmuKHqflBSn+8tBGFDgf2r9UItL9hupCCe9h5wC7KVWxNFR1K0At24hsifVjt9f8j1HnFjZxmJGFmdwQ==
-  dependencies:
-    ajv "^6.12.3"
-    amplify-cli-logger "1.1.0"
-    amplify-prompts "1.2.0"
-    chalk "^4.1.1"
-    ci-info "^2.0.0"
-    cloudform-types "^4.2.0"
-    dotenv "^8.2.0"
-    execa "^5.1.1"
-    fs-extra "^8.1.0"
-    globby "^11.0.3"
-    hjson "^3.2.1"
-    js-yaml "^4.0.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.1"
-    open "^7.3.1"
-    proxy-agent "^5.0.0"
-    semver "^7.3.5"
-    which "^2.0.2"
-
 amplify-cli-core@2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-2.4.1.tgz#864bd152dc9b3cb4f8061f819bf6bc1b3c56de8e"
@@ -7866,123 +7643,6 @@ amplify-codegen@^2.23.1:
     ora "^4.0.3"
     semver "^7.3.5"
     slash "^3.0.0"
-
-amplify-prompts@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/amplify-prompts/-/amplify-prompts-1.2.0.tgz#7afdec5ac045ffb2c5a8b37b8ab9c8aa94c2ef85"
-  integrity sha512-vDo7yElJDq84RTVlLY0rOpMhED3XuLiWAHNiz5xIqxq3yj+XUoRJhAn+FE9D2f0Ukk7QHHrLe4kG2yC4PpjorA==
-  dependencies:
-    chalk "^4.1.1"
-    enquirer "^2.3.6"
-
-amplify-provider-awscloudformation@4.61.1:
-  version "4.61.1"
-  resolved "https://registry.npmjs.org/amplify-provider-awscloudformation/-/amplify-provider-awscloudformation-4.61.1.tgz#dcafdbf61bc720e0ec6953063185fd0b31402d3f"
-  integrity sha512-OZa5O45m8mMJD4IARD4GMff5RNt2V84OEO22IBuPYyz8HHazUZ/IEcd5bsCYztdaU9sDCSpd2BgWqdGoYr2HIw==
-  dependencies:
-    "@aws-amplify/graphql-function-transformer" "0.4.4"
-    "@aws-amplify/graphql-http-transformer" "0.5.4"
-    "@aws-amplify/graphql-index-transformer" "0.3.3"
-    "@aws-amplify/graphql-model-transformer" "0.6.3"
-    "@aws-amplify/graphql-predictions-transformer" "0.3.4"
-    "@aws-amplify/graphql-relational-transformer" "0.3.0"
-    "@aws-amplify/graphql-searchable-transformer" "0.6.2"
-    "@aws-amplify/graphql-transformer-core" "0.9.1"
-    "@aws-amplify/graphql-transformer-interfaces" "1.9.1"
-    "@aws-cdk/assets" "~1.124.0"
-    "@aws-cdk/aws-apigatewayv2" "~1.124.0"
-    "@aws-cdk/aws-autoscaling" "~1.124.0"
-    "@aws-cdk/aws-batch" "~1.124.0"
-    "@aws-cdk/aws-cloudformation" "~1.124.0"
-    "@aws-cdk/aws-cloudwatch" "~1.124.0"
-    "@aws-cdk/aws-codebuild" "~1.124.0"
-    "@aws-cdk/aws-codecommit" "~1.124.0"
-    "@aws-cdk/aws-codedeploy" "~1.124.0"
-    "@aws-cdk/aws-codepipeline" "~1.124.0"
-    "@aws-cdk/aws-codepipeline-actions" "~1.124.0"
-    "@aws-cdk/aws-ec2" "~1.124.0"
-    "@aws-cdk/aws-ecr" "~1.124.0"
-    "@aws-cdk/aws-ecr-assets" "~1.124.0"
-    "@aws-cdk/aws-ecs" "~1.124.0"
-    "@aws-cdk/aws-elasticloadbalancing" "~1.124.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "~1.124.0"
-    "@aws-cdk/aws-events" "~1.124.0"
-    "@aws-cdk/aws-events-targets" "~1.124.0"
-    "@aws-cdk/aws-iam" "~1.124.0"
-    "@aws-cdk/aws-kinesis" "~1.124.0"
-    "@aws-cdk/aws-kinesisfirehose" "~1.124.0"
-    "@aws-cdk/aws-kms" "~1.124.0"
-    "@aws-cdk/aws-lambda" "~1.124.0"
-    "@aws-cdk/aws-logs" "~1.124.0"
-    "@aws-cdk/aws-route53" "~1.124.0"
-    "@aws-cdk/aws-s3" "~1.124.0"
-    "@aws-cdk/aws-s3-assets" "~1.124.0"
-    "@aws-cdk/aws-secretsmanager" "~1.124.0"
-    "@aws-cdk/aws-servicecatalog" "~1.124.0"
-    "@aws-cdk/aws-servicediscovery" "~1.124.0"
-    "@aws-cdk/aws-sns" "~1.124.0"
-    "@aws-cdk/aws-sns-subscriptions" "~1.124.0"
-    "@aws-cdk/aws-sqs" "~1.124.0"
-    "@aws-cdk/aws-stepfunctions" "~1.124.0"
-    "@aws-cdk/core" "~1.124.0"
-    "@aws-cdk/custom-resources" "~1.124.0"
-    "@aws-cdk/region-info" "~1.124.0"
-    "@octokit/rest" "^18.0.9"
-    amplify-cli-core "1.30.0"
-    amplify-cli-logger "1.1.0"
-    amplify-codegen "^2.23.1"
-    amplify-util-import "1.5.13"
-    archiver "^5.3.0"
-    aws-sdk "^2.963.0"
-    bottleneck "2.19.5"
-    cfn-lint "^1.9.7"
-    chalk "^4.1.1"
-    cloudform "^4.2.0"
-    cloudform-types "^4.2.0"
-    columnify "^1.5.4"
-    constructs "^3.3.125"
-    cors "^2.8.5"
-    deep-diff "^1.0.2"
-    extract-zip "^2.0.1"
-    folder-hash "^4.0.1"
-    fs-extra "^8.1.0"
-    glob "^7.1.6"
-    graphql "^14.5.8"
-    graphql-auth-transformer "6.24.24"
-    graphql-connection-transformer "4.21.23"
-    graphql-dynamodb-transformer "6.22.23"
-    graphql-elasticsearch-transformer "4.12.3"
-    graphql-function-transformer "2.5.22"
-    graphql-http-transformer "4.18.10"
-    graphql-key-transformer "2.23.23"
-    graphql-predictions-transformer "2.5.22"
-    graphql-transformer-core "6.30.0"
-    graphql-versioned-transformer "4.17.23"
-    ignore "^5.1.8"
-    import-from "^3.0.0"
-    import-global "^0.1.0"
-    ini "^1.3.5"
-    inquirer "^7.3.3"
-    is-wsl "^2.2.0"
-    jose "^2.0.2"
-    lodash "^4.17.21"
-    lodash.throttle "^4.1.1"
-    moment "^2.24.0"
-    netmask "^2.0.2"
-    node-fetch "^2.6.1"
-    ora "^4.0.3"
-    promise-sequential "^1.1.1"
-    proxy-agent "^5.0.0"
-    rimraf "^3.0.0"
-    xstate "^4.14.0"
-
-amplify-util-import@1.5.13:
-  version "1.5.13"
-  resolved "https://registry.npmjs.org/amplify-util-import/-/amplify-util-import-1.5.13.tgz#ab191c3c1cc3e6ac5cf1089fd2c9ca35042107b7"
-  integrity sha512-OriJeF7l3pEv4PDjVjPh7ElhMnJE2HiMoMgTs5sdZbkqyigisEoEn1EWrdfzJNT7eBsBH8xDKuZjs3yRqooc4Q==
-  dependencies:
-    amplify-cli-core "1.30.0"
-    aws-sdk "^2.963.0"
 
 ansi-align@^3.0.0:
   version "3.0.1"
@@ -14030,17 +13690,6 @@ graphiql@^1.3.2:
     graphql-language-service "^4.1.4"
     markdown-it "^12.2.0"
 
-graphql-auth-transformer@6.24.24:
-  version "6.24.24"
-  resolved "https://registry.npmjs.org/graphql-auth-transformer/-/graphql-auth-transformer-6.24.24.tgz#b56728f2a830f16c68ff15d7371d2fdac459cbd3"
-  integrity sha512-zktdk6+RnILB3QlaW1q+n8lOgbRiPOb5RMTxvXYRWKOfkQyE23uf9uzuTRpDUHtg4ldIqSPTcEE1H/+IzKURaQ==
-  dependencies:
-    graphql "^14.5.8"
-    graphql-connection-transformer "4.21.23"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
-
 graphql-config@^2.2.1:
   version "2.2.2"
   resolved "https://registry.npmjs.org/graphql-config/-/graphql-config-2.2.2.tgz#a4b577826bba9b83e7b0f6cd617be43ca67da045"
@@ -14069,66 +13718,6 @@ graphql-config@^4.1.0:
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
 
-graphql-connection-transformer@4.21.23:
-  version "4.21.23"
-  resolved "https://registry.npmjs.org/graphql-connection-transformer/-/graphql-connection-transformer-4.21.23.tgz#77a1c6ad4f6d4b2708c89ee96a08ba38165d0088"
-  integrity sha512-R24n5Ea4og3s9vI7emMKydVCCpHaTSxpdXfSTUQCKqFwXuaIQM8pUTZqhanAkaRJzdXg7n43f2VryFwTUL4GwA==
-  dependencies:
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-dynamodb-transformer "6.22.23"
-    graphql-key-transformer "2.23.23"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
-
-graphql-dynamodb-transformer@6.22.23:
-  version "6.22.23"
-  resolved "https://registry.npmjs.org/graphql-dynamodb-transformer/-/graphql-dynamodb-transformer-6.22.23.tgz#6c931fc2b4ecabbf56d7ebc1a2ed5849c542bd5f"
-  integrity sha512-Q7qW/NdiQy8Lu4kjWo2P4I9augDL9RePkyQQHP+x3Z2pYsXFf8Z9FuufiH1RQYZ8a89wboVpfunUByYYn1LVLw==
-  dependencies:
-    "@types/pluralize" "^0.0.29"
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
-    md5 "^2.2.1"
-    pluralize "^8.0.0"
-
-graphql-elasticsearch-transformer@4.12.3:
-  version "4.12.3"
-  resolved "https://registry.npmjs.org/graphql-elasticsearch-transformer/-/graphql-elasticsearch-transformer-4.12.3.tgz#6e8192d291c0a941c376ecc645d7ded21e0b9579"
-  integrity sha512-XsNtkaIfJMrV4bJltdMAlZ1v3HodC3Y+Qkyzgh8uQozHV0YhZzTpwY9tpnpKO0Z+PK34Jsuy5B3fFJlrkgUAuw==
-  dependencies:
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
-
-graphql-function-transformer@2.5.22:
-  version "2.5.22"
-  resolved "https://registry.npmjs.org/graphql-function-transformer/-/graphql-function-transformer-2.5.22.tgz#b3f65d74e4955f292468ee08d24d3b02b7d5e52c"
-  integrity sha512-Yyn20ZtrwBS444pp0Qzp+hEwQGBE+Wemg4OK7Np6gGWu1s9XTgYhzvdSkm8l36FR3SYDxKu+sWFZ96mdm6Q+Eg==
-  dependencies:
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
-
-graphql-http-transformer@4.18.10:
-  version "4.18.10"
-  resolved "https://registry.npmjs.org/graphql-http-transformer/-/graphql-http-transformer-4.18.10.tgz#70b69d095f492a9c77899ed3da13a50f417d918d"
-  integrity sha512-sPowKCAd2+Tf6KdpTj46l6i8aNI9m9nTur+sHpMKPAqS0sxhCFpBUsz0Xdy2mks6mZWKG9V4NFDh5FaoD816Og==
-  dependencies:
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
-
 graphql-import@^0.7.1:
   version "0.7.1"
   resolved "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz#4add8d91a5f752d764b0a4a7a461fcd93136f223"
@@ -14141,18 +13730,6 @@ graphql-iso-date@^3.6.1:
   version "3.6.1"
   resolved "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz#bd2d0dc886e0f954cbbbc496bbf1d480b57ffa96"
   integrity sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q==
-
-graphql-key-transformer@2.23.23:
-  version "2.23.23"
-  resolved "https://registry.npmjs.org/graphql-key-transformer/-/graphql-key-transformer-2.23.23.tgz#bfd40f63a828a45306fff0230df498603278c696"
-  integrity sha512-GWRGRXV5zwsPDKuFwnU4bTuzeeQfXBMO0sL/V0SeslkHv6HCI/rPEkffh98bz5W0H4T7tqzfX7/y8zv7125Mfw==
-  dependencies:
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-dynamodb-transformer "6.22.23"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
 
 graphql-language-service-interface@^2.10.2:
   version "2.10.2"
@@ -14198,22 +13775,6 @@ graphql-language-service@^4.1.4:
     graphql-language-service-parser "^1.10.4"
     graphql-language-service-types "^1.8.7"
     graphql-language-service-utils "^2.7.1"
-
-graphql-mapping-template@4.18.3:
-  version "4.18.3"
-  resolved "https://registry.npmjs.org/graphql-mapping-template/-/graphql-mapping-template-4.18.3.tgz#2c002df699d46353a3c695422e4193ff03a983d0"
-  integrity sha512-3VoxldV/8ioVXvATiVkYXnw1YjRS+ndmWyL/tH06gVl5y3nIMycDCdiNDxel6qKkVM36H27vyTdov98JtZ+L/A==
-
-graphql-predictions-transformer@2.5.22:
-  version "2.5.22"
-  resolved "https://registry.npmjs.org/graphql-predictions-transformer/-/graphql-predictions-transformer-2.5.22.tgz#4ea2b2d5afa168916901732b017b2a7d62b9b9b6"
-  integrity sha512-5OFl7laJ1s0B9WEv7zf98VwXh4KEJvry836k0ggOr8/Oo1i6ZUcf1UFMk8VK7p811b/hLu4pO6rPfLkNbssKBA==
-  dependencies:
-    cloudform-types "^4.2.0"
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
 
 graphql-request@^1.5.0:
   version "1.8.2"
@@ -14262,43 +13823,10 @@ graphql-tag@^2.10.1, graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
-graphql-transformer-common@4.19.10:
-  version "4.19.10"
-  resolved "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.19.10.tgz#2a84d2d3e9ad263611f1830aed487236836ea705"
-  integrity sha512-/4BMDToXFfEPQkAIWv0zVtQBM0Q7vDbNBza18rqGscP1dWYCtSUpqyT2UnHpboXvTSVezHSzMbyDbtMVsqi9Kw==
-  dependencies:
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    md5 "^2.2.1"
-    pluralize "8.0.0"
-
-graphql-transformer-core@6.30.0:
-  version "6.30.0"
-  resolved "https://registry.npmjs.org/graphql-transformer-core/-/graphql-transformer-core-6.30.0.tgz#c532ad8b01400bdf5044e5f43f944f013750a66b"
-  integrity sha512-YBxdJpUE8K9zenHaLubnLhKlJBjMYfJgzwT5Zv/IowAwyTvNUoDsnox6M1ov8kEHru2VV+eKVqQjlswKWHnXog==
-  dependencies:
-    amplify-cli-core "1.30.0"
-    cloudform-types "^4.2.0"
-    deep-diff "^1.0.2"
-    fs-extra "^8.1.0"
-    glob "^7.1.6"
-    graphql "^14.5.8"
-    graphql-transformer-common "4.19.10"
-
 graphql-type-json@^0.3.1:
   version "0.3.2"
   resolved "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
-
-graphql-versioned-transformer@4.17.23:
-  version "4.17.23"
-  resolved "https://registry.npmjs.org/graphql-versioned-transformer/-/graphql-versioned-transformer-4.17.23.tgz#c4157542db61b98af4460370749a4fc88c6e714f"
-  integrity sha512-pYBa/1o9fwX4WX4HKmxDXYtdSrOgUiuj1d0gmuYLoFPTzkl3sOoJ1WUskX5Jk8az0bvuw91hQP/NAFeU8p/tSw==
-  dependencies:
-    graphql "^14.5.8"
-    graphql-mapping-template "4.18.3"
-    graphql-transformer-common "4.19.10"
-    graphql-transformer-core "6.30.0"
 
 graphql-ws@^5.4.1:
   version "5.5.5"
@@ -16419,12 +15947,10 @@ jmespath@0.15.0:
   resolved "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-jose@^2.0.2:
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz#29746a18d9fff7dcf9d5d2a6f62cb0c7cd27abd3"
-  integrity sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==
-  dependencies:
-    "@panva/asn1.js" "^1.0.0"
+jose@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.3.7.tgz#5000e4a2d41ae411a5abdd11e6baf63fc2973a69"
+  integrity sha512-S7Xfsy8nN9Iw/AZxk+ZxEbd5ImIwJPM0TfAo8zI8FF+3lidQ2yiK4dqzsaPKSbZD0woNVSY0KCql6rlKc5V7ug==
 
 jquery@x.*:
   version "3.6.0"


### PR DESCRIPTION
There is an out of date dependency on `amplify-provider-awscloudformation`, which is pulling in a number of older dependency versions. This commit fixes the dependency version.

This commit also updates some of our test suites to use the Node testing environment instead of the default of jsdom. This is done because the default does not properly handle some Node globals.

Refs: https://github.com/panva/jose/issues/307
