### PR TITLE
test: use 'publish' for migration tests

### DIFF
--- a/packages/amplify-migration-tests/src/migration-helpers/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/init.ts
@@ -105,7 +105,7 @@ export function initJSProjectWithProfile(cwd: string, settings: Object, testingW
       .sendCarriageReturn()
       .wait('Please choose the profile you want to use')
       .sendLine(s.profileName)
-      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
+      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
       .run((err: Error) => {
         if (!err) {
           resolve();


### PR DESCRIPTION
migration test expectations need to look for "publish" and non-migration tests look for "push" in

```
      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
```