### PR TITLE
Revert "chore: correct the "pro-tip" to use "push" instead of "publis…

### DIFF
--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -200,6 +200,6 @@ function printWelcomeMessage(context: $TSContext) {
   );
   context.print.info('');
   context.print.success('Pro tip:');
-  context.print.info('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything');
+  context.print.info('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything');
   context.print.info('');
 }

--- a/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
+++ b/packages/amplify-console-integration-tests/src/consoleHosting/consoleHosting.ts
@@ -40,7 +40,7 @@ export function addEnvironment(cwd: string, settings: any): Promise<void> {
     spawn(getCLIPath(), ['env', 'add', '--providers', JSON.stringify(settings.providersParam)], { cwd, stripColors: true })
       .wait('Enter a name for the environment')
       .sendLine(settings.envName)
-      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
+      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -80,7 +80,7 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
         .sendLine(s.profileName);
     }
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (err) {
         reject(err);
       } else {

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -119,7 +119,7 @@ export function initProjectForPinpoint(cwd: string): Promise<void> {
 
     singleSelect(chain, settings.region, amplifyRegions);
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
         resolve();
       } else {

--- a/packages/amplify-e2e-tests/src/environment/env.ts
+++ b/packages/amplify-e2e-tests/src/environment/env.ts
@@ -200,7 +200,7 @@ export function addEnvironmentHostedUI(cwd: string, settings: { envName: string 
       .sendLine(APPLE_KEY_ID)
       .wait('Enter your Private Key for your OAuth flow:')
       .sendLine(APPLE_PRIVATE_KEY)
-      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
+      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-e2e-tests/src/init-special-cases/index.ts
@@ -87,7 +87,7 @@ async function initWorkflow(cwd: string, settings: { accessKeyId: string; secret
 
     singleSelect(chain, settings.region, amplifyRegions);
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
       if (!err) {
         resolve();
       } else {

--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -55,7 +55,7 @@ export function initJSProjectWithProfileOldDX(cwd: string, settings: Object, tes
       .sendCarriageReturn()
       .wait('Please choose the profile you want to use')
       .sendLine(s.profileName)
-      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
+      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();


### PR DESCRIPTION
Revert "chore: correct the "pro-tip" to use "push" instead of "publish" (#8573)"

This reverts commit 50f0f313f451bd04896b346c70d9e90d6185c857.

It caused e2e tests to fail with error:

```
Received:
  "Try \"amplify add api\" to create a backend API and then \"amplify publish\" to deploy everything"

Message:
  expected "Try \"amplify add api\" to create a backend API and then \"amplify publish\" to deploy everything" to contain "Try \"amplify add api\" to create a backend API and then \"amplify push\" to deploy everything"
```

see example: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/5726/workflows/50a6597e-7f7d-4ba0-95bc-69e7d3968b64/jobs/134746
