### PR TITLE
ci: build tests as part of build step in CI

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -72,6 +72,9 @@ jobs:
     steps:
       - checkout
       - run: yarn run production-build
+      - run:
+          name: Build tests
+          command: yarn build-tests
       - save_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
           paths:


### PR DESCRIPTION
Some times e2e tests can fail in CI due to compilation error. These tests fail later in the pipeline when individual e2e tests are run. Updating the build process to run these tests early to detect any compilation issues so build can bail early

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
