### PR TITLE
fix: use id as nullable field

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -326,8 +326,8 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
   expectNullableFields(createInput, ['description']);
   expect(createInput.fields).toHaveLength(4);
   const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
-  expectNonNullFields(updateInput, ['id', 'email', 'createdAt']);
-  expectNullableFields(updateInput, ['category', 'description']);
+  expectNonNullFields(updateInput, ['email', 'createdAt']);
+  expectNullableFields(updateInput, ['id', 'category', 'description']);
   expect(updateInput.fields).toHaveLength(5);
   const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
   expectNonNullFields(deleteInput, ['email', 'createdAt']);


### PR DESCRIPTION
this fixes an e2e test related to https://github.com/aws-amplify/amplify-cli/commit/45cd9736b5fc09d78a3f445f62fc2a971c11fec7