### PR TITLE
fix: temporarily remove isCI check from env var flow

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import _ from 'lodash';
 import * as uuid from 'uuid';
 import inquirer from 'inquirer';
-import { $TSContext, stateManager, pathManager, JSONUtilities, exitOnNextTick, isCI } from 'amplify-cli-core';
+import { $TSContext, stateManager, pathManager, JSONUtilities, exitOnNextTick } from 'amplify-cli-core';
 import { functionParametersFileName } from './constants';
 import { categoryName } from '../../../constants';
 import { formatter, maxLength, printer, prompter } from 'amplify-prompts';
@@ -190,7 +190,7 @@ export const ensureEnvironmentVariableValues = async (context: $TSContext) => {
 
   // there are some missing env vars
 
-  if (yesFlagSet || isCI()) {
+  if (yesFlagSet) {
     // in this case, we can't prompt for missing values, so fail gracefully
     const errMessage = `Cannot push Amplify environment "${currentEnvName}" due to missing Lambda function environment variable values. Rerun 'amplify push' without '--yes' to fix.`;
     printer.error(errMessage);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removing the isCI check from the missing environment variables workflow to unblock the pipeline. Will follow up with a PR to reinstate the check with some special logic to handle our CI environment differently

#### Issue #, if available
https://135684-145880460-gh.circle-artifacts.com/0/packages/amplify-e2e-tests/amplify-e2e-reports/index.html

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
