### PR TITLE
fix: make update input id field required

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1337,5 +1337,7 @@ describe('ModelTransformer: ', () => {
     expect(updateTodoInput).toBeDefined();
 
     expectFieldsOnInputType(updateTodoInput!, ['id']);
+    const updateTodoIdField = getFieldOnInputType(updateTodoInput!, 'id');
+    expect(updateTodoIdField.type.kind).toBe('NonNullType');
   });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
@@ -46,7 +46,7 @@ export const makeUpdateInputField = (
 
   if (!hasIdField) {
     // Add id field and make it optional
-    input.addField(InputFieldWrapper.create('id', 'ID', true));
+    input.addField(InputFieldWrapper.create('id', 'ID', false));
   } else {
     const idField = input.fields.find(f => f.name === 'id');
     if (idField) {

--- a/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
+++ b/packages/graphql-dynamodb-transformer/src/__tests__/DynamoDBModelTransformer.test.ts
@@ -771,6 +771,8 @@ it('should generate id for the update input object', async () => {
   expect(updateTodoInput).toBeDefined();
 
   expectFieldsOnInputType(updateTodoInput!, ['id']);
+  const updateTodoIdField = getFieldOnInputType(updateTodoInput!, 'id');
+  expect(updateTodoIdField.type.kind).toBe('NonNullType');
 });
 
 function transformerVersionSnapshot(version: number): string {

--- a/packages/graphql-dynamodb-transformer/src/definitions.ts
+++ b/packages/graphql-dynamodb-transformer/src/definitions.ts
@@ -275,7 +275,7 @@ export function makeUpdateInputObject(
     },
     fields: [
       // add default id field and expose that
-      ...(hasIdField ? [] : [makeInputValueDefinition('id', makeNamedType('ID'))]),
+      ...(hasIdField ? [] : [makeInputValueDefinition('id', makeNonNullType(makeNamedType('ID')))]),
       ...fields,
     ],
     directives: [],

--- a/packages/graphql-key-transformer/src/KeyTransformer.ts
+++ b/packages/graphql-key-transformer/src/KeyTransformer.ts
@@ -847,9 +847,18 @@ function replaceUpdateInput(
   input: InputObjectTypeDefinitionNode,
   keyFields: string[],
 ): InputObjectTypeDefinitionNode {
+  const schemaHasIdField = definition.fields!.some(f => f.name.value === 'id');
+  const inputFields = input.fields!.filter(f => {
+    if (!schemaHasIdField && f.name.value === 'id') {
+      return false;
+    }
+
+    return true;
+  });
+
   return {
     ...input,
-    fields: input.fields.map(f => {
+    fields: inputFields.map(f => {
       if (keyFields.find(k => k === f.name.value)) {
         return makeInputValueDefinition(f.name.value, wrapNonNull(withNamedNodeNamed(f.type, getBaseType(f.type))));
       }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformerLocal.e2e.test.ts
@@ -327,8 +327,8 @@ test('Test that a secondary @key with a multiple field adds an GSI.', () => {
   expect(createInput.fields).toHaveLength(4);
   const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTestInput') as ObjectTypeDefinitionNode;
   expectNonNullFields(updateInput, ['email', 'createdAt']);
-  expectNullableFields(updateInput, ['id', 'category', 'description']);
-  expect(updateInput.fields).toHaveLength(5);
+  expectNullableFields(updateInput, ['category', 'description']);
+  expect(updateInput.fields).toHaveLength(4);
   const deleteInput = schema.definitions.find((def: any) => def.name && def.name.value === 'DeleteTestInput') as ObjectTypeDefinitionNode;
   expectNonNullFields(deleteInput, ['email', 'createdAt']);
   expect(deleteInput.fields).toHaveLength(2);
@@ -347,13 +347,13 @@ test('Test that a secondary @key with a multiple field adds an LSI with GSI FF t
 
   const transformer = new GraphQLTransform({
     transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
-    featureFlags: ({
+    featureFlags: {
       getBoolean: (featureName: string, defaultValue: boolean) => {
         if (featureName === 'secondaryKeyAsGSI') return false;
         if (featureName === 'improvePluralization') return true;
         return defaultValue || false;
       },
-    } as unknown) as FeatureFlagProvider,
+    } as unknown as FeatureFlagProvider,
   });
 
   const out = transformer.transform(validSchema);
@@ -391,13 +391,13 @@ test('Test that a secondary @key with a multiple field adds an GSI based on enab
 
   const transformer = new GraphQLTransform({
     transformers: [new DynamoDBModelTransformer(), new KeyTransformer()],
-    featureFlags: ({
+    featureFlags: {
       getBoolean: (featureName: string, defaultValue: boolean) => {
         if (featureName === 'secondaryKeyAsGSI') return true;
         if (featureName === 'improvePluralization') return true;
         return defaultValue || false;
       },
-    } as unknown) as FeatureFlagProvider,
+    } as unknown as FeatureFlagProvider,
   });
 
   const out = transformer.transform(validSchema);


### PR DESCRIPTION
#### Description of changes
- make the id on update input field required

#### Description of how you validated changes
- yarn test
- e2e tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
