### PR TITLE
fix: update graphqltransformer e2e tests

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexTransformer.e2e.test.ts
@@ -852,7 +852,7 @@ async function listGSIShippingUpdate(orderId: string, itemId: object, sortDirect
   const input = { orderId, itemId, sortDirection };
   const result = await GRAPHQL_CLIENT.query(
     `query queryGSI(
-        $orderId: ID,
+        $orderId: ID!,
         $itemIdStatus: ModelShippingUpdateByOrderItemStatusCompositeKeyConditionInput,
         $sortDirection:  ModelSortDirection) {
             shippingUpdates(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -326,9 +326,9 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
   expectNullableFields(createInput, ['description']);
   expect(createInput.fields).toHaveLength(4);
   const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
-  expectNonNullFields(updateInput, ['email', 'createdAt']);
+  expectNonNullFields(updateInput, ['id', 'email', 'createdAt']);
   expectNullableFields(updateInput, ['category', 'description']);
-  expect(updateInput.fields).toHaveLength(4);
+  expect(updateInput.fields).toHaveLength(5);
   const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
   expectNonNullFields(deleteInput, ['email', 'createdAt']);
   expect(deleteInput.fields).toHaveLength(2);


### PR DESCRIPTION
This pr updates e2e tests to conform with new behavior.

* https://github.com/aws-amplify/amplify-cli/commit/45cd9736b5fc09d78a3f445f62fc2a971c11fec7
* https://github.com/aws-amplify/amplify-cli/commit/e0f7de6bdba1ddc484de341e903bc56460bbb442